### PR TITLE
MXRoom: BF in handleInvitedRoomSync: The app was not notified on live…

### DIFF
--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -259,6 +259,12 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
             event.eventId = [NSString stringWithFormat:@"%@%@", kMXRoomInviteStateEventIdPrefix, [[NSProcessInfo processInfo] globallyUniqueString]];
         }
         
+        // Report the room id if not defined
+        if (!event.roomId)
+        {
+            event.roomId = _state.roomId;
+        }
+        
         [self handleLiveEvent:event];
     }
 }


### PR DESCRIPTION
… invitations.

The reason is the hs saves few bytes by avoiding repeating room id in the event.