### PR TITLE
invalid_read_receipts

### DIFF
--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -337,6 +337,16 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
     {
         [self notifyListeners:event direction:direction];
     }
+    else
+    {
+        MXReceiptData* data = [[MXReceiptData alloc] init];
+        data.userId = event.sender;
+        data.eventId = event.eventId;
+        data.ts = event.originServerTs;
+        
+        [mxSession.store storeReceipt:data roomId:_state.roomId];
+        // notifyListeners call is performed in the calling method.
+    }
 }
 
 


### PR DESCRIPTION
-> generate a read receipt for the sender of an incoming message
1 - Some clients don't send read receipt so it is a way to have read receipt
2 - The read receipts can be sent with delay so it avoids having a read receipt older than a message sent by an user.