### PR TITLE
Mxevent optimisation

### DIFF
--- a/MatrixSDK/JSONModels/MXEvent.m
+++ b/MatrixSDK/JSONModels/MXEvent.m
@@ -83,6 +83,31 @@ uint64_t const kMXUndefinedTimestamp = (uint64_t)-1;
     return self;
 }
 
++ (id)modelFromJSON:(NSDictionary *)JSONDictionary
+{
+    MXEvent *event = [[MXEvent alloc] init];
+    if (event)
+    {
+        event.eventId = JSONDictionary[@"event_id"];
+        event.type = JSONDictionary[@"type"];
+        event.roomId = JSONDictionary[@"room_id"];
+        event.sender = JSONDictionary[@"sender"];
+        event.userId = JSONDictionary[@"user_id"];
+        event.content = JSONDictionary[@"content"];
+        event.prevContent = JSONDictionary[@"prev_content"];
+        event.stateKey = JSONDictionary[@"state_key"];
+        event.originServerTs = [((NSNumber*)JSONDictionary[@"origin_server_ts"]) unsignedLongLongValue];
+        event.age = [((NSNumber*)JSONDictionary[@"age"]) unsignedIntegerValue];
+        event.redacts = JSONDictionary[@"redacts"];
+        event.redactedBecause = JSONDictionary[@"redacted_because"];
+
+        [event finalise];
+    }
+
+    return event;
+}
+
+// TODO: To remove once v2 methods will use [MXEvent modelFromJSON]
 - (instancetype)initWithDictionary:(NSDictionary *)dictionaryValue error:(NSError *__autoreleasing *)error
 {
     // Do the JSON -> class instance properties mapping
@@ -90,29 +115,37 @@ uint64_t const kMXUndefinedTimestamp = (uint64_t)-1;
 
     if (self)
     {
-        if (MXEventTypePresence == eventType)
-        {
-            // Workaround: Presence events provided by the home server do not contain userId
-            // in the root of the JSON event object but under its content sub object.
-            // Set self.userId in order to follow other events format.
-            if (nil == self.sender)
-            {
-                // userId may be in the event content
-                self.sender = self.content[@"user_id"];
-            }
-        }
-        else if (nil == self.sender)
-        {
-            // Catch up the legacy field user_id (deprecated in v2)
-            self.sender = self.userId;
-        }
-
-        // Clean JSON data by removing all null values
-        _content = [MXJSONModel removeNullValuesInJSON:_content];
-        _prevContent = [MXJSONModel removeNullValuesInJSON:_prevContent];
+        [self finalise];
     }
 
     return self;
+}
+
+/**
+ Finalise the parsing of a Matrix event.
+ */
+- (void)finalise
+{
+    if (MXEventTypePresence == eventType)
+    {
+        // Workaround: Presence events provided by the home server do not contain userId
+        // in the root of the JSON event object but under its content sub object.
+        // Set self.userId in order to follow other events format.
+        if (nil == self.sender)
+        {
+            // userId may be in the event content
+            self.sender = self.content[@"user_id"];
+        }
+    }
+    else if (nil == self.sender)
+    {
+        // Catch up the legacy field user_id (deprecated in v2)
+        self.sender = self.userId;
+    }
+
+    // Clean JSON data by removing all null values
+    _content = [MXJSONModel removeNullValuesInJSON:_content];
+    _prevContent = [MXJSONModel removeNullValuesInJSON:_prevContent];
 }
 
 - (MXEventType)eventType

--- a/MatrixSDK/JSONModels/MXEvent.m
+++ b/MatrixSDK/JSONModels/MXEvent.m
@@ -107,20 +107,6 @@ uint64_t const kMXUndefinedTimestamp = (uint64_t)-1;
     return event;
 }
 
-// TODO: To remove once v2 methods will use [MXEvent modelFromJSON]
-- (instancetype)initWithDictionary:(NSDictionary *)dictionaryValue error:(NSError *__autoreleasing *)error
-{
-    // Do the JSON -> class instance properties mapping
-    self = [super initWithDictionary:dictionaryValue error:error];
-
-    if (self)
-    {
-        [self finalise];
-    }
-
-    return self;
-}
-
 /**
  Finalise the parsing of a Matrix event.
  */

--- a/MatrixSDK/JSONModels/MXJSONModel.m
+++ b/MatrixSDK/JSONModels/MXJSONModel.m
@@ -95,21 +95,45 @@ static NSMutableDictionary *JSONKeyPathsByPropertyKeyByClass;
 
 + (NSDictionary *)removeNullValuesInJSON:(NSDictionary *)JSONDictionary
 {
-    NSMutableDictionary *dictionary = [NSMutableDictionary dictionaryWithDictionary:JSONDictionary];
-    NSArray *keys = dictionary.allKeys;
-    for (NSString *key in keys)
+    // A new dictionary is created and returned only if necessary
+    NSMutableDictionary *dictionary;
+
+    for (NSString *key in JSONDictionary)
     {
-        id value = dictionary[key];
+        id value = JSONDictionary[key];
         if ([value isEqual:[NSNull null]])
         {
+            if (!dictionary)
+            {
+               dictionary = [NSMutableDictionary dictionaryWithDictionary:JSONDictionary];
+            }
+
             [dictionary removeObjectForKey:key];
         }
         else if ([value isKindOfClass:[NSDictionary class]])
         {
-            [dictionary setObject:[MXJSONModel removeNullValuesInJSON:value] forKey:key];
+            NSDictionary *subDictionary = [MXJSONModel removeNullValuesInJSON:value];
+            if (subDictionary != value)
+            {
+                if (!dictionary)
+                {
+                    dictionary = [NSMutableDictionary dictionaryWithDictionary:JSONDictionary];
+                }
+
+                dictionary[key] = subDictionary;
+
+            }
         }
     }
-    return dictionary;
+
+    if (dictionary)
+    {
+        return dictionary;
+    }
+    else
+    {
+        return JSONDictionary;
+    }
 }
 
 - (void)setOthers:(NSDictionary *)JSONDictionary

--- a/MatrixSDK/JSONModels/MXJSONModels.m
+++ b/MatrixSDK/JSONModels/MXJSONModels.m
@@ -20,6 +20,22 @@
 #import "MXTools.h"
 
 @implementation MXPublicRoom
+
++ (id)modelFromJSON:(NSDictionary *)JSONDictionary
+{
+    MXPublicRoom *publicRoom = [[MXPublicRoom alloc] init];
+
+    NSDictionary *sanitisedJSONDictionary = [MXJSONModel removeNullValuesInJSON:JSONDictionary];
+
+    publicRoom.roomId = sanitisedJSONDictionary[@"room_id"];
+    publicRoom.name = sanitisedJSONDictionary[@"name"];
+    publicRoom.aliases = sanitisedJSONDictionary[@"aliases"];
+    publicRoom.topic = sanitisedJSONDictionary[@"topic"];
+    publicRoom.numJoinedMembers = [((NSNumber*)sanitisedJSONDictionary[@"num_joined_members"]) unsignedIntegerValue];
+
+    return publicRoom;
+}
+
 - (NSString *)displayname
 {
     NSString *displayname;

--- a/MatrixSDK/JSONModels/MXJSONModels.m
+++ b/MatrixSDK/JSONModels/MXJSONModels.m
@@ -70,10 +70,22 @@ NSString *const kMXLoginFlowTypeRecaptcha = @"m.login.recaptcha";
 
 @implementation MXPaginationResponse
 
-// Automatically convert array in chunk to an array of MXEvents.
-+ (NSValueTransformer *)chunkJSONTransformer
++ (id)modelFromJSON:(NSDictionary *)JSONDictionary
 {
-    return [MTLJSONAdapter arrayTransformerWithModelClass:MXEvent.class];
+    MXPaginationResponse *paginationResponse = [[MXPaginationResponse alloc] init];
+
+    paginationResponse.chunk = [MXEvent modelsFromJSON:JSONDictionary[@"chunk"]];
+    paginationResponse.start = JSONDictionary[@"start"];
+    paginationResponse.end = JSONDictionary[@"end"];
+
+    // Have the same behavior as before when JSON was parsed by Mantle: return an empty chunk array
+    // rather than nil
+    if (!paginationResponse.chunk)
+    {
+        paginationResponse.chunk = [NSArray array];
+    }
+
+    return paginationResponse;
 }
 
 @end
@@ -429,44 +441,36 @@ NSString *const kMXPushRuleScopeStringDevice           = @"device";
 
 @implementation MXRoomInitialSync
 
-// Automatically convert state array to an array of MXEvents.
-+ (NSValueTransformer *)stateJSONTransformer
++ (id)modelFromJSON:(NSDictionary *)JSONDictionary
 {
-    return [MTLJSONAdapter arrayTransformerWithModelClass:MXEvent.class];
-}
+    MXRoomInitialSync *initialSync = [[MXRoomInitialSync alloc] init];
 
-// Automatically convert presence array to an array of MXEvents.
-+ (NSValueTransformer *)presenceJSONTransformer
-{
-    return [MTLJSONAdapter arrayTransformerWithModelClass:MXEvent.class];
-}
+    initialSync.roomId = JSONDictionary[@"room_id"];
+    initialSync.messages = [MXPaginationResponse modelFromJSON:JSONDictionary[@"messages"]];
+    initialSync.state = [MXEvent modelsFromJSON:JSONDictionary[@"state"]];
+    initialSync.membership = JSONDictionary[@"membership"];
+    initialSync.visibility = JSONDictionary[@"visibility"];
+    initialSync.inviter = JSONDictionary[@"inviter"];
+    initialSync.presence = [MXEvent modelsFromJSON:JSONDictionary[@"presence"]];
+    initialSync.receipts = [MXEvent modelsFromJSON:JSONDictionary[@"receipts"]];
 
-// Automatically convert receipts array to an array of MXEvents.
-+ (NSValueTransformer *)receiptsJSONTransformer
-{
-    return [MTLJSONAdapter arrayTransformerWithModelClass:MXEvent.class];
+    return initialSync;
 }
 
 @end
 
 @implementation MXInitialSyncResponse
 
-// Automatically convert rooms array to an array of MXRoomInitialSync.
-+ (NSValueTransformer *)roomsJSONTransformer
++ (id)modelFromJSON:(NSDictionary *)JSONDictionary
 {
-    return [MTLJSONAdapter arrayTransformerWithModelClass:MXRoomInitialSync.class];
-}
+    MXInitialSyncResponse *initialSyncResponse = [[MXInitialSyncResponse alloc] init];
 
-// Automatically convert presence array to an array of MXEvents.
-+ (NSValueTransformer *)presenceJSONTransformer
-{
-    return [MTLJSONAdapter arrayTransformerWithModelClass:MXEvent.class];
-}
+    initialSyncResponse.rooms = [MXRoomInitialSync modelsFromJSON:JSONDictionary[@"rooms"]];
+    initialSyncResponse.presence = [MXEvent modelsFromJSON:JSONDictionary[@"presence"]];
+    initialSyncResponse.receipts = [MXEvent modelsFromJSON:JSONDictionary[@"receipts"]];
+    initialSyncResponse.end = JSONDictionary[@"end"];
 
-// Automatically convert receipts array to an array of MXEvents.
-+ (NSValueTransformer *)receiptsJSONTransformer
-{
-    return [MTLJSONAdapter arrayTransformerWithModelClass:MXEvent.class];
+    return initialSyncResponse;
 }
 
 @end

--- a/MatrixSDK/JSONModels/MXJSONModels.m
+++ b/MatrixSDK/JSONModels/MXJSONModels.m
@@ -728,9 +728,7 @@ NSString *const kMXPushRuleScopeStringDevice           = @"device";
 + (id)modelFromJSON:(NSDictionary *)JSONDictionary
 {
     MXSyncResponse *syncResponse = [[MXSyncResponse alloc] init];
-
-    // The server response must contain here a 'rooms' key.
-    if (syncResponse && JSONDictionary[@"rooms"])
+    if (syncResponse)
     {
         syncResponse.nextBatch = JSONDictionary[@"next_batch"];
         syncResponse.presence = [MXPresenceSyncResponse modelFromJSON:JSONDictionary[@"presence"]];

--- a/MatrixSDK/JSONModels/MXJSONModels.m
+++ b/MatrixSDK/JSONModels/MXJSONModels.m
@@ -513,20 +513,28 @@ NSString *const kMXPushRuleScopeStringDevice           = @"device";
 
 @implementation MXRoomSyncEphemeral
 
-// Automatically convert events array to an array of MXEvents.
-+ (NSValueTransformer *)eventsJSONTransformer
++ (id)modelFromJSON:(NSDictionary *)JSONDictionary
 {
-    return [MTLJSONAdapter arrayTransformerWithModelClass:MXEvent.class];
+    MXRoomSyncEphemeral *roomSyncEphemeral = [[MXRoomSyncEphemeral alloc] init];
+    if (roomSyncEphemeral)
+    {
+        roomSyncEphemeral.events = [MXEvent modelsFromJSON:JSONDictionary[@"events"]];
+    }
+    return roomSyncEphemeral;
 }
 
 @end
 
 @implementation MXRoomInviteState
 
-// Automatically convert events array to an array of MXEvents.
-+ (NSValueTransformer *)eventsJSONTransformer
++ (id)modelFromJSON:(NSDictionary *)JSONDictionary
 {
-    return [MTLJSONAdapter arrayTransformerWithModelClass:MXEvent.class];
+    MXRoomInviteState *roomInviteState = [[MXRoomInviteState alloc] init];
+    if (roomInviteState)
+    {
+        roomInviteState.events = [MXEvent modelsFromJSON:JSONDictionary[@"events"]];
+    }
+    return roomInviteState;
 }
 
 @end
@@ -596,20 +604,28 @@ NSString *const kMXPushRuleScopeStringDevice           = @"device";
 
 @implementation MXInvitedRoomSync
 
-// Automatically convert invite_state dictionary in MXRoomInviteState.
-+ (NSValueTransformer *)inviteStateJSONTransformer
++ (id)modelFromJSON:(NSDictionary *)JSONDictionary
 {
-    return [MTLJSONAdapter dictionaryTransformerWithModelClass:MXRoomInviteState.class];
+    MXInvitedRoomSync *invitedRoomSync = [[MXInvitedRoomSync alloc] init];
+    if (invitedRoomSync)
+    {
+        invitedRoomSync.inviteState = [MXRoomInviteState modelFromJSON:JSONDictionary[@"invite_state"]];
+    }
+    return invitedRoomSync;
 }
 
 @end
 
 @implementation MXPresenceSyncResponse
 
-// Automatically convert events array to an array of MXEvents.
-+ (NSValueTransformer *)eventsJSONTransformer
++ (id)modelFromJSON:(NSDictionary *)JSONDictionary
 {
-    return [MTLJSONAdapter arrayTransformerWithModelClass:MXEvent.class];
+    MXPresenceSyncResponse *presenceSyncResponse = [[MXPresenceSyncResponse alloc] init];
+    if (presenceSyncResponse)
+    {
+        presenceSyncResponse.events = [MXEvent modelsFromJSON:JSONDictionary[@"events"]];
+    }
+    return presenceSyncResponse;
 }
 
 @end
@@ -704,15 +720,6 @@ NSString *const kMXPushRuleScopeStringDevice           = @"device";
 
 @end
 
-@interface MXSyncResponse ()
-
-    /**
-     The original list of rooms.
-     */
-    @property (nonatomic) NSDictionary<NSString*, NSDictionary*> *rooms;
-
-@end
-
 @implementation MXSyncResponse
 
 // Override the default Mantle modelFromJSON method to prepare rooms dictionary.
@@ -720,25 +727,17 @@ NSString *const kMXPushRuleScopeStringDevice           = @"device";
 // all its sub-items. We obtain then a full converted JSON in a MXRoomsSyncResponse object 'mxRooms'.
 + (id)modelFromJSON:(NSDictionary *)JSONDictionary
 {
-    MXSyncResponse *syncResponse = [super modelFromJSON:JSONDictionary];
-    
-    // The server response must contain here a 'rooms' key.
-    if (syncResponse && syncResponse.rooms)
-    {
-        // Trigger a full conversion of this JSON dictionary.
-        syncResponse.mxRooms = [MXRoomsSyncResponse modelFromJSON:syncResponse.rooms];
-        
-        // Remove original dictionary
-        syncResponse.rooms = nil;
-    }
-    
-    return syncResponse;
-}
+    MXSyncResponse *syncResponse = [[MXSyncResponse alloc] init];
 
-// Automatically convert presence dictionary to MXPresenceSyncResponse instance.
-+ (NSValueTransformer *)presenceJSONTransformer
-{
-    return [MTLJSONAdapter dictionaryTransformerWithModelClass:MXPresenceSyncResponse.class];
+    // The server response must contain here a 'rooms' key.
+    if (syncResponse && JSONDictionary[@"rooms"])
+    {
+        syncResponse.nextBatch = JSONDictionary[@"next_batch"];
+        syncResponse.presence = [MXPresenceSyncResponse modelFromJSON:JSONDictionary[@"presence"]];
+        syncResponse.mxRooms = [MXRoomsSyncResponse modelFromJSON:JSONDictionary[@"rooms"]];
+    }
+
+    return syncResponse;
 }
 
 @end

--- a/MatrixSDK/JSONModels/MXJSONModels.m
+++ b/MatrixSDK/JSONModels/MXJSONModels.m
@@ -24,14 +24,16 @@
 + (id)modelFromJSON:(NSDictionary *)JSONDictionary
 {
     MXPublicRoom *publicRoom = [[MXPublicRoom alloc] init];
+    if (publicRoom)
+    {
+        NSDictionary *sanitisedJSONDictionary = [MXJSONModel removeNullValuesInJSON:JSONDictionary];
 
-    NSDictionary *sanitisedJSONDictionary = [MXJSONModel removeNullValuesInJSON:JSONDictionary];
-
-    publicRoom.roomId = sanitisedJSONDictionary[@"room_id"];
-    publicRoom.name = sanitisedJSONDictionary[@"name"];
-    publicRoom.aliases = sanitisedJSONDictionary[@"aliases"];
-    publicRoom.topic = sanitisedJSONDictionary[@"topic"];
-    publicRoom.numJoinedMembers = [((NSNumber*)sanitisedJSONDictionary[@"num_joined_members"]) unsignedIntegerValue];
+        publicRoom.roomId = sanitisedJSONDictionary[@"room_id"];
+        publicRoom.name = sanitisedJSONDictionary[@"name"];
+        publicRoom.aliases = sanitisedJSONDictionary[@"aliases"];
+        publicRoom.topic = sanitisedJSONDictionary[@"topic"];
+        publicRoom.numJoinedMembers = [((NSNumber*)sanitisedJSONDictionary[@"num_joined_members"]) unsignedIntegerValue];
+    }
 
     return publicRoom;
 }
@@ -89,16 +91,18 @@ NSString *const kMXLoginFlowTypeRecaptcha = @"m.login.recaptcha";
 + (id)modelFromJSON:(NSDictionary *)JSONDictionary
 {
     MXPaginationResponse *paginationResponse = [[MXPaginationResponse alloc] init];
-
-    paginationResponse.chunk = [MXEvent modelsFromJSON:JSONDictionary[@"chunk"]];
-    paginationResponse.start = JSONDictionary[@"start"];
-    paginationResponse.end = JSONDictionary[@"end"];
-
-    // Have the same behavior as before when JSON was parsed by Mantle: return an empty chunk array
-    // rather than nil
-    if (!paginationResponse.chunk)
+    if (paginationResponse)
     {
-        paginationResponse.chunk = [NSArray array];
+        paginationResponse.chunk = [MXEvent modelsFromJSON:JSONDictionary[@"chunk"]];
+        paginationResponse.start = JSONDictionary[@"start"];
+        paginationResponse.end = JSONDictionary[@"end"];
+
+        // Have the same behavior as before when JSON was parsed by Mantle: return an empty chunk array
+        // rather than nil
+        if (!paginationResponse.chunk)
+        {
+            paginationResponse.chunk = [NSArray array];
+        }
     }
 
     return paginationResponse;
@@ -115,10 +119,12 @@ NSString *const kMXLoginFlowTypeRecaptcha = @"m.login.recaptcha";
 + (id)modelFromJSON:(NSDictionary *)JSONDictionary
 {
     MXRoomMemberEventContent *roomMemberEventContent = [[MXRoomMemberEventContent alloc] init];
-
-    roomMemberEventContent.displayname = JSONDictionary[@"displayname"];
-    roomMemberEventContent.avatarUrl = JSONDictionary[@"avatar_url"];
-    roomMemberEventContent.membership = JSONDictionary[@"membership"];
+    if (roomMemberEventContent)
+    {
+        roomMemberEventContent.displayname = JSONDictionary[@"displayname"];
+        roomMemberEventContent.avatarUrl = JSONDictionary[@"avatar_url"];
+        roomMemberEventContent.membership = JSONDictionary[@"membership"];
+    }
 
     return roomMemberEventContent;
 }
@@ -460,15 +466,17 @@ NSString *const kMXPushRuleScopeStringDevice           = @"device";
 + (id)modelFromJSON:(NSDictionary *)JSONDictionary
 {
     MXRoomInitialSync *initialSync = [[MXRoomInitialSync alloc] init];
-
-    initialSync.roomId = JSONDictionary[@"room_id"];
-    initialSync.messages = [MXPaginationResponse modelFromJSON:JSONDictionary[@"messages"]];
-    initialSync.state = [MXEvent modelsFromJSON:JSONDictionary[@"state"]];
-    initialSync.membership = JSONDictionary[@"membership"];
-    initialSync.visibility = JSONDictionary[@"visibility"];
-    initialSync.inviter = JSONDictionary[@"inviter"];
-    initialSync.presence = [MXEvent modelsFromJSON:JSONDictionary[@"presence"]];
-    initialSync.receipts = [MXEvent modelsFromJSON:JSONDictionary[@"receipts"]];
+    if (initialSync)
+    {
+        initialSync.roomId = JSONDictionary[@"room_id"];
+        initialSync.messages = [MXPaginationResponse modelFromJSON:JSONDictionary[@"messages"]];
+        initialSync.state = [MXEvent modelsFromJSON:JSONDictionary[@"state"]];
+        initialSync.membership = JSONDictionary[@"membership"];
+        initialSync.visibility = JSONDictionary[@"visibility"];
+        initialSync.inviter = JSONDictionary[@"inviter"];
+        initialSync.presence = [MXEvent modelsFromJSON:JSONDictionary[@"presence"]];
+        initialSync.receipts = [MXEvent modelsFromJSON:JSONDictionary[@"receipts"]];
+    }
 
     return initialSync;
 }
@@ -480,11 +488,13 @@ NSString *const kMXPushRuleScopeStringDevice           = @"device";
 + (id)modelFromJSON:(NSDictionary *)JSONDictionary
 {
     MXInitialSyncResponse *initialSyncResponse = [[MXInitialSyncResponse alloc] init];
-
-    initialSyncResponse.rooms = [MXRoomInitialSync modelsFromJSON:JSONDictionary[@"rooms"]];
-    initialSyncResponse.presence = [MXEvent modelsFromJSON:JSONDictionary[@"presence"]];
-    initialSyncResponse.receipts = [MXEvent modelsFromJSON:JSONDictionary[@"receipts"]];
-    initialSyncResponse.end = JSONDictionary[@"end"];
+    if (initialSyncResponse)
+    {
+        initialSyncResponse.rooms = [MXRoomInitialSync modelsFromJSON:JSONDictionary[@"rooms"]];
+        initialSyncResponse.presence = [MXEvent modelsFromJSON:JSONDictionary[@"presence"]];
+        initialSyncResponse.receipts = [MXEvent modelsFromJSON:JSONDictionary[@"receipts"]];
+        initialSyncResponse.end = JSONDictionary[@"end"];
+    }
 
     return initialSyncResponse;
 }


### PR DESCRIPTION
Improved processing of HS requests responses that contain matrix events.
The improvement mainly consists in removing the Mantle modelling which appears to be slow on arrays with thousands of items.

Even if such processing is done on a separated thread, not on the UI one, it still worths to save CPU time

Here is the result of the improvement on a /initialSync response processing:
- before: 2.4s
![before] (https://matrix.org/_matrix/media/v1/download/matrix.org/aBuYmahzTwEtMYwQhpbKdaHM)

- after: 0.2s
![after] (https://matrix.org/_matrix/media/v1/download/matrix.org/StcNllSHowSkCLczMeTfLUUT)