### PR TITLE
Room invite race conditions

### DIFF
--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -412,17 +412,6 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
             MXRoomMember *roomMember = [_state memberWithUserId:event.sender];
             if (roomMember && MXMembershipJoin == roomMember.membership)
             {
-                // store the accountData when the oneself user joins
-                // to let him play with tags
-                if ([roomMember.userId isEqualToString:self.mxSession.myUser.userId])
-                {
-                    if ([mxSession.store respondsToSelector:@selector(storeAccountDataForRoom:userData:)])
-                    {
-                        [mxSession.store storeAccountDataForRoom:_state.roomId userData:_accountData];
-                        [mxSession.store commit];
-                    }
-                }
-                
                 [user updateWithRoomMemberEvent:event roomMember:roomMember];
             }
         }

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -118,7 +118,11 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
                 [self handleStateEvent:event direction:MXEventDirectionSync];
             }
 
-            _accountData = accountData;
+            // the account data cannot be nil
+            if (accountData)
+            {
+                _accountData = accountData;
+            }
         }
     }
     return self;
@@ -408,6 +412,17 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
             MXRoomMember *roomMember = [_state memberWithUserId:event.sender];
             if (roomMember && MXMembershipJoin == roomMember.membership)
             {
+                // store the accountData when the oneself user joins
+                // to let him play with tags
+                if ([roomMember.userId isEqualToString:self.mxSession.myUser.userId])
+                {
+                    if ([mxSession.store respondsToSelector:@selector(storeAccountDataForRoom:userData:)])
+                    {
+                        [mxSession.store storeAccountDataForRoom:_state.roomId userData:_accountData];
+                        [mxSession.store commit];
+                    }
+                }
+                
                 [user updateWithRoomMemberEvent:event roomMember:roomMember];
             }
         }

--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
@@ -458,6 +458,13 @@ NSString *const kMXReceiptsFolder = @"receipts";
     {
         NSString *roomFile = [storeRoomsAccountDataPath stringByAppendingPathComponent:roomId];
         roomUserdData =[NSKeyedUnarchiver unarchiveObjectWithFile:roomFile];
+        
+        // if the file does not exist, create the roomAccountData
+        // the file saving could have failed.
+        if (!roomUserdData)
+        {
+            roomUserdData = [[MXRoomAccountData alloc] init];
+        }
 
         if (NO == [NSThread isMainThread])
         {


### PR DESCRIPTION
The room accountData  for the new room is only stored if there is a tag update.
So, after an application restarts, this object was nil in the MXRoom class.

After, any new tag management was ignored because of this nil pointer.

By now, the accountData class is created if the dedicated file does not exist.. 
