### PR TITLE
MXEvent Add readReceiptEventIds property

### DIFF
--- a/MatrixSDK/JSONModels/MXEvent.h
+++ b/MatrixSDK/JSONModels/MXEvent.h
@@ -169,18 +169,6 @@ typedef enum : NSUInteger
 @property (nonatomic) NSString *sender;
 
 /**
- This property is relevant only for events with 'kMXEventTypeStringReceipt' type.
- Contains the event IDs for which a read receipt is defined in this event.
- */
-@property (nonatomic) NSArray *readReceiptEventIds;
-
-/**
- Contains the fully-qualified IDs of the users who sent read receipts with this event.
- This property is relevant only for events with 'kMXEventTypeStringReceipt' type.
- */
-@property (nonatomic) NSArray *receiptSenders;
-
-/**
 Contains the fully-qualified ID of the user who sent this event (deprecated since API v2).
  */
 @property (nonatomic) NSString *userId;
@@ -256,6 +244,20 @@ Contains the fully-qualified ID of the user who sent this event (deprecated sinc
  Unlike [MXJSONModel originalDictionary], it returns also properties computed by the SDK.
  */
 - (NSDictionary *)dictionary;
+
+/**
+ Returns the event IDs for which a read receipt is defined in this event.
+ 
+ This property is relevant only for events with 'kMXEventTypeStringReceipt' type.
+ */
+- (NSArray *)readReceiptEventIds;
+
+/**
+ Returns the fully-qualified IDs of the users who sent read receipts with this event.
+ 
+ This property is relevant only for events with 'kMXEventTypeStringReceipt' type.
+ */
+- (NSArray *)readReceiptSenders;
 
 /**
  Returns a pruned version of the event, which removes all keys we

--- a/MatrixSDK/JSONModels/MXEvent.h
+++ b/MatrixSDK/JSONModels/MXEvent.h
@@ -169,6 +169,12 @@ typedef enum : NSUInteger
 @property (nonatomic) NSString *sender;
 
 /**
+ This property is relevant only for events with 'kMXEventTypeStringReceipt' type.
+ Contains the event IDs for which a read receipt is defined in this event.
+ */
+@property (nonatomic) NSArray *readReceiptEventIds;
+
+/**
  Contains the fully-qualified IDs of the users who sent read receipts with this event.
  This property is relevant only for events with 'kMXEventTypeStringReceipt' type.
  */

--- a/MatrixSDK/JSONModels/MXEvent.m
+++ b/MatrixSDK/JSONModels/MXEvent.m
@@ -219,13 +219,14 @@ uint64_t const kMXUndefinedTimestamp = (uint64_t)-1;
     return list;
 }
 
-- (NSArray *)receiptSenders
+- (NSArray *)readReceiptSenders
 {
-    NSMutableArray* list = [[NSMutableArray alloc] init];
+    NSMutableArray* list = nil;
     
     if (eventType == MXEventTypeReceipt)
     {
         NSArray* eventIds = [_content allKeys];
+        list = [[NSMutableArray alloc] initWithCapacity:eventIds.count];
         
         for(NSString* eventId in eventIds)
         {
@@ -245,10 +246,6 @@ uint64_t const kMXUndefinedTimestamp = (uint64_t)-1;
                 }
             }
         }
-    }
-    else if (_sender)
-    {
-        [list addObject:_sender];
     }
     
     return list;

--- a/MatrixSDK/JSONModels/MXEvent.m
+++ b/MatrixSDK/JSONModels/MXEvent.m
@@ -195,7 +195,31 @@ uint64_t const kMXUndefinedTimestamp = (uint64_t)-1;
     return (nil != self.stateKey);
 }
 
-- (NSArray*)receiptSenders
+- (NSArray *)readReceiptEventIds
+{
+    NSMutableArray* list = nil;
+    
+    if (eventType == MXEventTypeReceipt)
+    {
+        NSArray* eventIds = [_content allKeys];
+        list = [[NSMutableArray alloc] initWithCapacity:eventIds.count];
+        
+        for (NSString* eventId in eventIds)
+        {
+            NSDictionary* eventDict = [_content objectForKey:eventId];
+            NSDictionary* readDict = [eventDict objectForKey:kMXEventTypeStringRead];
+            
+            if (readDict)
+            {
+                [list addObject:eventId];
+            }
+        }
+    }
+    
+    return list;
+}
+
+- (NSArray *)receiptSenders
 {
     NSMutableArray* list = [[NSMutableArray alloc] init];
     


### PR DESCRIPTION
This property is relevant only for events with 'kMXEventTypeStringReceipt' type.
Contains the event IDs for which a read receipt is defined in this event.