### PR TITLE
Moving to r0 - Step #1

### DIFF
--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -1039,14 +1039,7 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
 }
 
 - (BOOL)acknowledgeLatestEvent:(BOOL)sendReceipt;
-{
-    // Sanity check on supported C-S version
-    if (mxSession.matrixRestClient.preferredAPIVersion < MXRestClientAPIVersion2)
-    {
-        NSLog(@"[MXRoom] acknowledgeLatestEvent failed: read receipts are not supported on C-S v1 API");
-        return NO;
-    }
-    
+{    
     MXEvent* event =[mxSession.store lastMessageOfRoom:_state.roomId withTypeIn:_acknowledgableEventTypes];
     // Sanity check on event id: Do not send read receipt on event without id
     if (event.eventId && ([event.eventId hasPrefix:kMXRoomInviteStateEventIdPrefix] == NO))

--- a/MatrixSDK/JSONModels/MXJSONModels.h
+++ b/MatrixSDK/JSONModels/MXJSONModels.h
@@ -783,7 +783,7 @@ FOUNDATION_EXPORT NSString *const kMXPushRuleScopeStringDevice;
 @end
 
 
-#pragma mark - Server sync v1 response
+#pragma mark - Server sync
 #pragma mark -
 
 /**
@@ -842,36 +842,6 @@ FOUNDATION_EXPORT NSString *const kMXPushRuleScopeStringDevice;
     @property (nonatomic) NSArray<MXEvent*> *receipts;
 
 @end
-
-/**
- `MXInitialSyncResponse` represents the request response for server initial sync v1. @see http://matrix.org/docs/api/client-server/#!/-events/initial_sync
- */
-@interface MXInitialSyncResponse : MXJSONModel
-
-    /**
-     List of rooms.
-     */
-    @property (nonatomic) NSArray<MXRoomInitialSync*> *rooms;
-
-    /**
-     The presence status of other users.
-     */
-    @property (nonatomic) NSArray<MXEvent*> *presence;
-
-    /**
-     The read receipts.
-     */
-    @property (nonatomic) NSArray<MXEvent*> *receipts;
-
-    /**
-     The opaque token for the end.
-     */
-    @property (nonatomic) NSString *end;
-
-@end
-
-#pragma mark - Server sync v2 response
-#pragma mark -
 
 /**
  `MXRoomSyncState` represents the state updates for a room during server sync v2.

--- a/MatrixSDK/JSONModels/MXJSONModels.m
+++ b/MatrixSDK/JSONModels/MXJSONModels.m
@@ -735,7 +735,7 @@ NSString *const kMXPushRuleScopeStringDevice = @"device";
 @end
 
 
-#pragma mark - Server sync v1 response
+#pragma mark - Server sync
 #pragma mark -
 
 @implementation MXRoomInitialSync
@@ -761,28 +761,6 @@ NSString *const kMXPushRuleScopeStringDevice = @"device";
 }
 
 @end
-
-@implementation MXInitialSyncResponse
-
-+ (id)modelFromJSON:(NSDictionary *)JSONDictionary
-{
-    MXInitialSyncResponse *initialSyncResponse = [[MXInitialSyncResponse alloc] init];
-    if (initialSyncResponse)
-    {
-        MXJSONModelSetMXJSONModelArray(initialSyncResponse.rooms, MXRoomInitialSync, JSONDictionary[@"rooms"]);
-        MXJSONModelSetMXJSONModelArray(initialSyncResponse.presence, MXEvent, JSONDictionary[@"presence"]);
-        MXJSONModelSetMXJSONModelArray(initialSyncResponse.receipts, MXEvent, JSONDictionary[@"receipts"]);
-        MXJSONModelSetString(initialSyncResponse.end, JSONDictionary[@"end"]);
-    }
-
-    return initialSyncResponse;
-}
-
-@end
-
-
-#pragma mark - Server sync v2 response
-#pragma mark -
 
 @implementation MXRoomSyncState
 

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -927,17 +927,6 @@ typedef enum : NSUInteger
                  success:(void (^)(MXPresenceResponse *presence))success
                  failure:(void (^)(NSError *error))failure;
 
-/**
- Get the presence for all of the user's friends.
-
- @param success A block object called when the operation succeeds. It provides an array of presence events.
- @param failure A block object called when the operation fails.
-
- @return a MXHTTPOperation instance.
- */
-- (MXHTTPOperation*)allUsersPresence:(void (^)(NSArray *userPresenceEvents))success
-                         failure:(void (^)(NSError *error))failure;
-
 
 #pragma mark - Sync
 /**

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -946,54 +946,7 @@ typedef enum : NSUInteger
                          failure:(void (^)(NSError *error))failure;
 
 
-#pragma mark - Event operations
-/**
- Get this user's current state.
- Get all the current information for all rooms (including messages and state events) and
- presence of the users he has interaction with
- 
- @param limit the maximum number of messages to return.
- 
- @param success A block object called when the operation succeeds.
- @param failure A block object called when the operation fails.
-
- @return a MXHTTPOperation instance.
- */
-- (MXHTTPOperation*)initialSyncWithLimit:(NSInteger)limit
-                             success:(void (^)(MXInitialSyncResponse *initialSyncResponse))success
-                             failure:(void (^)(NSError *error))failure;
-
-/**
- Get the list of public rooms hosted by the home server.
- 
- @param success A block object called when the operation succeeds. rooms is an array of MXPublicRoom objects
- @param failure A block object called when the operation fails.
-
- @return a MXHTTPOperation instance.
- */
-- (MXHTTPOperation*)publicRooms:(void (^)(NSArray *rooms))success
-                    failure:(void (^)(NSError *error))failure;
-
-/**
- Get events from the given token.
- 
- @param token the token to stream from.
- @param serverTimeout the maximum time in ms to wait for an event.
- @param clientTimeout the maximum time in ms the SDK must wait for the server response.
- 
- @param success A block object called when the operation succeeds. It provides a `MXPaginationResponse` object.
- @param failure A block object called when the operation fails.
- 
- @return a MXHTTPOperation instance.
-
- @return a MXHTTPOperation instance.
- */
-- (MXHTTPOperation *)eventsFromToken:(NSString*)token
-                   serverTimeout:(NSUInteger)serverTimeout
-                   clientTimeout:(NSUInteger)clientTimeout
-                         success:(void (^)(MXPaginationResponse *paginatedResponse))success
-                         failure:(void (^)(NSError *error))failure;
-
+#pragma mark - Sync
 /**
  Synchronise the client's state and receive new messages. Based on server sync C-S v2 API.
  
@@ -1024,7 +977,19 @@ typedef enum : NSUInteger
                            success:(void (^)(MXSyncResponse *syncResponse))success
                            failure:(void (^)(NSError *error))failure;
 
+
 #pragma mark - Directory operations
+/**
+ Get the list of public rooms hosted by the home server.
+
+ @param success A block object called when the operation succeeds. rooms is an array of MXPublicRoom objects
+ @param failure A block object called when the operation fails.
+
+ @return a MXHTTPOperation instance.
+ */
+- (MXHTTPOperation*)publicRooms:(void (^)(NSArray *rooms))success
+                        failure:(void (^)(NSError *error))failure;
+
 /**
  Get the room ID corresponding to this room alias
  

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -24,9 +24,14 @@
 
 #pragma mark - Constants definitions
 /**
- Prefix used in path of home server API requests.
+ A constant representing the URI path for release 0 of the Client-Server HTTP API.
  */
-FOUNDATION_EXPORT NSString *const kMXAPIPrefixPath;
+FOUNDATION_EXPORT NSString *const kMXAPIPrefixPathR0;
+
+/**
+ A constant representing tthe URI path for as-yet unspecified of the Client-Server HTTP API.
+ */
+FOUNDATION_EXPORT NSString *const kMXAPIPrefixPathUnstable;
 
 /**
  Prefix used in path of identity server API requests.
@@ -111,17 +116,6 @@ typedef enum : NSUInteger
 @interface MXRestClient : NSObject
 
 /**
- The preferred Client-Server API version. This value is applied to each new MXRestClient instance
- during initialisation step (see 'preferredAPIVersion' property).
- By default the C-S API v2 is considered.
- 
- CAUTION: Change of the preferred version impacts only the new MXRestClient instances.
- 
- @param preferredAPIVersion the preferred C-S API version.
- */
-+ (void)registerPreferredAPIVersion:(MXRestClientAPIVersion)preferredAPIVersion;
-
-/**
  The homeserver.
  */
 @property (nonatomic, readonly) NSString *homeserver;
@@ -137,11 +131,10 @@ typedef enum : NSUInteger
 @property (nonatomic, readonly) NSString *homeserverSuffix;
 
 /**
- The preferred Client-Server API version. This version is used during server requests insofar as it is supported.
- A prior version is used in case the preferred one is not supported yet.
- It is set during initialisation according to the registered value (see [registerPreferredAPIVersion:]).
+ The Client-Server API prefix to use.
+ By default, it is '/_matrix/client/r0'. See kMXAPIPrefixPathR0 and kMXAPIPrefixPathUnstable for constants.
  */
-@property (nonatomic, readonly) MXRestClientAPIVersion preferredAPIVersion;
+@property (nonatomic) NSString *apiPathPrefix;
 
 /**
  The identity server.

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -1789,45 +1789,6 @@ MXAuthAction;
                                  }];
 }
 
-- (MXHTTPOperation*)allUsersPresence:(void (^)(NSArray *userPresenceEvents))success
-                             failure:(void (^)(NSError *error))failure
-{
-    // In C-S API v1, the only way to get all user presence is to make
-    // a global initialSync
-    // @TODO: Change it with C-S API v2 new APIs
-    return [httpClient requestWithMethod:@"GET"
-                                    path:[NSString stringWithFormat:@"%@/initialSync", apiPathPrefix]
-                              parameters:@{
-                                           @"limit": [NSNumber numberWithInteger:0]
-                                           }
-                                 success:^(NSDictionary *JSONResponse) {
-                                     if (success)
-                                     {
-                                         // Create model from JSON dictionary on the processing queue
-                                         dispatch_async(processingQueue, ^{
-
-                                             // Parse only events from the `presence` field of the response.
-                                             // There is no interest to parse all JSONResponse with the MXInitialSyncResponse model,
-                                             // which is CPU expensive due to the possible high number of rooms states events.
-                                             NSArray<MXEvent*> *presence;
-                                             MXJSONModelSetMXJSONModelArray(presence, MXEvent, JSONResponse[@"presence"]);
-
-                                             dispatch_async(dispatch_get_main_queue(), ^{
-
-                                                 success(presence);
-
-                                             });
-                                        });
-                                     }
-                                 }
-                                 failure:^(NSError *error) {
-                                     if (failure)
-                                     {
-                                         failure(error);
-                                     }
-                                 }];
-}
-
 - (MXHTTPOperation*)presenceList:(void (^)(MXPresenceResponse *presence))success
                          failure:(void (^)(NSError *error))failure
 {

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -274,15 +274,7 @@ MXAuthAction;
     NSString *authActionPath = @"api/v1/login";
     if (MXAuthActionRegister == authAction)
     {
-        // TODO GFO server register v2 is not available yet (use C-S v1 by default)
-//        if (preferredAPIVersion == MXRestClientAPIVersion2)
-//        {
-//            authActionPath = @"v2_alpha/register";
-//        }
-//        else
-        {
-            authActionPath = @"api/v1/register";
-        }
+        authActionPath = @"v2_alpha/register";
     }
     return authActionPath;
 }
@@ -293,15 +285,15 @@ MXAuthAction;
     NSString *httpMethod = @"GET";
     NSDictionary *parameters = nil;
     
-    // TODO GFO server register v2 is not available yet (use C-S v1 by default)
-//    if ((MXAuthActionRegister == authAction) && (preferredAPIVersion == MXRestClientAPIVersion2))
-//    {
-//        // C-S API v2: use POST with no params to get the login mechanism to use when registering
-//        // The request will failed with Unauthorized status code, but the login mechanism will be available in response data.
-//        httpMethod = @"POST";
-//        parameters = @{};
-//    }
-    
+
+    if (MXAuthActionRegister == authAction)
+    {
+        // For registration, use POST with no params to get the login mechanism to use
+        // The request will failed with Unauthorized status code, but the login mechanism will be available in response data.
+        httpMethod = @"POST";
+        parameters = @{};
+    }
+
     return [httpClient requestWithMethod:httpMethod
                                     path:[self authActionPath:authAction]
                               parameters:parameters

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -431,7 +431,7 @@ MXAuthAction;
 - (MXHTTPOperation *)pushRules:(void (^)(MXPushRulesResponse *pushRules))success failure:(void (^)(NSError *))failure
 {
     return [httpClient requestWithMethod:@"GET"
-                                    path:[NSString stringWithFormat:@"%@/pushrules", apiPathPrefix]
+                                    path:[NSString stringWithFormat:@"%@/pushrules/", apiPathPrefix]
                               parameters:nil
                                  success:^(NSDictionary *JSONResponse) {
                                      @autoreleasepool

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -26,9 +26,6 @@
 #import "MXMemoryStore.h"
 #import "MXFileStore.h"
 
-// FIXME SYNCV2 Enable server sync v2
-#define MXSESSION_ENABLE_SERVER_SYNC_V2
-
 #pragma mark - Constants definitions
 
 const NSString *MatrixSDKVersion = @"0.6.2";
@@ -346,30 +343,8 @@ typedef void (^MXOnResumeDone)();
             }];
         };
         
-#ifdef MXSESSION_ENABLE_SERVER_SYNC_V2
-        if (matrixRestClient.preferredAPIVersion == MXRestClientAPIVersion2)
-        {
-            // Resume the stream (presence will be retrieved durng server sync)
-            resumeEventsStream();
-        }
-        else
-#endif
-        {
-            // Then, apply
-            if (_loadPresenceBeforeCompletingSessionStart)
-            {
-                // Load presence before resuming the stream
-                loadPresence(^() {
-                    resumeEventsStream();
-                }, failure);
-            }
-            else
-            {
-                // Resume the stream and load presence in parralel
-                resumeEventsStream();
-                loadPresence(nil, nil);
-            }
-        }
+        // Resume the stream (presence will be retrieved during server sync)
+        resumeEventsStream();
     }
     else
     {
@@ -388,18 +363,8 @@ typedef void (^MXOnResumeDone)();
                 // Additional step: load push rules from the home server
                 [_notificationCenter refreshRules:^{
                     
-                    // Initial server sync - Check the supported C-S version.
-#ifdef MXSESSION_ENABLE_SERVER_SYNC_V2
-                    if (matrixRestClient.preferredAPIVersion == MXRestClientAPIVersion2)
-                    {
-                        [self serverSyncWithServerTimeout:0 success:onServerSyncDone failure:failure clientTimeout:CLIENT_TIMEOUT_MS setPresence:nil];
-                    }
-                    else
-#endif
-                    {
-                        // sync based on API v1 (Legacy)
-                        [self initialServerSync:onServerSyncDone failure:failure];
-                    }
+                    // Initial server sync
+                    [self serverSyncWithServerTimeout:0 success:onServerSyncDone failure:failure clientTimeout:CLIENT_TIMEOUT_MS setPresence:nil];
                     
                 } failure:^(NSError *error) {
                     [self setState:MXSessionStateHomeserverNotReachable];
@@ -414,190 +379,6 @@ typedef void (^MXOnResumeDone)();
             failure(error);
         }];
     }
-}
-
-- (void)streamEventsFromToken:(NSString*)token withLongPoll:(BOOL)longPoll
-{
-    [self streamEventsFromToken:token withLongPoll:longPoll serverTimeOut:(longPoll ? SERVER_TIMEOUT_MS : 0) clientTimeout:CLIENT_TIMEOUT_MS];
-}
-
-- (void)streamEventsFromToken:(NSString*)token withLongPoll:(BOOL)longPoll serverTimeOut:(NSUInteger)serverTimeout clientTimeout:(NSUInteger)clientTimeout
-{
-    eventStreamRequest = [matrixRestClient eventsFromToken:token serverTimeout:serverTimeout clientTimeout:clientTimeout success:^(MXPaginationResponse *paginatedResponse) {
-
-        // eventStreamRequest is nil when the event stream has been paused
-        if (eventStreamRequest)
-        {
-            // Convert chunk array into an array of MXEvents
-            NSArray *events = paginatedResponse.chunk;
-
-            // And handle them
-            [self handleLiveEvents:events];
-
-            _store.eventStreamToken = paginatedResponse.end;
-            
-            // Commit store changes
-            if ([_store respondsToSelector:@selector(commit)])
-            {
-                [_store commit];
-            }
-            
-            // there is a pending backgroundSync
-            if (onBackgroundSyncDone)
-            {
-                NSLog(@"[MXSession] background Sync with %tu new events", events.count);
-                
-                // Operations on session may occur during this block. For example, [MXSession close] may be triggered.
-                // We run a copy of the block to prevent app from crashing if the block is released by one of these operations.
-                MXOnBackgroundSyncDone onBackgroundSyncDoneCpy = [onBackgroundSyncDone copy];
-                onBackgroundSyncDoneCpy();
-                onBackgroundSyncDone = nil;
-                
-                // check that the application was not resumed while catching up
-                if (_state == MXSessionStateBackgroundSyncInProgress)
-                {
-                    NSLog(@"[MXSession] go to paused ");
-                    eventStreamRequest = nil;
-                    [self setState:MXSessionStatePaused];
-                    return;
-                }
-                else
-                {
-                    NSLog(@"[MXSession] resume after a background Sync ");
-                }
-            }
-
-            // If we are resuming inform the app that it received the last uptodate data
-            if (onResumeDone)
-            {
-                NSLog(@"[MXSession] Events stream resumed with %tu new events", events.count);
-                
-                // Operations on session may occur during this block. For example, [MXSession close] or [MXSession pause] may be triggered.
-                // We run a copy of the block to prevent app from crashing if the block is released by one of these operations.
-                MXOnResumeDone onResumeDoneCpy = [onResumeDone copy];
-                onResumeDoneCpy();
-                onResumeDone = nil;
-                
-                // Stop here if [MXSession close] or [MXSession pause] has been triggered during onResumeDone block.
-                if (nil == _myUser || _state == MXSessionStatePaused)
-                {
-                    return;
-                }
-            }
-            
-            // The event stream is running by now
-            [self setState:MXSessionStateRunning];
-            
-            // Check SDK user did not called [MXSession close] or [MXSession pause] during the session state change notification handling.
-            if (nil == _myUser || _state == MXSessionStatePaused)
-            {
-                return;
-            }
-
-            // Go streaming from the returned token
-            [self streamEventsFromToken:paginatedResponse.end withLongPoll:YES];
-            
-            // Broadcast that a server sync has been processed.
-            [[NSNotificationCenter defaultCenter] postNotificationName:kMXSessionDidSyncNotification
-                                                                object:self
-                                                              userInfo:nil];
-        }
-
-    } failure:^(NSError *error) {
-
-        if (onBackgroundSyncFail)
-        {
-            NSLog(@"[MXSession] background Sync fails %@", error);
-            
-            // Operations on session may occur during this block. For example, [MXSession close] may be triggered.
-            // We run a copy of the block to prevent app from crashing if the block is released by one of these operations.
-            MXOnBackgroundSyncFail onBackgroundSyncFailCpy = [onBackgroundSyncFail copy];
-            onBackgroundSyncFailCpy(error);
-            onBackgroundSyncFail = nil;
-            
-            // check that the application was not resumed while catching up in background
-            if (_state == MXSessionStateBackgroundSyncInProgress)
-            {
-                NSLog(@"[MXSession] go to paused ");
-                eventStreamRequest = nil;
-                [self setState:MXSessionStatePaused];
-                return;
-            }
-            else
-            {
-                NSLog(@"[MXSession] resume after a background Sync");
-            }
-        }
-        
-        if (eventStreamRequest)
-        {
-            // on 64 bits devices, the error codes are huge integers.
-            int32_t code = (int32_t)error.code;
-            
-            if (code == kCFURLErrorCancelled)
-            {
-                NSLog(@"[MXSession] The connection has been cancelled.");
-            }
-            // timeout case : the request has been triggerd with a timeout value
-            // but there is no data to retrieve
-            else if ((code == kCFURLErrorTimedOut) && !longPoll)
-            {
-                NSLog(@"[MXSession] The connection has been timeout.");
-                
-                [eventStreamRequest cancel];
-                eventStreamRequest = nil;
-                
-                // Broadcast that a server sync is processed.
-                [[NSNotificationCenter defaultCenter] postNotificationName:kMXSessionDidSyncNotification
-                                                                    object:self
-                                                                  userInfo:nil];
-                
-                // switch back to the long poll management
-                [self streamEventsFromToken:token withLongPoll:YES];
-            }
-            else
-            {
-                // Inform the app there is a problem with the connection to the homeserver
-                [self setState:MXSessionStateHomeserverNotReachable];
-
-                // Check if it is a network connectivity issue
-                AFNetworkReachabilityManager *networkReachabilityManager = [AFNetworkReachabilityManager sharedManager];
-                NSLog(@"[MXSession] events stream broken. Network reachability: %d", networkReachabilityManager.isReachable);
-
-                if (networkReachabilityManager.isReachable)
-                {
-                    // The problem is not the network
-                    // Relaunch the request in a random near futur.
-                    // Random time it used to avoid all Matrix clients to retry all in the same time
-                    // if there is server side issue like server restart
-                     dispatch_time_t delayTime = dispatch_time(DISPATCH_TIME_NOW, [MXHTTPClient jitterTimeForRetry] * NSEC_PER_MSEC);
-                     dispatch_after(delayTime, dispatch_get_main_queue(), ^(void) {
-
-                         if (eventStreamRequest)
-                         {
-                             NSLog(@"[MXSession] Retry resuming events stream");
-                             [self streamEventsFromToken:token withLongPoll:longPoll];
-                         }
-                     });
-                }
-                else
-                {
-                    // The device is not connected to the internet, wait for the connection to be up again before retrying
-                    __block __weak id reachabilityObserver =
-                    [[NSNotificationCenter defaultCenter] addObserverForName:AFNetworkingReachabilityDidChangeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *note) {
-
-                        if (networkReachabilityManager.isReachable && eventStreamRequest)
-                        {
-                            [[NSNotificationCenter defaultCenter] removeObserver:reachabilityObserver];
-
-                            NSLog(@"[MXSession] Retry resuming events stream");
-                            [self streamEventsFromToken:token withLongPoll:longPoll];
-                        }
-                    }];
-                }
-            }
-        }
-    }];
 }
 
 - (void)handleLiveEvents:(NSArray*)events
@@ -772,18 +553,8 @@ typedef void (^MXOnResumeDone)();
         
         if (!eventStreamRequest)
         {
-            // Relaunch live events stream (long polling) - Check supported C-S version
-#ifdef MXSESSION_ENABLE_SERVER_SYNC_V2
-            if (matrixRestClient.preferredAPIVersion == MXRestClientAPIVersion2)
-            {
-                [self serverSyncWithServerTimeout:0 success:nil failure:nil clientTimeout:CLIENT_TIMEOUT_MS setPresence:nil];
-            }
-            else
-#endif
-            {
-                // sync based on API v1 (Legacy)
-                [self streamEventsFromToken:_store.eventStreamToken withLongPoll:NO];
-            }
+            // Relaunch live events stream (long polling)
+            [self serverSyncWithServerTimeout:0 success:nil failure:nil clientTimeout:CLIENT_TIMEOUT_MS setPresence:nil];
         }
     }
 }
@@ -808,19 +579,8 @@ typedef void (^MXOnResumeDone)();
             // BackgroundSync from the latest known token
             onBackgroundSyncDone = backgroundSyncDone;
             onBackgroundSyncFail = backgroundSyncfails;
-            
-            // Check supported C-S version
-#ifdef MXSESSION_ENABLE_SERVER_SYNC_V2
-            if (matrixRestClient.preferredAPIVersion == MXRestClientAPIVersion2)
-            {
-                [self serverSyncWithServerTimeout:0 success:nil failure:nil clientTimeout:timeout setPresence:@"offline"];
-            }
-            else
-#endif
-            {
-                // sync based on API v1 (Legacy)
-                [self streamEventsFromToken:_store.eventStreamToken withLongPoll:NO serverTimeOut:0 clientTimeout:timeout];
-            }
+
+            [self serverSyncWithServerTimeout:0 success:nil failure:nil clientTimeout:timeout setPresence:@"offline"];
         }
     }
 }
@@ -835,19 +595,7 @@ typedef void (^MXOnResumeDone)();
         
         // retrieve the available data asap
         // disable the long poll to get the available data asap
-        
-        // Check supported C-S version
-#ifdef MXSESSION_ENABLE_SERVER_SYNC_V2
-        if (matrixRestClient.preferredAPIVersion == MXRestClientAPIVersion2)
-        {
-            [self serverSyncWithServerTimeout:0 success:nil failure:nil clientTimeout:10 setPresence:nil];
-        }
-        else
-#endif
-        {
-            // sync based on API v1 (Legacy)
-            [self streamEventsFromToken:_store.eventStreamToken withLongPoll:NO serverTimeOut:0 clientTimeout:10];
-        }
+        [self serverSyncWithServerTimeout:0 success:nil failure:nil clientTimeout:10 setPresence:nil];
         
         return YES;
     }
@@ -908,125 +656,6 @@ typedef void (^MXOnResumeDone)();
     matrixRestClient = nil;
 
     [self setState:MXSessionStateClosed];
-}
-
-#pragma mark - Internals
-
-- (void)initialServerSync:(void (^)())onServerSyncDone
-                  failure:(void (^)(NSError *error))failure
-{
-    NSDate *startDate = [NSDate date];
-    NSLog(@"[MXSession] Do a global initialSync");
-    
-    // Then, we can do the global sync
-    [matrixRestClient initialSyncWithLimit:initialSyncMessagesLimit success:^(MXInitialSyncResponse *initialSync) {
-        
-        // Make sure [MXSession close] has not been called before the server response
-        if (nil == _myUser)
-        {
-            return;
-        }
-        
-        NSMutableArray * roomids = [[NSMutableArray alloc] init];
-        
-        NSLog(@"[MXSession] Received %tu rooms in %.3fms", initialSync.rooms.count, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
-
-        NSDate *startDate2 = [NSDate date];
-        
-        for (MXRoomInitialSync* roomInitialSync in initialSync.rooms)
-        {
-            @autoreleasepool
-            {
-                MXRoom *room = [self getOrCreateRoom:roomInitialSync.roomId withInitialSync:roomInitialSync notify:NO];
-                [roomids addObject:room.state.roomId];
-                
-                if (roomInitialSync.messages)
-                {
-                    [room handleMessages:roomInitialSync.messages
-                               direction:MXEventDirectionBackwards isTimeOrdered:YES];
-                    
-                    // Uncomment the following lines when SYN-482 will be fixed
-//                    // If the initialSync returns less messages than requested, we got all history from the home server
-//                    if (roomInitialSync.messages.chunk.count < initialSyncMessagesLimit)
-//                    {
-//                        [_store storeHasReachedHomeServerPaginationEndForRoom:room.state.roomId andValue:YES];
-//                    }
-                }
-                if (roomInitialSync.state)
-                {
-                    [room handleStateEvents:roomInitialSync.state direction:MXEventDirectionSync];
-                    
-                    if (!room.state.isPublic && room.state.members.count == 2)
-                    {
-                        // Update one-to-one room dictionary
-                        [self handleOneToOneRoom:room];
-                    }
-                }
-                if (roomInitialSync.accountData)
-                {
-                    [room handleAccounDataEvents:roomInitialSync.accountData  direction:MXEventDirectionSync];
-                }
-                
-                // Notify that room has been sync'ed
-                [[NSNotificationCenter defaultCenter] postNotificationName:kMXRoomInitialSyncNotification
-                                                                    object:room
-                                                                  userInfo:nil];
-            }
-        }
-        
-        // Manage presence
-        @autoreleasepool
-        {
-            for (MXEvent *presenceEvent in initialSync.presence)
-            {
-                [self handlePresenceEvent:presenceEvent direction:MXEventDirectionSync];
-            }
-        }
-        
-        // Manage receipts
-        @autoreleasepool
-        {
-            for (MXEvent *receiptEvent in initialSync.receipts)
-            {
-                MXRoom *room = [self roomWithRoomId:receiptEvent.roomId];
-                
-                if (room)
-                {
-                    [room handleReceiptEvent:receiptEvent direction:MXEventDirectionSync];
-                }
-            }
-        }
-        
-//        // init the receips to the latest received one.
-//        // else the unread messages counter will not be properly managed.
-//        for (MXRoomInitialSync* roomInitialSync in initialSync.rooms)
-//        {
-//            MXRoom *room = [self roomWithRoomId:roomInitialSync.roomId];
-//            [room acknowledgeLatestEvent:NO];
-//        }
-        
-        // Start listening to live events
-        _store.eventStreamToken = initialSync.end;
-        
-        // Commit store changes done in [room handleMessages]
-        if ([_store respondsToSelector:@selector(commit)])
-        {
-            [_store commit];
-        }
-
-        NSLog(@"[MXSession] InitialSync events processed and stored in %.3fms", [[NSDate date] timeIntervalSinceDate:startDate2] * 1000);
-
-        // Resume from the last known token
-        [self streamEventsFromToken:_store.eventStreamToken withLongPoll:YES];
-        
-        [self setState:MXSessionStateRunning];
-        
-        onServerSyncDone();
-        
-    } failure:^(NSError *error) {
-        [self setState:MXSessionStateHomeserverNotReachable];
-        failure(error);
-    }];
 }
 
 #pragma mark - server sync v2
@@ -1384,19 +1013,10 @@ typedef void (^MXOnResumeDone)();
                                                                          kMXSessionNotificationRoomIdKey: room.state.roomId,
                                                                          }];
         }
-        
-#ifdef MXSESSION_ENABLE_SERVER_SYNC_V2
-        if (matrixRestClient.preferredAPIVersion == MXRestClientAPIVersion2)
+
+        if (success)
         {
-            if (success)
-            {
-                success(room);
-            }
-        }
-        else
-#endif
-        {
-            [self initialSyncOfRoom:theRoomId withLimit:initialSyncMessagesLimit success:success failure:failure];
+            success(room);
         }
 
     } failure:failure];


### PR DESCRIPTION
This PR replaces calls to v1 and v2_alpha apis by r0, which is configurable via MXRestClient.apiPathPrefix.
v1 global initialSync and related objects have been removed.

In step \#2, call of room initialSync will be removed as v2 /sync do the job. All comments relative to v1/v2 will also be removed

