### PR TITLE
MXSDKOption:  Configure identicon use at SDK level.

### DIFF
--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -124,6 +124,7 @@
 		71DE22E01BC7C51200284153 /* MXReceiptData.m in Sources */ = {isa = PBXBuildFile; fileRef = 71DE22DC1BC7C51200284153 /* MXReceiptData.m */; };
 		71DE22E11BC7C51200284153 /* MXReceiptData.h in Headers */ = {isa = PBXBuildFile; fileRef = 71DE22DD1BC7C51200284153 /* MXReceiptData.h */; };
 		A23A8594855481FEFA0E9A22 /* libPods-MatrixSDK.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E1674C6FF8BBF074E7F76059 /* libPods-MatrixSDK.a */; };
+		F0C34CBB1C18C93700C36F09 /* MXSDKOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = F0C34CBA1C18C93700C36F09 /* MXSDKOptions.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -275,6 +276,8 @@
 		71DE22DC1BC7C51200284153 /* MXReceiptData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXReceiptData.m; sourceTree = "<group>"; };
 		71DE22DD1BC7C51200284153 /* MXReceiptData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXReceiptData.h; sourceTree = "<group>"; };
 		E1674C6FF8BBF074E7F76059 /* libPods-MatrixSDK.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-MatrixSDK.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		F0C34CB91C18C80000C36F09 /* MXSDKOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXSDKOptions.h; sourceTree = "<group>"; };
+		F0C34CBA1C18C93700C36F09 /* MXSDKOptions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXSDKOptions.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -480,6 +483,8 @@
 				32DC15CA1A8CF7AE006F9AD3 /* NotificationCenter */,
 				320DFDD619DD99B60068622A /* Utils */,
 				3245A74B1AF7B2930001D8A7 /* VoIP */,
+				F0C34CB91C18C80000C36F09 /* MXSDKOptions.h */,
+				F0C34CBA1C18C93700C36F09 /* MXSDKOptions.m */,
 				32C6F93219DD814400EA4E9C /* MatrixSDK.h */,
 				320DFDD419DD99B60068622A /* MXRestClient.h */,
 				320DFDD519DD99B60068622A /* MXRestClient.m */,
@@ -809,6 +814,7 @@
 				327E37B71A974F75007F026F /* MXLogger.m in Sources */,
 				320DFDE719DD99B60068622A /* MXHTTPClient.m in Sources */,
 				320DFDE119DD99B60068622A /* MXSession.m in Sources */,
+				F0C34CBB1C18C93700C36F09 /* MXSDKOptions.m in Sources */,
 				320DFDDC19DD99B60068622A /* MXRoom.m in Sources */,
 				3291D4D51A68FFEB00C3BA41 /* MXFileRoomStore.m in Sources */,
 				329FB1801A0B665800A5E88E /* MXUser.m in Sources */,

--- a/MatrixSDK/Data/MXRoomState.m
+++ b/MatrixSDK/Data/MXRoomState.m
@@ -16,6 +16,8 @@
 
 #import "MXRoomState.h"
 
+#import "MXSDKOptions.h"
+
 #import "MXSession.h"
 #import "MXTools.h"
 
@@ -421,9 +423,10 @@
             {
                 members[roomMember.userId] = roomMember;
 
-                // If the member has no defined, force to use an identicon
-                if (nil == roomMember.avatarUrl)
+                // Handle here the case where the member has no defined avatar.
+                if (nil == roomMember.avatarUrl && ![MXSDKOptions sharedInstance].disableIdenticonUseForUserAvatar)
                 {
+                    // Force to use an identicon url
                     roomMember.avatarUrl = [mxSession.matrixRestClient urlOfIdenticon:roomMember.userId];
                 }
             }

--- a/MatrixSDK/Data/MXUser.m
+++ b/MatrixSDK/Data/MXUser.m
@@ -16,6 +16,8 @@
 
 #import "MXUser.h"
 
+#import "MXSDKOptions.h"
+
 #import "MXSession.h"
 #import "MXEvent.h"
 #import "MXJSONModels.h"
@@ -66,10 +68,11 @@
     {
         self.displayname = [roomMember.displayname copy];
         self.avatarUrl = [roomMember.avatarUrl copy];
-
-        // If the member has no defined, force to use an identicon
-        if (nil == self.avatarUrl)
+        
+        // Handle here the case where the user has no defined avatar.
+        if (nil == self.avatarUrl && ![MXSDKOptions sharedInstance].disableIdenticonUseForUserAvatar)
         {
+            // Force to use an identicon url
             self.avatarUrl = [mxSession.matrixRestClient urlOfIdenticon:self.userId];
         }
 
@@ -103,9 +106,11 @@
             self.avatarUrl = nil;
         }
     }
-    // If the member has no defined, force to use an identicon
-    if (nil == self.avatarUrl)
+    
+    // Handle here the case where the user has no defined avatar.
+    if (nil == self.avatarUrl && ![MXSDKOptions sharedInstance].disableIdenticonUseForUserAvatar)
     {
+        // Force to use an identicon url
         self.avatarUrl = [mxSession.matrixRestClient urlOfIdenticon:self.userId];
     }
 

--- a/MatrixSDK/MXSDKOptions.h
+++ b/MatrixSDK/MXSDKOptions.h
@@ -1,5 +1,5 @@
 /*
- Copyright 2014 OpenMarket Ltd
+ Copyright 2015 OpenMarket Ltd
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -14,25 +14,16 @@
  limitations under the License.
  */
 
-#import <UIKit/UIKit.h>
+@interface MXSDKOptions : NSObject
+
++ (MXSDKOptions *)sharedInstance;
 
 /**
- The Matrix iOS SDK version.
+ By default Matrix SDK sets an identicon url when user's avatar is undefined
+ (see [MXRestClient urlOfIdenticon:] use).
+ 
+ Use this property to disable identicon use at SDK level. NO by default.
  */
-FOUNDATION_EXPORT NSString *MatrixSDKVersion;
+@property (nonatomic) BOOL disableIdenticonUseForUserAvatar;
 
-#import <MatrixSDK/MXRestClient.h>
-#import <MatrixSDK/MXSession.h>
-#import <MatrixSDK/MXError.h>
-
-#import <MatrixSDK/MXStore.h>
-#import <MatrixSDK/MXNoStore.h>
-#import <MatrixSDK/MXMemoryStore.h>
-#import <MatrixSDK/MXFileStore.h>
-#import <MatrixSDK/MXCoreDataStore.h>
-
-#import <MatrixSDK/MXLogger.h>
-
-#import "MXTools.h"
-
-#import "MXSDKOptions.h"
+@end

--- a/MatrixSDK/MXSDKOptions.m
+++ b/MatrixSDK/MXSDKOptions.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2014 OpenMarket Ltd
+ Copyright 2015 OpenMarket Ltd
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -14,25 +14,17 @@
  limitations under the License.
  */
 
-#import <UIKit/UIKit.h>
-
-/**
- The Matrix iOS SDK version.
- */
-FOUNDATION_EXPORT NSString *MatrixSDKVersion;
-
-#import <MatrixSDK/MXRestClient.h>
-#import <MatrixSDK/MXSession.h>
-#import <MatrixSDK/MXError.h>
-
-#import <MatrixSDK/MXStore.h>
-#import <MatrixSDK/MXNoStore.h>
-#import <MatrixSDK/MXMemoryStore.h>
-#import <MatrixSDK/MXFileStore.h>
-#import <MatrixSDK/MXCoreDataStore.h>
-
-#import <MatrixSDK/MXLogger.h>
-
-#import "MXTools.h"
-
 #import "MXSDKOptions.h"
+
+static MXSDKOptions *sharedOnceInstance = nil;
+
+@implementation MXSDKOptions
+
++ (MXSDKOptions *)sharedInstance
+{
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{ sharedOnceInstance = [[self alloc] init]; });
+    return sharedOnceInstance;
+}
+
+@end


### PR DESCRIPTION
By default Matrix SDK sets an identicon url when user's avatar is undefined
 (see [MXRestClient urlOfIdenticon:] use).

We define here a new property named 'disableIdenticonUseForUserAvatar' to disable identicon use at SDK level.