### PR TITLE
Add methods to change/read room settings to/from the hs

### DIFF
--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -132,6 +132,8 @@
 		32E226A71D06AC9F00E6CA54 /* MXPeekingRoom.m in Sources */ = {isa = PBXBuildFile; fileRef = 32E226A51D06AC9F00E6CA54 /* MXPeekingRoom.m */; };
 		32E226A91D081CE200E6CA54 /* MXPeekingRoomTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 32E226A81D081CE200E6CA54 /* MXPeekingRoomTests.m */; };
 		32FCAB4D19E578860049C555 /* MXRestClientTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 32FCAB4C19E578860049C555 /* MXRestClientTests.m */; };
+		32FE41361D0AB7070060835E /* MXEnumConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 32FE41341D0AB7070060835E /* MXEnumConstants.h */; };
+		32FE41371D0AB7070060835E /* MXEnumConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 32FE41351D0AB7070060835E /* MXEnumConstants.m */; };
 		71DE22E01BC7C51200284153 /* MXReceiptData.m in Sources */ = {isa = PBXBuildFile; fileRef = 71DE22DC1BC7C51200284153 /* MXReceiptData.m */; };
 		71DE22E11BC7C51200284153 /* MXReceiptData.h in Headers */ = {isa = PBXBuildFile; fileRef = 71DE22DD1BC7C51200284153 /* MXReceiptData.h */; };
 		A23A8594855481FEFA0E9A22 /* libPods-MatrixSDK.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E1674C6FF8BBF074E7F76059 /* libPods-MatrixSDK.a */; };
@@ -295,6 +297,8 @@
 		32E226A81D081CE200E6CA54 /* MXPeekingRoomTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXPeekingRoomTests.m; sourceTree = "<group>"; };
 		32F1FE9AF82A426C2EAED587 /* Pods-MatrixSDK.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MatrixSDK.release.xcconfig"; path = "Pods/Target Support Files/Pods-MatrixSDK/Pods-MatrixSDK.release.xcconfig"; sourceTree = "<group>"; };
 		32FCAB4C19E578860049C555 /* MXRestClientTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = MXRestClientTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
+		32FE41341D0AB7070060835E /* MXEnumConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXEnumConstants.h; sourceTree = "<group>"; };
+		32FE41351D0AB7070060835E /* MXEnumConstants.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXEnumConstants.m; sourceTree = "<group>"; };
 		71DE22DC1BC7C51200284153 /* MXReceiptData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXReceiptData.m; sourceTree = "<group>"; };
 		71DE22DD1BC7C51200284153 /* MXReceiptData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXReceiptData.h; sourceTree = "<group>"; };
 		E1674C6FF8BBF074E7F76059 /* libPods-MatrixSDK.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-MatrixSDK.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -513,8 +517,6 @@
 				32DC15CA1A8CF7AE006F9AD3 /* NotificationCenter */,
 				320DFDD619DD99B60068622A /* Utils */,
 				3245A74B1AF7B2930001D8A7 /* VoIP */,
-				F0C34CB91C18C80000C36F09 /* MXSDKOptions.h */,
-				F0C34CBA1C18C93700C36F09 /* MXSDKOptions.m */,
 				32C6F93219DD814400EA4E9C /* MatrixSDK.h */,
 				320DFDD419DD99B60068622A /* MXRestClient.h */,
 				320DFDD519DD99B60068622A /* MXRestClient.m */,
@@ -522,6 +524,10 @@
 				320DFDD119DD99B60068622A /* MXSession.m */,
 				320DFDD219DD99B60068622A /* MXError.h */,
 				320DFDD319DD99B60068622A /* MXError.m */,
+				32FE41341D0AB7070060835E /* MXEnumConstants.h */,
+				32FE41351D0AB7070060835E /* MXEnumConstants.m */,
+				F0C34CB91C18C80000C36F09 /* MXSDKOptions.h */,
+				F0C34CBA1C18C93700C36F09 /* MXSDKOptions.m */,
 				32C6F93019DD814400EA4E9C /* Supporting Files */,
 			);
 			path = MatrixSDK;
@@ -666,6 +672,7 @@
 				3220094519EFBF30008DE41D /* MXSessionEventListener.h in Headers */,
 				32BED28F1B00A23F00E668FE /* MXCallStack.h in Headers */,
 				3264DB911CEC528D00B99881 /* MXAccountData.h in Headers */,
+				32FE41361D0AB7070060835E /* MXEnumConstants.h in Headers */,
 				32E226A61D06AC9F00E6CA54 /* MXPeekingRoom.h in Headers */,
 				323B2AF81BCE8AC800B11F34 /* MXCoreDataRoom.h in Headers */,
 				329FB1751A0A3A1600A5E88E /* MXRoomMember.h in Headers */,
@@ -854,6 +861,7 @@
 				71DE22E01BC7C51200284153 /* MXReceiptData.m in Sources */,
 				327E37B71A974F75007F026F /* MXLogger.m in Sources */,
 				320DFDE719DD99B60068622A /* MXHTTPClient.m in Sources */,
+				32FE41371D0AB7070060835E /* MXEnumConstants.m in Sources */,
 				320DFDE119DD99B60068622A /* MXSession.m in Sources */,
 				F0C34CBB1C18C93700C36F09 /* MXSDKOptions.m in Sources */,
 				320DFDDC19DD99B60068622A /* MXRoom.m in Sources */,

--- a/MatrixSDK/Data/MXEventTimeline.h
+++ b/MatrixSDK/Data/MXEventTimeline.h
@@ -22,20 +22,6 @@
 #import "MXHTTPOperation.h"
 
 /**
- The direction of an event in the timeline.
- */
-typedef enum : NSUInteger
-{
-    // Forwards when the event is added to the end of the timeline.
-    // These events come from the /sync stream or from forwards pagination.
-    MXTimelineDirectionForwards,
-
-    // Backwards when the event is added to the start of the timeline.
-    // These events come from a back pagination.
-    MXTimelineDirectionBackwards
-} MXTimelineDirection;
-
-/**
  Prefix used to build fake invite event.
  */
 FOUNDATION_EXPORT NSString *const kMXRoomInviteStateEventIdPrefix;

--- a/MatrixSDK/Data/MXRoom.h
+++ b/MatrixSDK/Data/MXRoom.h
@@ -25,6 +25,7 @@
 #import "MXHTTPOperation.h"
 #import "MXCall.h"
 #import "MXEventTimeline.h"
+#import "MXRestClient.h"
 
 @class MXRoom;
 @class MXSession;
@@ -285,6 +286,19 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidUpdateUnreadNotification;
 - (MXHTTPOperation*)setName:(NSString*)name
                     success:(void (^)())success
                     failure:(void (^)(NSError *error))failure;
+
+/**
+ Set the history visibility of the room.
+
+ @param historyVisibility the visibily to set.
+ @param success A block object called when the operation succeeds.
+ @param failure A block object called when the operation fails.
+
+ @return a MXHTTPOperation instance.
+ */
+- (MXHTTPOperation*)setHistoryVisibility:(MXRoomHistoryVisibility)historyVisibility
+                                 success:(void (^)())success
+                                 failure:(void (^)(NSError *error))failure;
 
 /**
  Join this room where the user has been invited.

--- a/MatrixSDK/Data/MXRoom.h
+++ b/MatrixSDK/Data/MXRoom.h
@@ -289,7 +289,7 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidUpdateUnreadNotification;
 /**
  Set the history visibility of the room.
 
- @param historyVisibility the visibily to set.
+ @param historyVisibility the history visibility to set.
  @param success A block object called when the operation succeeds.
  @param failure A block object called when the operation fails.
 
@@ -298,6 +298,19 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidUpdateUnreadNotification;
 - (MXHTTPOperation*)setHistoryVisibility:(MXRoomHistoryVisibility)historyVisibility
                                  success:(void (^)())success
                                  failure:(void (^)(NSError *error))failure;
+
+/**
+ Set the join rule of the room.
+
+ @param joinRule the join rule to set.
+ @param success A block object called when the operation succeeds.
+ @param failure A block object called when the operation fails.
+
+ @return a MXHTTPOperation instance.
+ */
+- (MXHTTPOperation*)setJoinRule:(MXRoomJoinRule)joinRule
+                        success:(void (^)())success
+                        failure:(void (^)(NSError *error))failure;
 
 /**
  Join this room where the user has been invited.

--- a/MatrixSDK/Data/MXRoom.h
+++ b/MatrixSDK/Data/MXRoom.h
@@ -25,7 +25,6 @@
 #import "MXHTTPOperation.h"
 #import "MXCall.h"
 #import "MXEventTimeline.h"
-#import "MXRestClient.h"
 
 @class MXRoom;
 @class MXSession;

--- a/MatrixSDK/Data/MXRoom.h
+++ b/MatrixSDK/Data/MXRoom.h
@@ -313,6 +313,19 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidUpdateUnreadNotification;
                         failure:(void (^)(NSError *error))failure;
 
 /**
+ Set the guest access of the room.
+
+ @param guestAccess the guest access to set.
+ @param success A block object called when the operation succeeds.
+ @param failure A block object called when the operation fails.
+
+ @return a MXHTTPOperation instance.
+ */
+- (MXHTTPOperation*)setGuestAccess:(MXRoomGuestAccess)guestAccess
+                           success:(void (^)())success
+                           failure:(void (^)(NSError *error))failure;
+
+/**
  Join this room where the user has been invited.
  
  @param success A block object called when the operation is complete.

--- a/MatrixSDK/Data/MXRoom.h
+++ b/MatrixSDK/Data/MXRoom.h
@@ -326,6 +326,35 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidUpdateUnreadNotification;
                            failure:(void (^)(NSError *error))failure;
 
 /**
+ Set the visbility of the room in the current HS's room directory.
+
+ @param directoryVisibility the directory visibility to set.
+ @param success A block object called when the operation succeeds.
+ @param failure A block object called when the operation fails.
+
+ @return a MXHTTPOperation instance.
+ */
+- (MXHTTPOperation*)setDirectoryVisibility:(MXRoomDirectoryVisibility)directoryVisibility
+                                   success:(void (^)())success
+                                   failure:(void (^)(NSError *error))failure;
+
+/**
+ Get the visibility of the room in the current HS's room directory.
+ 
+ Note: This information is not part of the room state because it is related
+ to the current homeserver.
+ There is currently no way to be updated on directory visibility change. That's why a
+ request must be issued everytime.
+
+ @param success A block object called when the operation succeeds. It provides the room directory visibility.
+ @param failure A block object called when the operation fails.
+
+ @return a MXHTTPOperation instance.
+ */
+- (MXHTTPOperation*)directoryVisibility:(void (^)(MXRoomDirectoryVisibility directoryVisibility))success
+                                failure:(void (^)(NSError *error))failure;
+
+/**
  Join this room where the user has been invited.
  
  @param success A block object called when the operation is complete.

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -281,6 +281,13 @@ NSString *const kMXRoomDidUpdateUnreadNotification = @"kMXRoomDidUpdateUnreadNot
     return [mxSession.matrixRestClient setJoinRule:self.state.roomId joinRule:joinRule success:success failure:failure];
 }
 
+- (MXHTTPOperation*)setGuestAccess:(MXRoomGuestAccess)guestAccess
+                           success:(void (^)())success
+                           failure:(void (^)(NSError *error))failure
+{
+    return [mxSession.matrixRestClient setRoomGuestAccess:self.state.roomId guestAccess:guestAccess success:success failure:failure];
+}
+
 - (MXHTTPOperation*)join:(void (^)())success
                  failure:(void (^)(NSError *error))failure
 {

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -267,6 +267,13 @@ NSString *const kMXRoomDidUpdateUnreadNotification = @"kMXRoomDidUpdateUnreadNot
     return [mxSession.matrixRestClient setRoomName:self.state.roomId name:name success:success failure:failure];
 }
 
+- (MXHTTPOperation *)setHistoryVisibility:(MXRoomHistoryVisibility)historyVisibility
+                                  success:(void (^)())success
+                                  failure:(void (^)(NSError *))failure
+{
+    return [mxSession.matrixRestClient setHistoryVisibility:self.state.roomId historyVisibility:historyVisibility success:success failure:failure];
+}
+
 - (MXHTTPOperation*)join:(void (^)())success
                  failure:(void (^)(NSError *error))failure
 {

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -274,6 +274,13 @@ NSString *const kMXRoomDidUpdateUnreadNotification = @"kMXRoomDidUpdateUnreadNot
     return [mxSession.matrixRestClient setHistoryVisibility:self.state.roomId historyVisibility:historyVisibility success:success failure:failure];
 }
 
+- (MXHTTPOperation*)setJoinRule:(MXRoomJoinRule)joinRule
+                        success:(void (^)())success
+                        failure:(void (^)(NSError *error))failure
+{
+    return [mxSession.matrixRestClient setJoinRule:self.state.roomId joinRule:joinRule success:success failure:failure];
+}
+
 - (MXHTTPOperation*)join:(void (^)())success
                  failure:(void (^)(NSError *error))failure
 {

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -271,7 +271,7 @@ NSString *const kMXRoomDidUpdateUnreadNotification = @"kMXRoomDidUpdateUnreadNot
                                   success:(void (^)())success
                                   failure:(void (^)(NSError *))failure
 {
-    return [mxSession.matrixRestClient setHistoryVisibility:self.state.roomId historyVisibility:historyVisibility success:success failure:failure];
+    return [mxSession.matrixRestClient setRoomHistoryVisibility:self.state.roomId historyVisibility:historyVisibility success:success failure:failure];
 }
 
 - (MXHTTPOperation*)setJoinRule:(MXRoomJoinRule)joinRule

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -288,6 +288,19 @@ NSString *const kMXRoomDidUpdateUnreadNotification = @"kMXRoomDidUpdateUnreadNot
     return [mxSession.matrixRestClient setRoomGuestAccess:self.state.roomId guestAccess:guestAccess success:success failure:failure];
 }
 
+- (MXHTTPOperation*)setDirectoryVisibility:(MXRoomDirectoryVisibility)directoryVisibility
+                                   success:(void (^)())success
+                                   failure:(void (^)(NSError *error))failure
+{
+    return [mxSession.matrixRestClient setRoomDirectoryVisibility:self.state.roomId directoryVisibility:directoryVisibility success:success failure:failure];
+}
+
+- (MXHTTPOperation*)directoryVisibility:(void (^)(MXRoomDirectoryVisibility directoryVisibility))success
+                                failure:(void (^)(NSError *error))failure
+{
+    return [mxSession.matrixRestClient directoryVisibilityOfRoom:self.state.roomId success:success failure:failure];
+}
+
 - (MXHTTPOperation*)join:(void (^)())success
                  failure:(void (^)(NSError *error))failure
 {

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -278,7 +278,7 @@ NSString *const kMXRoomDidUpdateUnreadNotification = @"kMXRoomDidUpdateUnreadNot
                         success:(void (^)())success
                         failure:(void (^)(NSError *error))failure
 {
-    return [mxSession.matrixRestClient setJoinRule:self.state.roomId joinRule:joinRule success:success failure:failure];
+    return [mxSession.matrixRestClient setRoomJoinRule:self.state.roomId joinRule:joinRule success:success failure:failure];
 }
 
 - (MXHTTPOperation*)setGuestAccess:(MXRoomGuestAccess)guestAccess

--- a/MatrixSDK/Data/MXRoomState.h
+++ b/MatrixSDK/Data/MXRoomState.h
@@ -21,6 +21,7 @@
 #import "MXRoomMember.h"
 #import "MXRoomThirdPartyInvite.h"
 #import "MXRoomPowerLevels.h"
+#import "MXEnumConstants.h"
 
 @class MXSession;
 
@@ -94,6 +95,11 @@ A copy of the list of third party invites (actually MXRoomThirdPartyInvite insta
  The avatar url of the room.
  */
 @property (nonatomic, readonly) NSString *avatar;
+
+/**
+ The history visibility of the room.
+ */
+@property (nonatomic, readonly) MXRoomHistoryVisibility historyVisibility;
 
 /**
  The display name of the room.

--- a/MatrixSDK/Data/MXRoomState.h
+++ b/MatrixSDK/Data/MXRoomState.h
@@ -67,11 +67,6 @@ A copy of the list of third party invites (actually MXRoomThirdPartyInvite insta
 @property (nonatomic, readonly) MXRoomPowerLevels *powerLevels;
 
 /**
- The visibility of the room: public or, else, private
- */
-@property (nonatomic) BOOL isPublic;
-
-/**
  The aliases of this room.
  */
 @property (nonatomic, readonly) NSArray *aliases;
@@ -105,6 +100,11 @@ A copy of the list of third party invites (actually MXRoomThirdPartyInvite insta
  The join rule of the room.
  */
 @property (nonatomic, readonly) MXRoomJoinRule joinRule;
+
+/**
+ Shortcut to check if the self.joinRule is public.
+ */
+@property (nonatomic, readonly) BOOL isJoinRulePublic;
 
 /**
  The guest access of the room.

--- a/MatrixSDK/Data/MXRoomState.h
+++ b/MatrixSDK/Data/MXRoomState.h
@@ -107,6 +107,11 @@ A copy of the list of third party invites (actually MXRoomThirdPartyInvite insta
 @property (nonatomic, readonly) MXRoomJoinRule joinRule;
 
 /**
+ The guest access of the room.
+ */
+@property (nonatomic, readonly) MXRoomGuestAccess guestAccess;
+
+/**
  The display name of the room.
  It is computed from information retrieved so far.
  */

--- a/MatrixSDK/Data/MXRoomState.h
+++ b/MatrixSDK/Data/MXRoomState.h
@@ -102,6 +102,11 @@ A copy of the list of third party invites (actually MXRoomThirdPartyInvite insta
 @property (nonatomic, readonly) MXRoomHistoryVisibility historyVisibility;
 
 /**
+ The join rule of the room.
+ */
+@property (nonatomic, readonly) MXRoomJoinRule joinRule;
+
+/**
  The display name of the room.
  It is computed from information retrieved so far.
  */

--- a/MatrixSDK/Data/MXRoomState.m
+++ b/MatrixSDK/Data/MXRoomState.m
@@ -257,6 +257,20 @@
     return avatar;
 }
 
+- (MXRoomHistoryVisibility)historyVisibility
+{
+    NSString *historyVisibility = kMXRoomHistoryVisibilityShared;
+
+    // Check it from the state events
+    MXEvent *event = [stateEvents objectForKey:kMXEventTypeStringRoomHistoryVisibility];
+    if (event && [self contentOfEvent:event])
+    {
+        MXJSONModelSetString(historyVisibility, [self contentOfEvent:event][@"history_visibility"]);
+        historyVisibility = [historyVisibility copy];
+    }
+    return historyVisibility;
+}
+
 - (NSString *)displayname
 {
     // Reuse the Synapse web client algo

--- a/MatrixSDK/Data/MXRoomState.m
+++ b/MatrixSDK/Data/MXRoomState.m
@@ -178,7 +178,7 @@
     {
         NSString *join_rule;
         MXJSONModelSetString(join_rule, [self contentOfEvent:event][@"join_rule"]);
-        if ([join_rule isEqualToString:kMXRoomVisibilityPublic])
+        if ([join_rule isEqualToString:kMXRoomDirectoryVisibilityPublic])
         {
             isPublic = YES;
         }

--- a/MatrixSDK/Data/MXRoomState.m
+++ b/MatrixSDK/Data/MXRoomState.m
@@ -285,6 +285,20 @@
     return joinRule;
 }
 
+- (MXRoomGuestAccess)guestAccess
+{
+    MXRoomGuestAccess guestAccess = kMXRoomGuestAccessForbidden;
+
+    // Check it from the state events
+    MXEvent *event = [stateEvents objectForKey:kMXEventTypeStringRoomGuestAccess];
+    if (event && [self contentOfEvent:event])
+    {
+        MXJSONModelSetString(guestAccess, [self contentOfEvent:event][@"guest_access"]);
+        guestAccess = [guestAccess copy];
+    }
+    return guestAccess;
+}
+
 - (NSString *)displayname
 {
     // Reuse the Synapse web client algo

--- a/MatrixSDK/Data/MXRoomState.m
+++ b/MatrixSDK/Data/MXRoomState.m
@@ -59,7 +59,7 @@
 @end
 
 @implementation MXRoomState
-@synthesize powerLevels, isPublic;
+@synthesize powerLevels;
 
 - (id)initWithRoomId:(NSString*)roomId
     andMatrixSession:(MXSession*)matrixSession
@@ -169,24 +169,6 @@
     return [thirdPartyInvites allValues];
 }
 
-- (BOOL)isPublic
-{
-    // The information is in the join_rule state event
-    isPublic = NO;
-    MXEvent *event = [stateEvents objectForKey:kMXEventTypeStringRoomJoinRules];
-    if (event && [self contentOfEvent:event])
-    {
-        NSString *join_rule;
-        MXJSONModelSetString(join_rule, [self contentOfEvent:event][@"join_rule"]);
-        if ([join_rule isEqualToString:kMXRoomDirectoryVisibilityPublic])
-        {
-            isPublic = YES;
-        }
-    }
-
-    return isPublic;
-}
-
 - (NSArray *)aliases
 {
     NSArray *aliases;
@@ -283,6 +265,11 @@
         joinRule = [joinRule copy];
     }
     return joinRule;
+}
+
+- (BOOL)isJoinRulePublic
+{
+    return [self.joinRule isEqualToString:kMXRoomJoinRulePublic];
 }
 
 - (MXRoomGuestAccess)guestAccess
@@ -669,7 +656,6 @@
 
     stateCopy->membersWithThirdPartyInviteTokenCache= [[NSMutableDictionary allocWithZone:zone] initWithDictionary:membersWithThirdPartyInviteTokenCache];
     
-    stateCopy->isPublic = isPublic;
     stateCopy->membership = membership;
 
     stateCopy->membersNamesCache = [[NSMutableDictionary allocWithZone:zone] initWithDictionary:membersNamesCache copyItems:YES];

--- a/MatrixSDK/Data/MXRoomState.m
+++ b/MatrixSDK/Data/MXRoomState.m
@@ -259,7 +259,7 @@
 
 - (MXRoomHistoryVisibility)historyVisibility
 {
-    NSString *historyVisibility = kMXRoomHistoryVisibilityShared;
+    MXRoomHistoryVisibility historyVisibility = kMXRoomHistoryVisibilityShared;
 
     // Check it from the state events
     MXEvent *event = [stateEvents objectForKey:kMXEventTypeStringRoomHistoryVisibility];
@@ -269,6 +269,20 @@
         historyVisibility = [historyVisibility copy];
     }
     return historyVisibility;
+}
+
+- (MXRoomJoinRule)joinRule
+{
+    MXRoomJoinRule joinRule = kMXRoomJoinRuleInvite;
+
+    // Check it from the state events
+    MXEvent *event = [stateEvents objectForKey:kMXEventTypeStringRoomJoinRules];
+    if (event && [self contentOfEvent:event])
+    {
+        MXJSONModelSetString(joinRule, [self contentOfEvent:event][@"join_rule"]);
+        joinRule = [joinRule copy];
+    }
+    return joinRule;
 }
 
 - (NSString *)displayname

--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
@@ -20,7 +20,7 @@
 
 #import "MXFileStoreMetaData.h"
 
-NSUInteger const kMXFileVersion = 26;
+NSUInteger const kMXFileVersion = 27;
 
 NSString *const kMXFileStoreFolder = @"MXFileStore";
 NSString *const kMXFileStoreMedaDataFile = @"MXFileStore";

--- a/MatrixSDK/JSONModels/MXEvent.h
+++ b/MatrixSDK/JSONModels/MXEvent.h
@@ -37,6 +37,7 @@ typedef enum : NSUInteger
     MXEventTypeRoomPowerLevels,
     MXEventTypeRoomAliases,
     MXEventTypeRoomCanonicalAlias,
+    MXEventTypeRoomHistoryVisibility,
     MXEventTypeRoomMessage,
     MXEventTypeRoomMessageFeedback,
     MXEventTypeRoomRedaction,
@@ -68,6 +69,7 @@ FOUNDATION_EXPORT NSString *const kMXEventTypeStringRoomJoinRules;
 FOUNDATION_EXPORT NSString *const kMXEventTypeStringRoomPowerLevels;
 FOUNDATION_EXPORT NSString *const kMXEventTypeStringRoomAliases;
 FOUNDATION_EXPORT NSString *const kMXEventTypeStringRoomCanonicalAlias;
+FOUNDATION_EXPORT NSString *const kMXEventTypeStringRoomHistoryVisibility;
 FOUNDATION_EXPORT NSString *const kMXEventTypeStringRoomMessage;
 FOUNDATION_EXPORT NSString *const kMXEventTypeStringRoomMessageFeedback;
 FOUNDATION_EXPORT NSString *const kMXEventTypeStringRoomRedaction;
@@ -77,7 +79,6 @@ FOUNDATION_EXPORT NSString *const kMXEventTypeStringPresence;
 FOUNDATION_EXPORT NSString *const kMXEventTypeStringTypingNotification;
 FOUNDATION_EXPORT NSString *const kMXEventTypeStringReceipt;
 FOUNDATION_EXPORT NSString *const kMXEventTypeStringRead;
-
 FOUNDATION_EXPORT NSString *const kMXEventTypeStringCallInvite;
 FOUNDATION_EXPORT NSString *const kMXEventTypeStringCallCandidates;
 FOUNDATION_EXPORT NSString *const kMXEventTypeStringCallAnswer;

--- a/MatrixSDK/JSONModels/MXEvent.h
+++ b/MatrixSDK/JSONModels/MXEvent.h
@@ -37,6 +37,7 @@ typedef enum : NSUInteger
     MXEventTypeRoomPowerLevels,
     MXEventTypeRoomAliases,
     MXEventTypeRoomCanonicalAlias,
+    MXEventTypeRoomGuestAccess,
     MXEventTypeRoomHistoryVisibility,
     MXEventTypeRoomMessage,
     MXEventTypeRoomMessageFeedback,
@@ -69,6 +70,7 @@ FOUNDATION_EXPORT NSString *const kMXEventTypeStringRoomJoinRules;
 FOUNDATION_EXPORT NSString *const kMXEventTypeStringRoomPowerLevels;
 FOUNDATION_EXPORT NSString *const kMXEventTypeStringRoomAliases;
 FOUNDATION_EXPORT NSString *const kMXEventTypeStringRoomCanonicalAlias;
+FOUNDATION_EXPORT NSString *const kMXEventTypeStringRoomGuestAccess;
 FOUNDATION_EXPORT NSString *const kMXEventTypeStringRoomHistoryVisibility;
 FOUNDATION_EXPORT NSString *const kMXEventTypeStringRoomMessage;
 FOUNDATION_EXPORT NSString *const kMXEventTypeStringRoomMessageFeedback;

--- a/MatrixSDK/JSONModels/MXEvent.m
+++ b/MatrixSDK/JSONModels/MXEvent.m
@@ -20,24 +20,25 @@
 
 #pragma mark - Constants definitions
 
-NSString *const kMXEventTypeStringRoomName            = @"m.room.name";
-NSString *const kMXEventTypeStringRoomTopic           = @"m.room.topic";
-NSString *const kMXEventTypeStringRoomAvatar          = @"m.room.avatar";
-NSString *const kMXEventTypeStringRoomMember          = @"m.room.member";
-NSString *const kMXEventTypeStringRoomCreate          = @"m.room.create";
-NSString *const kMXEventTypeStringRoomJoinRules       = @"m.room.join_rules";
-NSString *const kMXEventTypeStringRoomPowerLevels     = @"m.room.power_levels";
-NSString *const kMXEventTypeStringRoomAliases         = @"m.room.aliases";
-NSString *const kMXEventTypeStringRoomCanonicalAlias  = @"m.room.canonical_alias";
-NSString *const kMXEventTypeStringRoomMessage         = @"m.room.message";
-NSString *const kMXEventTypeStringRoomMessageFeedback = @"m.room.message.feedback";
-NSString *const kMXEventTypeStringRoomRedaction       = @"m.room.redaction";
-NSString *const kMXEventTypeStringRoomThirdPartyInvite= @"m.room.third_party_invite";
-NSString *const kMXEventTypeStringRoomTag             = @"m.tag";
-NSString *const kMXEventTypeStringPresence            = @"m.presence";
-NSString *const kMXEventTypeStringTypingNotification  = @"m.typing";
-NSString *const kMXEventTypeStringReceipt             = @"m.receipt";
-NSString *const kMXEventTypeStringRead                = @"m.read";
+NSString *const kMXEventTypeStringRoomName              = @"m.room.name";
+NSString *const kMXEventTypeStringRoomTopic             = @"m.room.topic";
+NSString *const kMXEventTypeStringRoomAvatar            = @"m.room.avatar";
+NSString *const kMXEventTypeStringRoomMember            = @"m.room.member";
+NSString *const kMXEventTypeStringRoomCreate            = @"m.room.create";
+NSString *const kMXEventTypeStringRoomJoinRules         = @"m.room.join_rules";
+NSString *const kMXEventTypeStringRoomPowerLevels       = @"m.room.power_levels";
+NSString *const kMXEventTypeStringRoomAliases           = @"m.room.aliases";
+NSString *const kMXEventTypeStringRoomCanonicalAlias    = @"m.room.canonical_alias";
+NSString *const kMXEventTypeStringRoomHistoryVisibility = @"m.room.history_visibility";
+NSString *const kMXEventTypeStringRoomMessage           = @"m.room.message";
+NSString *const kMXEventTypeStringRoomMessageFeedback   = @"m.room.message.feedback";
+NSString *const kMXEventTypeStringRoomRedaction         = @"m.room.redaction";
+NSString *const kMXEventTypeStringRoomThirdPartyInvite  = @"m.room.third_party_invite";
+NSString *const kMXEventTypeStringRoomTag               = @"m.tag";
+NSString *const kMXEventTypeStringPresence              = @"m.presence";
+NSString *const kMXEventTypeStringTypingNotification    = @"m.typing";
+NSString *const kMXEventTypeStringReceipt               = @"m.receipt";
+NSString *const kMXEventTypeStringRead                  = @"m.read";
 
 NSString *const kMXEventTypeStringCallInvite          = @"m.call.invite";
 NSString *const kMXEventTypeStringCallCandidates      = @"m.call.candidates";

--- a/MatrixSDK/JSONModels/MXEvent.m
+++ b/MatrixSDK/JSONModels/MXEvent.m
@@ -29,6 +29,7 @@ NSString *const kMXEventTypeStringRoomJoinRules         = @"m.room.join_rules";
 NSString *const kMXEventTypeStringRoomPowerLevels       = @"m.room.power_levels";
 NSString *const kMXEventTypeStringRoomAliases           = @"m.room.aliases";
 NSString *const kMXEventTypeStringRoomCanonicalAlias    = @"m.room.canonical_alias";
+NSString *const kMXEventTypeStringRoomGuestAccess       = @"m.room.guest_access";
 NSString *const kMXEventTypeStringRoomHistoryVisibility = @"m.room.history_visibility";
 NSString *const kMXEventTypeStringRoomMessage           = @"m.room.message";
 NSString *const kMXEventTypeStringRoomMessageFeedback   = @"m.room.message.feedback";

--- a/MatrixSDK/MXEnumConstants.h
+++ b/MatrixSDK/MXEnumConstants.h
@@ -22,14 +22,21 @@
  It is supposed to solve cross dependency issues.
  */
 
+/**
+ Room visibility in the current homeserver directory.
+ The default homeserver value is private.
+ */
+typedef NSString* MXRoomDirectoryVisibility;
 
 /**
- Room visibility.
- A nil value is interpreted as private by the homeserver.
+ The room is not listed in the homeserver directory.
  */
-typedef NSString* MXRoomVisibility;
-FOUNDATION_EXPORT NSString *const kMXRoomVisibilityPublic;
-FOUNDATION_EXPORT NSString *const kMXRoomVisibilityPrivate;
+FOUNDATION_EXPORT NSString *const kMXRoomDirectoryVisibilityPrivate;
+
+/**
+ The room is listed in the homeserver directory.
+ */
+FOUNDATION_EXPORT NSString *const kMXRoomDirectoryVisibilityPublic;
 
 
 /**
@@ -107,23 +114,6 @@ FOUNDATION_EXPORT NSString *const kMXRoomGuestAccessCanJoin;
  Guest access is forbidden.
  */
 FOUNDATION_EXPORT NSString *const kMXRoomGuestAccessForbidden;
-
-
-/**
- Room visibility in the current homeserver directory.
- The default homeserver value is private.
- */
-typedef NSString* MXRoomDirectoryVisibility;
-
-/**
- The room is not listed in the homeserver directory.
- */
-FOUNDATION_EXPORT NSString *const kMXRoomDirectoryVisibilityPrivate;
-
-/**
- The room is listed in the homeserver directory.
- */
-FOUNDATION_EXPORT NSString *const kMXRoomDirectoryVisibilityPublic;
 
 
 /**

--- a/MatrixSDK/MXEnumConstants.h
+++ b/MatrixSDK/MXEnumConstants.h
@@ -36,7 +36,7 @@ FOUNDATION_EXPORT NSString *const kMXRoomVisibilityPrivate;
  Room history visibility.
  It controls whether a user can see the events that happened in a room from before they
  joined.
- A nil value is interpreted as @TODO by the homeserver.
+ The default homeserver value is shared.
  */
 typedef NSString* MXRoomHistoryVisibility;
 
@@ -70,7 +70,7 @@ FOUNDATION_EXPORT NSString *const kMXRoomHistoryVisibilityJoined;
 
 /**
  Room join rule.
- A nil value is interpreted as invite by the homeserver.
+ The default homeserver value is invite.
  */
 typedef NSString* MXRoomJoinRule;
 
@@ -86,10 +86,27 @@ FOUNDATION_EXPORT NSString *const kMXRoomJoinRulePublic;
 FOUNDATION_EXPORT NSString *const kMXRoomJoinRuleInvite;
 
 /**
- Reeserved keywords which are not implemented by homeservers.
+ Reserved keywords which are not implemented by homeservers.
  */
 FOUNDATION_EXPORT NSString *const kMXRoomJoinRulePrivate;
 FOUNDATION_EXPORT NSString *const kMXRoomJoinRuleKnock;
+
+
+/**
+ Room guest access.
+ The default homeserver value is forbidden.
+ */
+typedef NSString* MXRoomGuestAccess;
+
+/**
+ Guests can join the room.
+ */
+FOUNDATION_EXPORT NSString *const kMXRoomGuestAccessCanJoin;
+
+/**
+ Guest access is forbidden.
+ */
+FOUNDATION_EXPORT NSString *const kMXRoomGuestAccessForbidden;
 
 
 /**

--- a/MatrixSDK/MXEnumConstants.h
+++ b/MatrixSDK/MXEnumConstants.h
@@ -110,6 +110,23 @@ FOUNDATION_EXPORT NSString *const kMXRoomGuestAccessForbidden;
 
 
 /**
+ Room visibility in the current homeserver directory.
+ The default homeserver value is private.
+ */
+typedef NSString* MXRoomDirectoryVisibility;
+
+/**
+ The room is not listed in the homeserver directory.
+ */
+FOUNDATION_EXPORT NSString *const kMXRoomDirectoryVisibilityPrivate;
+
+/**
+ The room is listed in the homeserver directory.
+ */
+FOUNDATION_EXPORT NSString *const kMXRoomDirectoryVisibilityPublic;
+
+
+/**
  The direction of an event in the timeline.
  */
 typedef enum : NSUInteger

--- a/MatrixSDK/MXEnumConstants.h
+++ b/MatrixSDK/MXEnumConstants.h
@@ -43,27 +43,27 @@ typedef NSString* MXRoomHistoryVisibility;
  participating homeserver with anyone, regardless of whether they have ever joined
  the room.
  */
-FOUNDATION_EXPORT NSString *const MXRoomHistoryVisibilityWorldReadable;
+FOUNDATION_EXPORT NSString *const kMXRoomHistoryVisibilityWorldReadable;
 
 /**
  Previous events are always accessible to newly joined members. All events in the
  room are accessible, even those sent when the member was not a part of the room.
  */
-FOUNDATION_EXPORT NSString *const MXRoomHistoryVisibilityShared;
+FOUNDATION_EXPORT NSString *const kMXRoomHistoryVisibilityShared;
 
 /**
  Events are accessible to newly joined members from the point they were invited onwards.
  Events stop being accessible when the member's state changes to something other than
  invite or join.
  */
-FOUNDATION_EXPORT NSString *const MXRoomHistoryVisibilityInvited;
+FOUNDATION_EXPORT NSString *const kMXRoomHistoryVisibilityInvited;
 
 /**
  Events are accessible to newly joined members from the point they joined the room
  onwards. Events stop being accessible when the member's state changes to something
  other than join.
  */
-FOUNDATION_EXPORT NSString *const MXRoomHistoryVisibilityJoined;
+FOUNDATION_EXPORT NSString *const kMXRoomHistoryVisibilityJoined;
 
 /**
  The direction of an event in the timeline.

--- a/MatrixSDK/MXEnumConstants.h
+++ b/MatrixSDK/MXEnumConstants.h
@@ -22,6 +22,7 @@
  It is supposed to solve cross dependency issues.
  */
 
+
 /**
  Room visibility.
  A nil value is interpreted as private by the homeserver.
@@ -29,6 +30,7 @@
 typedef NSString* MXRoomVisibility;
 FOUNDATION_EXPORT NSString *const kMXRoomVisibilityPublic;
 FOUNDATION_EXPORT NSString *const kMXRoomVisibilityPrivate;
+
 
 /**
  Room history visibility.
@@ -64,6 +66,31 @@ FOUNDATION_EXPORT NSString *const kMXRoomHistoryVisibilityInvited;
  other than join.
  */
 FOUNDATION_EXPORT NSString *const kMXRoomHistoryVisibilityJoined;
+
+
+/**
+ Room join rule.
+ A nil value is interpreted as invite by the homeserver.
+ */
+typedef NSString* MXRoomJoinRule;
+
+/**
+ Anyone can join the room without any prior action.
+ */
+FOUNDATION_EXPORT NSString *const kMXRoomJoinRulePublic;
+
+/**
+ A user who wishes to join the room must first receive an invite to the room from someone 
+ already inside of the room.
+ */
+FOUNDATION_EXPORT NSString *const kMXRoomJoinRuleInvite;
+
+/**
+ Reeserved keywords which are not implemented by homeservers.
+ */
+FOUNDATION_EXPORT NSString *const kMXRoomJoinRulePrivate;
+FOUNDATION_EXPORT NSString *const kMXRoomJoinRuleKnock;
+
 
 /**
  The direction of an event in the timeline.

--- a/MatrixSDK/MXEnumConstants.h
+++ b/MatrixSDK/MXEnumConstants.h
@@ -1,0 +1,80 @@
+/*
+ Copyright 2016 OpenMarket Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+/**
+ The file defines contants, enums and typdefs that are used from different classes
+ of the SDK.
+ It is supposed to solve cross dependency issues.
+ */
+
+/**
+ Room visibility.
+ A nil value is interpreted as private by the homeserver.
+ */
+typedef NSString* MXRoomVisibility;
+FOUNDATION_EXPORT NSString *const kMXRoomVisibilityPublic;
+FOUNDATION_EXPORT NSString *const kMXRoomVisibilityPrivate;
+
+/**
+ Room history visibility.
+ It controls whether a user can see the events that happened in a room from before they
+ joined.
+ A nil value is interpreted as @TODO by the homeserver.
+ */
+typedef NSString* MXRoomHistoryVisibility;
+
+/**
+ All events while this is the m.room.history_visibility value may be shared by any
+ participating homeserver with anyone, regardless of whether they have ever joined
+ the room.
+ */
+FOUNDATION_EXPORT NSString *const MXRoomHistoryVisibilityWorldReadable;
+
+/**
+ Previous events are always accessible to newly joined members. All events in the
+ room are accessible, even those sent when the member was not a part of the room.
+ */
+FOUNDATION_EXPORT NSString *const MXRoomHistoryVisibilityShared;
+
+/**
+ Events are accessible to newly joined members from the point they were invited onwards.
+ Events stop being accessible when the member's state changes to something other than
+ invite or join.
+ */
+FOUNDATION_EXPORT NSString *const MXRoomHistoryVisibilityInvited;
+
+/**
+ Events are accessible to newly joined members from the point they joined the room
+ onwards. Events stop being accessible when the member's state changes to something
+ other than join.
+ */
+FOUNDATION_EXPORT NSString *const MXRoomHistoryVisibilityJoined;
+
+/**
+ The direction of an event in the timeline.
+ */
+typedef enum : NSUInteger
+{
+    // Forwards when the event is added to the end of the timeline.
+    // These events come from the /sync stream or from forwards pagination.
+    MXTimelineDirectionForwards,
+
+    // Backwards when the event is added to the start of the timeline.
+    // These events come from a back pagination.
+    MXTimelineDirectionBackwards
+} MXTimelineDirection;

--- a/MatrixSDK/MXEnumConstants.m
+++ b/MatrixSDK/MXEnumConstants.m
@@ -43,3 +43,9 @@ NSString *const kMXRoomJoinRuleKnock   = @"knock";
  */
 NSString *const kMXRoomGuestAccessCanJoin   = @"can_join";
 NSString *const kMXRoomGuestAccessForbidden = @"forbidden";
+
+/**
+ Room visibility in the homeserver directory.
+ */
+NSString *const kMXRoomDirectoryVisibilityPrivate   = @"private";
+NSString *const kMXRoomDirectoryVisibilityPublic    = @"public";

--- a/MatrixSDK/MXEnumConstants.m
+++ b/MatrixSDK/MXEnumConstants.m
@@ -38,3 +38,8 @@ NSString *const kMXRoomJoinRuleInvite  = @"invite";
 NSString *const kMXRoomJoinRulePrivate = @"private";
 NSString *const kMXRoomJoinRuleKnock   = @"knock";
 
+/**
+ Room guest access.
+ */
+NSString *const kMXRoomGuestAccessCanJoin   = @"can_join";
+NSString *const kMXRoomGuestAccessForbidden = @"forbidden";

--- a/MatrixSDK/MXEnumConstants.m
+++ b/MatrixSDK/MXEnumConstants.m
@@ -25,8 +25,8 @@ NSString *const kMXRoomVisibilityPrivate = @"private";
 /**
  Room history visibility.
  */
-NSString *const MXRoomHistoryVisibilityWorldReadable= @"world_readable";
-NSString *const MXRoomHistoryVisibilityShared       = @"shared";
-NSString *const MXRoomHistoryVisibilityInvited      = @"invited";
-NSString *const MXRoomHistoryVisibilityJoined       = @"joined";
+NSString *const kMXRoomHistoryVisibilityWorldReadable= @"world_readable";
+NSString *const kMXRoomHistoryVisibilityShared       = @"shared";
+NSString *const kMXRoomHistoryVisibilityInvited      = @"invited";
+NSString *const kMXRoomHistoryVisibilityJoined       = @"joined";
 

--- a/MatrixSDK/MXEnumConstants.m
+++ b/MatrixSDK/MXEnumConstants.m
@@ -30,3 +30,11 @@ NSString *const kMXRoomHistoryVisibilityShared       = @"shared";
 NSString *const kMXRoomHistoryVisibilityInvited      = @"invited";
 NSString *const kMXRoomHistoryVisibilityJoined       = @"joined";
 
+/**
+ Room join rule.
+ */
+NSString *const kMXRoomJoinRulePublic  = @"public";
+NSString *const kMXRoomJoinRuleInvite  = @"invite";
+NSString *const kMXRoomJoinRulePrivate = @"private";
+NSString *const kMXRoomJoinRuleKnock   = @"knock";
+

--- a/MatrixSDK/MXEnumConstants.m
+++ b/MatrixSDK/MXEnumConstants.m
@@ -17,10 +17,10 @@
 #import "MXEnumConstants.h"
 
 /**
- Room visibility
+ Room visibility in the homeserver directory.
  */
-NSString *const kMXRoomVisibilityPublic  = @"public";
-NSString *const kMXRoomVisibilityPrivate = @"private";
+NSString *const kMXRoomDirectoryVisibilityPrivate   = @"private";
+NSString *const kMXRoomDirectoryVisibilityPublic    = @"public";
 
 /**
  Room history visibility.
@@ -44,8 +44,3 @@ NSString *const kMXRoomJoinRuleKnock   = @"knock";
 NSString *const kMXRoomGuestAccessCanJoin   = @"can_join";
 NSString *const kMXRoomGuestAccessForbidden = @"forbidden";
 
-/**
- Room visibility in the homeserver directory.
- */
-NSString *const kMXRoomDirectoryVisibilityPrivate   = @"private";
-NSString *const kMXRoomDirectoryVisibilityPublic    = @"public";

--- a/MatrixSDK/MXEnumConstants.m
+++ b/MatrixSDK/MXEnumConstants.m
@@ -1,0 +1,32 @@
+/*
+ Copyright 2016 OpenMarket Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXEnumConstants.h"
+
+/**
+ Room visibility
+ */
+NSString *const kMXRoomVisibilityPublic  = @"public";
+NSString *const kMXRoomVisibilityPrivate = @"private";
+
+/**
+ Room history visibility.
+ */
+NSString *const MXRoomHistoryVisibilityWorldReadable= @"world_readable";
+NSString *const MXRoomHistoryVisibilityShared       = @"shared";
+NSString *const MXRoomHistoryVisibilityInvited      = @"invited";
+NSString *const MXRoomHistoryVisibilityJoined       = @"joined";
+

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -608,10 +608,10 @@ typedef enum : NSUInteger
 
  @return a MXHTTPOperation instance.
  */
-- (MXHTTPOperation*)setJoinRule:(NSString*)roomId
-                        joinRule:(MXRoomJoinRule)joinRule
-                         success:(void (^)())success
-                         failure:(void (^)(NSError *error))failure;
+- (MXHTTPOperation*)setRoomJoinRule:(NSString*)roomId
+                           joinRule:(MXRoomJoinRule)joinRule
+                            success:(void (^)())success
+                            failure:(void (^)(NSError *error))failure;
 
 /**
  Get the join rule of a room.

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -49,49 +49,6 @@ FOUNDATION_EXPORT NSString *const kMXContentUriScheme;
 FOUNDATION_EXPORT NSString *const kMXContentPrefixPath;
 
 /**
- Room visibility.
- A nil value is interpreted as private by the homeserver.
- */
-typedef NSString* MXRoomVisibility;
-FOUNDATION_EXPORT NSString *const kMXRoomVisibilityPublic;
-FOUNDATION_EXPORT NSString *const kMXRoomVisibilityPrivate;
-
-/**
- Room history visibility.
- It controls whether a user can see the events that happened in a room from before they
- joined.
- A nil value is interpreted as @TODO by the homeserver.
- */
-typedef NSString* MXRoomHistoryVisibility;
-
-/**
- All events while this is the m.room.history_visibility value may be shared by any
- participating homeserver with anyone, regardless of whether they have ever joined
- the room.
- */
-FOUNDATION_EXPORT NSString *const MXRoomHistoryVisibilityWorldReadable;
-
-/**
- Previous events are always accessible to newly joined members. All events in the
- room are accessible, even those sent when the member was not a part of the room.
- */
-FOUNDATION_EXPORT NSString *const MXRoomHistoryVisibilityShared;
-
-/**
- Events are accessible to newly joined members from the point they were invited onwards.
- Events stop being accessible when the member's state changes to something other than
- invite or join.
- */
-FOUNDATION_EXPORT NSString *const MXRoomHistoryVisibilityInvited;
-
-/**
- Events are accessible to newly joined members from the point they joined the room
- onwards. Events stop being accessible when the member's state changes to something
- other than join.
- */
-FOUNDATION_EXPORT NSString *const MXRoomHistoryVisibilityJoined;
-
-/**
  Account data types
  */
 FOUNDATION_EXPORT NSString *const kMXAccountDataPushRules;

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -49,11 +49,47 @@ FOUNDATION_EXPORT NSString *const kMXContentUriScheme;
 FOUNDATION_EXPORT NSString *const kMXContentPrefixPath;
 
 /**
- Room visibility
+ Room visibility.
+ A nil value is interpreted as private by the homeserver.
  */
 typedef NSString* MXRoomVisibility;
 FOUNDATION_EXPORT NSString *const kMXRoomVisibilityPublic;
 FOUNDATION_EXPORT NSString *const kMXRoomVisibilityPrivate;
+
+/**
+ Room history visibility.
+ It controls whether a user can see the events that happened in a room from before they
+ joined.
+ A nil value is interpreted as @TODO by the homeserver.
+ */
+typedef NSString* MXRoomHistoryVisibility;
+
+/**
+ All events while this is the m.room.history_visibility value may be shared by any
+ participating homeserver with anyone, regardless of whether they have ever joined
+ the room.
+ */
+FOUNDATION_EXPORT NSString *const MXRoomHistoryVisibilityWorldReadable;
+
+/**
+ Previous events are always accessible to newly joined members. All events in the
+ room are accessible, even those sent when the member was not a part of the room.
+ */
+FOUNDATION_EXPORT NSString *const MXRoomHistoryVisibilityShared;
+
+/**
+ Events are accessible to newly joined members from the point they were invited onwards.
+ Events stop being accessible when the member's state changes to something other than
+ invite or join.
+ */
+FOUNDATION_EXPORT NSString *const MXRoomHistoryVisibilityInvited;
+
+/**
+ Events are accessible to newly joined members from the point they joined the room
+ onwards. Events stop being accessible when the member's state changes to something
+ other than join.
+ */
+FOUNDATION_EXPORT NSString *const MXRoomHistoryVisibilityJoined;
 
 /**
  Account data types
@@ -578,6 +614,34 @@ typedef enum : NSUInteger
                    failure:(void (^)(NSError *error))failure;
 
 /**
+ Set the history visibility of a room.
+
+ @param roomId the id of the room.
+ @param historyVisibility the visibily to set.
+ @param success A block object called when the operation succeeds.
+ @param failure A block object called when the operation fails.
+
+ @return a MXHTTPOperation instance.
+ */
+- (MXHTTPOperation*)setHistoryVisibility:(NSString*)roomId
+                       historyVisibility:(MXRoomHistoryVisibility)historyVisibility
+                                 success:(void (^)())success
+                                 failure:(void (^)(NSError *error))failure;
+
+/**
+ Get the history visibility of a room.
+
+ @param roomId the id of the room.
+ @param success A block object called when the operation succeeds. It provides the room name.
+ @param failure A block object called when the operation fails.
+
+ @return a MXHTTPOperation instance.
+ */
+- (MXHTTPOperation*)historyVisibilityOfRoom:(NSString*)roomId
+                                    success:(void (^)(MXRoomHistoryVisibility historyVisibility))success
+                                    failure:(void (^)(NSError *error))failure;
+
+/**
  Join a room.
  
  @param roomIdOrAlias the id or an alias of the room to join.
@@ -727,11 +791,11 @@ typedef enum : NSUInteger
  @return a MXHTTPOperation instance.
  */
 - (MXHTTPOperation*)createRoom:(NSString*)name
-                visibility:(MXRoomVisibility)visibility
-                 roomAlias:(NSString*)roomAlias
-                     topic:(NSString*)topic
-                   success:(void (^)(MXCreateRoomResponse *response))success
-                   failure:(void (^)(NSError *error))failure;
+                    visibility:(MXRoomVisibility)visibility
+                     roomAlias:(NSString*)roomAlias
+                         topic:(NSString*)topic
+                       success:(void (^)(MXCreateRoomResponse *response))success
+                       failure:(void (^)(NSError *error))failure;
 
 /**
  Get a list of messages for this room.

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -580,10 +580,10 @@ typedef enum : NSUInteger
 
  @return a MXHTTPOperation instance.
  */
-- (MXHTTPOperation*)setHistoryVisibility:(NSString*)roomId
-                       historyVisibility:(MXRoomHistoryVisibility)historyVisibility
-                                 success:(void (^)())success
-                                 failure:(void (^)(NSError *error))failure;
+- (MXHTTPOperation*)setRoomHistoryVisibility:(NSString*)roomId
+                           historyVisibility:(MXRoomHistoryVisibility)historyVisibility
+                                     success:(void (^)())success
+                                     failure:(void (^)(NSError *error))failure;
 
 /**
  Get the history visibility of a room.

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -589,7 +589,7 @@ typedef enum : NSUInteger
  Get the history visibility of a room.
 
  @param roomId the id of the room.
- @param success A block object called when the operation succeeds. It provides the room name.
+ @param success A block object called when the operation succeeds. It provides the room history visibility.
  @param failure A block object called when the operation fails.
 
  @return a MXHTTPOperation instance.
@@ -597,6 +597,34 @@ typedef enum : NSUInteger
 - (MXHTTPOperation*)historyVisibilityOfRoom:(NSString*)roomId
                                     success:(void (^)(MXRoomHistoryVisibility historyVisibility))success
                                     failure:(void (^)(NSError *error))failure;
+
+/**
+ Set the join rule of a room.
+
+ @param roomId the id of the room.
+ @param joinRule the rule to set.
+ @param success A block object called when the operation succeeds.
+ @param failure A block object called when the operation fails.
+
+ @return a MXHTTPOperation instance.
+ */
+- (MXHTTPOperation*)setJoinRule:(NSString*)roomId
+                        joinRule:(MXRoomJoinRule)joinRule
+                         success:(void (^)())success
+                         failure:(void (^)(NSError *error))failure;
+
+/**
+ Get the join rule of a room.
+
+ @param roomId the id of the room.
+ @param success A block object called when the operation succeeds. It provides the room join rule.
+ @param failure A block object called when the operation fails.
+
+ @return a MXHTTPOperation instance.
+ */
+- (MXHTTPOperation*)joinRuleOfRoom:(NSString*)roomId
+                            success:(void (^)(MXRoomJoinRule joinRule))success
+                            failure:(void (^)(NSError *error))failure;
 
 /**
  Join a room.

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -823,7 +823,7 @@ typedef enum : NSUInteger
  Create a room.
  
  @param name (optional) the room name.
- @param visibility (optional) the visibility of the room (kMXRoomVisibilityPublic or kMXRoomVisibilityPrivate).
+ @param visibility (optional) the visibility of the room in the current HS's room directory.
  @param roomAlias (optional) the room alias on the home server the room will be created.
  @param topic (optional) the room topic.
 
@@ -833,7 +833,7 @@ typedef enum : NSUInteger
  @return a MXHTTPOperation instance.
  */
 - (MXHTTPOperation*)createRoom:(NSString*)name
-                    visibility:(MXRoomVisibility)visibility
+                    visibility:(MXRoomDirectoryVisibility)visibility
                      roomAlias:(NSString*)roomAlias
                          topic:(NSString*)topic
                        success:(void (^)(MXCreateRoomResponse *response))success

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -651,8 +651,37 @@ typedef enum : NSUInteger
  @return a MXHTTPOperation instance.
  */
 - (MXHTTPOperation*)guestAccessOfRoom:(NSString*)roomId
-                           success:(void (^)(MXRoomGuestAccess guestAccess))success
-                           failure:(void (^)(NSError *error))failure;
+                              success:(void (^)(MXRoomGuestAccess guestAccess))success
+                              failure:(void (^)(NSError *error))failure;
+
+/**
+ Set the directory visibility of a room on the current homeserver.
+
+ @param roomId the id of the room.
+ @param directoryVisibility the directory visibility to set.
+ @param success A block object called when the operation succeeds.
+ @param failure A block object called when the operation fails.
+
+ @return a MXHTTPOperation instance.
+ */
+- (MXHTTPOperation*)setRoomDirectoryVisibility:(NSString*)roomId
+                           directoryVisibility:(MXRoomDirectoryVisibility)directoryVisibility
+                                       success:(void (^)())success
+                                       failure:(void (^)(NSError *error))failure;
+
+/**
+ Get the guest access of a room on the current homeserver.
+
+ @param roomId the id of the room.
+ @param success A block object called when the operation succeeds. It provides the room directory visibility.
+ @param failure A block object called when the operation fails.
+
+ @return a MXHTTPOperation instance.
+ */
+- (MXHTTPOperation*)directoryVisibilityOfRoom:(NSString*)roomId
+                              success:(void (^)(MXRoomDirectoryVisibility directoryVisibility))success
+                              failure:(void (^)(NSError *error))failure;
+
 
 /**
  Join a room.

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -670,7 +670,7 @@ typedef enum : NSUInteger
                                        failure:(void (^)(NSError *error))failure;
 
 /**
- Get the guest access of a room on the current homeserver.
+ Get the visibility of a room in the current HS's room directory.
 
  @param roomId the id of the room.
  @param success A block object called when the operation succeeds. It provides the room directory visibility.

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -627,6 +627,34 @@ typedef enum : NSUInteger
                             failure:(void (^)(NSError *error))failure;
 
 /**
+ Set the guest access of a room.
+
+ @param roomId the id of the room.
+ @param guestAccess the guest access to set.
+ @param success A block object called when the operation succeeds.
+ @param failure A block object called when the operation fails.
+
+ @return a MXHTTPOperation instance.
+ */
+- (MXHTTPOperation*)setRoomGuestAccess:(NSString*)roomId
+                           guestAccess:(MXRoomGuestAccess)guestAccess
+                               success:(void (^)())success
+                               failure:(void (^)(NSError *error))failure;
+
+/**
+ Get the guest access of a room.
+
+ @param roomId the id of the room.
+ @param success A block object called when the operation succeeds. It provides the room guest access.
+ @param failure A block object called when the operation fails.
+
+ @return a MXHTTPOperation instance.
+ */
+- (MXHTTPOperation*)guestAccessOfRoom:(NSString*)roomId
+                           success:(void (^)(MXRoomGuestAccess guestAccess))success
+                           failure:(void (^)(NSError *error))failure;
+
+/**
  Join a room.
  
  @param roomIdOrAlias the id or an alias of the room to join.

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -1058,6 +1058,35 @@ MXAuthAction;
                            } failure:failure];
 }
 
+- (MXHTTPOperation*)setJoinRule:(NSString*)roomId
+                       joinRule:(MXRoomJoinRule)joinRule
+                        success:(void (^)())success
+                        failure:(void (^)(NSError *error))failure
+{
+    return [self updateStateEvent:kMXEventTypeStringRoomJoinRules
+                        withValue:@{
+                                    @"join_rule": joinRule
+                                    }
+                           inRoom:roomId
+                          success:success failure:failure];
+}
+
+- (MXHTTPOperation*)joinRuleOfRoom:(NSString*)roomId
+                           success:(void (^)(MXRoomJoinRule joinRule))success
+                           failure:(void (^)(NSError *error))failure
+{
+    return [self valueOfStateEvent:kMXEventTypeStringRoomJoinRules
+                            inRoom:roomId
+                           success:^(NSDictionary *JSONResponse) {
+
+                               NSString *joinRule;
+                               MXJSONModelSetString(joinRule, JSONResponse[@"join_rule"]);
+                               success(joinRule);
+
+                           } failure:failure];
+}
+
+
 - (MXHTTPOperation*)joinRoom:(NSString*)roomIdOrAlias
                      success:(void (^)(NSString *theRoomId))success
                      failure:(void (^)(NSError *error))failure

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -1030,10 +1030,10 @@ MXAuthAction;
                            } failure:failure];
 }
 
-- (MXHTTPOperation *)setHistoryVisibility:(NSString *)roomId
-                        historyVisibility:(MXRoomHistoryVisibility)historyVisibility
-                                  success:(void (^)())success
-                                  failure:(void (^)(NSError *))failure
+- (MXHTTPOperation *)setRoomHistoryVisibility:(NSString *)roomId
+                            historyVisibility:(MXRoomHistoryVisibility)historyVisibility
+                                      success:(void (^)())success
+                                      failure:(void (^)(NSError *))failure
 {
     return [self updateStateEvent:kMXEventTypeStringRoomHistoryVisibility
                         withValue:@{

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -1398,7 +1398,7 @@ MXAuthAction;
 }
 
 - (MXHTTPOperation*)createRoom:(NSString*)name
-                    visibility:(MXRoomVisibility)visibility
+                    visibility:(MXRoomDirectoryVisibility)visibility
                      roomAlias:(NSString*)roomAlias
                          topic:(NSString*)topic
                        success:(void (^)(MXCreateRoomResponse *response))success

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -1086,6 +1086,33 @@ MXAuthAction;
                            } failure:failure];
 }
 
+- (MXHTTPOperation*)setRoomGuestAccess:(NSString*)roomId
+                           guestAccess:(MXRoomGuestAccess)guestAccess
+                               success:(void (^)())success
+                               failure:(void (^)(NSError *error))failure
+{
+    return [self updateStateEvent:kMXEventTypeStringRoomGuestAccess
+                        withValue:@{
+                                    @"guest_access": guestAccess
+                                    }
+                           inRoom:roomId
+                          success:success failure:failure];
+}
+
+- (MXHTTPOperation*)guestAccessOfRoom:(NSString*)roomId
+                              success:(void (^)(MXRoomGuestAccess guestAccess))success
+                              failure:(void (^)(NSError *error))failure
+{
+    return [self valueOfStateEvent:kMXEventTypeStringRoomGuestAccess
+                            inRoom:roomId
+                           success:^(NSDictionary *JSONResponse) {
+
+                               NSString *guestAccess;
+                               MXJSONModelSetString(guestAccess, JSONResponse[@"guest_access"]);
+                               success(guestAccess);
+
+                           } failure:failure];
+}
 
 - (MXHTTPOperation*)joinRoom:(NSString*)roomIdOrAlias
                      success:(void (^)(NSString *theRoomId))success

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -866,6 +866,7 @@ MXAuthAction;
  Generic method to set the value of a state event of a room.
 
  @param eventType the type of the state event.
+ @param value the value to set.
  @param roomId the id of the room.
  @param success A block object called when the operation succeeds.
  @param failure A block object called when the operation fails.

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -39,20 +39,6 @@ NSString *const kMXContentUriScheme  = @"mxc://";
 NSString *const kMXContentPrefixPath = @"/_matrix/media/v1";
 
 /**
- Room visibility
- */
-NSString *const kMXRoomVisibilityPublic  = @"public";
-NSString *const kMXRoomVisibilityPrivate = @"private";
-
-/**
- Room history visibility.
- */
-NSString *const MXRoomHistoryVisibilityWorldReadable= @"world_readable";
-NSString *const MXRoomHistoryVisibilityShared       = @"shared";
-NSString *const MXRoomHistoryVisibilityInvited      = @"invited";
-NSString *const MXRoomHistoryVisibilityJoined       = @"joined";
-
-/**
  Account data types
  */
 NSString *const kMXAccountDataTypeIgnoredUserList = @"m.ignored_user_list";

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -45,6 +45,14 @@ NSString *const kMXRoomVisibilityPublic  = @"public";
 NSString *const kMXRoomVisibilityPrivate = @"private";
 
 /**
+ Room history visibility.
+ */
+NSString *const MXRoomHistoryVisibilityWorldReadable= @"world_readable";
+NSString *const MXRoomHistoryVisibilityShared       = @"shared";
+NSString *const MXRoomHistoryVisibilityInvited      = @"invited";
+NSString *const MXRoomHistoryVisibilityJoined       = @"joined";
+
+/**
  Account data types
  */
 NSString *const kMXAccountDataTypeIgnoredUserList = @"m.ignored_user_list";
@@ -1031,6 +1039,34 @@ MXAuthAction;
 
                                NSString *name;
                                MXJSONModelSetString(name, JSONResponse[@"name"]);
+                               success(name);
+
+                           } failure:failure];
+}
+
+- (MXHTTPOperation *)setHistoryVisibility:(NSString *)roomId
+                        historyVisibility:(MXRoomHistoryVisibility)historyVisibility
+                                  success:(void (^)())success
+                                  failure:(void (^)(NSError *))failure
+{
+    return [self updateStateEvent:kMXEventTypeStringRoomHistoryVisibility
+                        withValue:@{
+                                    @"history_visibility": historyVisibility
+                                    }
+                           inRoom:roomId
+                          success:success failure:failure];
+}
+
+- (MXHTTPOperation *)historyVisibilityOfRoom:(NSString *)roomId
+                                     success:(void (^)(MXRoomHistoryVisibility))success
+                                     failure:(void (^)(NSError *))failure
+{
+    return [self valueOfStateEvent:kMXEventTypeStringRoomHistoryVisibility
+                            inRoom:roomId
+                           success:^(NSDictionary *JSONResponse) {
+
+                               NSString *name;
+                               MXJSONModelSetString(name, JSONResponse[@"history_visibility"]);
                                success(name);
 
                            } failure:failure];

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -1058,10 +1058,10 @@ MXAuthAction;
                            } failure:failure];
 }
 
-- (MXHTTPOperation*)setJoinRule:(NSString*)roomId
-                       joinRule:(MXRoomJoinRule)joinRule
-                        success:(void (^)())success
-                        failure:(void (^)(NSError *error))failure
+- (MXHTTPOperation*)setRoomJoinRule:(NSString*)roomId
+                           joinRule:(MXRoomJoinRule)joinRule
+                            success:(void (^)())success
+                            failure:(void (^)(NSError *error))failure
 {
     return [self updateStateEvent:kMXEventTypeStringRoomJoinRules
                         withValue:@{

--- a/MatrixSDK/MXSession.h
+++ b/MatrixSDK/MXSession.h
@@ -340,7 +340,7 @@ typedef void (^MXOnBackgroundSyncFail)(NSError *error);
  Create a room.
 
  @param name (optional) the room name.
- @param visibility (optional) the visibility of the room (kMXRoomVisibilityPublic or kMXRoomVisibilityPrivate).
+ @param visibility (optional) the visibility of the room in the current HS's room directory.
  @param roomAlias (optional) the room alias on the home server the room will be created.
  @param topic (optional) the room topic.
 
@@ -351,7 +351,7 @@ typedef void (^MXOnBackgroundSyncFail)(NSError *error);
  @return a MXHTTPOperation instance.
  */
 - (MXHTTPOperation*)createRoom:(NSString*)name
-                    visibility:(MXRoomVisibility)visibility
+                    visibility:(MXRoomDirectoryVisibility)visibility
                      roomAlias:(NSString*)roomAlias
                          topic:(NSString*)topic
                        success:(void (^)(MXRoom *room))success

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -524,13 +524,13 @@ typedef void (^MXOnResumeDone)();
                 }
                 else
                 {
-                    isOneToOneRoom = (!room.state.isPublic && room.state.members.count == 2);
+                    isOneToOneRoom = (!room.state.isJoinRulePublic && room.state.members.count == 2);
                 }
                 
                 // Sync room
                 [room handleJoinedRoomSync:roomSync];
 
-                if (isOneToOneRoom || (!room.state.isPublic && room.state.members.count == 2))
+                if (isOneToOneRoom || (!room.state.isJoinRulePublic && room.state.members.count == 2))
                 {
                     // Update one-to-one room dictionary
                     [self handleOneToOneRoom:room];
@@ -1151,7 +1151,7 @@ typedef void (^MXOnResumeDone)();
     [rooms setObject:room forKey:room.state.roomId];
     
     // We store one-to-one room in a second dictionary to ease their reuse.
-    if (!room.state.isPublic && room.state.members.count == 2)
+    if (!room.state.isJoinRulePublic && room.state.members.count == 2)
     {
         [self handleOneToOneRoom:room];
     }
@@ -1183,7 +1183,7 @@ typedef void (^MXOnResumeDone)();
         [_store deleteRoom:roomId];
         
         // Clean one-to-one room dictionary
-        if (!room.state.isPublic && room.state.members.count == 2)
+        if (!room.state.isJoinRulePublic && room.state.members.count == 2)
         {
             [self removeOneToOneRoom:room];
         }

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -904,7 +904,7 @@ typedef void (^MXOnResumeDone)();
 
 #pragma mark - Rooms operations
 - (MXHTTPOperation*)createRoom:(NSString*)name
-                    visibility:(MXRoomVisibility)visibility
+                    visibility:(MXRoomDirectoryVisibility)visibility
                      roomAlias:(NSString*)roomAlias
                          topic:(NSString*)topic
                        success:(void (^)(MXRoom *room))success

--- a/MatrixSDK/Utils/MXTools.m
+++ b/MatrixSDK/Utils/MXTools.m
@@ -35,6 +35,7 @@
                  kMXEventTypeStringRoomPowerLevels: [NSNumber numberWithUnsignedInteger:MXEventTypeRoomPowerLevels],
                  kMXEventTypeStringRoomAliases: [NSNumber numberWithUnsignedInteger:MXEventTypeRoomAliases],
                  kMXEventTypeStringRoomCanonicalAlias: [NSNumber numberWithUnsignedInteger:MXEventTypeRoomCanonicalAlias],
+                 kMXEventTypeStringRoomHistoryVisibility: [NSNumber numberWithUnsignedInteger:MXEventTypeRoomHistoryVisibility],
                  kMXEventTypeStringRoomMessage: [NSNumber numberWithUnsignedInteger:MXEventTypeRoomMessage],
                  kMXEventTypeStringRoomMessageFeedback: [NSNumber numberWithUnsignedInteger:MXEventTypeRoomMessageFeedback],
                  kMXEventTypeStringRoomRedaction: [NSNumber numberWithUnsignedInteger:MXEventTypeRoomRedaction],

--- a/MatrixSDK/Utils/MXTools.m
+++ b/MatrixSDK/Utils/MXTools.m
@@ -36,6 +36,7 @@
                  kMXEventTypeStringRoomAliases: [NSNumber numberWithUnsignedInteger:MXEventTypeRoomAliases],
                  kMXEventTypeStringRoomCanonicalAlias: [NSNumber numberWithUnsignedInteger:MXEventTypeRoomCanonicalAlias],
                  kMXEventTypeStringRoomHistoryVisibility: [NSNumber numberWithUnsignedInteger:MXEventTypeRoomHistoryVisibility],
+                 kMXEventTypeStringRoomGuestAccess: [NSNumber numberWithUnsignedInteger:MXEventTypeRoomGuestAccess],
                  kMXEventTypeStringRoomMessage: [NSNumber numberWithUnsignedInteger:MXEventTypeRoomMessage],
                  kMXEventTypeStringRoomMessageFeedback: [NSNumber numberWithUnsignedInteger:MXEventTypeRoomMessageFeedback],
                  kMXEventTypeStringRoomRedaction: [NSNumber numberWithUnsignedInteger:MXEventTypeRoomRedaction],

--- a/MatrixSDKTests/MXRestClientTests.m
+++ b/MatrixSDKTests/MXRestClientTests.m
@@ -187,7 +187,7 @@
     [matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
         __block MXRestClient *bobRestClient2 = bobRestClient;
-        [bobRestClient setJoinRule:roomId joinRule:kMXRoomJoinRulePublic success:^{
+        [bobRestClient setRoomJoinRule:roomId joinRule:kMXRoomJoinRulePublic success:^{
 
             [bobRestClient2 joinRuleOfRoom:roomId success:^(MXRoomJoinRule joinRule) {
 

--- a/MatrixSDKTests/MXRestClientTests.m
+++ b/MatrixSDKTests/MXRestClientTests.m
@@ -234,6 +234,32 @@
     }];
 }
 
+- (void)testRoomDirectoryVisibility
+{
+    [matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
+
+        __block MXRestClient *bobRestClient2 = bobRestClient;
+        [bobRestClient setRoomDirectoryVisibility:roomId directoryVisibility:kMXRoomDirectoryVisibilityPublic success:^{
+
+            [bobRestClient2 directoryVisibilityOfRoom:roomId success:^(MXRoomDirectoryVisibility directoryVisibility) {
+
+                XCTAssertNotNil(directoryVisibility);
+                XCTAssertNotEqual(directoryVisibility.length, 0);
+                XCTAssertEqualObjects(directoryVisibility, kMXRoomDirectoryVisibilityPublic, @"Room directory visibility is wrong");
+                [expectation fulfill];
+
+            } failure:^(NSError *error) {
+                XCTFail(@"The request should not fail - NSError: %@", error);
+                [expectation fulfill];
+            }];
+
+        } failure:^(NSError *error) {
+            XCTFail(@"The request should not fail - NSError: %@", error);
+            [expectation fulfill];
+        }];
+    }];
+}
+
 - (void)testJoinRoomWithRoomId
 {
     [matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {

--- a/MatrixSDKTests/MXRestClientTests.m
+++ b/MatrixSDKTests/MXRestClientTests.m
@@ -161,7 +161,7 @@
     [matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
         __block MXRestClient *bobRestClient2 = bobRestClient;
-        [bobRestClient setHistoryVisibility:roomId historyVisibility:kMXRoomHistoryVisibilityInvited success:^{
+        [bobRestClient setRoomHistoryVisibility:roomId historyVisibility:kMXRoomHistoryVisibilityInvited success:^{
 
             [bobRestClient2 historyVisibilityOfRoom:roomId success:^(MXRoomHistoryVisibility historyVisibility) {
 

--- a/MatrixSDKTests/MXRestClientTests.m
+++ b/MatrixSDKTests/MXRestClientTests.m
@@ -156,6 +156,32 @@
     }];
 }
 
+- (void)testRoomHistoryVisibility
+{
+    [matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
+
+        __block MXRestClient *bobRestClient2 = bobRestClient;
+        [bobRestClient setHistoryVisibility:roomId historyVisibility:kMXRoomHistoryVisibilityInvited success:^{
+
+            [bobRestClient2 historyVisibilityOfRoom:roomId success:^(MXRoomHistoryVisibility historyVisibility) {
+
+                XCTAssertNotNil(historyVisibility);
+                XCTAssertNotEqual(historyVisibility.length, 0);
+                XCTAssertEqualObjects(historyVisibility, kMXRoomHistoryVisibilityInvited, @"Room history visibility is wrong");
+                [expectation fulfill];
+
+            } failure:^(NSError *error) {
+                XCTFail(@"The request should not fail - NSError: %@", error);
+                [expectation fulfill];
+            }];
+
+        } failure:^(NSError *error) {
+            XCTFail(@"The request should not fail - NSError: %@", error);
+            [expectation fulfill];
+        }];
+    }];
+}
+
 - (void)testJoinRoomWithRoomId
 {
     [matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {

--- a/MatrixSDKTests/MXRestClientTests.m
+++ b/MatrixSDKTests/MXRestClientTests.m
@@ -208,6 +208,32 @@
     }];
 }
 
+- (void)testRoomGuestAccess
+{
+    [matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
+
+        __block MXRestClient *bobRestClient2 = bobRestClient;
+        [bobRestClient setRoomGuestAccess:roomId guestAccess:kMXRoomGuestAccessCanJoin success:^{
+
+            [bobRestClient2 guestAccessOfRoom:roomId success:^(MXRoomGuestAccess guestAccess) {
+
+                XCTAssertNotNil(guestAccess);
+                XCTAssertNotEqual(guestAccess.length, 0);
+                XCTAssertEqualObjects(guestAccess, kMXRoomGuestAccessCanJoin, @"Room guest access is wrong");
+                [expectation fulfill];
+
+            } failure:^(NSError *error) {
+                XCTFail(@"The request should not fail - NSError: %@", error);
+                [expectation fulfill];
+            }];
+
+        } failure:^(NSError *error) {
+            XCTFail(@"The request should not fail - NSError: %@", error);
+            [expectation fulfill];
+        }];
+    }];
+}
+
 - (void)testJoinRoomWithRoomId
 {
     [matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {

--- a/MatrixSDKTests/MXRestClientTests.m
+++ b/MatrixSDKTests/MXRestClientTests.m
@@ -182,6 +182,32 @@
     }];
 }
 
+- (void)testRoomJoinRule
+{
+    [matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
+
+        __block MXRestClient *bobRestClient2 = bobRestClient;
+        [bobRestClient setJoinRule:roomId joinRule:kMXRoomJoinRulePublic success:^{
+
+            [bobRestClient2 joinRuleOfRoom:roomId success:^(MXRoomJoinRule joinRule) {
+
+                XCTAssertNotNil(joinRule);
+                XCTAssertNotEqual(joinRule.length, 0);
+                XCTAssertEqualObjects(joinRule, kMXRoomJoinRulePublic, @"Room join rule is wrong");
+                [expectation fulfill];
+
+            } failure:^(NSError *error) {
+                XCTFail(@"The request should not fail - NSError: %@", error);
+                [expectation fulfill];
+            }];
+
+        } failure:^(NSError *error) {
+            XCTFail(@"The request should not fail - NSError: %@", error);
+            [expectation fulfill];
+        }];
+    }];
+}
+
 - (void)testJoinRoomWithRoomId
 {
     [matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {

--- a/MatrixSDKTests/MXRoomStateTests.m
+++ b/MatrixSDKTests/MXRoomStateTests.m
@@ -54,25 +54,25 @@
     [super tearDown];
 }
 
-- (void)testIsPublic
+- (void)testIsJoinRulePublic
 {
     [matrixSDKTestsData doMXSessionTestWithBobAndThePublicRoom:self readyToTest:^(MXSession *mxSession2, MXRoom *room, XCTestExpectation *expectation) {
 
         mxSession = mxSession2;
 
-        XCTAssertTrue(room.state.isPublic, @"The room must be public");
+        XCTAssertTrue(room.state.isJoinRulePublic, @"The room join rule must be public");
         
         [expectation fulfill];
     }];
 }
 
-- (void)testIsPublicForAPrivateRoom
+- (void)testIsJoinRulePublicForAPrivateRoom
 {
     [matrixSDKTestsData doMXSessionTestWithBobAndARoomWithMessages:self readyToTest:^(MXSession *mxSession2, MXRoom *room, XCTestExpectation *expectation) {
         
         mxSession = mxSession2;
 
-        XCTAssertFalse(room.state.isPublic, @"This room must be private");
+        XCTAssertFalse(room.state.isJoinRulePublic, @"This room join rule must be private");
         
         [expectation fulfill];
     }];
@@ -887,7 +887,7 @@
                         
                         // Now, we must have more information about the room
                         // Check its new state
-                        XCTAssertEqual(newRoom.state.isPublic, YES);
+                        XCTAssertEqual(newRoom.state.isJoinRulePublic, YES);
                         XCTAssertEqual(newRoom.state.members.count, 2);
                         XCTAssert([newRoom.state.topic isEqualToString:@"We test room invitation here"], @"Wrong topic. Found: %@", newRoom.state.topic);
                         

--- a/MatrixSDKTests/MXRoomStateTests.m
+++ b/MatrixSDKTests/MXRoomStateTests.m
@@ -301,7 +301,7 @@
 
         MXRestClient *bobRestClient2 = bobRestClient;
 
-        [bobRestClient setHistoryVisibility:roomId historyVisibility:kMXRoomHistoryVisibilityWorldReadable success:^{
+        [bobRestClient setRoomHistoryVisibility:roomId historyVisibility:kMXRoomHistoryVisibilityWorldReadable success:^{
 
             mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
             [mxSession start:^{

--- a/MatrixSDKTests/MXRoomStateTests.m
+++ b/MatrixSDKTests/MXRoomStateTests.m
@@ -374,7 +374,7 @@
 
         MXRestClient *bobRestClient2 = bobRestClient;
 
-        [bobRestClient setJoinRule:roomId joinRule:kMXRoomJoinRulePublic success:^{
+        [bobRestClient setRoomJoinRule:roomId joinRule:kMXRoomJoinRulePublic success:^{
 
             mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
             [mxSession start:^{

--- a/MatrixSDKTests/MXRoomTests.m
+++ b/MatrixSDKTests/MXRoomTests.m
@@ -426,6 +426,94 @@
     }];
 }
 
+- (void)testRoomDirectoryVisibilityProvidedByInitialSync
+{
+    [matrixSDKTestsData doMXRestClientTestInABobRoomAndANewTextMessage:self newTextMessage:@"This is a text message for recents" onReadyToTest:^(MXRestClient *bobRestClient, NSString *roomId, NSString *new_text_message_eventId, XCTestExpectation *expectation) {
+
+        MXRestClient *bobRestClient2 = bobRestClient;
+
+        [bobRestClient setRoomDirectoryVisibility:roomId directoryVisibility:kMXRoomDirectoryVisibilityPublic success:^{
+
+            mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
+            [mxSession start:^{
+
+                MXRoom *room = [mxSession roomWithRoomId:roomId];
+
+                [room directoryVisibility:^(MXRoomDirectoryVisibility directoryVisibility) {
+
+                    XCTAssertNotNil(directoryVisibility);
+                    XCTAssertEqualObjects(directoryVisibility, kMXRoomDirectoryVisibilityPublic, @"The room directory visibility is wrong");
+
+                    [expectation fulfill];
+
+                } failure:^(NSError *error) {
+                    XCTFail(@"The request should not fail - NSError: %@", error);
+                    [expectation fulfill];
+                }];
+
+            } failure:^(NSError *error) {
+                XCTFail(@"The request should not fail - NSError: %@", error);
+                [expectation fulfill];
+            }];
+
+        } failure:^(NSError *error) {
+            XCTFail(@"The request should not fail - NSError: %@", error);
+            [expectation fulfill];
+        }];
+
+    }];
+}
+
+- (void)tesRoomDirectoryVisibilityLive
+{
+    [matrixSDKTestsData doMXRestClientTestInABobRoomAndANewTextMessage:self newTextMessage:@"This is a text message for recents" onReadyToTest:^(MXRestClient *bobRestClient, NSString *roomId, NSString *new_text_message_eventId, XCTestExpectation *expectation) {
+
+        MXRestClient *bobRestClient2 = bobRestClient;
+
+        mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
+        [mxSession start:^{
+
+            MXRoom *room = [mxSession roomWithRoomId:roomId];
+
+            [room directoryVisibility:^(MXRoomDirectoryVisibility directoryVisibility) {
+
+                XCTAssertNotNil(directoryVisibility);
+                XCTAssertEqualObjects(directoryVisibility, kMXRoomDirectoryVisibilityPrivate, @"The room directory visibility is wrong");
+
+
+                // Change the directory visibility
+                [bobRestClient setRoomDirectoryVisibility:roomId directoryVisibility:kMXRoomDirectoryVisibilityPublic success:^{
+
+                    [room directoryVisibility:^(MXRoomDirectoryVisibility directoryVisibility) {
+
+                        XCTAssertNotNil(directoryVisibility);
+                        XCTAssertEqualObjects(directoryVisibility, kMXRoomDirectoryVisibilityPublic, @"The room directory visibility is wrong");
+
+                        [expectation fulfill];
+
+                    } failure:^(NSError *error) {
+                        XCTFail(@"The request should not fail - NSError: %@", error);
+                        [expectation fulfill];
+                    }];
+
+                } failure:^(NSError *error) {
+                    XCTFail(@"The request should not fail - NSError: %@", error);
+                    [expectation fulfill];
+                }];
+
+            } failure:^(NSError *error) {
+                XCTFail(@"The request should not fail - NSError: %@", error);
+                [expectation fulfill];
+            }];
+            
+        } failure:^(NSError *error) {
+            XCTFail(@"The request should not fail - NSError: %@", error);
+            [expectation fulfill];
+        }];
+        
+    }];
+}
+
 @end
 
 #pragma clang diagnostic pop

--- a/MatrixSDKTests/MXSessionTests.m
+++ b/MatrixSDKTests/MXSessionTests.m
@@ -62,7 +62,7 @@
         NSString *alias = [[NSProcessInfo processInfo] globallyUniqueString];
 
         // Room with a tag with "oranges" order
-        [bobRestClient createRoom:nil visibility:kMXRoomVisibilityPrivate roomAlias:alias topic:nil success:^(MXCreateRoomResponse *response) {
+        [bobRestClient createRoom:nil visibility:kMXRoomDirectoryVisibilityPrivate roomAlias:alias topic:nil success:^(MXCreateRoomResponse *response) {
 
             mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
             [mxSession start:^{
@@ -436,7 +436,7 @@
                 mxSession = nil;
 
                 // Create another random room to create more data server side
-                [bobRestClient createRoom:nil visibility:kMXRoomVisibilityPrivate roomAlias:nil topic:nil success:^(MXCreateRoomResponse *response) {
+                [bobRestClient createRoom:nil visibility:kMXRoomDirectoryVisibilityPrivate roomAlias:nil topic:nil success:^(MXCreateRoomResponse *response) {
 
                     // Check the stream has been correctly shutdowned. Checking that the store has not changed is one way to verify it
                     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 3 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
@@ -745,7 +745,7 @@
                 [expectation fulfill];
             }];
 
-            [mxSession.matrixRestClient createRoom:nil visibility:kMXRoomVisibilityPublic roomAlias:nil topic:nil success:^(MXCreateRoomResponse *response) {
+            [mxSession.matrixRestClient createRoom:nil visibility:kMXRoomDirectoryVisibilityPublic roomAlias:nil topic:nil success:^(MXCreateRoomResponse *response) {
 
             } failure:^(NSError *error) {
                 XCTFail(@"Cannot set up intial test conditions - error: %@", error);
@@ -847,15 +847,15 @@
         NSString *tag = [[NSProcessInfo processInfo] globallyUniqueString];
 
         // Room with a tag with "oranges" order
-        [bobRestClient createRoom:nil visibility:kMXRoomVisibilityPrivate roomAlias:nil topic:@"2" success:^(MXCreateRoomResponse *response) {
+        [bobRestClient createRoom:nil visibility:kMXRoomDirectoryVisibilityPrivate roomAlias:nil topic:@"2" success:^(MXCreateRoomResponse *response) {
             [bobRestClient addTag:tag withOrder:order2  toRoom:response.roomId success:^{
 
                 // Room with a tag with no order
-                [bobRestClient createRoom:nil visibility:kMXRoomVisibilityPrivate roomAlias:nil topic:@"3" success:^(MXCreateRoomResponse *response) {
+                [bobRestClient createRoom:nil visibility:kMXRoomDirectoryVisibilityPrivate roomAlias:nil topic:@"3" success:^(MXCreateRoomResponse *response) {
                     [bobRestClient addTag:tag withOrder:order3 toRoom:response.roomId success:^{
 
                         // Room with a tag with "apples" order
-                        [bobRestClient createRoom:nil visibility:kMXRoomVisibilityPrivate roomAlias:nil topic:@"1" success:^(MXCreateRoomResponse *response) {
+                        [bobRestClient createRoom:nil visibility:kMXRoomDirectoryVisibilityPrivate roomAlias:nil topic:@"1" success:^(MXCreateRoomResponse *response) {
                             [bobRestClient addTag:tag withOrder:order1 toRoom:response.roomId success:^{
 
 
@@ -943,11 +943,11 @@
         NSString *tag = [[NSProcessInfo processInfo] globallyUniqueString];
 
         // Room at position
-        [bobRestClient createRoom:nil visibility:kMXRoomVisibilityPrivate roomAlias:nil topic:@"oldest" success:^(MXCreateRoomResponse *response) {
+        [bobRestClient createRoom:nil visibility:kMXRoomDirectoryVisibilityPrivate roomAlias:nil topic:@"oldest" success:^(MXCreateRoomResponse *response) {
             [bobRestClient addTag:tag withOrder:@"0.2"  toRoom:response.roomId success:^{
 
                 // Room at position
-                [bobRestClient createRoom:nil visibility:kMXRoomVisibilityPrivate roomAlias:nil topic:@"newest" success:^(MXCreateRoomResponse *response) {
+                [bobRestClient createRoom:nil visibility:kMXRoomDirectoryVisibilityPrivate roomAlias:nil topic:@"newest" success:^(MXCreateRoomResponse *response) {
                     [bobRestClient addTag:tag withOrder:@"0.2" toRoom:response.roomId success:^{
 
                         // Do the tests
@@ -991,11 +991,11 @@
     [matrixSDKTestsData doMXRestClientTestWithBob:self readyToTest:^(MXRestClient *bobRestClient, XCTestExpectation *expectation) {
 
         // Create a tagged room
-        [bobRestClient createRoom:nil visibility:kMXRoomVisibilityPrivate roomAlias:nil topic:@"Tagged" success:^(MXCreateRoomResponse *response) {
+        [bobRestClient createRoom:nil visibility:kMXRoomDirectoryVisibilityPrivate roomAlias:nil topic:@"Tagged" success:^(MXCreateRoomResponse *response) {
             [bobRestClient addTag:@"aTag" withOrder:nil  toRoom:response.roomId success:^{
 
                 // And a not tagged room
-                [bobRestClient createRoom:nil visibility:kMXRoomVisibilityPrivate roomAlias:nil topic:@"Not tagged" success:^(MXCreateRoomResponse *response) {
+                [bobRestClient createRoom:nil visibility:kMXRoomDirectoryVisibilityPrivate roomAlias:nil topic:@"Not tagged" success:^(MXCreateRoomResponse *response) {
 
                     // Do the test
                     mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
@@ -1045,15 +1045,15 @@
         NSString *tag = [[NSProcessInfo processInfo] globallyUniqueString];
 
         // Room at position #1
-        [bobRestClient createRoom:nil visibility:kMXRoomVisibilityPrivate roomAlias:nil topic:nil success:^(MXCreateRoomResponse *response) {
+        [bobRestClient createRoom:nil visibility:kMXRoomDirectoryVisibilityPrivate roomAlias:nil topic:nil success:^(MXCreateRoomResponse *response) {
             [bobRestClient addTag:tag withOrder:@"0.1"  toRoom:response.roomId success:^{
 
                 // Room at position #2
-                [bobRestClient createRoom:nil visibility:kMXRoomVisibilityPrivate roomAlias:nil topic:nil success:^(MXCreateRoomResponse *response) {
+                [bobRestClient createRoom:nil visibility:kMXRoomDirectoryVisibilityPrivate roomAlias:nil topic:nil success:^(MXCreateRoomResponse *response) {
                     [bobRestClient addTag:tag withOrder:@"0.2" toRoom:response.roomId success:^{
 
                         // Room at position #3
-                        [bobRestClient createRoom:nil visibility:kMXRoomVisibilityPrivate roomAlias:nil topic:nil success:^(MXCreateRoomResponse *response) {
+                        [bobRestClient createRoom:nil visibility:kMXRoomDirectoryVisibilityPrivate roomAlias:nil topic:nil success:^(MXCreateRoomResponse *response) {
                             [bobRestClient addTag:tag withOrder:@"0.3" toRoom:response.roomId success:^{
 
                                 // Do the tests
@@ -1170,7 +1170,7 @@
         }];
 
         // Make Alice invite Bob in a room
-        [aliceRestClient createRoom:@"A room name" visibility:kMXRoomVisibilityPrivate roomAlias:nil topic:nil success:^(MXCreateRoomResponse *response) {
+        [aliceRestClient createRoom:@"A room name" visibility:kMXRoomDirectoryVisibilityPrivate roomAlias:nil topic:nil success:^(MXCreateRoomResponse *response) {
 
             testRoomId = response.roomId;
 

--- a/MatrixSDKTests/MXStoreTests.m
+++ b/MatrixSDKTests/MXStoreTests.m
@@ -929,7 +929,7 @@
                     mxSession = nil;
 
                     // Create another random room to create more data server side
-                    [bobRestClient createRoom:nil visibility:kMXRoomVisibilityPrivate roomAlias:nil topic:nil success:^(MXCreateRoomResponse *response) {
+                    [bobRestClient createRoom:nil visibility:kMXRoomDirectoryVisibilityPrivate roomAlias:nil topic:nil success:^(MXCreateRoomResponse *response) {
 
                         [bobRestClient sendTextMessageToRoom:response.roomId text:@"A Message" success:^(NSString *eventId) {
 
@@ -1238,15 +1238,15 @@
         NSString *tag2 = [[NSProcessInfo processInfo] globallyUniqueString];
 
         // Room #1
-        [bobRestClient createRoom:nil visibility:kMXRoomVisibilityPrivate roomAlias:nil topic:@"2" success:^(MXCreateRoomResponse *response) {
+        [bobRestClient createRoom:nil visibility:kMXRoomDirectoryVisibilityPrivate roomAlias:nil topic:@"2" success:^(MXCreateRoomResponse *response) {
             [bobRestClient addTag:tag1 withOrder:@"0.2"  toRoom:response.roomId success:^{
 
                 // Room #2
-                [bobRestClient createRoom:nil visibility:kMXRoomVisibilityPrivate roomAlias:nil topic:@"1" success:^(MXCreateRoomResponse *response) {
+                [bobRestClient createRoom:nil visibility:kMXRoomDirectoryVisibilityPrivate roomAlias:nil topic:@"1" success:^(MXCreateRoomResponse *response) {
                     [bobRestClient addTag:tag1 withOrder:@"0.1" toRoom:response.roomId success:^{
 
                         // Room #3
-                        [bobRestClient createRoom:nil visibility:kMXRoomVisibilityPrivate roomAlias:nil topic:@"the only one" success:^(MXCreateRoomResponse *response) {
+                        [bobRestClient createRoom:nil visibility:kMXRoomDirectoryVisibilityPrivate roomAlias:nil topic:@"the only one" success:^(MXCreateRoomResponse *response) {
                             [bobRestClient addTag:tag2 withOrder:@"0.1" toRoom:response.roomId success:^{
 
 

--- a/MatrixSDKTests/MatrixSDKTestsData.m
+++ b/MatrixSDKTests/MatrixSDKTestsData.m
@@ -582,7 +582,7 @@ NSMutableArray *roomsToClean;
         roomsToClean = [NSMutableArray array];
         for (MXRoom *room in mxSession.rooms)
         {
-            if (NO == room.state.isPublic && MXMembershipJoin == room.state.membership)
+            if (NO == room.state.isJoinRulePublic && MXMembershipJoin == room.state.membership)
             {
                 [roomsToClean addObject:room.state.roomId];
             }

--- a/MatrixSDKTests/MatrixSDKTestsData.m
+++ b/MatrixSDKTests/MatrixSDKTestsData.m
@@ -171,7 +171,7 @@ NSMutableArray *roomsToClean;
     [self doMXRestClientTestWithBob:testCase
                      readyToTest:^(MXRestClient *bobRestClient, XCTestExpectation *expectation) {
         // Create a random room to use
-        [bobRestClient createRoom:nil visibility:kMXRoomVisibilityPrivate roomAlias:nil topic:nil success:^(MXCreateRoomResponse *response) {
+        [bobRestClient createRoom:nil visibility:kMXRoomDirectoryVisibilityPrivate roomAlias:nil topic:nil success:^(MXCreateRoomResponse *response) {
 
             NSLog(@"Created room %@ for %@", response.roomId, testCase.name);
             
@@ -189,7 +189,7 @@ NSMutableArray *roomsToClean;
     [self doMXRestClientTestWithBob:testCase
                         readyToTest:^(MXRestClient *bobRestClient, XCTestExpectation *expectation) {
                             // Create a random room to use
-                            [bobRestClient createRoom:nil visibility:kMXRoomVisibilityPublic roomAlias:nil topic:nil success:^(MXCreateRoomResponse *response) {
+                            [bobRestClient createRoom:nil visibility:kMXRoomDirectoryVisibilityPublic roomAlias:nil topic:nil success:^(MXCreateRoomResponse *response) {
 
                                 NSLog(@"Created public room %@ for %@", response.roomId, testCase.name);
 
@@ -216,7 +216,7 @@ NSMutableArray *roomsToClean;
             _thePublicRoomAlias = [NSString stringWithFormat:@"mxPublic-%@", [[NSUUID UUID] UUIDString]];
 
             [bobRestClient createRoom:@"MX Public Room test"
-                           visibility:kMXRoomVisibilityPublic
+                           visibility:kMXRoomDirectoryVisibilityPublic
                             roomAlias:_thePublicRoomAlias
                                 topic:@"The public room used by SDK tests"
                               success:^(MXCreateRoomResponse *response) {
@@ -245,7 +245,7 @@ NSMutableArray *roomsToClean;
     
     [self getBobMXRestClient:^(MXRestClient *bobRestClient) {
         // Create a random room to use
-        [bobRestClient createRoom:nil visibility:kMXRoomVisibilityPrivate roomAlias:nil topic:nil success:^(MXCreateRoomResponse *response) {
+        [bobRestClient createRoom:nil visibility:kMXRoomDirectoryVisibilityPrivate roomAlias:nil topic:nil success:^(MXCreateRoomResponse *response) {
 
             NSLog(@"Created room %@ for %@", response.roomId, testCase.name);
 
@@ -340,7 +340,7 @@ NSMutableArray *roomsToClean;
     else
     {
         // Create the room
-        [mxRestClient2 createRoom:nil visibility:kMXRoomVisibilityPrivate roomAlias:nil topic:nil success:^(MXCreateRoomResponse *response) {
+        [mxRestClient2 createRoom:nil visibility:kMXRoomDirectoryVisibilityPrivate roomAlias:nil topic:nil success:^(MXCreateRoomResponse *response) {
 
             NSLog(@"Created room %@ in createRooms", response.roomId);
 


### PR DESCRIPTION
SDK part for https://github.com/vector-im/vector-ios/issues/337

Added the ability to set and read:
 - room visibility in the current VC's room directory
 - room join rule
 - room history visibility
 - room guest access

2 API breaks:
 - MXRoomVisibility has been replaced by MXRoomDirectoryVisibility
 - MXRoomState.isPublic has been replaced by MXRoomState.isJoinRulePublic
