### PR TITLE
Room state optimisation

### DIFF
--- a/MatrixSDK/Data/MXRoomMember.h
+++ b/MatrixSDK/Data/MXRoomMember.h
@@ -21,7 +21,7 @@
 /**
  `MXRoomMember` is the information about a user in a room.
  */
-@interface MXRoomMember : NSObject <NSCopying>
+@interface MXRoomMember : NSObject
 
 /**
  The user id.

--- a/MatrixSDK/Data/MXRoomMember.m
+++ b/MatrixSDK/Data/MXRoomMember.m
@@ -89,21 +89,4 @@
     return self;
 }
 
-
-#pragma mark - NSCopying
--(id)copyWithZone:(NSZone *)zone
-{
-    MXRoomMember *memberCopy = [[MXRoomMember allocWithZone:zone] init];
-    
-    memberCopy->_userId = [_userId copyWithZone:zone];
-    memberCopy->_displayname = [_displayname copyWithZone:zone];
-    memberCopy->_avatarUrl = [_avatarUrl copyWithZone:zone];
-    memberCopy->_membership = _membership;
-    memberCopy->_prevMembership = _prevMembership;
-    memberCopy->_originUserId = [_originUserId copyWithZone:zone];
-    memberCopy->_originalEvent = _originalEvent;
-
-    return memberCopy;
-}
-
 @end

--- a/MatrixSDK/Data/MXRoomState.m
+++ b/MatrixSDK/Data/MXRoomState.m
@@ -536,10 +536,13 @@
 
     stateCopy->_isLive = _isLive;
 
-    // Use [NSMutableDictionary initWithDictionary:copyItems:] to deep copy NSDictionaries values
-    stateCopy->stateEvents = [[NSMutableDictionary allocWithZone:zone] initWithDictionary:stateEvents copyItems:YES];
+    // Copy the list of state events pointers. A deep copy is not necessary as MXEvent objects are immutable
+    stateCopy->stateEvents = [[NSMutableDictionary allocWithZone:zone] initWithDictionary:stateEvents];
 
-    stateCopy->members = [[NSMutableDictionary allocWithZone:zone] initWithDictionary:members copyItems:YES];
+    // Same thing here. MXRoomMembers are also immutable. A new instance of it is created each time
+    // the sdk receives room member event, even if it is an update of an existing member like a
+    // membership change (ex: "invited" -> "joined")
+    stateCopy->members = [[NSMutableDictionary allocWithZone:zone] initWithDictionary:members];
 
     if (visibility)
     {

--- a/MatrixSDKTests/MXRoomStateDynamicTests.m
+++ b/MatrixSDKTests/MXRoomStateDynamicTests.m
@@ -233,7 +233,7 @@
 
                         XCTAssertNotNil(roomState);
 
-                        XCTAssert([roomState.topic isEqualToString:@"Topic #1"], @"roomState.topic is wrong. Found: %@", roomState.topic);
+                        XCTAssertEqualObjects(roomState.topic, @"Topic #1", @"roomState.topic is wrong. Found: %@", roomState.topic);
                         XCTAssert([room.state.topic isEqualToString:@"Topic #2"]);
                         break;
                         
@@ -363,7 +363,6 @@
             mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
             
             [mxSession start:^{
-        } onServerSyncDone:^{
                 
                 MXRoom *room = [mxSession roomWithRoomId:roomId];
 
@@ -546,7 +545,6 @@
         mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
         
         [mxSession start:^{
-        } onServerSyncDone:^{
             
             MXRoom *room = [mxSession roomWithRoomId:roomId];
             
@@ -709,6 +707,6 @@
         
     }];
 }
-*/ 
+*/
 
 @end


### PR DESCRIPTION
This PR contains 2 improvements on [MXRoomState copyWithZone:]:
- limit the number of calls of it
- avoid useless deep copies in its implementation