### PR TITLE
read_receipts_for_incoming_messages

### DIFF
--- a/MatrixSDK/Data/MXRoom.h
+++ b/MatrixSDK/Data/MXRoom.h
@@ -522,12 +522,14 @@ typedef void (^MXOnRoomEvent)(MXEvent *event, MXEventDirection direction, MXRoom
 - (BOOL)handleReceiptEvent:(MXEvent *)event direction:(MXEventDirection)direction;
 
 /**
- Update the read receipt token.
+ Update the read receipt token of an userId.
+ @param userID the userId
  @param token the new token
  @param ts the token ts
-@return true if the token is refreshed
+
+ @return true if the token is refreshed
  */
-- (BOOL)setReadReceiptToken:(NSString*)token ts:(long)ts;
+- (BOOL)setReadReceipt:(NSString*)userID token:(NSString*)token ts:(uint64_t)ts;
 
 /**
  Acknowlegde the latest event of type defined in acknowledgableEventTypes.

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -343,21 +343,6 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
     {
         [self notifyListeners:event direction:direction];
     }
-    else
-    {
-        // for each new message
-        // assume that the sender aknowledges oldest messages
-        if (event.sender && event.eventId)
-        {
-            MXReceiptData* data = [[MXReceiptData alloc] init];
-            data.userId = event.sender;
-            data.eventId = event.eventId;
-            data.ts = event.ageLocalTs;
-        
-            [mxSession.store storeReceipt:data roomId:_state.roomId];
-        }
-    }
-
 }
 
 
@@ -932,11 +917,11 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
     return managedEvents;
 }
 
-- (BOOL)setReadReceiptToken:(NSString*)token ts:(long)ts
+- (BOOL)setReadReceipt:(NSString*)userID token:(NSString*)token ts:(uint64_t)ts
 {
     MXReceiptData *data = [[MXReceiptData alloc] init];
     
-    data.userId = mxSession.myUser.userId;
+    data.userId = userID;
     data.eventId = token;
     data.ts = ts;
     
@@ -952,7 +937,7 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
     return NO;
 }
 
-- (BOOL)acknowledgeLatestEvent:(BOOL)sendReceipt;
+- (BOOL)acknowledgeLatestEvent:(BOOL)sendReceipt
 {
     // Sanity check on supported C-S version
     if (mxSession.matrixRestClient.preferredAPIVersion < MXRestClientAPIVersion2)

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -343,6 +343,21 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
     {
         [self notifyListeners:event direction:direction];
     }
+    else
+    {
+        // for each new message
+        // assume that the sender aknowledges oldest messages
+        if (event.sender && event.eventId)
+        {
+            MXReceiptData* data = [[MXReceiptData alloc] init];
+            data.userId = event.sender;
+            data.eventId = event.eventId;
+            data.ts = event.ageLocalTs;
+        
+            [mxSession.store storeReceipt:data roomId:_state.roomId];
+        }
+    }
+
 }
 
 


### PR DESCRIPTION
The client assumes that an event sender reads the messages until its own messages.
Read receipts are created by now for each received messages.