### PR TITLE
Separate out handling the offer and getting the answer back

### DIFF
--- a/MatrixSDK/VoIP/CallStack/MXCallStackCall.h
+++ b/MatrixSDK/VoIP/CallStack/MXCallStackCall.h
@@ -64,17 +64,25 @@
 /**
  Handle a incoming offer from a peer.
 
- This offer came within a m.call.invite event sent by the peer. 
- The implementation must return a sdp description `MXCallManager` will
- send back in a m.call.answer event.
+ This offer came within a m.call.invite event sent by the peer.
 
  @param sdpOffer the description of the peer media.
+ */
+- (void)handleOffer:(NSString*)sdpOffer;
+
+/**
+ Generate an answer to send to the peer.
+ 
+ handleOffer must have been called with a valid offer.
+ 
+ The implementation must return a sdp description `MXCallManager` will
+ send back in a m.call.answer event.
+ 
  @param success A block object called when the operation succeeds. It provides a description
-                of the answer.
+ of the answer.
  @param failure A block object called when the operation fails.
  */
-- (void)handleOffer:(NSString*)sdpOffer
-            success:(void (^)(NSString *sdpAnswer))success
+- (void)createAnswer:(void (^)(NSString *sdpAnswer))success
             failure:(void (^)(NSError *error))failure;
 
 

--- a/MatrixSDK/VoIP/CallStack/OpenWebRTC/MXOpenWebRTCCallStackCall.m
+++ b/MatrixSDK/VoIP/CallStack/OpenWebRTC/MXOpenWebRTCCallStackCall.m
@@ -32,9 +32,9 @@
     void (^onStartCapturingMediaWithVideoSuccess)();
 
     /**
-     Success block for the async `handleAnswer` method.
+     Success block for the async `createAnswer` method.
      */
-    void (^onHandleOfferSuccess)(NSString *sdpAnswer);
+    void (^onCreateAnswerSuccess)(NSString *sdpAnswer);
 
     /**
      Success block for the async `createOffer` method.
@@ -46,6 +46,8 @@
      */
     void (^onHandleAnswerSuccess)();
 }
+
+@property (nonatomic, readwrite, retain) NSString *answer;
 
 @end
 
@@ -120,10 +122,18 @@
 
 
 #pragma mark - Incoming call
-- (void)handleOffer:(NSString *)sdpOffer success:(void (^)(NSString *sdpAnswer))success failure:(void (^)(NSError *))failure
+- (void)handleOffer:(NSString *)sdpOffer
 {
-    onHandleOfferSuccess = success;
     [openWebRTCHandler handleOfferReceived:sdpOffer];
+}
+
+- (void)createAnswer:(void (^)(NSString *))success failure:(void (^)(NSError *))failure
+{
+    if (self.answer) {
+        success(self.answer);
+    } else {
+        onCreateAnswerSuccess = success;
+    }
 }
 
 
@@ -164,10 +174,13 @@
 {
     dispatch_async(dispatch_get_main_queue(), ^{
 
-        if (onHandleOfferSuccess)
+        if (onCreateAnswerSuccess)
         {
-            onHandleOfferSuccess(answer[@"sdp"]);
-            onHandleOfferSuccess = nil;
+            onCreateAnswerSuccess(answer[@"sdp"]);
+            onCreateAnswerSuccess = nil;
+        }
+        else {
+            self.answer = answer[@"sdp"];
         }
     });
 }


### PR DESCRIPTION
OWR needs the offer when trickle candidates come in, else it can't process them. Start capturing before we start the call ringing because it needs capture sources to process the offer. Other way of doing this would be to buffer the trickle candidates until the user answers, but we probably want to start capturing before answering so we can show mirrored video and I think it makes for a better API if the matrix layer doesn't have to buffer candidates.

There is still a problem where calls can't be established after a call is hung up from the other end (I think).