### PR TITLE
BugFix SYIOS-170: Public Room: room history is wrong when user joins …

### DIFF
--- a/MatrixSDK/Data/MXRoom.h
+++ b/MatrixSDK/Data/MXRoom.h
@@ -101,21 +101,6 @@ typedef void (^MXOnRoomEvent)(MXEvent *event, MXEventDirection direction, MXRoom
  */
 @property (nonatomic) NSArray* acknowledgableEventTypes;
 
-
-/**
- Flag indicating that the room has been initialSynced with the homeserver.
- 
- @discussion
- The room is marked as not sync'ed when its room state is not fully known. This happens in
- two situations:
-     - the user is invited to a room (the membership is `MXMembershipInvite`). To get 
-       the full room state, he has to join the room.
-     - the membership is currently MXMembershipUnknown. The room came down the events stream
-       and the SDK is doing an initialSync on it. When complete, it will send the `MXSessionInitialSyncedRoomNotification`.
- */
-@property (nonatomic) BOOL isSync;
-
-
 - (id)initWithRoomId:(NSString*)roomId andMatrixSession:(MXSession*)mxSession;
 
 - (id)initWithRoomId:(NSString*)roomId andMatrixSession:(MXSession*)mxSession andJSONData:(NSDictionary*)JSONData;

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -107,10 +107,6 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
 
             [mxSession.store storeEventForRoom:roomId event:fakeMembershipEvent direction:MXEventDirectionSync];
         }
-        else if (JSONData)
-        {
-            _isSync = YES;
-        }
     }
     return self;
 }

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -867,11 +867,12 @@ typedef void (^MXOnResumeDone)();
                     [room handleMessages:roomMessages
                                direction:MXEventDirectionBackwards isTimeOrdered:YES];
                     
-                    // If the initialSync returns less messages than requested, we got all history from the home server
-                    if (roomMessages.chunk.count < initialSyncMessagesLimit)
-                    {
-                        [_store storeHasReachedHomeServerPaginationEndForRoom:room.state.roomId andValue:YES];
-                    }
+                    // Uncomment the following lines when SYN-482 will be fixed
+//                    // If the initialSync returns less messages than requested, we got all history from the home server
+//                    if (roomMessages.chunk.count < initialSyncMessagesLimit)
+//                    {
+//                        [_store storeHasReachedHomeServerPaginationEndForRoom:room.state.roomId andValue:YES];
+//                    }
                 }
                 if ([roomDict objectForKey:@"state"])
                 {
@@ -883,6 +884,11 @@ typedef void (^MXOnResumeDone)();
                         [self handleOneToOneRoom:room];
                     }
                 }
+                
+                room.isSync = YES;
+                [[NSNotificationCenter defaultCenter] postNotificationName:kMXRoomInitialSyncNotification
+                                                                    object:room
+                                                                  userInfo:nil];
             }
         }
         
@@ -1351,6 +1357,7 @@ typedef void (^MXOnResumeDone)();
             [_store deleteRoom:theRoomId];
         }
         
+        // Retrieve an existing room or create a new one.
         MXRoom *room = [self getOrCreateRoom:theRoomId withJSONData:JSONData notify:YES];
 
         // Manage room messages

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -887,7 +887,7 @@ typedef void (^MXOnResumeDone)();
                     }
                 }
                 
-                room.isSync = YES;
+                // Notify that room has been sync'ed
                 [[NSNotificationCenter defaultCenter] postNotificationName:kMXRoomInitialSyncNotification
                                                                     object:room
                                                                   userInfo:nil];
@@ -1417,8 +1417,6 @@ typedef void (^MXOnResumeDone)();
         [roomsInInitialSyncing removeObject:roomId];
 
         // Notify that room has been sync'ed
-        room.isSync = YES;
-        
         [[NSNotificationCenter defaultCenter] postNotificationName:kMXRoomInitialSyncNotification
                                                             object:room
                                                           userInfo:nil];

--- a/MatrixSDKTests/MXRoomStateTests.m
+++ b/MatrixSDKTests/MXRoomStateTests.m
@@ -450,8 +450,7 @@
                         
                         XCTAssertNotNil(newRoom);
                         
-                        XCTAssertEqual(newRoom.state.membership, MXMembershipInvite);;
-                        XCTAssertFalse(newRoom.isSync, @"The initialSync can be done only on joined room");
+                        XCTAssertEqual(newRoom.state.membership, MXMembershipInvite);
                         
                         // The room must have only one member: Alice who has been invited by Bob.
                         // While Alice does not join the room, we cannot get more information
@@ -526,7 +525,6 @@
                         
                         // Now, we must have more information about the room
                         // Check its new state
-                        XCTAssert(newRoom.isSync, @"The room must be advertised as synced");
                         XCTAssertEqual(newRoom.state.members.count, 2);
                         XCTAssert([newRoom.state.topic isEqualToString:@"We test room invitation here"], @"Wrong topic. Found: %@", newRoom.state.topic);
                         
@@ -734,7 +732,9 @@
 
                 MXRoom *room = [mxSession roomWithRoomId:newRoomId];
                 XCTAssertNotNil(room);
-                XCTAssertFalse(room.isSync, @"The room is not yet sync'ed");
+                
+                BOOL isSync = (room.state.membership != MXMembershipInvite && room.state.membership != MXMembershipUnknown);
+                XCTAssertFalse(isSync, @"The room is not yet sync'ed");
 
                 [[NSNotificationCenter defaultCenter] removeObserver:newRoomObserver];
             }];
@@ -747,7 +747,9 @@
                 MXRoom *room = note.object;
 
                 XCTAssertEqualObjects(newRoomId, room.state.roomId);
-                XCTAssert(room.isSync, @"The room must be sync'ed now");
+                
+                BOOL isSync = (room.state.membership != MXMembershipInvite && room.state.membership != MXMembershipUnknown);
+                XCTAssert(isSync, @"The room must be sync'ed now");
 
                 [[NSNotificationCenter defaultCenter] removeObserver:initialSyncObserver];
                 [expectation fulfill];

--- a/MatrixSDKTests/MXSessionTests.m
+++ b/MatrixSDKTests/MXSessionTests.m
@@ -598,7 +598,9 @@
         [mxSession createRoom:nil visibility:nil roomAlias:nil topic:nil success:^(MXRoom *room) {
 
             XCTAssertNotNil(room);
-            XCTAssertTrue(room.isSync, @"The callback must be called once the room has been initialSynced");
+            
+            BOOL isSync = (room.state.membership != MXMembershipInvite && room.state.membership != MXMembershipUnknown);
+            XCTAssertTrue(isSync, @"The callback must be called once the room has been initialSynced");
 
             XCTAssertEqual(1, room.state.members.count, @"Bob must be the only one. members: %@", room.state.members);
 
@@ -748,7 +750,8 @@
                     MXRoom *publicRoom = (MXRoom*)note.object;
                     XCTAssertNotNil(publicRoom);
 
-                    XCTAssert(publicRoom.isSync, @"kMXRoomInitialSyncNotification must inform when the room state is fully known");
+                    BOOL isSync = (publicRoom.state.membership != MXMembershipInvite && publicRoom.state.membership != MXMembershipUnknown);
+                    XCTAssert(isSync, @"kMXRoomInitialSyncNotification must inform when the room state is fully known");
 
                     XCTAssertEqual(mxSession, publicRoom.mxSession, @"The session of the sent MXRoom must be the right one");
 


### PR DESCRIPTION
…for the second time.

This issue is due to a race condition between live event stream handling and initial sync of the joined room.

The boolean 'isSync' was updated too early. The server response handling must be complete before updating this flag.