### PR TITLE
Remove mantle

### DIFF
--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -28,6 +28,5 @@ Pod::Spec.new do |s|
   s.requires_arc  = true
 
   s.dependency 'AFNetworking', '~> 2.6.0'
-  s.dependency 'Mantle', '~> 2.0.5'
 
 end

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -445,7 +445,7 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
     {
         // Redact the stored event
         redactedEvent = [redactedEvent prune];
-        redactedEvent.redactedBecause = redactionEvent.originalDictionary;
+        redactedEvent.redactedBecause = redactionEvent.JSONDictionary;
         
         if (redactedEvent.isState) {
             // FIXME: The room state must be refreshed here since this redacted event.
@@ -751,7 +751,7 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
 {
     // To set this new value, we have to take the current powerLevels content,
     // Update it with expected values and send it to the home server.
-    NSMutableDictionary *newPowerLevelsEventContent = [NSMutableDictionary dictionaryWithDictionary:_state.powerLevels.dictionaryValue];
+    NSMutableDictionary *newPowerLevelsEventContent = [NSMutableDictionary dictionaryWithDictionary:_state.powerLevels.JSONDictionary];
 
     NSMutableDictionary *newPowerLevelsEventContentUsers = [NSMutableDictionary dictionaryWithDictionary:newPowerLevelsEventContent[@"users"]];
     newPowerLevelsEventContentUsers[userId] = [NSNumber numberWithUnsignedInteger:powerLevel];

--- a/MatrixSDK/JSONModels/MXEvent.h
+++ b/MatrixSDK/JSONModels/MXEvent.h
@@ -241,9 +241,14 @@ Contains the fully-qualified ID of the user who sent this event (deprecated sinc
 
 /**
  Returns all MXEvent properties into a dictionary.
- Unlike [MXJSONModel originalDictionary], it returns also properties computed by the SDK.
+ Unlike [self originalDictionary], it returns also properties computed by the SDK.
  */
 - (NSDictionary *)dictionary;
+
+/**
+ Rebuild the original JSON dictionary
+ */
+- (NSDictionary *)originalDictionary;
 
 /**
  Returns the event IDs for which a read receipt is defined in this event.

--- a/MatrixSDK/JSONModels/MXEvent.h
+++ b/MatrixSDK/JSONModels/MXEvent.h
@@ -240,17 +240,6 @@ Contains the fully-qualified ID of the user who sent this event (deprecated sinc
 - (BOOL)isState;
 
 /**
- Returns all MXEvent properties into a dictionary.
- Unlike [self originalDictionary], it returns also properties computed by the SDK.
- */
-- (NSDictionary *)dictionary;
-
-/**
- Rebuild the original JSON dictionary
- */
-- (NSDictionary *)originalDictionary;
-
-/**
  Returns the event IDs for which a read receipt is defined in this event.
  
  This property is relevant only for events with 'kMXEventTypeStringReceipt' type.

--- a/MatrixSDK/JSONModels/MXEvent.m
+++ b/MatrixSDK/JSONModels/MXEvent.m
@@ -196,42 +196,33 @@ uint64_t const kMXUndefinedTimestamp = (uint64_t)-1;
     return age;
 }
 
-- (NSDictionary *)originalDictionary
+- (NSDictionary *)JSONDictionary
 {
-    NSMutableDictionary *originalDictionary = [NSMutableDictionary dictionary];
-    if (originalDictionary)
+    NSMutableDictionary *JSONDictionary = [NSMutableDictionary dictionary];
+    if (JSONDictionary)
     {
-        originalDictionary[@"event_id"] = _eventId;
-        originalDictionary[@"type"] = _type;
-        originalDictionary[@"room_id"] = _roomId;
-        originalDictionary[@"user_id"] = _userId;
-        originalDictionary[@"content"] = _content;
-        originalDictionary[@"state_key"] = _stateKey;
-        originalDictionary[@"origin_server_ts"] = @(_originServerTs);
-        originalDictionary[@"redacts"] = _redacts;
+        JSONDictionary[@"event_id"] = _eventId;
+        JSONDictionary[@"type"] = _type;
+        JSONDictionary[@"room_id"] = _roomId;
+        JSONDictionary[@"user_id"] = _userId;
+        JSONDictionary[@"content"] = _content;
+        JSONDictionary[@"state_key"] = _stateKey;
+        JSONDictionary[@"origin_server_ts"] = @(_originServerTs);
+        JSONDictionary[@"redacts"] = _redacts;
 
         // XXX: Should not be under "undefined" in V2 ?
         // Store them at the dictionary root as there are before
-        originalDictionary[@"prev_content"] = _prevContent;
-        originalDictionary[@"age"] = @(self.age);
-        originalDictionary[@"redacted_because"] = _redactedBecause;
+        JSONDictionary[@"prev_content"] = _prevContent;
+        JSONDictionary[@"age"] = @(self.age);
+        JSONDictionary[@"redacted_because"] = _redactedBecause;
 
         if (_inviteRoomState)
         {
-            originalDictionary[@"invite_room_state"] = _inviteRoomState;
+            JSONDictionary[@"invite_room_state"] = _inviteRoomState;
         }
     }
 
-    return originalDictionary;
-}
-
-- (NSDictionary *)dictionary
-{
-    // Return originalDictionary plus the useful age_local_ts info.
-    NSMutableDictionary *dictionary = [NSMutableDictionary dictionaryWithDictionary:[self originalDictionary]];
-    dictionary[@"age_local_ts"] = @(_ageLocalTs);
-
-    return dictionary;
+    return JSONDictionary;
 }
 
 - (BOOL)isState
@@ -403,7 +394,7 @@ uint64_t const kMXUndefinedTimestamp = (uint64_t)-1;
 #pragma mark - private
 - (NSMutableDictionary*)filterInEventWithKeys:(NSArray*)keys
 {
-    NSDictionary *originalDict = self.originalDictionary;
+    NSDictionary *originalDict = self.JSONDictionary;
     NSMutableDictionary *filteredEvent = [NSMutableDictionary dictionary];
     
     for (NSString* key in keys)

--- a/MatrixSDK/JSONModels/MXEvent.m
+++ b/MatrixSDK/JSONModels/MXEvent.m
@@ -209,9 +209,6 @@ uint64_t const kMXUndefinedTimestamp = (uint64_t)-1;
         JSONDictionary[@"state_key"] = _stateKey;
         JSONDictionary[@"origin_server_ts"] = @(_originServerTs);
         JSONDictionary[@"redacts"] = _redacts;
-
-        // XXX: Should not be under "undefined" in V2 ?
-        // Store them at the dictionary root as there are before
         JSONDictionary[@"prev_content"] = _prevContent;
         JSONDictionary[@"age"] = @(self.age);
         JSONDictionary[@"redacted_because"] = _redactedBecause;

--- a/MatrixSDK/JSONModels/MXEvent.m
+++ b/MatrixSDK/JSONModels/MXEvent.m
@@ -198,18 +198,40 @@ uint64_t const kMXUndefinedTimestamp = (uint64_t)-1;
 
 - (NSDictionary *)originalDictionary
 {
-    NSMutableDictionary *originalDictionary = [NSMutableDictionary dictionaryWithDictionary:[super originalDictionary]];
+    NSMutableDictionary *originalDictionary = [NSMutableDictionary dictionary];
+    if (originalDictionary)
+    {
+        originalDictionary[@"event_id"] = _eventId;
+        originalDictionary[@"type"] = _type;
+        originalDictionary[@"room_id"] = _roomId;
+        originalDictionary[@"user_id"] = _userId;
+        originalDictionary[@"content"] = _content;
+        originalDictionary[@"state_key"] = _stateKey;
+        originalDictionary[@"origin_server_ts"] = @(_originServerTs);
+        originalDictionary[@"redacts"] = _redacts;
 
-    // Remove properties that are created by the SDK
-    [originalDictionary removeObjectForKey:@"age_local_ts"];
+        // XXX: Should not be under "undefined" in V2 ?
+        // Store them at the dictionary root as there are before
+        originalDictionary[@"prev_content"] = _prevContent;
+        originalDictionary[@"age"] = @(self.age);
+        originalDictionary[@"redacted_because"] = _redactedBecause;
+
+        if (_inviteRoomState)
+        {
+            originalDictionary[@"invite_room_state"] = _inviteRoomState;
+        }
+    }
 
     return originalDictionary;
 }
 
 - (NSDictionary *)dictionary
 {
-    // Return originalDictionary as is. It will contain the useful age_local_ts info.
-    return [super originalDictionary];
+    // Return originalDictionary plus the useful age_local_ts info.
+    NSMutableDictionary *dictionary = [NSMutableDictionary dictionaryWithDictionary:[self originalDictionary]];
+    dictionary[@"age_local_ts"] = @(_ageLocalTs);
+
+    return dictionary;
 }
 
 - (BOOL)isState

--- a/MatrixSDK/JSONModels/MXJSONModel.h
+++ b/MatrixSDK/JSONModels/MXJSONModel.h
@@ -16,8 +16,6 @@
 
 #import <Foundation/Foundation.h>
 
-#import <Mantle/Mantle.h>
-
 /**
  A class that inherits from `MXJSONModel` represents the response to a request to a Matrix home server.
  

--- a/MatrixSDK/JSONModels/MXJSONModel.h
+++ b/MatrixSDK/JSONModels/MXJSONModel.h
@@ -23,14 +23,10 @@
  
  Matrix home server responses are a JSON string. The `MXJSONModel` class maps the members in the JSON object to the properties declared in the class that inherits from MXJSONModel
  */
-@interface MXJSONModel : MTLModel <MTLJSONSerializing>
+@interface MXJSONModel : NSObject <NSCopying, NSCoding>
 
-/**
- This dictionary contains keys/values that have been in the JSON source object but not decoded.
- TODO: To implement to that app can manage custom events or paramaters.
- */
-- (NSDictionary *)others;
 
+#pragma mark - Class methods
 /**
  Create a model instance from a JSON dictionary
  
@@ -54,5 +50,18 @@
  @return JSON data without null values
  */
 + (NSDictionary *)removeNullValuesInJSON:(NSDictionary *)JSONDictionary;
+
+
+#pragma mark - Instance methods
+/**
+ Rebuild the original JSON dictionary
+ */
+- (NSDictionary *)JSONDictionary;
+
+/**
+ This dictionary contains keys/values that have been in the JSON source object but not decoded.
+ TODO: To implement to that app can manage custom events or paramaters.
+ */
+- (NSDictionary *)others;
 
 @end

--- a/MatrixSDK/JSONModels/MXJSONModel.h
+++ b/MatrixSDK/JSONModels/MXJSONModel.h
@@ -17,16 +17,21 @@
 #import <Foundation/Foundation.h>
 
 /**
- A class that inherits from `MXJSONModel` represents the response to a request to a Matrix home server.
+ A class that inherits from `MXJSONModel` represents the response to a request
+ to a Matrix home server.
  
- Matrix home server responses are a JSON string. The `MXJSONModel` class maps the members in the JSON object to the properties declared in the class that inherits from MXJSONModel
+ Matrix home server responses are JSON strings. `MXJSONModel` derived classes map
+ the members of the JSON object into their properties.
+ 
+ Some of the methods below are pure virtual methods in C++ definition and must be
+ implemented by the derived class if they are used by the code.
  */
 @interface MXJSONModel : NSObject <NSCopying, NSCoding>
 
 
 #pragma mark - Class methods
 /**
- Create a model instance from a JSON dictionary
+ Create a model instance from a JSON dictionary.
  
  @param JSONDictionary the JSON data.
  @return the newly created instance.
@@ -57,8 +62,9 @@
 - (NSDictionary *)JSONDictionary;
 
 /**
- This dictionary contains keys/values that have been in the JSON source object but not decoded.
- TODO: To implement to that app can manage custom events or paramaters.
+ This dictionary contains keys/values that have been in the JSON source object
+ but not decoded.
+ TODO: To implement so that app can manage custom events or paramaters.
  */
 - (NSDictionary *)others;
 

--- a/MatrixSDK/JSONModels/MXJSONModel.h
+++ b/MatrixSDK/JSONModels/MXJSONModel.h
@@ -26,7 +26,8 @@
 @interface MXJSONModel : MTLModel <MTLJSONSerializing>
 
 /**
- This dictionary contains keys/values that have been in the JSON source object.
+ This dictionary contains keys/values that have been in the JSON source object but not decoded.
+ TODO: To implement to that app can manage custom events or paramaters.
  */
 - (NSDictionary *)others;
 

--- a/MatrixSDK/JSONModels/MXJSONModel.h
+++ b/MatrixSDK/JSONModels/MXJSONModel.h
@@ -32,11 +32,6 @@
 - (NSDictionary *)others;
 
 /**
- Rebuild the original JSON dictionary
- */
-- (NSDictionary *)originalDictionary;
-
-/**
  Create a model instance from a JSON dictionary
  
  @param JSONDictionary the JSON data.

--- a/MatrixSDK/JSONModels/MXJSONModel.m
+++ b/MatrixSDK/JSONModels/MXJSONModel.m
@@ -18,53 +18,12 @@
 
 @implementation MXJSONModel
 
-/**
- * The JSONKeyPathsByPropertyKey dictionnaries for all subclasses of MXJSONModel.
- * The key is the child class name. The value, the JSONKeyPathsByPropertyKey dictionnary of the child class.
- */
-static NSMutableDictionary *JSONKeyPathsByPropertyKeyByClass;
 
-+ (void)initialize
-{
-    @synchronized(JSONKeyPathsByPropertyKeyByClass)
-    {
-        if (!JSONKeyPathsByPropertyKeyByClass)
-        {
-            JSONKeyPathsByPropertyKeyByClass = [NSMutableDictionary dictionary];
-        }
-
-        // Compute the JSONKeyPathsByPropertyKey for this subclass
-        NSMutableDictionary *JSONKeyPathsByPropertyKey = [NSMutableDictionary dictionary];
-
-        NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"(?<=[a-z])([A-Z])|([A-Z])(?=[a-z])" options:0 error:nil];
-
-        // List all properties defined by the class
-        NSSet *propertyKeys = [self.class propertyKeys];
-        for (NSString *propertyKey in propertyKeys)
-        {
-            // Manage camel-cased properties
-            // Home server uses underscore-separated compounds keys like "event_id". ObjC properties name trend is more camelCase like "eventId".
-            NSString *underscoredString = [[regex stringByReplacingMatchesInString:propertyKey options:0 range:NSMakeRange(0, propertyKey.length) withTemplate:@"_$1$2"] lowercaseString];
-            JSONKeyPathsByPropertyKey[propertyKey] = underscoredString;
-        }
-
-        JSONKeyPathsByPropertyKeyByClass[NSStringFromClass(self.class)] = JSONKeyPathsByPropertyKey;
-    }
-}
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey
-{
-    return JSONKeyPathsByPropertyKeyByClass[NSStringFromClass(self.class)];
-}
-
+#pragma mark - Class methods
 + (id)modelFromJSON:(NSDictionary *)JSONDictionary
 {
-    // Use Mantle 
-    id model = [MTLJSONAdapter modelOfClass:[self class]
-                     fromJSONDictionary:JSONDictionary
-                                  error:nil];
-    
-    return model;
+    NSAssert(NO, @"%@ must implement modelFromJSON", self);
+    return nil;
 }
 
 + (NSArray *)modelsFromJSON:(NSArray *)JSONDictionaries
@@ -167,25 +126,39 @@ static NSMutableDictionary *JSONKeyPathsByPropertyKeyByClass;
     }
 }
 
-- (NSDictionary *)originalDictionary
+
+#pragma mark - Instance methods
+- (NSDictionary *)JSONDictionary
 {
-    NSMutableDictionary * originalDictionary = [NSMutableDictionary dictionary];
+    NSAssert(NO, @"%@ does not implement JSONDictionary", self.class);
+    return nil;
+}
 
-    NSDictionary *JSONKeyPathsByPropertyKey = [self.class JSONKeyPathsByPropertyKey];
-    NSDictionary *dictValue = self.dictionaryValue;
-    
-    for (NSString *key in dictValue)
-    {
-        // Ignore NSNull values introduced by dictionaryWithValuesForKeys use in 'dictionaryValue' getter.
-        if (![dictValue[key] isKindOfClass:[NSNull class]])
-        {
-            // Convert back camelCased property names (ex:roomId) to underscored names (ex:room_id)
-            // Thus, we store events as they come from the home server.
-            originalDictionary[JSONKeyPathsByPropertyKey[key]] = dictValue[key];
-        }
-    }
+- (NSDictionary *)others
+{
+    NSAssert(NO, @"%@ does not implement others", self.class);
+    return nil;
+}
 
-    return originalDictionary;
+
+#pragma mark - NSCopying
+- (id)copyWithZone:(NSZone *)zone
+{
+    NSAssert(NO, @"%@ does not implement NSCopying", self.class);
+    return nil;
+}
+
+
+#pragma mark - NSCoding
+- (instancetype)initWithCoder:(NSCoder *)aDecoder
+{
+    NSAssert(NO, @"%@ does not implement NSCoding", self.class);
+    return nil;
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder
+{
+    NSAssert(NO, @"%@ does not implement NSCoding", self.class);
 }
 
 @end

--- a/MatrixSDK/JSONModels/MXJSONModel.m
+++ b/MatrixSDK/JSONModels/MXJSONModel.m
@@ -17,9 +17,6 @@
 #import "MXJSONModel.h"
 
 @implementation MXJSONModel
-{
-    NSMutableDictionary *others;
-}
 
 /**
  * The JSONKeyPathsByPropertyKey dictionnaries for all subclasses of MXJSONModel.
@@ -66,9 +63,6 @@ static NSMutableDictionary *JSONKeyPathsByPropertyKeyByClass;
     id model = [MTLJSONAdapter modelOfClass:[self class]
                      fromJSONDictionary:JSONDictionary
                                   error:nil];
-    
-    // Put JSON keys not defined as class properties under the others dict
-    [model setOthers:JSONDictionary];
     
     return model;
 }
@@ -171,28 +165,6 @@ static NSMutableDictionary *JSONKeyPathsByPropertyKeyByClass;
     {
         return JSONDictionary;
     }
-}
-
-- (void)setOthers:(NSDictionary *)JSONDictionary
-{
-    // Store non declared JSON keys into the others property
-    NSArray *modelJSONKeys = [[self.class JSONKeyPathsByPropertyKey] allValues];
-    for (NSString *key in JSONDictionary)
-    {
-        if (![modelJSONKeys containsObject:key])
-        {
-            if (nil == others)
-            {
-                others = [NSMutableDictionary dictionary];
-            }
-            others[key] = JSONDictionary[key];
-        }
-    }
-}
-
--(NSDictionary *)others
-{
-    return others;
 }
 
 - (NSDictionary *)originalDictionary

--- a/MatrixSDK/JSONModels/MXJSONModels.h
+++ b/MatrixSDK/JSONModels/MXJSONModels.h
@@ -419,6 +419,16 @@ typedef enum : NSUInteger
      */
     @property (nonatomic) NSString *scope;
 
+    /**
+     Override [MXJSONModel modelsFromJSON] by adding scope and kind to all decoded `MXPushRule` objects.
+
+     @param JSONDictionaries the JSON data array.
+     @param scope the rule scope (global, device).
+     @param kind the rule kind (override, content, ...).
+     @return the newly created instances.
+     */
+    + (NSArray *)modelsFromJSON:(NSArray *)JSONDictionaries withScope:(NSString*)scope andKind:(MXPushRuleKind)kind;
+
 @end
 
 /**
@@ -562,6 +572,14 @@ FOUNDATION_EXPORT NSString *const kMXPushRuleConditionStringRoomMemberCount;
      */
     @property (nonatomic) NSArray *underride;
 
+    /**
+     Override [MXJSONModel modelFromJSON] by adding scope all decoded `MXPushRule` objects.
+
+     @param JSONDictionaries the JSON data array.
+     @param scope the rule scope (global, device).
+     @return the newly created instances.
+     */
+    + (id)modelFromJSON:(NSDictionary *)JSONDictionary withScope:(NSString*)scope;
 @end
 
 /**

--- a/MatrixSDK/JSONModels/MXJSONModels.m
+++ b/MatrixSDK/JSONModels/MXJSONModels.m
@@ -417,12 +417,15 @@ NSString *const kMXPushRuleConditionStringRoomMemberCount       = @"room_member_
 
 + (id)modelFromJSON:(NSDictionary *)JSONDictionary
 {
-    MXPushRuleCondition *condition = [super modelFromJSON:JSONDictionary];
+    MXPushRuleCondition *condition = [[MXPushRuleCondition alloc] init];
     if (condition)
     {
+        condition.kind = JSONDictionary[@"kind"];
+
         // MXPushRuleCondition.parameters are all other JSON objects which keys is not `kind`
-        // MXJSONModel stores them in `others`.
-        condition.parameters = condition.others;
+        NSMutableDictionary *parameters = [NSMutableDictionary dictionaryWithDictionary:JSONDictionary];
+        [parameters removeObjectForKey:@"kind"];
+        condition.parameters = parameters;
     }
     return condition;
 }

--- a/MatrixSDK/JSONModels/MXJSONModels.m
+++ b/MatrixSDK/JSONModels/MXJSONModels.m
@@ -80,7 +80,20 @@ NSString *const kMXLoginFlowTypeRecaptcha = @"m.login.recaptcha";
 
 @implementation MXCredentials
 
--(instancetype)initWithHomeServer:(NSString *)homeServer userId:(NSString *)userId accessToken:(NSString *)accessToken
++ (id)modelFromJSON:(NSDictionary *)JSONDictionary
+{
+    MXCredentials *credentials = [[MXCredentials alloc] init];
+    if (credentials)
+    {
+        credentials.homeServer = JSONDictionary[@"home_server"];
+        credentials.userId = JSONDictionary[@"user_id"];
+        credentials.accessToken = JSONDictionary[@"access_token"];
+    }
+
+    return credentials;
+}
+
+- (instancetype)initWithHomeServer:(NSString *)homeServer userId:(NSString *)userId accessToken:(NSString *)accessToken
 {
     self = [super init];
     if (self)
@@ -95,6 +108,18 @@ NSString *const kMXLoginFlowTypeRecaptcha = @"m.login.recaptcha";
 @end
 
 @implementation MXCreateRoomResponse
+
++ (id)modelFromJSON:(NSDictionary *)JSONDictionary
+{
+    MXCreateRoomResponse *createRoomResponse = [[MXCreateRoomResponse alloc] init];
+    if (createRoomResponse)
+    {
+        createRoomResponse.roomId = JSONDictionary[@"room_id"];
+    }
+
+    return createRoomResponse;
+}
+
 @end
 
 @implementation MXPaginationResponse

--- a/MatrixSDK/JSONModels/MXJSONModels.m
+++ b/MatrixSDK/JSONModels/MXJSONModels.m
@@ -296,16 +296,18 @@ NSString *const kMXPresenceHidden = @"hidden";
 
 @implementation MXPresenceResponse
 
-- (instancetype)initWithDictionary:(NSDictionary *)dictionaryValue error:(NSError *__autoreleasing *)error
++ (id)modelFromJSON:(NSDictionary *)JSONDictionary
 {
-    // Do the JSON -> class instance properties mapping
-    self = [super initWithDictionary:dictionaryValue error:error];
-    if (self)
+    MXPresenceResponse *presenceResponse = [[MXPresenceResponse alloc] init];
+    if (presenceResponse)
     {
-        _presenceStatus = [MXTools presence:_presence];
-    }
+        presenceResponse.lastActiveAgo = [((NSNumber*)JSONDictionary[@"last_active_ago"]) unsignedIntegerValue];
+        presenceResponse.presence = JSONDictionary[@"presence"];
+        presenceResponse.presenceStatus = [MXTools presence:presenceResponse.presence];
+        presenceResponse.statusMsg = JSONDictionary[@"status_msg"];
 
-    return self;
+    }
+    return presenceResponse;
 }
 
 @end

--- a/MatrixSDK/JSONModels/MXJSONModels.m
+++ b/MatrixSDK/JSONModels/MXJSONModels.m
@@ -916,41 +916,121 @@ NSString *const kMXPushRuleScopeStringDevice = @"device";
 #pragma mark -
 
 @implementation MXCallSessionDescription
+
++ (id)modelFromJSON:(NSDictionary *)JSONDictionary
+{
+    MXCallSessionDescription *callSessionDescription = [[MXCallSessionDescription alloc] init];
+    if (callSessionDescription)
+    {
+        callSessionDescription.type = JSONDictionary[@"type"];
+        callSessionDescription.sdp = JSONDictionary[@"sdp"];
+    }
+
+    return callSessionDescription;
+}
+
 @end
 
 @implementation MXCallInviteEventContent
 
-+ (NSValueTransformer *)offerJSONTransformer
++ (id)modelFromJSON:(NSDictionary *)JSONDictionary
 {
-    return [MTLJSONAdapter dictionaryTransformerWithModelClass:MXCallSessionDescription.class];
+    MXCallInviteEventContent *callInviteEventContent = [[MXCallInviteEventContent alloc] init];
+    if (callInviteEventContent)
+    {
+        callInviteEventContent.callId = JSONDictionary[@"call_id"];
+        callInviteEventContent.offer = [MXCallSessionDescription modelFromJSON:JSONDictionary[@"offer"]];
+        callInviteEventContent.version = [((NSNumber*)JSONDictionary[@"version"]) unsignedIntegerValue];
+        callInviteEventContent.lifetime = [((NSNumber*)JSONDictionary[@"lifetime"]) unsignedIntegerValue];
+    }
+
+    return callInviteEventContent;
 }
 
 @end
 
 @implementation MXCallCandidate
+
++ (id)modelFromJSON:(NSDictionary *)JSONDictionary
+{
+    MXCallCandidate *callCandidate = [[MXCallCandidate alloc] init];
+    if (callCandidate)
+    {
+        callCandidate.sdpMid = JSONDictionary[@"sdpMid"];
+        callCandidate.sdpMLineIndex = [((NSNumber*)JSONDictionary[@"sdpMLineIndex"]) unsignedIntegerValue];
+        callCandidate.candidate = JSONDictionary[@"candidate"];
+    }
+
+    return callCandidate;
+}
+
 @end
 
 @implementation MXCallCandidatesEventContent
 
-+ (NSValueTransformer *)candidateJSONTransformer
++ (id)modelFromJSON:(NSDictionary *)JSONDictionary
 {
-    return [MTLJSONAdapter arrayTransformerWithModelClass:MXCallCandidate.class];
+    MXCallCandidatesEventContent *callCandidatesEventContent = [[MXCallCandidatesEventContent alloc] init];
+    if (callCandidatesEventContent)
+    {
+        callCandidatesEventContent.callId = JSONDictionary[@"call_id"];
+        callCandidatesEventContent.version = [((NSNumber*)JSONDictionary[@"version"]) unsignedIntegerValue];
+        callCandidatesEventContent.candidates = [MXCallCandidate modelsFromJSON:JSONDictionary[@"candidates"]];
+    }
+
+    return callCandidatesEventContent;
 }
+
 @end
 
 @implementation MXCallAnswerEventContent
 
-+ (NSValueTransformer *)answerJSONTransformer
++ (id)modelFromJSON:(NSDictionary *)JSONDictionary
 {
-    return [MTLJSONAdapter dictionaryTransformerWithModelClass:MXCallSessionDescription.class];
+    MXCallAnswerEventContent *callAnswerEventContent = [[MXCallAnswerEventContent alloc] init];
+    if (callAnswerEventContent)
+    {
+        callAnswerEventContent.callId = JSONDictionary[@"call_id"];
+        callAnswerEventContent.version = [((NSNumber*)JSONDictionary[@"version"]) unsignedIntegerValue];
+        callAnswerEventContent.answer = [MXCallSessionDescription modelFromJSON:JSONDictionary[@"answer"]];
+    }
+
+    return callAnswerEventContent;
 }
 
 @end
 
 @implementation MXCallHangupEventContent
+
++ (id)modelFromJSON:(NSDictionary *)JSONDictionary
+{
+    MXCallHangupEventContent *callHangupEventContent = [[MXCallHangupEventContent alloc] init];
+    if (callHangupEventContent)
+    {
+        callHangupEventContent.callId = JSONDictionary[@"call_id"];
+        callHangupEventContent.version = [((NSNumber*)JSONDictionary[@"version"]) unsignedIntegerValue];
+    }
+
+    return callHangupEventContent;
+}
+
 @end
 
 @implementation MXTurnServerResponse
+
++ (id)modelFromJSON:(NSDictionary *)JSONDictionary
+{
+    MXTurnServerResponse *turnServerResponse = [[MXTurnServerResponse alloc] init];
+    if (turnServerResponse)
+    {
+        turnServerResponse.username = JSONDictionary[@"username"];
+        turnServerResponse.password = JSONDictionary[@"password"];
+        turnServerResponse.uris = JSONDictionary[@"uris"];
+        turnServerResponse.ttl = [((NSNumber*)JSONDictionary[@"ttl"]) unsignedIntegerValue];
+    }
+
+    return turnServerResponse;
+}
 
 - (instancetype)init
 {

--- a/MatrixSDK/JSONModels/MXRoomPowerLevels.m
+++ b/MatrixSDK/JSONModels/MXRoomPowerLevels.m
@@ -19,6 +19,25 @@
 #import "MXTools.h"
 
 @implementation MXRoomPowerLevels
+
++ (id)modelFromJSON:(NSDictionary *)JSONDictionary
+{
+    MXRoomPowerLevels *roomPowerLevels = [[MXRoomPowerLevels alloc] init];
+    if (roomPowerLevels)
+    {
+        roomPowerLevels.users = JSONDictionary[@"users"];
+        roomPowerLevels.usersDefault = [(NSNumber*)JSONDictionary[@"users_default"] unsignedIntegerValue];
+        roomPowerLevels.ban = [(NSNumber*)JSONDictionary[@"ban"] unsignedIntegerValue];
+        roomPowerLevels.kick = [(NSNumber*)JSONDictionary[@"kick"] unsignedIntegerValue];
+        roomPowerLevels.redact = [(NSNumber*)JSONDictionary[@"redact"] unsignedIntegerValue];
+        roomPowerLevels.invite = [(NSNumber*)JSONDictionary[@"invite"] unsignedIntegerValue];
+        roomPowerLevels.events = JSONDictionary[@"events"];
+        roomPowerLevels.eventsDefault = [(NSNumber*)JSONDictionary[@"events_default"] unsignedIntegerValue];
+        roomPowerLevels.stateDefault = [(NSNumber*)JSONDictionary[@"state_default"] unsignedIntegerValue];
+    }
+    return roomPowerLevels;
+}
+
 - (instancetype)init
 {
     self = [super init];
@@ -84,6 +103,41 @@
     }
 
     return minimumPowerLevel;
+}
+
+- (NSDictionary *)JSONDictionary
+{
+    NSMutableDictionary *JSONDictionary = [NSMutableDictionary dictionary];
+
+    JSONDictionary[@"users"] = _users;
+    JSONDictionary[@"usersDefault"] = @(_usersDefault);
+    JSONDictionary[@"ban"] = @(_ban);
+    JSONDictionary[@"kick"] = @(_kick);
+    JSONDictionary[@"redact"] = @(_redact);
+    JSONDictionary[@"invite"] = @(_invite);
+    JSONDictionary[@"events"] = _events;
+    JSONDictionary[@"eventsDefault"] = @(_eventsDefault);
+    JSONDictionary[@"stateDefault"] = @(_stateDefault);
+
+    return JSONDictionary;
+}
+
+#pragma mark - NSCopying
+- (id)copyWithZone:(NSZone *)zone
+{
+    MXRoomPowerLevels *roomPowerLevelsCopy = [[MXRoomPowerLevels allocWithZone:zone] init];
+
+    roomPowerLevelsCopy.users = [_users copyWithZone:zone];
+    roomPowerLevelsCopy.usersDefault = _usersDefault;
+    roomPowerLevelsCopy.ban = _ban;
+    roomPowerLevelsCopy.kick = _kick;
+    roomPowerLevelsCopy.redact = _redact;
+    roomPowerLevelsCopy.invite = _invite;
+    roomPowerLevelsCopy.events = [_events copyWithZone:zone];
+    roomPowerLevelsCopy.eventsDefault = _eventsDefault;
+    roomPowerLevelsCopy.stateDefault = _stateDefault;
+
+    return roomPowerLevelsCopy;
 }
 
 @end

--- a/MatrixSDK/NotificationCenter/MXNotificationCenter.m
+++ b/MatrixSDK/NotificationCenter/MXNotificationCenter.m
@@ -164,7 +164,7 @@ NSString *const kMXNotificationCenterAllOtherRoomMessagesRuleID = @".m.rule.mess
                 
                 if (!JSONDictionary)
                 {
-                    JSONDictionary = event.originalDictionary;
+                    JSONDictionary = event.JSONDictionary;
                 }
                 
                 BOOL conditionsOk = YES;

--- a/MatrixSDKTests/MXEventTests.m
+++ b/MatrixSDKTests/MXEventTests.m
@@ -152,14 +152,14 @@
     }];
 }
 
-- (void)testOriginalDictionary
+- (void)testJSONDictionary
 {
     [self doTestWithMXEvents:^(MXRestClient *bobRestClient, NSString *roomId, NSArray *events, XCTestExpectation *expectation) {
 
         for (MXEvent *event in events)
         {
-            XCTAssertNil([event.originalDictionary objectForKey:@"event_type"], @"eventType is an information added by the SDK not sent by the home server");
-            XCTAssertNil([event.originalDictionary objectForKey:@"age_local_ts"], @"ageLocalTs is an information added by the SDK not sent by the home server");
+            XCTAssertNil([event.JSONDictionary objectForKey:@"event_type"], @"eventType is an information added by the SDK not sent by the home server");
+            XCTAssertNil([event.JSONDictionary objectForKey:@"age_local_ts"], @"ageLocalTs is an information added by the SDK not sent by the home server");
         }
 
         [expectation fulfill];

--- a/MatrixSDKTests/MXJSONModelTests.m
+++ b/MatrixSDKTests/MXJSONModelTests.m
@@ -142,40 +142,6 @@
     XCTAssert(((NSDictionary*)cleanDict[@"dict1"][@"dict2"]).count == 0, @"JSON null value must be removed. Found: %@", cleanDict[@"dict1"][@"dict2"]);
 }
 
-- (void)testOthers
-{
-    [[MatrixSDKTestsData sharedData] doMXRestClientTestWithBobAndThePublicRoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
-        
-        [httpClient requestWithMethod:@"GET"
-                                 path:@"api/v1/publicRooms"
-                           parameters:nil
-                              success:^(NSDictionary *JSONResponse)
-         {
-             NSArray *chunk = JSONResponse[@"chunk"];
-             
-             // Convert the JSON in a MXJSONModel class with no property
-             // All values in the JSON must go into the MXJSONModel.others dictionary
-             MXJSONModelTestClass *nonTypedObject = [MXJSONModelTestClass modelFromJSON:chunk[0]];
-             XCTAssertNotNil(nonTypedObject.others);
-             
-             // Check expected keys for a MXPublicRoom JSON
-             NSDictionary *others = nonTypedObject.others;
-             XCTAssertNotNil(others[@"room_id"]);
-             XCTAssertNotNil(others[@"name"]);
-             XCTAssertNotNil(others[@"aliases"]);
-             
-             MXPublicRoom *publicRoom = [MXPublicRoom modelFromJSON:chunk[0]];
-             XCTAssertNil(publicRoom.others, @"Each field of a publicRooms JSON response should be declared as property in MXPublicRoom.");
-             
-             [expectation fulfill];
-             
-         } failure:^(NSError *error) {
-             XCTFail(@"The request should not fail - NSError: %@", error);
-             [expectation fulfill];
-         }];
-    }];
-}
-
 - (void)testNullValue
 {
     NSDictionary *JSONDict = @{

--- a/Podfile
+++ b/Podfile
@@ -5,7 +5,6 @@ source 'https://github.com/CocoaPods/Specs.git'
 
 target "MatrixSDK" do
 pod 'AFNetworking', '~> 2.6.0'
-pod 'Mantle', '~> 2.0.5'
 end
 
 target "MatrixSDKTests" do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -20,16 +20,11 @@ PODS:
   - AFNetworking/UIKit (2.6.3):
     - AFNetworking/NSURLConnection
     - AFNetworking/NSURLSession
-  - Mantle (2.0.6):
-    - Mantle/extobjc (= 2.0.6)
-  - Mantle/extobjc (2.0.6)
 
 DEPENDENCIES:
   - AFNetworking (~> 2.6.0)
-  - Mantle (~> 2.0.5)
 
 SPEC CHECKSUMS:
   AFNetworking: cb8d14a848e831097108418f5d49217339d4eb60
-  Mantle: 299966b00759634931699f69cb6a30b9239b944d
 
 COCOAPODS: 0.39.0


### PR DESCRIPTION
In the continuation of https://matrix.org/jira/browse/SYIOS-169, Mantle has been totally removed.
The pro is that we have the best performance. 
The con is that we lost nice automatic conversion methods (dictionaryValue, NSCoding, NSCopying). These methods must be now coded by "hand" for each MXJSON derived class.