### PR TITLE
Server Sync V2: Increase supported Server-Client version API: v2

### DIFF
--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -815,6 +815,13 @@
 
 - (BOOL)acknowledgeLatestEvent:(BOOL)sendReceipt;
 {
+    // Sanity check on supported C-S version
+    if (mxSession.matrixRestClient.preferredAPIVersion < MXRestClientAPIVersion2)
+    {
+        NSLog(@"[MXRoom] acknowledgeLatestEvent failed: read receipts are not supported on C-S v1 API");
+        return NO;
+    }
+    
     MXEvent* event =[mxSession.store lastMessageOfRoom:_state.roomId withTypeIn:_acknowledgableEventTypes];
     if (event)
     {
@@ -831,10 +838,10 @@
             if (sendReceipt)
             {
                 [mxSession.matrixRestClient sendReadReceipts:_state.roomId eventId:event.eventId success:^(NSString *eventId) {
-                }
-
-                 failure:^(NSError *error) {
-                 }];
+                    
+                } failure:^(NSError *error) {
+                    
+                }];
             }
             
             return YES;

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -862,7 +862,7 @@ typedef enum : NSUInteger
                          failure:(void (^)(NSError *error))failure;
 
 /**
- Get/Update this user's current state.
+ Get/Update this user's current state. Based on server sync C-S v2 API.
  Get/Update information for all rooms (including messages and state events) from the given token (if any).
  
  @param limit the maximum number of messages to return by room.
@@ -1075,7 +1075,7 @@ typedef enum : NSUInteger
 
 #pragma mark - read receips
 /**
- Send a read receipt.
+ Send a read receipt (available only on C-S v2).
  
  @param roomId the id of the room.
  @param eventId the id of the event.

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -54,8 +54,8 @@ NSString *const kMX3PIDMediumMSISDN = @"msisdn";
  */
 NSString *const kMXRestClientErrorDomain = @"kMXRestClientErrorDomain";
 
-// TODO GFO increase this preferred API version when new version is available
-static MXRestClientAPIVersion _currentPreferredAPIVersion = MXRestClientAPIVersion1;
+// Increase this preferred API version when new version is available
+static MXRestClientAPIVersion _currentPreferredAPIVersion = MXRestClientAPIVersion2;
 
 /**
  Authentication flow: register or login
@@ -220,11 +220,12 @@ MXAuthAction;
     NSString *authActionPath = @"api/v1/login";
     if (MXAuthActionRegister == authAction)
     {
-        if (preferredAPIVersion == MXRestClientAPIVersion2)
-        {
-            authActionPath = @"v2_alpha/register";
-        }
-        else
+        // TODO GFO server register v2 is not available yet (use C-S v1 by default)
+//        if (preferredAPIVersion == MXRestClientAPIVersion2)
+//        {
+//            authActionPath = @"v2_alpha/register";
+//        }
+//        else
         {
             authActionPath = @"api/v1/register";
         }
@@ -238,13 +239,14 @@ MXAuthAction;
     NSString *httpMethod = @"GET";
     NSDictionary *parameters = nil;
     
-    if ((MXAuthActionRegister == authAction) && (preferredAPIVersion == MXRestClientAPIVersion2))
-    {
-        // C-S API v2: use POST with no params to get the login mechanism to use when registering
-        // The request will failed with Unauthorized status code, but the login mechanism will be available in response data.
-        httpMethod = @"POST";
-        parameters = @{};
-    }
+    // TODO GFO server register v2 is not available yet (use C-S v1 by default)
+//    if ((MXAuthActionRegister == authAction) && (preferredAPIVersion == MXRestClientAPIVersion2))
+//    {
+//        // C-S API v2: use POST with no params to get the login mechanism to use when registering
+//        // The request will failed with Unauthorized status code, but the login mechanism will be available in response data.
+//        httpMethod = @"POST";
+//        parameters = @{};
+//    }
     
     return [httpClient requestWithMethod:httpMethod
                                     path:[self authActionPath:authAction]
@@ -1428,6 +1430,9 @@ MXAuthAction;
     return operation;
 }
 
+/**
+ server sync v2
+ */
 - (MXHTTPOperation *)syncWithLimit:(NSInteger)limit
                                gap:(BOOL)gap
                               sort:(NSString*)sort
@@ -1443,15 +1448,15 @@ MXAuthAction;
     // Fill the url parameters (CAUTION: boolean value must be true or false string)
     NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
     
-    parameters[@"limit"] = [NSNumber numberWithInteger:limit];
-    parameters[@"gap"] = gap ? @"true" : @"false";
-    parameters[@"backfill"] = backfill ? @"true" : @"false";
+//    parameters[@"limit"] = [NSNumber numberWithInteger:limit];
+//    parameters[@"gap"] = gap ? @"true" : @"false";
+//    parameters[@"backfill"] = backfill ? @"true" : @"false";
     
     // Handle optional params
-    if (sort)
-    {
-        parameters[@"sort"] = sort;
-    }
+//    if (sort)
+//    {
+//        parameters[@"sort"] = sort;
+//    }
     if (token)
     {
         parameters[@"since"] = token;
@@ -1841,7 +1846,7 @@ MXAuthAction;
 
 #pragma mark - read receips
 /**
- Send a read receipt.
+ Send a read receipt (available only on C-S v2).
  
  @param roomId the id of the room.
  @param eventId the id of the event.

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -330,7 +330,7 @@ typedef void (^MXOnResumeDone)();
                 // Additional step: load push rules from the home server
                 [_notificationCenter refreshRules:^{
                     
-                    // Initial server sync
+                    // Initial server sync - Check the supported C-S version.
                     // TODO GFO server sync v2 is not available yet (use C-S v1 by default)
 //                    if (matrixRestClient.preferredAPIVersion == MXRestClientAPIVersion2)
 //                    {
@@ -624,7 +624,7 @@ typedef void (^MXOnResumeDone)();
 
 - (void)pause
 {
-    NSLog(@"[MXSession] pause the event stream in state %lu", _state);
+    NSLog(@"[MXSession] pause the event stream in state %tu", _state);
     
     if ((_state == MXSessionStateRunning) || (_state == MXSessionStateCatchingUp))
     {
@@ -656,7 +656,7 @@ typedef void (^MXOnResumeDone)();
         // Resume from the last known token
         onResumeDone = resumeDone;
         
-        // Relaunch live events stream (long polling)
+        // Relaunch live events stream (long polling) - Check supported C-S version
         // TODO GFO server sync v2 is not available yet (use C-S v1 by default)
 //        if (matrixRestClient.preferredAPIVersion == MXRestClientAPIVersion2)
 //        {
@@ -680,7 +680,7 @@ typedef void (^MXOnResumeDone)();
     {
         if (MXSessionStatePaused != _state)
         {
-            NSLog(@"[MXSession] catchup cannot be done in the current state %lu", _state);
+            NSLog(@"[MXSession] catchup cannot be done in the current state %tu", _state);
             dispatch_async(dispatch_get_main_queue(), ^{
                 catchupfails(nil);
             });
@@ -860,6 +860,9 @@ typedef void (^MXOnResumeDone)();
     }];
 }
 
+/**
+ server sync v2
+ */
 - (void)serverSyncWithTimeout:(NSUInteger)serverTimeout
                       success:(void (^)())success
                       failure:(void (^)(NSError *error))failure


### PR DESCRIPTION
Only read receipts are enabled.
Other C-S v2 implementation is commented (uncomplete).