### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -313,7 +313,7 @@ MatrixSDKTests scheme and click on the "Test" action.
 Known issues
 ============
 
-Cocoapods may fail to install on OSX 10.8.x with "i18n requires Ruby version 
+CocoaPods may fail to install on OSX 10.8.x with "i18n requires Ruby version 
 >= 1.9.3.".  This is a known problem similar to
 https://github.com/CocoaPods/CocoaPods/issues/2458 that needs to be raised with
 the cocoapods team.


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
