### PR TITLE
Crash Fix: Fixed crash in [MXFileStore saveReceipts]

### DIFF
--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
@@ -951,8 +951,11 @@ NSString *const kMXReceiptsFolder = @"receipts";
                 {
                     NSString *receiptsFile = [storeReceiptsPath stringByAppendingPathComponent:roomId];
                     NSUInteger filesize = [[[[NSFileManager defaultManager] attributesOfItemAtPath:receiptsFile error:nil] objectForKey:NSFileSize] intValue];
-                    
-                    [NSKeyedArchiver archiveRootObject:receiptsByUserId toFile:receiptsFile];
+
+                    @synchronized (receiptsByUserId)
+                    {
+                        [NSKeyedArchiver archiveRootObject:receiptsByUserId toFile:receiptsFile];
+                    }
                     
                     deltaCacheSize += [[[[NSFileManager defaultManager] attributesOfItemAtPath:receiptsFile error:nil] objectForKey:NSFileSize] intValue] - filesize;
                 }

--- a/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryStore.m
+++ b/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryStore.m
@@ -213,7 +213,10 @@
     // not yet defined or a new event
     if (!curReceipt || (![receipt.eventId isEqualToString:curReceipt.eventId] && (receipt.ts > curReceipt.ts)))
     {
-        [receiptsByUserId setObject:receipt forKey:receipt.userId];
+        @synchronized (receiptsByUserId)
+        {
+            [receiptsByUserId setObject:receipt forKey:receipt.userId];
+        }
         return true;
     }
     


### PR DESCRIPTION
There was a race condition. While the storing thread saves a read receipt, it may have just been replaced (and released) by a new incoming one managed by the UI thread.

It should fix this crash:

[2016-03-28 13:10:25 +0000]
-[__NSCFType encodeWithCoder:]: unrecognized selector sent to instance 0x13a75bb40
Application: Vector (im.vector.app)
Application version: 0.1.2 (r0)
Matrix SDK version: 0.6.4
Build: develop #551
iPhone 9.3
(
	0   CoreFoundation                      0x0000000183db2e50 <redacted> + 148
	1   libobjc.A.dylib                     0x0000000183417f80 objc_exception_throw + 56
	2   CoreFoundation                      0x0000000183db9ccc <redacted> + 0
	3   CoreFoundation                      0x0000000183db6c74 <redacted> + 872
	4   CoreFoundation                      0x0000000183cb4d1c _CF_forwarding_prep_0 + 92
	5   Foundation                          0x00000001846feb80 <redacted> + 1180
	6   Foundation                          0x0000000184700034 <redacted> + 448
	7   Foundation                          0x00000001846ffc54 <redacted> + 936
	8   Foundation                          0x00000001846feb80 <redacted> + 1180
	9   Foundation                          0x000000018475b760 <redacted> + 236
	10  Vector                              0x00000001001339b0 Vector + 1227184 -> __27-[MXFileStore saveReceipts]_block_invoke (in Vector) (MXFileStore.m:957)
	11  libdispatch.dylib                   0x00000001837fd4bc <redacted> + 24
	12  libdispatch.dylib                   0x00000001837fd47c <redacted> + 16
	13  libdispatch.dylib                   0x00000001838094c0 <redacted> + 864
	14  libdispatch.dylib                   0x0000000183800f80 <redacted> + 464
	15  libdispatch.dylib                   0x00000001837fd47c <redacted> + 16
	16  libdispatch.dylib                   0x000000018380b914 <redacted> + 2140
	17  libdispatch.dylib                   0x000000018380b0b0 <redacted> + 112
	18  libsystem_pthread.dylib             0x0000000183a15470 _pthread_wqthread + 1092
	19  libsystem_pthread.dylib             0x0000000183a15020 start_wqthread + 4
)