### PR TITLE
MXSession: Detect when the access token is no more valid

### DIFF
--- a/MatrixSDK/MXSession.h
+++ b/MatrixSDK/MXSession.h
@@ -85,7 +85,17 @@ typedef enum : NSUInteger
      @discussion
      The Matrix session will stay in this state until a new call of [MXSession start:failure:].
      */
-    MXSessionStateInitialSyncFailed
+    MXSessionStateInitialSyncFailed,
+
+    /**
+     The access token is no more valid.
+
+     @discussion
+     This can happen when the user made a forget password request for example.
+     The Matrix session is no more usable. The user must log in again.
+     */
+    MXSessionStateUnknownToken
+
 } MXSessionState;
 
 

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -679,6 +679,20 @@ typedef void (^MXOnResumeDone)();
         {
             return;
         }
+
+        if ([MXError isMXError:error])
+        {
+            // Detect invalidated access token
+            // This can happen when the user made a forget password request for example
+            MXError *mxError = [[MXError alloc] initWithNSError:error];
+            if ([mxError.errcode isEqualToString:kMXErrCodeStringUnknownToken])
+            {
+                [self setState:MXSessionStateUnknownToken];
+
+                // Do nothing more because without a valid access_token, the session is useless
+                return;
+            }
+        }
         
         // Handle failure during catch up first
         if (onBackgroundSyncFail)


### PR DESCRIPTION
https://github.com/vector-im/vector-ios/issues/247
