### PR TITLE
MXStore: Added a new optimised eventExistsWithEventId: method 

### DIFF
--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -286,8 +286,7 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
         for (MXEvent *event in events) {
 
             // Make sure we have not processed this event yet
-            MXEvent *storedEvent = [mxSession.store eventWithEventId:event.eventId inRoom:_state.roomId];
-            if (!storedEvent)
+            if (![mxSession.store eventExistsWithEventId:event.eventId inRoom:_state.roomId])
             {
                 [self handleMessage:event direction:direction];
 
@@ -465,8 +464,7 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
     else
     {
         // Make sure we have not processed this event yet
-        MXEvent *storedEvent = [mxSession.store eventWithEventId:event.eventId inRoom:_state.roomId];
-        if (!storedEvent)
+        if (![mxSession.store eventExistsWithEventId:event.eventId inRoom:_state.roomId])
         {
             // Handle here redaction event from live event stream
             if (event.eventType == MXEventTypeRoomRedaction)

--- a/MatrixSDK/Data/Store/MXCoreDataStore/MXCoreDataStore.m
+++ b/MatrixSDK/Data/Store/MXCoreDataStore/MXCoreDataStore.m
@@ -202,6 +202,14 @@ NSString *const kMXCoreDataStoreFolder = @"MXCoreDataStore";
     }];
 }
 
+- (BOOL)eventExistsWithEventId:(NSString *)eventId inRoom:(NSString *)roomId
+{
+    // TODO: Do the correct implementation in Core Data
+    // Checking event id existence in the db is far quicker than extracting all data
+    // to rebuild the MXEvent object
+    return (nil != [self eventWithEventId:eventId inRoom:roomId]);
+}
+
 - (MXEvent *)eventWithEventId:(NSString *)eventId inRoom:(NSString *)roomId
 {
     NSDate *startDate = [NSDate date];

--- a/MatrixSDK/Data/Store/MXCoreDataStore/MXCoreDataStore.m
+++ b/MatrixSDK/Data/Store/MXCoreDataStore/MXCoreDataStore.m
@@ -204,19 +204,24 @@ NSString *const kMXCoreDataStoreFolder = @"MXCoreDataStore";
 
 - (BOOL)eventExistsWithEventId:(NSString *)eventId inRoom:(NSString *)roomId
 {
-    // TODO: Do the correct implementation in Core Data
-    // Checking event id existence in the db is far quicker than extracting all data
-    // to rebuild the MXEvent object
-    return (nil != [self eventWithEventId:eventId inRoom:roomId]);
+    // Look up directy in the db
+    // Event ids are unique. We do not need to filter per room
+    NSFetchRequest *fetchRequest = [[NSFetchRequest alloc] init];
+    NSEntityDescription *entity = [NSEntityDescription entityForName:@"MXCoreDataEvent"
+                                              inManagedObjectContext:uiManagedObjectContext];
+    [fetchRequest setEntity:entity];
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"eventId == %@", eventId];
+    [fetchRequest setPredicate:predicate];
+
+    NSUInteger count = [uiManagedObjectContext countForFetchRequest:fetchRequest error:nil];
+
+    return (count != NSNotFound) ? (count > 0) : NO;
 }
 
 - (MXEvent *)eventWithEventId:(NSString *)eventId inRoom:(NSString *)roomId
 {
-    NSDate *startDate = [NSDate date];
-
     MXEvent *event = [MXCoreDataRoom eventWithEventId:eventId inRoom:roomId moc:uiManagedObjectContext];
 
-    NSLog(@"[MXCoreDataStore] eventWithEventId %@ (%tu): %.3fms", eventId, [eventId hash], [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
     return event;
 }
 

--- a/MatrixSDK/Data/Store/MXFileStore/MXFileRoomStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileRoomStore.m
@@ -29,6 +29,16 @@
         self.paginationToken = [aDecoder decodeObjectForKey:@"paginationToken"];
 
         self.hasReachedHomeServerPaginationEnd = [aDecoder decodeBoolForKey:@"hasReachedHomeServerPaginationEnd"];
+
+        // Rebuild the messagesByEventIds cache
+        for (MXEvent *event in messages)
+        {
+            if (event.eventId)
+            {
+                messagesByEventIds[event.eventId] = event;
+            }
+        }
+
     }
     return self;
 }

--- a/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryRoomStore.h
+++ b/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryRoomStore.h
@@ -23,7 +23,12 @@
     @protected
     // The events downloaded so far.
     // The order is chronological: the first item is the oldest message.
-    NSMutableArray *messages;
+    NSMutableArray<MXEvent*> *messages;
+
+    // A cache to quickly retrieve an event by its event id.
+    // This significanly improves [MXMemoryStore eventWithEventId:] and [MXMemoryStore eventExistsWithEventId:]
+    // speed. The last one is critical since it is called on each received event to check event duplication.
+    NSMutableDictionary<NSString*, MXEvent*> *messagesByEventIds;
 }
 
 /**

--- a/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryRoomStore.m
+++ b/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryRoomStore.m
@@ -32,6 +32,7 @@
     if (self)
     {
         messages = [NSMutableArray array];
+        messagesByEventIds = [NSMutableDictionary dictionary];
     }
     return self;
 }
@@ -46,6 +47,11 @@
     {
         [messages insertObject:event atIndex:0];
     }
+
+    if (event.eventId)
+    {
+        messagesByEventIds[event.eventId] = event;
+    }
 }
 
 - (void)replaceEvent:(MXEvent*)event
@@ -57,6 +63,8 @@
         if ([anEvent.eventId isEqualToString:event.eventId])
         {
             [messages replaceObjectAtIndex:index withObject:event];
+
+            messagesByEventIds[event.eventId] = event;
             break;
         }
     }
@@ -64,21 +72,13 @@
 
 - (MXEvent *)eventWithEventId:(NSString *)eventId
 {
-    MXEvent *theEvent;
-    for (MXEvent *event in messages)
-    {
-        if ([eventId isEqualToString:event.eventId])
-        {
-            theEvent = event;
-            break;
-        }
-    }
-    return theEvent;
+    return messagesByEventIds[eventId];
 }
 
 - (void)removeAllMessages
 {
     [messages removeAllObjects];
+    [messagesByEventIds removeAllObjects];
 }
 
 - (void)resetPagination

--- a/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryStore.m
+++ b/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryStore.m
@@ -59,6 +59,11 @@
     [roomStore replaceEvent:event];
 }
 
+- (BOOL)eventExistsWithEventId:(NSString *)eventId inRoom:(NSString *)roomId
+{
+    return (nil != [self eventWithEventId:eventId inRoom:roomId]);
+}
+
 - (MXEvent *)eventWithEventId:(NSString *)eventId inRoom:(NSString *)roomId
 {
     MXMemoryRoomStore *roomStore = [self getOrCreateRoomStore:roomId];

--- a/MatrixSDK/Data/Store/MXNoStore/MXNoStore.m
+++ b/MatrixSDK/Data/Store/MXNoStore/MXNoStore.m
@@ -77,6 +77,12 @@
     }
 }
 
+- (BOOL)eventExistsWithEventId:(NSString *)eventId inRoom:(NSString *)roomId
+{
+    // Events are not stored. So, we cannot find it.
+    return NO;
+}
+
 - (MXEvent *)eventWithEventId:(NSString *)eventId inRoom:(NSString *)roomId
 {
     // Events are not stored. So, we cannot find it.

--- a/MatrixSDK/Data/Store/MXStore.h
+++ b/MatrixSDK/Data/Store/MXStore.h
@@ -60,6 +60,16 @@
 - (void)replaceEvent:(MXEvent*)event inRoom:(NSString*)roomId;
 
 /**
+ Returns a Boolean value that indicates whether an event is already stored.
+ 
+ @param eventId the id of the event to retrieve.
+ @param roomId the id of the room.
+
+ @return YES if the event exists in the store.
+ */
+- (BOOL)eventExistsWithEventId:(NSString*)eventId inRoom:(NSString*)roomId;
+
+/**
  Get an event in a room from the store.
 
  @param eventId the id of the event to retrieve.

--- a/MatrixSDKTests/MXStoreCoreDataStoreTests.m
+++ b/MatrixSDKTests/MXStoreCoreDataStoreTests.m
@@ -49,6 +49,12 @@
 
 
 #pragma mark - MXCoreDataStore
+- (void)testMXCoreDataStoreEventExistsWithEventId
+{
+    MXCoreDataStore *store = [[MXCoreDataStore alloc] init];
+    [self checkEventExistsWithEventIdOfStore:store];
+}
+
 - (void)testMXCoreDataStoreEventWithEventId
 {
     MXCoreDataStore *store = [[MXCoreDataStore alloc] init];

--- a/MatrixSDKTests/MXStoreFileStoreTests.m
+++ b/MatrixSDKTests/MXStoreFileStoreTests.m
@@ -49,7 +49,13 @@
 
 
 #pragma mark - MXFileStore
-- (void)testMXFileEventWithEventId
+- (void)testMXFileStoreEventExistsWithEventId
+{
+    MXMemoryStore *store = [[MXMemoryStore alloc] init];
+    [self checkEventExistsWithEventIdOfStore:store];
+}
+
+- (void)testMXFileStoreEventWithEventId
 {
     MXFileStore *store = [[MXFileStore alloc] init];
     [self checkEventWithEventIdOfStore:store];

--- a/MatrixSDKTests/MXStoreMemoryStoreTests.m
+++ b/MatrixSDKTests/MXStoreMemoryStoreTests.m
@@ -49,7 +49,13 @@
 
 
 #pragma mark - MXMemoryStore
-- (void)testMXMemoryEventWithEventId
+- (void)testMXMemoryStoreEventExistsWithEventId
+{
+    MXMemoryStore *store = [[MXMemoryStore alloc] init];
+    [self checkEventExistsWithEventIdOfStore:store];
+}
+
+- (void)testMXMemoryStoreEventWithEventId
 {
     MXMemoryStore *store = [[MXMemoryStore alloc] init];
     [self checkEventWithEventIdOfStore:store];

--- a/MatrixSDKTests/MXStoreNoStoreTests.m
+++ b/MatrixSDKTests/MXStoreNoStoreTests.m
@@ -50,6 +50,12 @@
 
 #pragma mark - MXNoStore tests
 /* This feature is not available with MXNoStore
+- (void)testMXNoStoreEventExistsWithEventId
+{
+    MXNoStore *store = [[MXNoStore alloc] init];
+    [self checkEventExistsWithEventIdOfStore:store];
+}
+
 - (void)testMXNoStoreEventWithEventId
 {
     MXNoStore *store = [[MXNoStore alloc] init];

--- a/MatrixSDKTests/MXStoreTests.h
+++ b/MatrixSDKTests/MXStoreTests.h
@@ -35,6 +35,7 @@
 
 - (void)assertNoDuplicate:(NSArray*)events text:(NSString*)text;
 
+- (void)checkEventExistsWithEventIdOfStore:(id<MXStore>)store;
 - (void)checkEventWithEventIdOfStore:(id<MXStore>)store;
 - (void)checkPaginateBack:(MXRoom*)room;
 - (void)checkPaginateBackFilter:(MXRoom*)room;

--- a/MatrixSDKTests/MXStoreTests.m
+++ b/MatrixSDKTests/MXStoreTests.m
@@ -176,6 +176,37 @@
 
 #pragma mark - MXStore generic tests
 
+- (void)checkEventExistsWithEventIdOfStore:(id<MXStore>)store
+{
+    MatrixSDKTestsData *sharedData = [MatrixSDKTestsData sharedData];
+
+    [sharedData doMXRestClientTestWithBob:self readyToTest:^(MXRestClient *bobRestClient, XCTestExpectation *expectation2) {
+
+        expectation = expectation2;
+
+        [store openWithCredentials:bobRestClient.credentials onComplete:^{
+            MXEvent *event = [MXEvent modelFromJSON:@{
+                                                      @"event_id": @"anID",
+                                                      @"type": @"type",
+                                                      @"room_id": @"roomId",
+                                                      @"user_id": @"userId:"
+                                                      }];
+
+            [store storeEventForRoom:@"roomId" event:event direction:MXEventDirectionForwards];
+
+            BOOL exists = [store eventExistsWithEventId:@"anID" inRoom:@"roomId"];
+
+            XCTAssertEqual(exists, YES);
+
+            [expectation fulfill];
+
+        } failure:^(NSError *error) {
+            XCTFail(@"The request should not fail - NSError: %@", error);
+            [expectation fulfill];
+        }];
+    }];
+}
+
 - (void)checkEventWithEventIdOfStore:(id<MXStore>)store
 {
     MatrixSDKTestsData *sharedData = [MatrixSDKTestsData sharedData];


### PR DESCRIPTION
In this PR, a dedicated method to check duplicate events has been added to MXStore : [MXStore eventExistsWithEventId].
The previously method used for that, [MXStore eventWithEventId:], can cost too much time in MXStore implementations - specially for the core data store. It is quicker to check existence in a db than retrieving all data to build the MXEvent matching the event id.

The implementation of this method has been improved in MXMemoryStore and MXFileStore so that it is 350 times quicker:
- Before: 
![before] (https://matrix.org/_matrix/media/v1/download/matrix.org/KNvNykQdVdFPOXlDQtOgPAAk)
- After:
![after] (https://matrix.org/_matrix/media/v1/download/matrix.org/hoMyIDXibHeIdvAQhbizpNsB)