### PR TITLE
BugFix SYIOS-202: IOS should no longer reset badge count on launch.

### DIFF
--- a/MatrixSDK/Data/MXRoom.h
+++ b/MatrixSDK/Data/MXRoom.h
@@ -99,10 +99,22 @@ FOUNDATION_EXPORT NSString *const kMXRoomSyncWithLimitedTimelineNotification;
 - (MXEvent*)lastMessageWithTypeIn:(NSArray*)type;
 
 /**
- The unread events.
- They are filtered by acknowledgableEventTypes.
+ Tell whether the room has unread events.
+ This value depends on acknowledgableEventTypes.
  */
-@property (nonatomic, readonly) NSArray* unreadEvents;
+@property (nonatomic, readonly) BOOL hasUnreadEvents;
+
+/**
+ The number of unread messages that match the push notification rules.
+ It is based on the notificationCount field in /sync response.
+ */
+@property (nonatomic, readonly) NSUInteger notificationCount;
+
+/**
+ The number of highlighted unread messages (subset of notifications).
+ It is based on the notificationCount field in /sync response.
+ */
+@property (nonatomic, readonly) NSUInteger highlightCount;
 
 /**
  * An array of event types strings (MXEventTypeString).

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -135,6 +135,10 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
             [self handleReceiptEvent:event direction:MXTimelineDirectionForwards];
         }
     }
+    
+    // Update bing counts from the notificationCount field in /sync response
+    _notificationCount = roomSync.unreadNotifications.notificationCount;
+    _highlightCount = roomSync.unreadNotifications.highlightCount;
 
     // Handle account data events (if any)
     [self handleAccounDataEvents:roomSync.accountData.events direction:MXTimelineDirectionForwards];
@@ -514,9 +518,15 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
     return NO;
 }
 
--(NSArray*) unreadEvents
+- (BOOL)hasUnreadEvents
 {
-    return [mxSession.store unreadEvents:self.state.roomId withTypeIn:_acknowledgableEventTypes];
+    if (_notificationCount)
+    {
+        return YES;
+    }
+    
+    // Else check for unread events in store
+    return [mxSession.store hasUnreadEvents:self.state.roomId withTypeIn:_acknowledgableEventTypes];
 }
 
 - (NSArray*)getEventReceipts:(NSString*)eventId sorted:(BOOL)sort

--- a/MatrixSDK/Data/Store/MXCoreDataStore/MXCoreDataStore.m
+++ b/MatrixSDK/Data/Store/MXCoreDataStore/MXCoreDataStore.m
@@ -336,10 +336,10 @@ NSString *const kMXCoreDataStoreFolder = @"MXCoreDataStore";
     return NO;
 }
 
-- (NSArray*)unreadEvents:(NSString*)roomId withTypeIn:(NSArray*)types
+- (BOOL)hasUnreadEvents:(NSString*)roomId withTypeIn:(NSArray*)types
 {
     // TODO
-    return nil;
+    return NO;
 }
 
 - (BOOL)isPermanent

--- a/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryStore.m
+++ b/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryStore.m
@@ -220,7 +220,7 @@
     return false;
 }
 
-- (NSArray*)unreadEvents:(NSString*)roomId withTypeIn:(NSArray*)types
+- (BOOL)hasUnreadEvents:(NSString*)roomId withTypeIn:(NSArray*)types
 {
     MXMemoryRoomStore* store = [roomStores valueForKey:roomId];
     NSMutableDictionary* receipsByUserId = [receiptsByRoomId objectForKey:roomId];
@@ -231,13 +231,13 @@
         
         if (data)
         {
-            // ignore oneself events
-            // assume you read what you wrote
-            return [store eventsAfter:data.eventId except:credentials.userId withTypeIn:[NSSet setWithArray:types]];
+            // Check the current stored events (by ignoring oneself events)
+            NSArray *array = [store eventsAfter:data.eventId except:credentials.userId withTypeIn:[NSSet setWithArray:types]];
+            return (array.count != 0);
         }
     }
    
-    return nil;
+    return NO;
 }
 
 - (BOOL)isPermanent

--- a/MatrixSDK/Data/Store/MXNoStore/MXNoStore.m
+++ b/MatrixSDK/Data/Store/MXNoStore/MXNoStore.m
@@ -211,26 +211,14 @@
     return nil;
 }
 
-/**
- * Store the receipt for an user in a room
- * @param receipt The event
- * @param roomId The roomId
- * @return true if the receipt has been stored
- */
 - (BOOL)storeReceipt:(MXReceiptData*)receipt roomId:(NSString*)roomId
 {
     return NO;
 }
 
-/**
- * Provides the unread events list.
- * @param roomId the room id.
- * @param types an array of event types strings (MXEventTypeString).
- * @return the unread events list.
- */
-- (NSArray*)unreadEvents:(NSString*)roomId withTypeIn:(NSArray*)types
+- (BOOL)hasUnreadEvents:(NSString*)roomId withTypeIn:(NSArray*)types
 {
-    return nil;
+    return NO;
 }
 
 

--- a/MatrixSDK/Data/Store/MXStore.h
+++ b/MatrixSDK/Data/Store/MXStore.h
@@ -190,12 +190,12 @@
 - (BOOL)storeReceipt:(MXReceiptData*)receipt roomId:(NSString*)roomId;
 
 /**
- * Provides the unread events list.
+ * Check whether a room has some unread events.
  * @param roomId the room id.
  * @param types an array of event types strings (MXEventTypeString).
- * @return the unread events list.
+ * @return YES if at least one stored event has its type listed in provided array.
  */
-- (NSArray*)unreadEvents:(NSString*)roomId withTypeIn:(NSArray*)types;
+- (BOOL)hasUnreadEvents:(NSString*)roomId withTypeIn:(NSArray*)types;
 
 /**
  Indicate if the MXStore implementation stores data permanently.

--- a/MatrixSDK/JSONModels/MXJSONModels.h
+++ b/MatrixSDK/JSONModels/MXJSONModels.h
@@ -956,6 +956,23 @@ FOUNDATION_EXPORT NSString *const kMXPushRuleScopeStringDevice;
 @end
 
 /**
+ `MXRoomSyncUnreadNotifications` represents the unread counts for a room.
+ */
+@interface MXRoomSyncUnreadNotifications : MXJSONModel
+
+    /**
+     The number of unread messages that match the push notification rules.
+     */
+    @property (nonatomic) NSUInteger notificationCount;
+
+    /**
+     The number of highlighted unread messages (subset of notifications).
+     */
+    @property (nonatomic) NSUInteger highlightCount;
+
+@end
+
+/**
  `MXRoomSync` represents the response for a room during server sync.
  */
 @interface MXRoomSync : MXJSONModel
@@ -979,6 +996,11 @@ FOUNDATION_EXPORT NSString *const kMXPushRuleScopeStringDevice;
      The account data events for the room (e.g. tags).
      */
     @property (nonatomic) MXRoomSyncAccountData *accountData;
+
+    /**
+     The notification counts for the room.
+     */
+    @property (nonatomic) MXRoomSyncUnreadNotifications *unreadNotifications;
 
 @end
 

--- a/MatrixSDK/JSONModels/MXJSONModels.m
+++ b/MatrixSDK/JSONModels/MXJSONModels.m
@@ -857,6 +857,21 @@ NSString *const kMXPushRuleScopeStringDevice = @"device";
 
 @end
 
+@implementation MXRoomSyncUnreadNotifications
+
++ (id)modelFromJSON:(NSDictionary *)JSONDictionary
+{
+    MXRoomSyncUnreadNotifications *roomSyncUnreadNotifications = [[MXRoomSyncUnreadNotifications alloc] init];
+    if (roomSyncUnreadNotifications)
+    {
+        MXJSONModelSetUInteger(roomSyncUnreadNotifications.notificationCount, JSONDictionary[@"notification_count"]);
+        MXJSONModelSetUInteger(roomSyncUnreadNotifications.highlightCount, JSONDictionary[@"highlight_count"]);
+    }
+    return roomSyncUnreadNotifications;
+}
+
+@end
+
 @implementation MXRoomSync
 
 + (id)modelFromJSON:(NSDictionary *)JSONDictionary
@@ -868,6 +883,7 @@ NSString *const kMXPushRuleScopeStringDevice = @"device";
         MXJSONModelSetMXJSONModel(roomSync.timeline, MXRoomSyncTimeline, JSONDictionary[@"timeline"]);
         MXJSONModelSetMXJSONModel(roomSync.ephemeral, MXRoomSyncEphemeral, JSONDictionary[@"ephemeral"]);
         MXJSONModelSetMXJSONModel(roomSync.accountData, MXRoomSyncAccountData, JSONDictionary[@"account_data"]);
+        MXJSONModelSetMXJSONModel(roomSync.unreadNotifications, MXRoomSyncUnreadNotifications, JSONDictionary[@"unread_notifications"]);
     }
     return roomSync;
 }


### PR DESCRIPTION
+ fix: MXRoom.unreadEvents and [MXStore unreadEvents::] should be removed #82