### PR TITLE
Remove MXEventDirectionSync

### DIFF
--- a/MatrixSDK/Data/MXEventListener.h
+++ b/MatrixSDK/Data/MXEventListener.h
@@ -17,6 +17,7 @@
 #import <Foundation/Foundation.h>
 
 #import "MXEvent.h"
+#import "MXEventTimeline.h"
 
 /**
  Block called when an event of the registered types has been handled by the Matrix SDK.
@@ -26,7 +27,7 @@
  @param customObject additional contect for the event. In case of room event, customObject is a
  RoomState instance.
  */
-typedef void (^MXOnEvent)(MXEvent *event, MXEventDirection direction, id customObject);
+typedef void (^MXOnEvent)(MXEvent *event, MXTimelineDirection direction, id customObject);
 
 /**
  The `MXEventListener` class stores information about a listener to MXEvents that
@@ -46,7 +47,7 @@ typedef void (^MXOnEvent)(MXEvent *event, MXEventDirection direction, id customO
  @param event the new event.
  @param direction the origin of the event.
  */
-- (void)notify:(MXEvent*)event direction:(MXEventDirection)direction andCustomObject:(id)customObject;
+- (void)notify:(MXEvent*)event direction:(MXTimelineDirection)direction andCustomObject:(id)customObject;
 
 @property (nonatomic, readonly) id sender;
 @property (nonatomic, readonly) NSArray* eventTypes;

--- a/MatrixSDK/Data/MXEventListener.m
+++ b/MatrixSDK/Data/MXEventListener.m
@@ -37,7 +37,7 @@
     return self;
 }
 
-- (void)notify:(MXEvent*)event direction:(MXEventDirection)direction andCustomObject:(id)customObject
+- (void)notify:(MXEvent*)event direction:(MXTimelineDirection)direction andCustomObject:(id)customObject
 {
     // Check if the event match with eventTypes
     BOOL match = NO;

--- a/MatrixSDK/Data/MXEventTimeline.h
+++ b/MatrixSDK/Data/MXEventTimeline.h
@@ -18,10 +18,22 @@
 
 #import "MXEvent.h"
 #import "MXJSONModels.h"
-#import "MXRoomMember.h"
-#import "MXEventListener.h"
 #import "MXRoomState.h"
 #import "MXHTTPOperation.h"
+
+/**
+ The direction of an event in the timeline.
+ */
+typedef enum : NSUInteger
+{
+    // Forwards when the event is added to the end of the timeline.
+    // These events come from the /sync stream or from forwards pagination.
+    MXTimelineDirectionForwards,
+
+    // Backwards when the event is added to the start of the timeline.
+    // These events come from a back pagination.
+    MXTimelineDirectionBackwards
+} MXTimelineDirection;
 
 /**
  Prefix used to build fake invite event.
@@ -36,7 +48,7 @@ FOUNDATION_EXPORT NSString *const kMXRoomInviteStateEventIdPrefix;
  @param direction the origin of the event.
  @param roomState the room state right before the event.
  */
-typedef void (^MXOnRoomEvent)(MXEvent *event, MXEventDirection direction, MXRoomState *roomState);
+typedef void (^MXOnRoomEvent)(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState);
 
 @class MXRoom;
 
@@ -102,11 +114,11 @@ typedef void (^MXOnRoomEvent)(MXEvent *event, MXEventDirection direction, MXRoom
  
  canPaginate in forward direction has no meaning for a live timeline.
 
- @param direction MXEventDirectionBackwards to check if we can paginate backwards.
-                  MXEventDirectionForwards to check if we can go forwards.
+ @param direction MXTimelineDirectionBackwards to check if we can paginate backwards.
+                  MXTimelineDirectionForwards to check if we can go forwards.
  @return true if we can paginate in the given direction.
  */
-- (BOOL)canPaginate:(MXEventDirection)direction;
+- (BOOL)canPaginate:(MXTimelineDirection)direction;
 
 /**
  Reset the pagination so that future calls to paginate start over from live or
@@ -121,7 +133,7 @@ typedef void (^MXOnRoomEvent)(MXEvent *event, MXEventDirection direction, MXRoom
  It is not possible to paginate forwards on a live timeline.
 
  @param numItems the number of items to get.
- @param direction `MXEventDirectionForwards` or `MXEventDirectionBackwards`
+ @param direction `MXTimelineDirectionForwards` or `MXTimelineDirectionBackwards`
  @param onlyFromStore if YES, return available events from the store, do not make
                       a pagination request to the homeserver.
 
@@ -132,7 +144,7 @@ typedef void (^MXOnRoomEvent)(MXEvent *event, MXEventDirection direction, MXRoom
          to the homeserver is required.
  */
 - (MXHTTPOperation*)paginate:(NSUInteger)numItems
-                   direction:(MXEventDirection)direction
+                   direction:(MXTimelineDirection)direction
                onlyFromStore:(BOOL)onlyFromStore
                     complete:(void (^)())complete
                      failure:(void (^)(NSError *error))failure;
@@ -198,6 +210,6 @@ typedef void (^MXOnRoomEvent)(MXEvent *event, MXEventDirection direction, MXRoom
  @param event the event to notify.
  @param the event direction.
  */
-- (void)notifyListeners:(MXEvent*)event direction:(MXEventDirection)direction;
+- (void)notifyListeners:(MXEvent*)event direction:(MXTimelineDirection)direction;
 
 @end

--- a/MatrixSDK/Data/MXRoom.h
+++ b/MatrixSDK/Data/MXRoom.h
@@ -479,7 +479,7 @@ FOUNDATION_EXPORT NSString *const kMXRoomSyncWithLimitedTimelineNotification;
  @param the direction
  @param
  */
-- (BOOL)handleReceiptEvent:(MXEvent *)event direction:(MXEventDirection)direction;
+- (BOOL)handleReceiptEvent:(MXEvent *)event direction:(MXTimelineDirection)direction;
 
 /**
  Acknowlegde the latest event of type defined in acknowledgableEventTypes.

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -128,16 +128,16 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
             MXJSONModelSetArray(_typingUsers, event.content[@"user_ids"]);
 
             // Notify listeners
-            [_liveTimeline notifyListeners:event direction:MXEventDirectionForwards];
+            [_liveTimeline notifyListeners:event direction:MXTimelineDirectionForwards];
         }
         else if (event.eventType == MXEventTypeReceipt)
         {
-            [self handleReceiptEvent:event direction:MXEventDirectionForwards];
+            [self handleReceiptEvent:event direction:MXTimelineDirectionForwards];
         }
     }
 
     // Handle account data events (if any)
-    [self handleAccounDataEvents:roomSync.accountData.events direction:MXEventDirectionForwards];
+    [self handleAccounDataEvents:roomSync.accountData.events direction:MXTimelineDirectionForwards];
 }
 
 - (void)handleInvitedRoomSync:(MXInvitedRoomSync *)invitedRoomSync
@@ -152,9 +152,9 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
  Handle private user data events.
 
  @param accounDataEvents the events to handle.
- @param direction the process direction: MXEventDirectionSync or MXEventDirectionForwards. MXEventDirectionBackwards is not applicable here.
+ @param direction the process direction: MXTimelineDirectionSync or MXTimelineDirectionForwards. MXTimelineDirectionBackwards is not applicable here.
  */
-- (void)handleAccounDataEvents:(NSArray<MXEvent*>*)accounDataEvents direction:(MXEventDirection)direction
+- (void)handleAccounDataEvents:(NSArray<MXEvent*>*)accounDataEvents direction:(MXTimelineDirection)direction
 {
     for (MXEvent *event in accounDataEvents)
     {
@@ -430,7 +430,7 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
 
 #pragma mark - Read receipts management
 
-- (BOOL)handleReceiptEvent:(MXEvent *)event direction:(MXEventDirection)direction
+- (BOOL)handleReceiptEvent:(MXEvent *)event direction:(MXTimelineDirection)direction
 {
     BOOL managedEvents = false;
     

--- a/MatrixSDK/Data/MXSessionEventListener.h
+++ b/MatrixSDK/Data/MXSessionEventListener.h
@@ -30,7 +30,7 @@
  @param customObject additional contect for the event. In case of room event, customObject is a
                      RoomState instance. In the case of a presence, customObject is nil.
  */
-typedef void (^MXOnSessionEvent)(MXEvent *event, MXEventDirection direction, id customObject);
+typedef void (^MXOnSessionEvent)(MXEvent *event, MXTimelineDirection direction, id customObject);
 
 /**
  The `MXSessionEventListener` class stores information about a listener to MXSession events

--- a/MatrixSDK/Data/MXSessionEventListener.m
+++ b/MatrixSDK/Data/MXSessionEventListener.m
@@ -45,7 +45,7 @@
     if (![roomEventListeners objectForKey:room.state.roomId])
     {
         roomEventListeners[room.state.roomId] =
-        [room.liveTimeline listenToEventsOfTypes:self.eventTypes onEvent:^(MXEvent *event, MXEventDirection direction, MXRoomState *roomState) {
+        [room.liveTimeline listenToEventsOfTypes:self.eventTypes onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
             self.listenerBlock(event, direction, roomState);
         }];
     }

--- a/MatrixSDK/Data/Store/MXCoreDataStore/MXCoreDataRoom.h
+++ b/MatrixSDK/Data/Store/MXCoreDataStore/MXCoreDataRoom.h
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param event the MXEvent object to store.
  @param direction the origin of the event. Live or past events.
  */
-- (void)storeEvent:(MXEvent*)event direction:(MXEventDirection)direction;
+- (void)storeEvent:(MXEvent*)event direction:(MXTimelineDirection)direction;
 
 /**
  Replace room event (used in case of redaction for example).

--- a/MatrixSDK/Data/Store/MXCoreDataStore/MXCoreDataRoom.m
+++ b/MatrixSDK/Data/Store/MXCoreDataStore/MXCoreDataRoom.m
@@ -40,7 +40,7 @@
     return self;
 }
 
-- (void)storeEvent:(MXEvent *)event direction:(MXEventDirection)direction
+- (void)storeEvent:(MXEvent *)event direction:(MXTimelineDirection)direction
 {
 	// Convert Mantle MXEvent object to MXCoreDataEvent
     MXCoreDataEvent *cdEvent = [self coreDataEventFromEvent:event];
@@ -50,7 +50,7 @@
     // from working
     //cdEvent.room = self;
 
-    if (MXEventDirectionForwards == direction)
+    if (MXTimelineDirectionForwards == direction)
     {
         [self addMessagesObject:cdEvent];
     }

--- a/MatrixSDK/Data/Store/MXCoreDataStore/MXCoreDataStore.m
+++ b/MatrixSDK/Data/Store/MXCoreDataStore/MXCoreDataStore.m
@@ -183,7 +183,7 @@ NSString *const kMXCoreDataStoreFolder = @"MXCoreDataStore";
 
 
 #pragma mark - MXStore
-- (void)storeEventForRoom:(NSString*)roomId event:(MXEvent*)event direction:(MXEventDirection)direction
+- (void)storeEventForRoom:(NSString*)roomId event:(MXEvent*)event direction:(MXTimelineDirection)direction
 {
     //NSDate *startDate = [NSDate date];
 

--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
@@ -230,7 +230,7 @@ NSString *const kMXReceiptsFolder = @"receipts";
 
 
 #pragma mark - MXStore
-- (void)storeEventForRoom:(NSString*)roomId event:(MXEvent*)event direction:(MXEventDirection)direction
+- (void)storeEventForRoom:(NSString*)roomId event:(MXEvent*)event direction:(MXTimelineDirection)direction
 {
     [super storeEventForRoom:roomId event:event direction:direction];
 

--- a/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryRoomStore.h
+++ b/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryRoomStore.h
@@ -40,7 +40,7 @@
  @param event the MXEvent object to store.
  @param direction the origin of the event. Live or past events.
  */
-- (void)storeEvent:(MXEvent*)event direction:(MXEventDirection)direction;
+- (void)storeEvent:(MXEvent*)event direction:(MXTimelineDirection)direction;
 
 /**
  Replace room event (used in case of redaction for example).

--- a/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryRoomStore.m
+++ b/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryRoomStore.m
@@ -39,9 +39,9 @@
     return self;
 }
 
-- (void)storeEvent:(MXEvent *)event direction:(MXEventDirection)direction
+- (void)storeEvent:(MXEvent *)event direction:(MXTimelineDirection)direction
 {
-    if (MXEventDirectionForwards == direction)
+    if (MXTimelineDirectionForwards == direction)
     {
         [messages addObject:event];
     }

--- a/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryStore.m
+++ b/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryStore.m
@@ -47,7 +47,7 @@
     onComplete();
 }
 
-- (void)storeEventForRoom:(NSString*)roomId event:(MXEvent*)event direction:(MXEventDirection)direction
+- (void)storeEventForRoom:(NSString*)roomId event:(MXEvent*)event direction:(MXTimelineDirection)direction
 {
     MXMemoryRoomStore *roomStore = [self getOrCreateRoomStore:roomId];
     [roomStore storeEvent:event direction:direction];

--- a/MatrixSDK/Data/Store/MXNoStore/MXNoStore.m
+++ b/MatrixSDK/Data/Store/MXNoStore/MXNoStore.m
@@ -57,7 +57,7 @@
     onComplete();
 }
 
-- (void)storeEventForRoom:(NSString*)roomId event:(MXEvent*)event direction:(MXEventDirection)direction
+- (void)storeEventForRoom:(NSString*)roomId event:(MXEvent*)event direction:(MXTimelineDirection)direction
 {
     // Store nothing in the MXNoStore except the last message
     if (nil == lastMessages[roomId])
@@ -65,7 +65,7 @@
         // If there not yet a last message, store anything
         lastMessages[roomId] = event;
     }
-    else if (MXEventDirectionForwards == direction)
+    else if (MXTimelineDirectionForwards == direction)
     {
         // Else keep always the latest one
         lastMessages[roomId] = event;

--- a/MatrixSDK/Data/Store/MXStore.h
+++ b/MatrixSDK/Data/Store/MXStore.h
@@ -16,6 +16,7 @@
 
 #import "MXJSONModels.h"
 #import "MXEvent.h"
+#import "MXEventTimeline.h"
 #import "MXReceiptData.h"
 #import "MXRoomAccountData.h"
 
@@ -49,7 +50,7 @@
  @param event the MXEvent object to store.
  @param direction the origin of the event. Live or past events.
  */
-- (void)storeEventForRoom:(NSString*)roomId event:(MXEvent*)event direction:(MXEventDirection)direction;
+- (void)storeEventForRoom:(NSString*)roomId event:(MXEvent*)event direction:(MXTimelineDirection)direction;
 
 /**
  Replace a room event (in case of redaction for example).

--- a/MatrixSDK/JSONModels/MXEvent.h
+++ b/MatrixSDK/JSONModels/MXEvent.h
@@ -131,13 +131,7 @@ typedef enum : NSUInteger
     MXEventDirectionForwards,
 
     // Backwards for old events requested through pagination
-    MXEventDirectionBackwards,
-
-    // Sync for events coming from an initialSync API request to the home server
-    // The SDK internally makes such requests when the app call [MXSession start],
-    // [MXSession joinRoom] and [MXRoom join].
-    MXEventDirectionSync
-
+    MXEventDirectionBackwards
 } MXEventDirection;
 
 

--- a/MatrixSDK/JSONModels/MXEvent.h
+++ b/MatrixSDK/JSONModels/MXEvent.h
@@ -123,19 +123,6 @@ FOUNDATION_EXPORT uint64_t const kMXUndefinedTimestamp;
 
 
 /**
- The direction from which an incoming event is considered.
- */
-typedef enum : NSUInteger
-{
-    // Forwards for events coming down the live event stream
-    MXEventDirectionForwards,
-
-    // Backwards for old events requested through pagination
-    MXEventDirectionBackwards
-} MXEventDirection;
-
-
-/**
  `MXEvent` is the generic model of events received from the home server.
 
  It contains all possible keys an event can contain. Thus, all events can be resolved 

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -602,7 +602,7 @@ typedef void (^MXOnResumeDone)();
         // Handle presence of other users
         for (MXEvent *presenceEvent in syncResponse.presence.events)
         {
-            [self handlePresenceEvent:presenceEvent direction:MXEventDirectionSync];
+            [self handlePresenceEvent:presenceEvent direction:MXEventDirectionForwards];
         }
         
         // Update live event stream token
@@ -1276,7 +1276,7 @@ typedef void (^MXOnResumeDone)();
             // 2 - perform an initial sync when the join method call the success callback
             // 3 - receive the join event in the live stream -> this method is not called because the event has already been stored in the step 2
             // so, we need to manage the sync direction
-            if ((MXEventDirectionForwards == direction) || (MXEventDirectionSync == direction))
+            if (MXEventDirectionForwards == direction)
             {
                 BOOL notify = NO;
                 MXRoomState *roomPrevState = (MXRoomState *)customObject;

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -315,7 +315,7 @@ typedef void (^MXOnResumeDone)();
     }
 }
 
-- (void)handlePresenceEvent:(MXEvent *)event direction:(MXEventDirection)direction
+- (void)handlePresenceEvent:(MXEvent *)event direction:(MXTimelineDirection)direction
 {
     // Update MXUser with presence data
     NSString *userId = event.sender;
@@ -602,7 +602,7 @@ typedef void (^MXOnResumeDone)();
         // Handle presence of other users
         for (MXEvent *presenceEvent in syncResponse.presence.events)
         {
-            [self handlePresenceEvent:presenceEvent direction:MXEventDirectionForwards];
+            [self handlePresenceEvent:presenceEvent direction:MXTimelineDirectionForwards];
         }
         
         // Update live event stream token
@@ -1262,9 +1262,9 @@ typedef void (^MXOnResumeDone)();
         [invitedRooms sortUsingSelector:@selector(compareOriginServerTs:)];
 
         // Add a listener in order to update the app about invitation list change
-        [self listenToEventsOfTypes:@[kMXEventTypeStringRoomMember] onEvent:^(MXEvent *event, MXEventDirection direction, id customObject) {
+        [self listenToEventsOfTypes:@[kMXEventTypeStringRoomMember] onEvent:^(MXEvent *event, MXTimelineDirection direction, id customObject) {
 
-            // in some race conditions the oneself join event is received during the sync instead of MXEventDirectionSync
+            // in some race conditions the oneself join event is received during the sync instead of MXTimelineDirectionSync
             //
             // standard case
             // 1 - send a join request
@@ -1276,7 +1276,7 @@ typedef void (^MXOnResumeDone)();
             // 2 - perform an initial sync when the join method call the success callback
             // 3 - receive the join event in the live stream -> this method is not called because the event has already been stored in the step 2
             // so, we need to manage the sync direction
-            if (MXEventDirectionForwards == direction)
+            if (MXTimelineDirectionForwards == direction)
             {
                 BOOL notify = NO;
                 MXRoomState *roomPrevState = (MXRoomState *)customObject;
@@ -1539,7 +1539,7 @@ typedef void (^MXOnResumeDone)();
     }
 }
 
-- (void)notifyListeners:(MXEvent*)event direction:(MXEventDirection)direction
+- (void)notifyListeners:(MXEvent*)event direction:(MXTimelineDirection)direction
 {
     // Notify all listeners
     // The SDK client may remove a listener while calling them by enumeration

--- a/MatrixSDK/NotificationCenter/MXNotificationCenter.m
+++ b/MatrixSDK/NotificationCenter/MXNotificationCenter.m
@@ -88,9 +88,9 @@ NSString *const kMXNotificationCenterAllOtherRoomMessagesRuleID = @".m.rule.mess
 
 
         // Catch all live events sent from other users to check if we need to notify them
-        [mxSession listenToEvents:^(MXEvent *event, MXEventDirection direction, id customObject) {
+        [mxSession listenToEvents:^(MXEvent *event, MXTimelineDirection direction, id customObject) {
 
-            if (MXEventDirectionForwards == direction
+            if (MXTimelineDirectionForwards == direction
                 && NO == [event.sender isEqualToString:mxSession.matrixRestClient.credentials.userId])
             {
                 [self shouldNotify:event roomState:customObject];

--- a/MatrixSDK/VoIP/MXCallManager.m
+++ b/MatrixSDK/VoIP/MXCallManager.m
@@ -65,9 +65,9 @@ NSString *const kMXCallManagerFallbackSTUNServer = @"stun:stun.l.google.com:1930
                                                                 kMXEventTypeStringCallAnswer,
                                                                 kMXEventTypeStringCallHangup
                                                                 ]
-                                                      onEvent:^(MXEvent *event, MXEventDirection direction, id customObject) {
+                                                      onEvent:^(MXEvent *event, MXTimelineDirection direction, id customObject) {
 
-            if (MXEventDirectionForwards == direction)
+            if (MXTimelineDirectionForwards == direction)
             {
                 switch (event.eventType)
                 {

--- a/MatrixSDKTests/MXEventTests.m
+++ b/MatrixSDKTests/MXEventTests.m
@@ -111,7 +111,7 @@
             
             
             __block NSUInteger eventCount = 0;
-            [room.liveTimeline listenToEventsOfTypes:@[kMXEventTypeStringRoomMessage] onEvent:^(MXEvent *event, MXEventDirection direction, MXRoomState *roomState) {
+            [room.liveTimeline listenToEventsOfTypes:@[kMXEventTypeStringRoomMessage] onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
                 
                 eventCount++;
                 XCTAssertFalse(event.isState, "Room messages are not states. message: %@", event);
@@ -119,7 +119,7 @@
             }];
             
             [room.liveTimeline resetPagination];
-            [room.liveTimeline paginate:100 direction:MXEventDirectionBackwards onlyFromStore:NO complete:^() {
+            [room.liveTimeline paginate:100 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^() {
                 
                 XCTAssertGreaterThan(eventCount, 0, "We should have received events in registerEventListenerForTypes");
                 

--- a/MatrixSDKTests/MXNotificationCenterTests.m
+++ b/MatrixSDKTests/MXNotificationCenterTests.m
@@ -149,7 +149,7 @@
         mxSession = bobSession;
 
         MXRoom *room = [mxSession roomWithRoomId:roomId];
-        [room.liveTimeline listenToEventsOfTypes:@[kMXEventTypeStringRoomMember] onEvent:^(MXEvent *event, MXEventDirection direction, MXRoomState *roomState) {
+        [room.liveTimeline listenToEventsOfTypes:@[kMXEventTypeStringRoomMember] onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
 
             [bobSession.notificationCenter listenToNotifications:^(MXEvent *event, MXRoomState *roomState, MXPushRule *rule) {
 
@@ -185,7 +185,7 @@
         mxSession = bobSession;
 
         MXRoom *room = [mxSession roomWithRoomId:roomId];
-        [room.liveTimeline listenToEventsOfTypes:@[kMXEventTypeStringRoomMember] onEvent:^(MXEvent *event, MXEventDirection direction, MXRoomState *roomState) {
+        [room.liveTimeline listenToEventsOfTypes:@[kMXEventTypeStringRoomMember] onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
 
             NSString *messageFromAlice = [NSString stringWithFormat:@"%@: you should be notified for this message", bobSession.matrixRestClient.credentials.userId];
 
@@ -346,9 +346,9 @@
 
                 NSString *messageFromBob = @"Aalliiccee: where are you?";
 
-                [aliceSession listenToEventsOfTypes:@[kMXEventTypeStringRoomMessage] onEvent:^(MXEvent *event, MXEventDirection direction, id customObject) {
+                [aliceSession listenToEventsOfTypes:@[kMXEventTypeStringRoomMessage] onEvent:^(MXEvent *event, MXTimelineDirection direction, id customObject) {
 
-                    if (MXEventDirectionForwards == direction)
+                    if (MXTimelineDirectionForwards == direction)
                     {
                         MXPushRule *rule = [aliceSession.notificationCenter ruleMatchingEvent:event];
 

--- a/MatrixSDKTests/MXRestClientTests.m
+++ b/MatrixSDKTests/MXRestClientTests.m
@@ -942,7 +942,7 @@
         NSString *message = [[NSProcessInfo processInfo] globallyUniqueString];
         __block NSString *messageEventId;
 
-        [mxSession listenToEventsOfTypes:@[kMXEventTypeStringRoomMessage] onEvent:^(MXEvent *event, MXEventDirection direction, id customObject) {
+        [mxSession listenToEventsOfTypes:@[kMXEventTypeStringRoomMessage] onEvent:^(MXEvent *event, MXTimelineDirection direction, id customObject) {
 
             [mxSession.matrixRestClient searchMessageText:message
                                                   inRooms:nil

--- a/MatrixSDKTests/MXRoomStateDynamicTests.m
+++ b/MatrixSDKTests/MXRoomStateDynamicTests.m
@@ -111,7 +111,7 @@
                 MXRoom *room = [mxSession roomWithRoomId:roomId];
                 
                 __block NSUInteger eventCount = 0;
-                [room.liveTimeline listenToEventsOfTypes:nil onEvent:^(MXEvent *event, MXEventDirection direction, MXRoomState *roomState) {
+                [room.liveTimeline listenToEventsOfTypes:nil onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
                     
                     // Check each expected event and their roomState contect
                     // Events are received in the reverse order
@@ -163,7 +163,7 @@
                 }];
                 
                 [room.liveTimeline resetPagination];
-                [room.liveTimeline paginate:10 direction:MXEventDirectionBackwards onlyFromStore:NO complete:^{
+                [room.liveTimeline paginate:10 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^{
                     
                     XCTAssertGreaterThan(eventCount, 4, @"We must have received events");
                     
@@ -195,7 +195,7 @@
             MXRoom *room = [mxSession roomWithRoomId:roomId];
             
             __block NSUInteger eventCount = 0;
-            [room.liveTimeline listenToEventsOfTypes:nil onEvent:^(MXEvent *event, MXEventDirection direction, MXRoomState *roomState) {
+            [room.liveTimeline listenToEventsOfTypes:nil onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
                 
                 // Check each expected event and their roomState contect
                 // Events are live. Then comes in order
@@ -371,7 +371,7 @@
                 NSAssert(room, @"The room is required");
 
                 __block NSUInteger eventCount = 0;
-                [room listenToEventsOfTypes:nil onEvent:^(MXEvent *event, MXEventDirection direction, MXRoomState *roomState) {
+                [room listenToEventsOfTypes:nil onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
 
                     NSLog(@"eventCount: %tu - %@", eventCount, event);
                     
@@ -517,7 +517,7 @@
                 }];
                 
                 [room.liveTimeline resetPagination];
-                [room.liveTimeline paginate:2 direction:MXEventDirectionBackwards0 complete:^{
+                [room.liveTimeline paginate:2 direction:MXTimelineDirectionBackwards0 complete:^{
                     
                     XCTAssertGreaterThan(eventCount, 8, @"We must have received events");
                     
@@ -549,7 +549,7 @@
             MXRoom *room = [mxSession roomWithRoomId:roomId];
             
             __block NSUInteger eventCount = 0;
-            [room listenToEventsOfTypes:nil onEvent:^(MXEvent *event, MXEventDirection direction, MXRoomState *roomState) {
+            [room listenToEventsOfTypes:nil onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
                 
                 MXRoomMember *beforeEventAliceMember = [roomState memberWithUserId:matrixSDKTestsData.aliceCredentials.userId];
                 MXRoomMember *aliceMember = [room.state memberWithUserId:matrixSDKTestsData.aliceCredentials.userId];

--- a/MatrixSDKTests/MXRoomStateTests.m
+++ b/MatrixSDKTests/MXRoomStateTests.m
@@ -123,7 +123,7 @@
             XCTAssertNil(room.state.topic, @"There must be no room topic yet. Found: %@", room.state.topic);
             
             // Listen to live event. We should receive only one: a m.room.topic event
-            [room.liveTimeline listenToEventsOfTypes:nil onEvent:^(MXEvent *event, MXEventDirection direction, MXRoomState *roomState) {
+            [room.liveTimeline listenToEventsOfTypes:nil onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
                 
                 XCTAssertEqual(event.eventType, MXEventTypeRoomTopic);
                 
@@ -196,7 +196,7 @@
             XCTAssertNil(room.state.avatar, @"There must be no room avatar yet. Found: %@", room.state.avatar);
 
             // Listen to live event. We should receive only one: a m.room.avatar event
-            [room.liveTimeline listenToEventsOfTypes:nil onEvent:^(MXEvent *event, MXEventDirection direction, MXRoomState *roomState) {
+            [room.liveTimeline listenToEventsOfTypes:nil onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
 
                 XCTAssertEqual(event.eventType, MXEventTypeRoomAvatar);
 
@@ -268,7 +268,7 @@
             XCTAssertNil(room.state.name, @"There must be no room name yet. Found: %@", room.state.name);
             
             // Listen to live event. We should receive only one: a m.room.name event
-            [room.liveTimeline listenToEventsOfTypes:nil onEvent:^(MXEvent *event, MXEventDirection direction, MXRoomState *roomState) {
+            [room.liveTimeline listenToEventsOfTypes:nil onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
                 
                 XCTAssertEqual(event.eventType, MXEventTypeRoomName);
                 
@@ -523,7 +523,7 @@
                 
                 __block MXRoom *newRoom;
                 
-                [mxSession listenToEvents:^(MXEvent *event, MXEventDirection direction, id customObject) {
+                [mxSession listenToEvents:^(MXEvent *event, MXTimelineDirection direction, id customObject) {
                     
                     if ([event.roomId isEqualToString:roomId])
                     {
@@ -588,8 +588,8 @@
                     
                     MXRoom *newRoom = [mxSession roomWithRoomId:roomId];
                     
-                    [newRoom.liveTimeline listenToEvents:^(MXEvent *event, MXEventDirection direction, MXRoomState *roomState) {
-                        if (MXEventDirectionForwards == event)
+                    [newRoom.liveTimeline listenToEvents:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
+                        if (MXTimelineDirectionForwards == event)
                         {
                             // We should receive only join events in live
                             XCTAssertEqual(event.eventType, MXEventTypeRoomMember);
@@ -599,9 +599,9 @@
                         }
                     }];
                     
-                    [mxSession listenToEvents:^(MXEvent *event, MXEventDirection direction, id customObject) {
+                    [mxSession listenToEvents:^(MXEvent *event, MXTimelineDirection direction, id customObject) {
                         // Except presence, we should receive only join events in live
-                        if (MXEventDirectionForwards == event && MXEventTypePresence != event.eventType)
+                        if (MXTimelineDirectionForwards == event && MXEventTypePresence != event.eventType)
                         {
                             XCTAssertEqual(event.eventType, MXEventTypeRoomMember);
                             
@@ -761,9 +761,9 @@
 
             __block NSString *newRoomId;
             NSMutableArray *receivedMessages = [NSMutableArray array];
-            [mxSession listenToEventsOfTypes:@[kMXEventTypeStringRoomMessage] onEvent:^(MXEvent *event, MXEventDirection direction, id customObject) {
+            [mxSession listenToEventsOfTypes:@[kMXEventTypeStringRoomMessage] onEvent:^(MXEvent *event, MXTimelineDirection direction, id customObject) {
 
-                if (MXEventDirectionForwards == direction && [event.roomId isEqualToString:newRoomId])
+                if (MXTimelineDirectionForwards == direction && [event.roomId isEqualToString:newRoomId])
                 {
                     [receivedMessages addObject:event];
                 }

--- a/MatrixSDKTests/MXRoomTests.m
+++ b/MatrixSDKTests/MXRoomTests.m
@@ -74,9 +74,9 @@
         };
         
         // Register the listener
-        [room.liveTimeline listenToEvents:^(MXEvent *event, MXEventDirection direction, MXRoomState *roomState) {
+        [room.liveTimeline listenToEvents:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
             
-            XCTAssertEqual(direction, MXEventDirectionForwards);
+            XCTAssertEqual(direction, MXTimelineDirectionForwards);
             
             XCTAssertEqual(event.eventType, MXEventTypeRoomMessage);
             
@@ -129,9 +129,9 @@
         
         // Register the listener for m.room.message.only
         [room.liveTimeline listenToEventsOfTypes:@[kMXEventTypeStringRoomMessage]
-                                          onEvent:^(MXEvent *event, MXEventDirection direction, MXRoomState *roomState) {
+                                          onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
             
-            XCTAssertEqual(direction, MXEventDirectionForwards);
+            XCTAssertEqual(direction, MXTimelineDirectionForwards);
             
             XCTAssertEqual(event.eventType, MXEventTypeRoomMessage);
                                               
@@ -170,7 +170,7 @@
         NSString *roomId = room.state.roomId;
 
         __block MXMembership lastKnownMembership = MXMembershipUnknown;
-        [room.liveTimeline listenToEventsOfTypes:@[kMXEventTypeStringRoomMember] onEvent:^(MXEvent *event, MXEventDirection direction, MXRoomState *roomState) {
+        [room.liveTimeline listenToEventsOfTypes:@[kMXEventTypeStringRoomMember] onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
 
             lastKnownMembership = room.state.membership;
         }];
@@ -242,7 +242,7 @@
 
             MXRoom *room = [mxSession roomWithRoomId:roomId];
 
-            [room.liveTimeline listenToEventsOfTypes:@[kMXEventTypeStringRoomPowerLevels] onEvent:^(MXEvent *event, MXEventDirection direction, MXRoomState *roomState) {
+            [room.liveTimeline listenToEventsOfTypes:@[kMXEventTypeStringRoomPowerLevels] onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
 
                 XCTAssertEqual([room.state.powerLevels powerLevelOfUserWithUserID:aliceRestClient.credentials.userId], 36);
 
@@ -273,7 +273,7 @@
             MXRoom *room = [mxSession roomWithRoomId:roomId];
 
             __block NSUInteger eventCount = 0;
-            [room.liveTimeline listenToEvents:^(MXEvent *event, MXEventDirection direction, MXRoomState *roomState) {
+            [room.liveTimeline listenToEvents:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
 
                 eventCount++;
                 XCTFail(@"We should not receive events. Received: %@", event);
@@ -281,7 +281,7 @@
             }];
 
             [room.liveTimeline resetPagination];
-            MXHTTPOperation *pagination = [room.liveTimeline paginate:100 direction:MXEventDirectionBackwards onlyFromStore:NO complete:^() {
+            MXHTTPOperation *pagination = [room.liveTimeline paginate:100 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^() {
 
                 XCTFail(@"The cancelled operation must not complete");
                 [expectation fulfill];
@@ -313,7 +313,7 @@
 
             XCTAssertEqual(room.typingUsers.count, 0);
 
-            [room.liveTimeline listenToEventsOfTypes:@[kMXEventTypeStringTypingNotification] onEvent:^(MXEvent *event, MXEventDirection direction, MXRoomState *roomState) {
+            [room.liveTimeline listenToEventsOfTypes:@[kMXEventTypeStringTypingNotification] onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
 
                 XCTAssertEqual(room.typingUsers.count, 1);
                 XCTAssertEqualObjects(room.typingUsers[0], bobRestClient.credentials.userId);
@@ -345,7 +345,7 @@
         __block NSUInteger tagEventUpdata = 0;
 
         // Wait for the m.tag event to get the room tags update
-        [room.liveTimeline listenToEventsOfTypes:@[kMXEventTypeStringRoomTag] onEvent:^(MXEvent *event, MXEventDirection direction, MXRoomState *roomState) {
+        [room.liveTimeline listenToEventsOfTypes:@[kMXEventTypeStringRoomTag] onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
 
             if (++tagEventUpdata == 1)
             {
@@ -391,7 +391,7 @@
         NSString *newTagOrder = nil;
 
         // Wait for the m.tag event that corresponds to "newTag"
-        [room.liveTimeline listenToEventsOfTypes:@[kMXEventTypeStringRoomTag] onEvent:^(MXEvent *event, MXEventDirection direction, MXRoomState *roomState) {
+        [room.liveTimeline listenToEventsOfTypes:@[kMXEventTypeStringRoomTag] onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
 
             MXRoomTag *newRoomTag = room.accountData.tags[newTag];
             if (newRoomTag)

--- a/MatrixSDKTests/MXSessionTests.m
+++ b/MatrixSDKTests/MXSessionTests.m
@@ -264,35 +264,6 @@
     }];
 }
 
-- (void)testListenerForSyncEvents
-{
-    [matrixSDKTestsData doMXRestClientTestWihBobAndSeveralRoomsAndMessages:self readyToTest:^(MXRestClient *bobRestClient, XCTestExpectation *expectation) {
-        
-        mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
-        
-        __block NSUInteger eventCount = 0;
-        
-        // Listen to events received during rooms state sync
-        [mxSession listenToEvents:^(MXEvent *event, MXEventDirection direction, id customObject) {
-                                     
-                                     eventCount++;
-                                     
-                                     XCTAssertEqual(direction, MXEventDirectionSync);
-                                     
-                                 }];
-        
-        
-        // Create a room with messages in parallel
-        [mxSession startWithMessagesLimit:0 onServerSyncDone:^{
-            
-            XCTAssertGreaterThan(eventCount, 0);
-            [expectation fulfill];
-            
-        } failure:^(NSError *error) {
-            NSAssert(NO, @"Cannot set up intial test conditions - error: %@", error);
-        }];
-    }];
-}
 
 /* Disabled as lastActiveAgo events sent by the HS are less accurate than before
 - (void)testListenerForPresence

--- a/MatrixSDKTests/MXSessionTests.m
+++ b/MatrixSDKTests/MXSessionTests.m
@@ -177,9 +177,9 @@
         __block NSString *eventsRoomId;
         __block BOOL testDone = NO;
 
-        [mxSession listenToEvents:^(MXEvent *event, MXEventDirection direction, id customObject) {
+        [mxSession listenToEvents:^(MXEvent *event, MXTimelineDirection direction, id customObject) {
 
-            if (MXEventDirectionForwards == direction)
+            if (MXTimelineDirectionForwards == direction)
             {
                 if (event.roomId && event.eventId)
                 {
@@ -237,9 +237,9 @@
         // We should not see events coming before (m.room.create, and all state events)
         __block NSInteger messagesCount = 0;
         [mxSession listenToEventsOfTypes:@[kMXEventTypeStringRoomMessage]
-                                            onEvent:^(MXEvent *event, MXEventDirection direction, id customObject) {
+                                            onEvent:^(MXEvent *event, MXTimelineDirection direction, id customObject) {
             
-            if (MXEventDirectionForwards == direction)
+            if (MXTimelineDirectionForwards == direction)
             {
                 XCTAssertEqual(event.eventType, MXEventTypeRoomMessage, @"We must receive only m.room.message event - Event: %@", event);
 
@@ -277,9 +277,9 @@
         __block NSUInteger lastAliceActivity = -1;
         
         // Listen to m.presence only
-        [mxSession listenToEventsOfTypes:@[kMXEventTypeStringPresence] onEvent:^(MXEvent *event, MXEventDirection direction, id customObject) {
+        [mxSession listenToEventsOfTypes:@[kMXEventTypeStringPresence] onEvent:^(MXEvent *event, MXTimelineDirection direction, id customObject) {
 
-            if (MXEventDirectionForwards == direction)
+            if (MXTimelineDirectionForwards == direction)
             {
                 XCTAssertEqual(event.eventType, MXEventTypePresence, @"We must receive only m.presence - Event: %@", event);
 
@@ -331,13 +331,13 @@
 
         [mxSession start:^{
 
-            [mxSession listenToEvents:^(MXEvent *event, MXEventDirection direction, id customObject) {
+            [mxSession listenToEvents:^(MXEvent *event, MXTimelineDirection direction, id customObject) {
                 XCTFail(@"We should not receive events after closing the session. Received: %@", event);
             }];
 
             MXRoom *room = [mxSession roomWithRoomId:roomId];
             XCTAssert(room);
-            [room.liveTimeline listenToEvents:^(MXEvent *event, MXEventDirection direction, MXRoomState *roomState) {
+            [room.liveTimeline listenToEvents:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
                 XCTFail(@"We should not receive events after closing the session. Received: %@", event);
             }];
 
@@ -432,13 +432,13 @@
                 __block BOOL paused = NO;
                 __block NSInteger eventCount = 0;
 
-                [mxSession listenToEvents:^(MXEvent *event, MXEventDirection direction, id customObject) {
+                [mxSession listenToEvents:^(MXEvent *event, MXTimelineDirection direction, id customObject) {
                     eventCount++;
                     XCTAssertFalse(paused, @"We should not receive events when paused. Received: %@", event);
                 }];
 
                 MXRoom *room = [mxSession roomWithRoomId:roomId];
-                [room.liveTimeline listenToEvents:^(MXEvent *event, MXEventDirection direction, MXRoomState *roomState) {
+                [room.liveTimeline listenToEvents:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
                     eventCount++;
                     XCTAssertFalse(paused, @"We should not receive events when paused. Received: %@", event);
                 }];
@@ -499,13 +499,13 @@
                 __block BOOL paused = NO;
                 __block NSInteger eventCount = 0;
 
-                [mxSession listenToEvents:^(MXEvent *event, MXEventDirection direction, id customObject) {
+                [mxSession listenToEvents:^(MXEvent *event, MXTimelineDirection direction, id customObject) {
                     eventCount++;
                     XCTAssertFalse(paused, @"We should not receive events when paused. Received: %@", event);
                 }];
 
                 MXRoom *room = [mxSession roomWithRoomId:roomId];
-                [room.liveTimeline listenToEvents:^(MXEvent *event, MXEventDirection direction, MXRoomState *roomState) {
+                [room.liveTimeline listenToEvents:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
                     eventCount++;
                     XCTAssertFalse(paused, @"We should not receive events when paused. Received: %@", event);
                 }];

--- a/MatrixSDKTests/MXStoreMemoryStoreTests.m
+++ b/MatrixSDKTests/MXStoreMemoryStoreTests.m
@@ -191,7 +191,7 @@
 
         __block NSUInteger eventCount = 0;
         __block MXEvent *firstEventInTheRoom;
-        [room.liveTimeline listenToEvents:^(MXEvent *event, MXEventDirection direction, MXRoomState *roomState) {
+        [room.liveTimeline listenToEvents:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
 
             eventCount++;
 
@@ -200,7 +200,7 @@
 
         // First make a call to paginateBackMessages that will make a request to the server
         [room.liveTimeline resetPagination];
-        [room.liveTimeline paginate:100 direction:MXEventDirectionBackwards onlyFromStore:NO complete:^{
+        [room.liveTimeline paginate:100 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^{
 
             XCTAssertEqual(firstEventInTheRoom.eventType, MXEventTypeRoomCreate, @"First event in a room is always m.room.create");
 
@@ -208,7 +208,7 @@
 
             __block NSUInteger eventCount2 = 0;
             __block MXEvent *firstEventInTheRoom2;
-            [room.liveTimeline listenToEvents:^(MXEvent *event, MXEventDirection direction, MXRoomState *roomState) {
+            [room.liveTimeline listenToEvents:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
 
                 eventCount2++;
 
@@ -216,7 +216,7 @@
             }];
 
             [room.liveTimeline resetPagination];
-            [room.liveTimeline paginate:100 direction:MXEventDirectionBackwards onlyFromStore:NO complete:^{
+            [room.liveTimeline paginate:100 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^{
 
                 XCTAssertEqual(eventCount, eventCount2);
                 XCTAssertEqual(firstEventInTheRoom2.eventType, MXEventTypeRoomCreate, @"First event in a room is always m.room.create");
@@ -245,7 +245,7 @@
         __block NSInteger paginateBackMessagesCallCount = 0;
 
         __block NSMutableArray *roomEvents = [NSMutableArray array];
-        [room.liveTimeline listenToEventsOfTypes:nil onEvent:^(MXEvent *event, MXEventDirection direction, MXRoomState *roomState) {
+        [room.liveTimeline listenToEventsOfTypes:nil onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
 
             XCTAssertEqual(paginateBackMessagesCallCount, 1, @"Messages must asynchronously come");
 
@@ -253,42 +253,42 @@
         }];
 
         [room.liveTimeline resetPagination];
-        [room.liveTimeline paginate:8 direction:MXEventDirectionBackwards onlyFromStore:NO complete:^() {
+        [room.liveTimeline paginate:8 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^() {
 
             [room.liveTimeline removeAllListeners];
 
             __block NSMutableArray *room2Events = [NSMutableArray array];
-            [room.liveTimeline listenToEventsOfTypes:nil onEvent:^(MXEvent *event, MXEventDirection direction, MXRoomState *roomState) {
+            [room.liveTimeline listenToEventsOfTypes:nil onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
 
                 [room2Events addObject:event];
 
                 if (room2Events.count <=2)
                 {
-                    XCTAssertEqual(paginateBackMessagesCallCount, 1, @"Messages for 'paginate:2 direction:MXEventDirectionBackwards' must synchronously come");
+                    XCTAssertEqual(paginateBackMessagesCallCount, 1, @"Messages for 'paginate:2 direction:MXTimelineDirectionBackwards' must synchronously come");
                 }
                 else if (room2Events.count <=7)
                 {
-                    XCTAssertEqual(paginateBackMessagesCallCount, 1, @"Messages for 'paginate:5 direction:MXEventDirectionBackwards' must synchronously come");
+                    XCTAssertEqual(paginateBackMessagesCallCount, 1, @"Messages for 'paginate:5 direction:MXTimelineDirectionBackwards' must synchronously come");
                 }
                 else if (room2Events.count <=8)
                 {
-                    XCTAssertEqual(paginateBackMessagesCallCount, 1, @"The first messages for 'paginate:100 direction:MXEventDirectionBackwards' must synchronously come");
+                    XCTAssertEqual(paginateBackMessagesCallCount, 1, @"The first messages for 'paginate:100 direction:MXTimelineDirectionBackwards' must synchronously come");
                 }
                 else
                 {
-                    XCTAssertEqual(paginateBackMessagesCallCount, 4, @"Other Messages for 'paginate:100 direction:MXEventDirectionBackwards' must ssynchronously come");
+                    XCTAssertEqual(paginateBackMessagesCallCount, 4, @"Other Messages for 'paginate:100 direction:MXTimelineDirectionBackwards' must ssynchronously come");
                 }
             }];
 
-            XCTAssertTrue([room.liveTimeline canPaginate:MXEventDirectionBackwards], @"There is still at least one event to retrieve from the server");
+            XCTAssertTrue([room.liveTimeline canPaginate:MXTimelineDirectionBackwards], @"There is still at least one event to retrieve from the server");
 
             // The several paginations
             [room.liveTimeline resetPagination];
-            [room.liveTimeline paginate:2 direction:MXEventDirectionBackwards onlyFromStore:NO complete:^() {
+            [room.liveTimeline paginate:2 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^() {
 
-                [room.liveTimeline paginate:5 direction:MXEventDirectionBackwards onlyFromStore:NO complete:^() {
+                [room.liveTimeline paginate:5 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^() {
 
-                    [room.liveTimeline paginate:100 direction:MXEventDirectionBackwards onlyFromStore:NO complete:^() {
+                    [room.liveTimeline paginate:100 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^() {
 
                         // Now, compare the result with the reference
                         XCTAssertEqual(roomEvents.count, 8);
@@ -304,14 +304,14 @@
                         }
 
                         // Do one more round trip so that SDK detect the limit
-                        [room.liveTimeline paginate:1 direction:MXEventDirectionBackwards onlyFromStore:NO complete:^{
+                        [room.liveTimeline paginate:1 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^{
 
                             XCTAssertEqual(roomEvents.count, 8, @"We should have not received more events");
 
-                            XCTAssertFalse([room.liveTimeline canPaginate:MXEventDirectionBackwards], @"We reach the beginning of the history");
+                            XCTAssertFalse([room.liveTimeline canPaginate:MXTimelineDirectionBackwards], @"We reach the beginning of the history");
 
                             [room.liveTimeline resetPagination];
-                            XCTAssertTrue([room.liveTimeline canPaginate:MXEventDirectionBackwards], @"We must be able to paginate again");
+                            XCTAssertTrue([room.liveTimeline canPaginate:MXTimelineDirectionBackwards], @"We must be able to paginate again");
 
                             [expectation fulfill];
 
@@ -356,7 +356,7 @@
     [self doTestWithMXMemoryStore:^(MXRoom *room) {
 
         [room.liveTimeline resetPagination];
-        [room.liveTimeline paginate:8 direction:MXEventDirectionBackwards onlyFromStore:NO complete:^() {
+        [room.liveTimeline paginate:8 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^() {
 
             MXEvent *lastMessage = [room lastMessageWithTypeIn:nil];
             XCTAssertEqual(lastMessage.eventType, MXEventTypeRoomMessage);

--- a/MatrixSDKTests/MXStoreTests.m
+++ b/MatrixSDKTests/MXStoreTests.m
@@ -198,7 +198,7 @@
                                                       @"user_id": @"userId:"
                                                       }];
 
-            [store storeEventForRoom:@"roomId" event:event direction:MXEventDirectionForwards];
+            [store storeEventForRoom:@"roomId" event:event direction:MXTimelineDirectionForwards];
 
             BOOL exists = [store eventExistsWithEventId:@"anID" inRoom:@"roomId"];
 
@@ -227,7 +227,7 @@
                                                       @"user_id": @"userId:"
                                                       }];
 
-            [store storeEventForRoom:@"roomId" event:event direction:MXEventDirectionForwards];
+            [store storeEventForRoom:@"roomId" event:event direction:MXTimelineDirectionForwards];
 
             MXEvent *storedEvent = [store eventWithEventId:@"anID" inRoom:@"roomId"];
 
@@ -252,13 +252,13 @@
                                          ];
 
     __block NSUInteger eventCount = 0;
-    [room.liveTimeline listenToEventsOfTypes:eventsFilterForMessages onEvent:^(MXEvent *event, MXEventDirection direction, MXRoomState *roomState) {
+    [room.liveTimeline listenToEventsOfTypes:eventsFilterForMessages onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
 
         eventCount++;
     }];
 
     [room.liveTimeline resetPagination];
-    [room.liveTimeline paginate:5 direction:MXEventDirectionBackwards onlyFromStore:NO complete:^() {
+    [room.liveTimeline paginate:5 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^() {
 
         XCTAssertEqual(eventCount, 5, @"We should get as many messages as requested");
 
@@ -280,7 +280,7 @@
                                          ];
 
     __block NSUInteger eventCount = 0;
-    [room.liveTimeline listenToEventsOfTypes:eventsFilterForMessages onEvent:^(MXEvent *event, MXEventDirection direction, MXRoomState *roomState) {
+    [room.liveTimeline listenToEventsOfTypes:eventsFilterForMessages onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
 
         eventCount++;
 
@@ -291,7 +291,7 @@
     }];
 
     [room.liveTimeline resetPagination];
-    [room.liveTimeline paginate:100 direction:MXEventDirectionBackwards onlyFromStore:NO complete:^() {
+    [room.liveTimeline paginate:100 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^() {
 
         XCTAssert(eventCount, "We should have received events in registerEventListenerForTypes");
 
@@ -313,7 +313,7 @@
                                          ];
 
     __block uint64_t prev_ts = -1;
-    [room.liveTimeline listenToEventsOfTypes:eventsFilterForMessages onEvent:^(MXEvent *event, MXEventDirection direction, MXRoomState *roomState) {
+    [room.liveTimeline listenToEventsOfTypes:eventsFilterForMessages onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
 
         XCTAssert(event.originServerTs, @"The event should have an attempt: %@", event);
 
@@ -323,7 +323,7 @@
     }];
 
     [room.liveTimeline resetPagination];
-    [room.liveTimeline paginate:100 direction:MXEventDirectionBackwards onlyFromStore:NO complete:^() {
+    [room.liveTimeline paginate:100 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^() {
 
         XCTAssertNotEqual(prev_ts, -1, "We should have received events in registerEventListenerForTypes");
 
@@ -339,7 +339,7 @@
 {
     __block NSUInteger eventCount = 0;
     __block NSMutableArray *events = [NSMutableArray array];
-    [room.liveTimeline listenToEventsOfTypes:nil onEvent:^(MXEvent *event, MXEventDirection direction, MXRoomState *roomState) {
+    [room.liveTimeline listenToEventsOfTypes:nil onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
 
         eventCount++;
 
@@ -347,7 +347,7 @@
     }];
 
     [room.liveTimeline resetPagination];
-    [room.liveTimeline paginate:100 direction:MXEventDirectionBackwards onlyFromStore:NO complete:^() {
+    [room.liveTimeline paginate:100 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^() {
 
         XCTAssert(eventCount, "We should have received events in registerEventListenerForTypes");
 
@@ -365,19 +365,19 @@
 - (void)checkSeveralPaginateBacks:(MXRoom*)room
 {
     __block NSMutableArray *roomEvents = [NSMutableArray array];
-    [room.liveTimeline listenToEventsOfTypes:nil onEvent:^(MXEvent *event, MXEventDirection direction, MXRoomState *roomState) {
+    [room.liveTimeline listenToEventsOfTypes:nil onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
 
         [roomEvents addObject:event];
     }];
 
     [room.liveTimeline resetPagination];
-    [room.liveTimeline paginate:100 direction:MXEventDirectionBackwards onlyFromStore:NO complete:^() {
+    [room.liveTimeline paginate:100 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^() {
 
         // Use another MXRoom instance to do pagination in several times
         MXRoom *room2 = [[MXRoom alloc] initWithRoomId:room.state.roomId andMatrixSession:mxSession];
 
         __block NSMutableArray *room2Events = [NSMutableArray array];
-        [room2.liveTimeline listenToEventsOfTypes:nil onEvent:^(MXEvent *event, MXEventDirection direction, MXRoomState *roomState) {
+        [room2.liveTimeline listenToEventsOfTypes:nil onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
 
             [room2Events addObject:event];
         }];
@@ -390,16 +390,16 @@
             XCTAssertGreaterThanOrEqual(room2.liveTimeline.remainingMessagesForBackPaginationInStore, 7);
         }
 
-        [room2.liveTimeline paginate:2 direction:MXEventDirectionBackwards onlyFromStore:NO complete:^() {
+        [room2.liveTimeline paginate:2 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^() {
 
             if (mxSession.store.isPermanent)
             {
                 XCTAssertGreaterThanOrEqual(room2.liveTimeline.remainingMessagesForBackPaginationInStore, 5);
             }
 
-            [room2.liveTimeline paginate:5 direction:MXEventDirectionBackwards onlyFromStore:NO complete:^() {
+            [room2.liveTimeline paginate:5 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^() {
 
-                [room2.liveTimeline paginate:100 direction:MXEventDirectionBackwards onlyFromStore:NO complete:^() {
+                [room2.liveTimeline paginate:100 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^() {
 
                     [self assertNoDuplicate:room2Events text:@"events got one by one with testSeveralPaginateBacks"];
 
@@ -447,18 +447,18 @@
     MXRoom *room2 = [[MXRoom alloc] initWithRoomId:room.state.roomId andMatrixSession:mxSession];
 
     __block NSMutableArray *room2Events = [NSMutableArray array];
-    [room2.liveTimeline listenToEventsOfTypes:nil onEvent:^(MXEvent *event, MXEventDirection direction, MXRoomState *roomState) {
+    [room2.liveTimeline listenToEventsOfTypes:nil onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
 
-        if (MXEventDirectionForwards != direction)
+        if (MXTimelineDirectionForwards != direction)
         {
             [room2Events addObject:event];
         }
     }];
 
     __block NSUInteger liveEvents = 0;
-    [room.liveTimeline listenToEventsOfTypes:nil onEvent:^(MXEvent *event, MXEventDirection direction, MXRoomState *roomState) {
+    [room.liveTimeline listenToEventsOfTypes:nil onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
 
-        if (MXEventDirectionForwards == direction)
+        if (MXTimelineDirectionForwards == direction)
         {
             // Do some paginations after receiving live events
             liveEvents++;
@@ -469,7 +469,7 @@
                     XCTAssertGreaterThanOrEqual(room2.liveTimeline.remainingMessagesForBackPaginationInStore, 7);
                 }
 
-                [room2.liveTimeline paginate:2 direction:MXEventDirectionBackwards onlyFromStore:NO complete:^() {
+                [room2.liveTimeline paginate:2 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^() {
 
                     if (mxSession.store.isPermanent)
                     {
@@ -487,9 +487,9 @@
             }
             else if (3 == liveEvents)
 
-                [room2.liveTimeline paginate:5 direction:MXEventDirectionBackwards onlyFromStore:NO complete:^() {
+                [room2.liveTimeline paginate:5 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^() {
 
-                    [room2.liveTimeline paginate:100 direction:MXEventDirectionBackwards onlyFromStore:NO complete:^() {
+                    [room2.liveTimeline paginate:100 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^() {
 
                         [self assertNoDuplicate:room2Events text:@"events got one by one with testSeveralPaginateBacks"];
 
@@ -524,7 +524,7 @@
 
     // Take a snapshot of all room history
     [room.liveTimeline resetPagination];
-    [room.liveTimeline paginate:100 direction:MXEventDirectionBackwards onlyFromStore:NO complete:^{
+    [room.liveTimeline paginate:100 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^{
 
         // Messages are now in the cache
         // Start checking pagination from the cache
@@ -542,14 +542,14 @@
 - (void)checkCanPaginateFromHomeServer:(MXRoom*)room
 {
     [room.liveTimeline resetPagination];
-    XCTAssertTrue([room.liveTimeline canPaginate:MXEventDirectionBackwards], @"We can always paginate at the beginning");
+    XCTAssertTrue([room.liveTimeline canPaginate:MXTimelineDirectionBackwards], @"We can always paginate at the beginning");
 
-    [room.liveTimeline paginate:100 direction:MXEventDirectionBackwards onlyFromStore:NO complete:^() {
+    [room.liveTimeline paginate:100 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^() {
 
         // Due to SPEC-319, we need to paginate twice to be sure to hit the limit
-        [room.liveTimeline paginate:100 direction:MXEventDirectionBackwards onlyFromStore:NO complete:^() {
+        [room.liveTimeline paginate:100 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^() {
 
-            XCTAssertFalse([room.liveTimeline canPaginate:MXEventDirectionBackwards], @"We must have reached the end of the pagination");
+            XCTAssertFalse([room.liveTimeline canPaginate:MXTimelineDirectionBackwards], @"We must have reached the end of the pagination");
 
             [expectation fulfill];
 
@@ -567,14 +567,14 @@
 - (void)checkCanPaginateFromMXStore:(MXRoom*)room
 {
     [room.liveTimeline resetPagination];
-    XCTAssertTrue([room.liveTimeline canPaginate:MXEventDirectionBackwards], @"We can always paginate at the beginning");
+    XCTAssertTrue([room.liveTimeline canPaginate:MXTimelineDirectionBackwards], @"We can always paginate at the beginning");
 
-    [room.liveTimeline paginate:100 direction:MXEventDirectionBackwards onlyFromStore:NO complete:^() {
+    [room.liveTimeline paginate:100 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^() {
 
         // Do one more round trip so that SDK detect the limit
-        [room.liveTimeline paginate:1 direction:MXEventDirectionBackwards onlyFromStore:NO complete:^{
+        [room.liveTimeline paginate:1 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^{
 
-            XCTAssertFalse([room.liveTimeline canPaginate:MXEventDirectionBackwards], @"We must have reached the end of the pagination");
+            XCTAssertFalse([room.liveTimeline canPaginate:MXTimelineDirectionBackwards], @"We must have reached the end of the pagination");
 
             [expectation fulfill];
 
@@ -598,7 +598,7 @@
     MXEvent *lastMessage2 = [room lastMessageWithTypeIn:nil];
     XCTAssertEqualObjects(lastMessage2.eventId, lastMessage.eventId,  @"The last message should stay the same");
 
-    [room.liveTimeline paginate:100 direction:MXEventDirectionBackwards onlyFromStore:NO complete:^() {
+    [room.liveTimeline paginate:100 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^() {
 
         MXEvent *lastMessage3 = [room lastMessageWithTypeIn:nil];
         XCTAssertEqualObjects(lastMessage3.eventId, lastMessage.eventId,  @"The last message should stay the same");
@@ -628,14 +628,14 @@
                 __block BOOL joinedRequestMade = NO;
 
                 // Listen for the invitation by Alice
-                [mxSession listenToEventsOfTypes:@[kMXEventTypeStringRoomMember] onEvent:^(MXEvent *event, MXEventDirection direction, id customObject) {
+                [mxSession listenToEventsOfTypes:@[kMXEventTypeStringRoomMember] onEvent:^(MXEvent *event, MXTimelineDirection direction, id customObject) {
 
                     // Join the room again
                     MXRoom *room2 = [mxSession roomWithRoomId:roomId];
 
                     XCTAssertNotNil(room2);
 
-                    if (direction == MXEventDirectionForwards && MXMembershipInvite == room2.state.membership && !joinedRequestMade)
+                    if (direction == MXTimelineDirectionForwards && MXMembershipInvite == room2.state.membership && !joinedRequestMade)
                     {
                         // Join the room on the invitation and check we can paginate all expected text messages
                         // By default the last Alice's message (sent while Bob is not in the room) must be visible.
@@ -643,9 +643,9 @@
                         [room2 join:^{
 
                             NSMutableArray *events = [NSMutableArray array];
-                            [room2.liveTimeline listenToEventsOfTypes:@[kMXEventTypeStringRoomMessage] onEvent:^(MXEvent *event, MXEventDirection direction, MXRoomState *roomState) {
+                            [room2.liveTimeline listenToEventsOfTypes:@[kMXEventTypeStringRoomMessage] onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
 
-                                if (direction == MXEventDirectionBackwards)
+                                if (direction == MXTimelineDirectionBackwards)
                                 {
                                     if (0 == events.count)
                                     {
@@ -659,7 +659,7 @@
                             }];
 
                             [room2.liveTimeline resetPagination];
-                            [room2.liveTimeline paginate:100 direction:MXEventDirectionBackwards onlyFromStore:NO complete:^{
+                            [room2.liveTimeline paginate:100 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^{
 
                                 XCTAssertEqual(events.count, 6, "The room should contain only 6 messages (the last message sent while the user is not in the room must be visible)");
 
@@ -716,14 +716,14 @@
 - (void)checkPaginateWhenReachingTheExactBeginningOfTheRoom:(MXRoom*)room
 {
     __block NSUInteger eventCount = 0;
-    [room.liveTimeline listenToEvents:^(MXEvent *event, MXEventDirection direction, MXRoomState *roomState) {
+    [room.liveTimeline listenToEvents:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
 
         eventCount++;
     }];
 
     // First count how many messages to retrieve
     [room.liveTimeline resetPagination];
-    [room.liveTimeline paginate:100 direction:MXEventDirectionBackwards onlyFromStore:NO complete:^() {
+    [room.liveTimeline paginate:100 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^() {
 
         // Paginate for the exact number of events in the room
         NSUInteger pagEnd = eventCount;
@@ -731,18 +731,18 @@
         [mxSession.store deleteRoom:room.state.roomId];
         [room.liveTimeline resetPagination];
 
-        [room.liveTimeline paginate:pagEnd direction:MXEventDirectionBackwards onlyFromStore:NO complete:^{
+        [room.liveTimeline paginate:pagEnd direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^{
 
             XCTAssertEqual(eventCount, pagEnd, @"We should get as many messages as requested");
 
-            XCTAssert([room.liveTimeline canPaginate:MXEventDirectionBackwards], @"At this point the SDK cannot know it reaches the beginning of the history");
+            XCTAssert([room.liveTimeline canPaginate:MXTimelineDirectionBackwards], @"At this point the SDK cannot know it reaches the beginning of the history");
 
             // Try to load more messages
             eventCount = 0;
-            [room.liveTimeline paginate:1 direction:MXEventDirectionBackwards onlyFromStore:NO complete:^{
+            [room.liveTimeline paginate:1 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^{
 
                 XCTAssertEqual(eventCount, 0, @"There must be no more event");
-                XCTAssertFalse([room.liveTimeline canPaginate:MXEventDirectionBackwards], @"SDK must now indicate there is no more event to paginate");
+                XCTAssertFalse([room.liveTimeline canPaginate:MXTimelineDirectionBackwards], @"SDK must now indicate there is no more event to paginate");
 
                 [expectation fulfill];
 
@@ -766,7 +766,7 @@
 {
     __block NSString *messageEventId;
 
-    [room.liveTimeline listenToEvents:^(MXEvent *event, MXEventDirection direction, MXRoomState *roomState) {
+    [room.liveTimeline listenToEvents:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
 
         if (MXEventTypeRoomMessage == event.eventType)
         {
@@ -1100,7 +1100,7 @@
 
                 MXRoom *room = [mxSession roomWithRoomId:roomId];
                 [room.liveTimeline resetPagination];
-                [room.liveTimeline paginate:10 direction:MXEventDirectionBackwards onlyFromStore:NO complete:^{
+                [room.liveTimeline paginate:10 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^{
 
                     NSString *roomPaginationToken = [store paginationTokenOfRoom:roomId];
                     XCTAssert(roomPaginationToken, @"The room must have a pagination after a pagination");

--- a/MatrixSDKTests/MXVoIPTests.m
+++ b/MatrixSDKTests/MXVoIPTests.m
@@ -95,7 +95,7 @@
                                   };
 
 
-        [mxSession listenToEventsOfTypes:@[kMXEventTypeStringCallInvite] onEvent:^(MXEvent *event, MXEventDirection direction, id customObject) {
+        [mxSession listenToEventsOfTypes:@[kMXEventTypeStringCallInvite] onEvent:^(MXEvent *event, MXTimelineDirection direction, id customObject) {
 
             MXCall *call = [mxSession.callManager callWithCallId:callId];
 


### PR DESCRIPTION
Fixed https://matrix.org/jira/browse/SYIOS-207.

MXEventDirectionSync was used to identify events coming from an initialSync. They were managed differently than MXEventDirectionForwards events which came from /events.
In sync v2, everything comes from a single API, /sync, MXEventDirectionForwards. It is no more possible to make such distinction.

MXEventDirectionSync has been removed. MXEventDirection* has been renamed to MXTimelineDirection*.
MXEventTimeline.m has been refactored to match sync v2 mechanism better (no more handleLiveEvent for example as live event has no more sense with /sync v2).



