### PR TITLE
Update AFNetworking to 3.1

### DIFF
--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -27,6 +27,6 @@ Pod::Spec.new do |s|
 
   s.requires_arc  = true
 
-  s.dependency 'AFNetworking', '~> 2.6.0'
+  s.dependency 'AFNetworking', '~> 3.1.0'
 
 end

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -1239,7 +1239,7 @@ typedef enum : NSUInteger
                           timeout:(NSTimeInterval)timeoutInSeconds
                           success:(void (^)(NSString *url))success
                           failure:(void (^)(NSError *error))failure
-                   uploadProgress:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))uploadProgress;
+                   uploadProgress:(void (^)(NSProgress *uploadProgress))uploadProgress;
 
 /**
  Resolve a Matrix media content URI (in the form of "mxc://...") into an HTTP URL.

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -2433,7 +2433,7 @@ MXAuthAction;
                            timeout:(NSTimeInterval)timeoutInSeconds
                            success:(void (^)(NSString *url))success
                            failure:(void (^)(NSError *error))failure
-                    uploadProgress:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))uploadProgress
+                    uploadProgress:(void (^)(NSProgress *uploadProgress))uploadProgress
 {
     // Define an absolute path based on Matrix content respository path instead of the base url
     NSString* path = [NSString stringWithFormat:@"%@/upload", kMXContentPrefixPath];

--- a/MatrixSDK/Utils/MXHTTPClient.h
+++ b/MatrixSDK/Utils/MXHTTPClient.h
@@ -135,7 +135,7 @@ typedef BOOL (^MXHTTPClientOnUnrecognizedCertificate)(NSData *certificate);
                              data:(NSData *)data
                           headers:(NSDictionary*)headers
                           timeout:(NSTimeInterval)timeoutInSeconds
-                   uploadProgress:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))uploadProgress
+                   uploadProgress:(void (^)(NSProgress *uploadProgress))uploadProgress
                           success:(void (^)(NSDictionary *JSONResponse))success
                           failure:(void (^)(NSError *error))failure;
 

--- a/MatrixSDK/Utils/MXHTTPClient.m
+++ b/MatrixSDK/Utils/MXHTTPClient.m
@@ -214,7 +214,7 @@ NSString * const MXHTTPClientErrorResponseDataKey = @"com.matrixsdk.httpclient.e
             });
         }
         
-    } downloadProgress:nil completionHandler:^(NSURLResponse * _Nonnull response, NSDictionary *JSONResponse, NSError * _Nullable error) {
+    } downloadProgress:nil completionHandler:^(NSURLResponse * _Nonnull theResponse, NSDictionary *JSONResponse, NSError * _Nullable error) {
 
         mxHTTPOperation.operation = nil;
         
@@ -224,8 +224,10 @@ NSString * const MXHTTPClientErrorResponseDataKey = @"com.matrixsdk.httpclient.e
         }
         else
         {
+            NSHTTPURLResponse *response = (NSHTTPURLResponse*)theResponse;
+
 #if DEBUG
-            NSLog(@"[MXHTTPClient] Request %p failed for path: %@ - HTTP code: %tu", mxHTTPOperation, path, ((NSHTTPURLResponse*)response).statusCode);
+            NSLog(@"[MXHTTPClient] Request %p failed for path: %@ - HTTP code: %@", mxHTTPOperation, path, response ? @(response.statusCode) : @"none");
             NSLog(@"[MXHTTPClient] error: %@", error);
 #else
             // Hide access token in printed path
@@ -250,7 +252,7 @@ NSString * const MXHTTPClientErrorResponseDataKey = @"com.matrixsdk.httpclient.e
             }
 #endif
 
-            if (JSONResponse)
+            if (response)
             {
                 // If the home server (or any other Matrix server) sent data, it may contain 'errcode' and 'error'.
                 // In this case, we return an NSError which encapsulates MXError information.
@@ -410,11 +412,11 @@ NSString * const MXHTTPClientErrorResponseDataKey = @"com.matrixsdk.httpclient.e
                 }
                 error = nil;
             }
-            
-            if (error)
-            {
-                failure(error);
-            }
+        }
+
+        if (error)
+        {
+            failure(error);
         }
 
         // Delay the call of 'cleanupBackgroundTask' in order to let httpManager.tasks.count

--- a/MatrixSDK/Utils/MXHTTPClient.m
+++ b/MatrixSDK/Utils/MXHTTPClient.m
@@ -46,7 +46,7 @@ NSString * const MXHTTPClientErrorResponseDataKey = @"com.matrixsdk.httpclient.e
     /**
      Use AFNetworking as HTTP client.
      */
-    AFHTTPRequestOperationManager *httpManager;
+    AFHTTPSessionManager *httpManager;
 
     /**
      If defined, append it to the requested URL.
@@ -85,8 +85,11 @@ NSString * const MXHTTPClientErrorResponseDataKey = @"com.matrixsdk.httpclient.e
     if (self)
     {
         accessToken = access_token;
+
+         // Make requests continue in background
+        NSURLSessionConfiguration *backgroundSessionConfiguration = [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:@"org.matrix.sdk.MXHTTPClient"];
         
-        httpManager = [[AFHTTPRequestOperationManager alloc] initWithBaseURL:[NSURL URLWithString:baseURL]];
+        httpManager = [[AFHTTPSessionManager alloc] initWithBaseURL:[NSURL URLWithString:baseURL] sessionConfiguration:backgroundSessionConfiguration];
         
         // If some certificates are included in app bundle, we enable the AFNetworking pinning mode based on certificate 'AFSSLPinningModeCertificate'.
         // These certificates will be handled as pinned certificates, the app allows them without prompting the user.
@@ -134,7 +137,7 @@ NSString * const MXHTTPClientErrorResponseDataKey = @"com.matrixsdk.httpclient.e
                    data:(NSData *)data
                 headers:(NSDictionary*)headers
                 timeout:(NSTimeInterval)timeoutInSeconds
-         uploadProgress:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))uploadProgress
+         uploadProgress:(void (^)(NSProgress *uploadProgress))uploadProgress
                 success:(void (^)(NSDictionary *JSONResponse))success
                 failure:(void (^)(NSError *error))failure
 {
@@ -152,7 +155,7 @@ NSString * const MXHTTPClientErrorResponseDataKey = @"com.matrixsdk.httpclient.e
               data:(NSData *)data
            headers:(NSDictionary*)headers
            timeout:(NSTimeInterval)timeoutInSeconds
-    uploadProgress:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))uploadProgress
+    uploadProgress:(void (^)(NSProgress *uploadProgress))uploadProgress
            success:(void (^)(NSDictionary *JSONResponse))success
            failure:(void (^)(NSError *error))failure
 {
@@ -185,301 +188,304 @@ NSString * const MXHTTPClientErrorResponseDataKey = @"com.matrixsdk.httpclient.e
     }
 
     mxHTTPOperation.numberOfTries++;
-    mxHTTPOperation.operation = [httpManager HTTPRequestOperationWithRequest:request success:^(AFHTTPRequestOperation *operation, NSDictionary *JSONResponse) {
-        mxHTTPOperation.operation = nil;
-        success(JSONResponse);
-    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+    mxHTTPOperation.operation = [httpManager dataTaskWithRequest:request uploadProgress:^(NSProgress * _Nonnull theUploadProgress) {
 
-        mxHTTPOperation.operation = nil;
-
-#if DEBUG
-        NSLog(@"[MXHTTPClient] Request %p failed for path: %@ - HTTP code: %ld", mxHTTPOperation, path, (long)operation.response.statusCode);
-        NSLog(@"[MXHTTPClient] error: %@", error);
-#else
-        // Hide access token in printed path
-        NSMutableString *printedPath = [NSMutableString stringWithString:path];
-        if (accessToken)
+        if (uploadProgress)
         {
-            NSRange range = [path rangeOfString:accessToken];
-            if (range.location != NSNotFound)
-            {
-                [printedPath replaceCharactersInRange:range withString:@"..."];
-            }
+            // theUploadProgress is not called from an AFNetworking thread. So, switch to the UI one
+            dispatch_async(dispatch_get_main_queue(), ^{
+                uploadProgress(theUploadProgress);
+            });
         }
-        NSLog(@"[MXHTTPClient] Request %p failed for path: %@ - HTTP code: %ld", mxHTTPOperation, printedPath, (long)operation.response.statusCode);
         
-        if (error.userInfo[NSLocalizedDescriptionKey])
+    } downloadProgress:nil completionHandler:^(NSURLResponse * _Nonnull response, NSDictionary *JSONResponse, NSError * _Nullable error) {
+
+        mxHTTPOperation.operation = nil;
+        
+        if (!error)
         {
-            NSLog(@"[MXHTTPClient] error domain: %@, code:%zd, description: %@", error.domain, error.code, error.userInfo[NSLocalizedDescriptionKey]);
+            success(JSONResponse);
         }
         else
         {
-            NSLog(@"[MXHTTPClient] error domain: %@, code:%zd", error.domain, error.code);
-        }
+#if DEBUG
+            NSLog(@"[MXHTTPClient] Request %p failed for path: %@ - HTTP code: %tu", mxHTTPOperation, path, ((NSHTTPURLResponse*)response).statusCode);
+            NSLog(@"[MXHTTPClient] error: %@", error);
+#else
+            // Hide access token in printed path
+            NSMutableString *printedPath = [NSMutableString stringWithString:path];
+            if (accessToken)
+            {
+                NSRange range = [path rangeOfString:accessToken];
+                if (range.location != NSNotFound)
+                {
+                    [printedPath replaceCharactersInRange:range withString:@"..."];
+                }
+            }
+            NSLog(@"[MXHTTPClient] Request %p failed for path: %@ - HTTP code: %ld", mxHTTPOperation, printedPath, (long)operation.response.statusCode);
+
+            if (error.userInfo[NSLocalizedDescriptionKey])
+            {
+                NSLog(@"[MXHTTPClient] error domain: %@, code:%zd, description: %@", error.domain, error.code, error.userInfo[NSLocalizedDescriptionKey]);
+            }
+            else
+            {
+                NSLog(@"[MXHTTPClient] error domain: %@, code:%zd", error.domain, error.code);
+            }
 #endif
 
-        if (operation.responseData)
-        {
-            // If the home server (or any other Matrix server) sent data, it may contain 'errcode' and 'error'.
-            // In this case, we return an NSError which encapsulates MXError information.
-            // When neither 'errcode' nor 'error' are present the received data are reported in NSError userInfo thanks to 'MXHTTPClientErrorResponseDataKey' key.
-            NSError *serializationError = nil;
-            NSDictionary *JSONResponse = [httpManager.responseSerializer responseObjectForResponse:operation.response
-                                                                                              data:operation.responseData
-                                                                                             error:&serializationError];
-            
             if (JSONResponse)
             {
-                NSLog(@"[MXHTTPClient] Error JSONResponse: %@", JSONResponse);
-                
-                if (JSONResponse[@"errcode"] || JSONResponse[@"error"])
+                // If the home server (or any other Matrix server) sent data, it may contain 'errcode' and 'error'.
+                // In this case, we return an NSError which encapsulates MXError information.
+                // When neither 'errcode' nor 'error' are present, the received data are reported in NSError userInfo thanks to 'MXHTTPClientErrorResponseDataKey' key.
+                if (JSONResponse)
                 {
-                    // Extract values from the home server JSON response
-                    MXError *mxError = [[MXError alloc] initWithErrorCode:JSONResponse[@"errcode"]
-                                                                    error:JSONResponse[@"error"]];
-                    
-                    if ([mxError.errcode isEqualToString:kMXErrCodeStringLimitExceeded])
+                    NSLog(@"[MXHTTPClient] Error JSONResponse: %@", JSONResponse);
+
+                    if (JSONResponse[@"errcode"] || JSONResponse[@"error"])
                     {
-                        // Wait and retry if we have not retried too much
-                        if (mxHTTPOperation.age < MXHTTPCLIENT_RATE_LIMIT_MAX_MS)
+                        // Extract values from the home server JSON response
+                        MXError *mxError = [[MXError alloc] initWithErrorCode:JSONResponse[@"errcode"]
+                                                                        error:JSONResponse[@"error"]];
+
+                        if ([mxError.errcode isEqualToString:kMXErrCodeStringLimitExceeded])
                         {
-                            NSString *retryAfterMsString = JSONResponse[@"retry_after_ms"];
-                            if (retryAfterMsString)
+                            // Wait and retry if we have not retried too much
+                            if (mxHTTPOperation.age < MXHTTPCLIENT_RATE_LIMIT_MAX_MS)
                             {
-                                error = nil;
-                                
-                                NSLog(@"[MXHTTPClient] Request %p reached rate limiting. Wait for %@ms", mxHTTPOperation, retryAfterMsString);
-                                
-                                // Wait for the time provided by the server before retrying
-                                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, [retryAfterMsString intValue] * USEC_PER_SEC), dispatch_get_main_queue(), ^{
-                                    
-                                    NSLog(@"[MXHTTPClient] Retry rate limited request %p", mxHTTPOperation);
-                                    
-                                    [self tryRequest:mxHTTPOperation method:httpMethod path:path parameters:parameters data:data headers:headers timeout:timeoutInSeconds uploadProgress:uploadProgress success:^(NSDictionary *JSONResponse) {
-                                        
-                                        NSLog(@"[MXHTTPClient] Success of rate limited request %p after %tu tries", mxHTTPOperation, mxHTTPOperation.numberOfTries);
-                                        
-                                        success(JSONResponse);
-                                        
-                                    } failure:^(NSError *error) {
-                                        failure(error);
-                                    }];
-                                });
+                                NSString *retryAfterMsString = JSONResponse[@"retry_after_ms"];
+                                if (retryAfterMsString)
+                                {
+                                    error = nil;
+
+                                    NSLog(@"[MXHTTPClient] Request %p reached rate limiting. Wait for %@ms", mxHTTPOperation, retryAfterMsString);
+
+                                    // Wait for the time provided by the server before retrying
+                                    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, [retryAfterMsString intValue] * USEC_PER_SEC), dispatch_get_main_queue(), ^{
+
+                                        NSLog(@"[MXHTTPClient] Retry rate limited request %p", mxHTTPOperation);
+
+                                        [self tryRequest:mxHTTPOperation method:httpMethod path:path parameters:parameters data:data headers:headers timeout:timeoutInSeconds uploadProgress:uploadProgress success:^(NSDictionary *JSONResponse) {
+
+                                            NSLog(@"[MXHTTPClient] Success of rate limited request %p after %tu tries", mxHTTPOperation, mxHTTPOperation.numberOfTries);
+
+                                            success(JSONResponse);
+
+                                        } failure:^(NSError *error) {
+                                            failure(error);
+                                        }];
+                                    });
+                                }
+                            }
+                            else
+                            {
+                                NSLog(@"[MXHTTPClient] Giving up rate limited request %p: spent too long retrying.", mxHTTPOperation);
                             }
                         }
                         else
                         {
-                            NSLog(@"[MXHTTPClient] Giving up rate limited request %p: spent too long retrying.", mxHTTPOperation);
+                            error = [mxError createNSError];
                         }
                     }
                     else
                     {
-                        error = [mxError createNSError];
+                        // Report the received data in userInfo dictionary
+                        NSMutableDictionary *userInfo;
+                        if (error.userInfo)
+                        {
+                            userInfo = [NSMutableDictionary dictionaryWithDictionary:error.userInfo];
+                        }
+                        else
+                        {
+                            userInfo = [NSMutableDictionary dictionary];
+                        }
+
+                        [userInfo setObject:JSONResponse forKey:MXHTTPClientErrorResponseDataKey];
+
+                        error = [NSError errorWithDomain:error.domain code:error.code userInfo:userInfo];
                     }
                 }
-                else
+            }
+            else if (mxHTTPOperation.numberOfTries < mxHTTPOperation.maxNumberOfTries && mxHTTPOperation.age < mxHTTPOperation.maxRetriesTime)
+            {
+                // Check if it is a network connectivity issue
+                AFNetworkReachabilityManager *networkReachabilityManager = [AFNetworkReachabilityManager sharedManager];
+                NSLog(@"[MXHTTPClient] request %p. Network reachability: %d", mxHTTPOperation, networkReachabilityManager.isReachable);
+
+                if (networkReachabilityManager.isReachable)
                 {
-                    // Report the received data in userInfo dictionary
-                    NSMutableDictionary *userInfo;
-                    if (error.userInfo)
-                    {
-                        userInfo = [NSMutableDictionary dictionaryWithDictionary:error.userInfo];
-                    }
-                    else
-                    {
-                        userInfo = [NSMutableDictionary dictionary];
-                    }
-                    
-                    [userInfo setObject:JSONResponse forKey:MXHTTPClientErrorResponseDataKey];
-                    
-                    error = [NSError errorWithDomain:error.domain code:error.code userInfo:userInfo];
-                }
-            }
-        }
-        else if (mxHTTPOperation.numberOfTries < mxHTTPOperation.maxNumberOfTries && mxHTTPOperation.age < mxHTTPOperation.maxRetriesTime)
-        {
-            // Check if it is a network connectivity issue
-            AFNetworkReachabilityManager *networkReachabilityManager = [AFNetworkReachabilityManager sharedManager];
-            NSLog(@"[MXHTTPClient] request %p. Network reachability: %d", mxHTTPOperation, networkReachabilityManager.isReachable);
+                    // The problem is not the network, do simple retry later
+                    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, [MXHTTPClient jitterTimeForRetry] * NSEC_PER_MSEC), dispatch_get_main_queue(), ^{
 
-            if (networkReachabilityManager.isReachable)
-            {
-                // The problem is not the network, do simple retry later
-                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, [MXHTTPClient jitterTimeForRetry] * NSEC_PER_MSEC), dispatch_get_main_queue(), ^{
-
-                    NSLog(@"[MXHTTPClient] Retry request %p. Try #%tu/%tu. Age: %tums. Max retries time: %tums", mxHTTPOperation, mxHTTPOperation.numberOfTries + 1, mxHTTPOperation.maxNumberOfTries, mxHTTPOperation.age, mxHTTPOperation.maxRetriesTime);
-
-                    [self tryRequest:mxHTTPOperation method:httpMethod path:path parameters:parameters data:data headers:headers timeout:timeoutInSeconds uploadProgress:uploadProgress success:^(NSDictionary *JSONResponse) {
-
-                        NSLog(@"[MXHTTPClient] Request %p finally succeeded after %tu tries and %tums", mxHTTPOperation, mxHTTPOperation.numberOfTries, mxHTTPOperation.age);
-
-                        success(JSONResponse);
-
-                    } failure:^(NSError *error) {
-                        failure(error);
-                    }];
-
-                });
-            }
-            else
-            {
-                __block NSError *lastError = error;
-
-                // The device is not connected to the internet, wait for the connection to be up again before retrying
-                __weak __typeof(self)weakSelf = self;
-                id networkComeBackObserver = [self addObserverForNetworkComeBack:^{
-                    
-                    __strong __typeof(weakSelf)strongSelf = weakSelf;
-
-                    NSLog(@"[MXHTTPClient] Network is back for request %p", mxHTTPOperation);
-
-                    // Flag this request as retried
-                    lastError = nil;
-                    
-                    // Check whether the pending operation was not cancelled.
-                    if (mxHTTPOperation.maxNumberOfTries)
-                    {
                         NSLog(@"[MXHTTPClient] Retry request %p. Try #%tu/%tu. Age: %tums. Max retries time: %tums", mxHTTPOperation, mxHTTPOperation.numberOfTries + 1, mxHTTPOperation.maxNumberOfTries, mxHTTPOperation.age, mxHTTPOperation.maxRetriesTime);
-                        
-                        [strongSelf tryRequest:mxHTTPOperation method:httpMethod path:path parameters:parameters data:data headers:headers timeout:timeoutInSeconds uploadProgress:uploadProgress success:^(NSDictionary *JSONResponse) {
-                            
+
+                        [self tryRequest:mxHTTPOperation method:httpMethod path:path parameters:parameters data:data headers:headers timeout:timeoutInSeconds uploadProgress:uploadProgress success:^(NSDictionary *JSONResponse) {
+
                             NSLog(@"[MXHTTPClient] Request %p finally succeeded after %tu tries and %tums", mxHTTPOperation, mxHTTPOperation.numberOfTries, mxHTTPOperation.age);
-                            
+
                             success(JSONResponse);
-                            
-                            // The request is complete, managed the next one
-                            [strongSelf wakeUpNextReachabilityServer];
-                            
+
                         } failure:^(NSError *error) {
                             failure(error);
-                            
-                            // The request is complete, managed the next one
-                            [strongSelf wakeUpNextReachabilityServer];
                         }];
-                    }
-                    else
-                    {
-                        NSLog(@"[MXHTTPClient] The request %p has been cancelled", mxHTTPOperation);
-                        
-                        // The request is complete, managed the next one
-                        [strongSelf wakeUpNextReachabilityServer];
-                    }
-                    
-                }];
 
-                // Wait for a limit of time. After that the request is considered expired
-                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (mxHTTPOperation.maxRetriesTime - mxHTTPOperation.age) * USEC_PER_SEC), dispatch_get_main_queue(), ^{
-                    __strong __typeof(weakSelf)strongSelf = weakSelf;
-
-                    // If the request has not been retried yet, consider we are in error
-                    if (lastError)
-                    {
-                        NSLog(@"[MXHTTPClient] Give up retry for request %p. Time expired.", mxHTTPOperation);
-
-                        [strongSelf removeObserverForNetworkComeBack:networkComeBackObserver];
-                        failure(lastError);
-                    }
-                });
-            }
-            error = nil;
-        }
-
-        if (error)
-        {
-            failure(error);
-        }
-    }];
-    
-    // Handle SSL certificates
-    [mxHTTPOperation.operation setWillSendRequestForAuthenticationChallengeBlock:^(NSURLConnection *connection, NSURLAuthenticationChallenge *challenge) {
-        
-        NSURLProtectionSpace *protectionSpace = [challenge protectionSpace];
-        
-        if ([protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust])
-        {
-            if ([httpManager.securityPolicy evaluateServerTrust:protectionSpace.serverTrust forDomain:protectionSpace.host])
-            {
-                NSURLCredential *credential = [NSURLCredential credentialForTrust:protectionSpace.serverTrust];
-                [[challenge sender] useCredential:credential forAuthenticationChallenge:challenge];
-            }
-            else
-            {
-                NSLog(@"[MXHTTPClient] Shall we trust %@?", protectionSpace.host);
-                
-                if (onUnrecognizedCertificateBlock)
-                {
-                    SecTrustRef trust = [protectionSpace serverTrust];
-                    
-                    if (SecTrustGetCertificateCount(trust) > 0)
-                    {
-                        // Consider here the leaf certificate (the one at index 0).
-                        SecCertificateRef certif = SecTrustGetCertificateAtIndex(trust, 0);
-                        
-                        NSData *certifData = (__bridge NSData*)SecCertificateCopyData(certif);
-                        if (onUnrecognizedCertificateBlock(certifData))
-                        {
-                            NSLog(@"[MXHTTPClient] Yes, the user trusts its certificate");
-                            
-                            _allowedCertificate = certifData;
-                            
-                            // Update http manager security policy with this trusted certificate.
-                            AFSecurityPolicy *securityPolicy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeCertificate];
-                            securityPolicy.pinnedCertificates = @[certifData];
-                            securityPolicy.allowInvalidCertificates = YES;
-                            // Disable the domain validation for this certificate trusted by the user.
-                            securityPolicy.validatesDomainName = NO;
-                            httpManager.securityPolicy = securityPolicy;
-                            
-                            // Evaluate again server security
-                            if ([httpManager.securityPolicy evaluateServerTrust:protectionSpace.serverTrust forDomain:protectionSpace.host])
-                            {
-                                NSURLCredential *credential = [NSURLCredential credentialForTrust:protectionSpace.serverTrust];
-                                [[challenge sender] useCredential:credential forAuthenticationChallenge:challenge];
-                                return;
-                            }
-                            
-                            // Here pin certificate failed
-                            NSLog(@"[MXHTTPClient] Failed to pin certificate for %@", protectionSpace.host);
-                            [[challenge sender] continueWithoutCredentialForAuthenticationChallenge:challenge];
-                            return;
-                        }
-                    }
-                }
-                
-                // Here we don't trust the certificate
-                NSLog(@"[MXHTTPClient] No, the user doesn't trust it");
-                [[challenge sender] cancelAuthenticationChallenge:challenge];
-            }
-        }
-        else
-        {
-            if ([challenge previousFailureCount] == 0)
-            {
-                if (httpManager.credential)
-                {
-                    [[challenge sender] useCredential:httpManager.credential forAuthenticationChallenge:challenge];
+                    });
                 }
                 else
                 {
-                    [[challenge sender] continueWithoutCredentialForAuthenticationChallenge:challenge];
+                    __block NSError *lastError = error;
+
+                    // The device is not connected to the internet, wait for the connection to be up again before retrying
+                    __weak __typeof(self)weakSelf = self;
+                    id networkComeBackObserver = [self addObserverForNetworkComeBack:^{
+
+                        __strong __typeof(weakSelf)strongSelf = weakSelf;
+
+                        NSLog(@"[MXHTTPClient] Network is back for request %p", mxHTTPOperation);
+
+                        // Flag this request as retried
+                        lastError = nil;
+
+                        // Check whether the pending operation was not cancelled.
+                        if (mxHTTPOperation.maxNumberOfTries)
+                        {
+                            NSLog(@"[MXHTTPClient] Retry request %p. Try #%tu/%tu. Age: %tums. Max retries time: %tums", mxHTTPOperation, mxHTTPOperation.numberOfTries + 1, mxHTTPOperation.maxNumberOfTries, mxHTTPOperation.age, mxHTTPOperation.maxRetriesTime);
+
+                            [strongSelf tryRequest:mxHTTPOperation method:httpMethod path:path parameters:parameters data:data headers:headers timeout:timeoutInSeconds uploadProgress:uploadProgress success:^(NSDictionary *JSONResponse) {
+
+                                NSLog(@"[MXHTTPClient] Request %p finally succeeded after %tu tries and %tums", mxHTTPOperation, mxHTTPOperation.numberOfTries, mxHTTPOperation.age);
+
+                                success(JSONResponse);
+
+                                // The request is complete, managed the next one
+                                [strongSelf wakeUpNextReachabilityServer];
+
+                            } failure:^(NSError *error) {
+                                failure(error);
+
+                                // The request is complete, managed the next one
+                                [strongSelf wakeUpNextReachabilityServer];
+                            }];
+                        }
+                        else
+                        {
+                            NSLog(@"[MXHTTPClient] The request %p has been cancelled", mxHTTPOperation);
+
+                            // The request is complete, managed the next one
+                            [strongSelf wakeUpNextReachabilityServer];
+                        }
+
+                    }];
+                    
+                    // Wait for a limit of time. After that the request is considered expired
+                    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (mxHTTPOperation.maxRetriesTime - mxHTTPOperation.age) * USEC_PER_SEC), dispatch_get_main_queue(), ^{
+                        __strong __typeof(weakSelf)strongSelf = weakSelf;
+                        
+                        // If the request has not been retried yet, consider we are in error
+                        if (lastError)
+                        {
+                            NSLog(@"[MXHTTPClient] Give up retry for request %p. Time expired.", mxHTTPOperation);
+                            
+                            [strongSelf removeObserverForNetworkComeBack:networkComeBackObserver];
+                            failure(lastError);
+                        }
+                    });
                 }
+                error = nil;
             }
-            else
+            
+            if (error)
             {
-                [[challenge sender] continueWithoutCredentialForAuthenticationChallenge:challenge];
+                failure(error);
             }
         }
+
     }];
 
-    // Make the request continue in background
-    [mxHTTPOperation.operation setShouldExecuteAsBackgroundTaskWithExpirationHandler:nil];
+    // @TODO
+    // Handle SSL certificates
+//    [mxHTTPOperation.operation setWillSendRequestForAuthenticationChallengeBlock:^(NSURLConnection *connection, NSURLAuthenticationChallenge *challenge) {
+//        
+//        NSURLProtectionSpace *protectionSpace = [challenge protectionSpace];
+//        
+//        if ([protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust])
+//        {
+//            if ([httpManager.securityPolicy evaluateServerTrust:protectionSpace.serverTrust forDomain:protectionSpace.host])
+//            {
+//                NSURLCredential *credential = [NSURLCredential credentialForTrust:protectionSpace.serverTrust];
+//                [[challenge sender] useCredential:credential forAuthenticationChallenge:challenge];
+//            }
+//            else
+//            {
+//                NSLog(@"[MXHTTPClient] Shall we trust %@?", protectionSpace.host);
+//                
+//                if (onUnrecognizedCertificateBlock)
+//                {
+//                    SecTrustRef trust = [protectionSpace serverTrust];
+//                    
+//                    if (SecTrustGetCertificateCount(trust) > 0)
+//                    {
+//                        // Consider here the leaf certificate (the one at index 0).
+//                        SecCertificateRef certif = SecTrustGetCertificateAtIndex(trust, 0);
+//                        
+//                        NSData *certifData = (__bridge NSData*)SecCertificateCopyData(certif);
+//                        if (onUnrecognizedCertificateBlock(certifData))
+//                        {
+//                            NSLog(@"[MXHTTPClient] Yes, the user trusts its certificate");
+//                            
+//                            _allowedCertificate = certifData;
+//                            
+//                            // Update http manager security policy with this trusted certificate.
+//                            AFSecurityPolicy *securityPolicy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeCertificate];
+//                            securityPolicy.pinnedCertificates = @[certifData];
+//                            securityPolicy.allowInvalidCertificates = YES;
+//                            // Disable the domain validation for this certificate trusted by the user.
+//                            securityPolicy.validatesDomainName = NO;
+//                            httpManager.securityPolicy = securityPolicy;
+//                            
+//                            // Evaluate again server security
+//                            if ([httpManager.securityPolicy evaluateServerTrust:protectionSpace.serverTrust forDomain:protectionSpace.host])
+//                            {
+//                                NSURLCredential *credential = [NSURLCredential credentialForTrust:protectionSpace.serverTrust];
+//                                [[challenge sender] useCredential:credential forAuthenticationChallenge:challenge];
+//                                return;
+//                            }
+//                            
+//                            // Here pin certificate failed
+//                            NSLog(@"[MXHTTPClient] Failed to pin certificate for %@", protectionSpace.host);
+//                            [[challenge sender] continueWithoutCredentialForAuthenticationChallenge:challenge];
+//                            return;
+//                        }
+//                    }
+//                }
+//                
+//                // Here we don't trust the certificate
+//                NSLog(@"[MXHTTPClient] No, the user doesn't trust it");
+//                [[challenge sender] cancelAuthenticationChallenge:challenge];
+//            }
+//        }
+//        else
+//        {
+//            if ([challenge previousFailureCount] == 0)
+//            {
+//                if (httpManager.credential)
+//                {
+//                    [[challenge sender] useCredential:httpManager.credential forAuthenticationChallenge:challenge];
+//                }
+//                else
+//                {
+//                    [[challenge sender] continueWithoutCredentialForAuthenticationChallenge:challenge];
+//                }
+//            }
+//            else
+//            {
+//                [[challenge sender] continueWithoutCredentialForAuthenticationChallenge:challenge];
+//            }
+//        }
+//    }];
 
-    if (uploadProgress)
-    {
-        [mxHTTPOperation.operation setUploadProgressBlock:uploadProgress];
-    }
-
-    [httpManager.operationQueue addOperation:mxHTTPOperation.operation];
+    [mxHTTPOperation.operation resume];
 }
 
 + (NSUInteger)jitterTimeForRetry

--- a/MatrixSDK/Utils/MXHTTPClient.m
+++ b/MatrixSDK/Utils/MXHTTPClient.m
@@ -208,7 +208,7 @@ NSString * const MXHTTPClientErrorResponseDataKey = @"com.matrixsdk.httpclient.e
 
         if (uploadProgress)
         {
-            // theUploadProgress is not called from an AFNetworking thread. So, switch to the UI one
+            // theUploadProgress is called from an AFNetworking thread. So, switch to the UI one
             dispatch_async(dispatch_get_main_queue(), ^{
                 uploadProgress(theUploadProgress);
             });

--- a/MatrixSDK/Utils/MXHTTPOperation.h
+++ b/MatrixSDK/Utils/MXHTTPOperation.h
@@ -30,7 +30,7 @@
  The underlying HTTP request.
  The reference changes in case of retries.
  */
-@property (nonatomic) AFHTTPRequestOperation *operation;
+@property (nonatomic) NSURLSessionDataTask *operation;
 
 /**
  The age in milliseconds of the instance.

--- a/Podfile
+++ b/Podfile
@@ -4,7 +4,7 @@
 source 'https://github.com/CocoaPods/Specs.git'
 
 target "MatrixSDK" do
-pod 'AFNetworking', '~> 2.6.0'
+pod 'AFNetworking', '~> 3.1.0'
 end
 
 target "MatrixSDKTests" do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,32 +1,26 @@
 PODS:
-  - AFNetworking (2.6.3):
-    - AFNetworking/NSURLConnection (= 2.6.3)
-    - AFNetworking/NSURLSession (= 2.6.3)
-    - AFNetworking/Reachability (= 2.6.3)
-    - AFNetworking/Security (= 2.6.3)
-    - AFNetworking/Serialization (= 2.6.3)
-    - AFNetworking/UIKit (= 2.6.3)
-  - AFNetworking/NSURLConnection (2.6.3):
+  - AFNetworking (3.1.0):
+    - AFNetworking/NSURLSession (= 3.1.0)
+    - AFNetworking/Reachability (= 3.1.0)
+    - AFNetworking/Security (= 3.1.0)
+    - AFNetworking/Serialization (= 3.1.0)
+    - AFNetworking/UIKit (= 3.1.0)
+  - AFNetworking/NSURLSession (3.1.0):
     - AFNetworking/Reachability
     - AFNetworking/Security
     - AFNetworking/Serialization
-  - AFNetworking/NSURLSession (2.6.3):
-    - AFNetworking/Reachability
-    - AFNetworking/Security
-    - AFNetworking/Serialization
-  - AFNetworking/Reachability (2.6.3)
-  - AFNetworking/Security (2.6.3)
-  - AFNetworking/Serialization (2.6.3)
-  - AFNetworking/UIKit (2.6.3):
-    - AFNetworking/NSURLConnection
+  - AFNetworking/Reachability (3.1.0)
+  - AFNetworking/Security (3.1.0)
+  - AFNetworking/Serialization (3.1.0)
+  - AFNetworking/UIKit (3.1.0):
     - AFNetworking/NSURLSession
 
 DEPENDENCIES:
-  - AFNetworking (~> 2.6.0)
+  - AFNetworking (~> 3.1.0)
 
 SPEC CHECKSUMS:
-  AFNetworking: cb8d14a848e831097108418f5d49217339d4eb60
+  AFNetworking: 5e0e199f73d8626b11e79750991f5d173d1f8b67
 
-PODFILE CHECKSUM: 9f930df9cc2493e9c0eeba90ea297db3342fbb66
+PODFILE CHECKSUM: df085036ef69abc13ecf9505af15ba806e6c0100
 
 COCOAPODS: 1.0.1


### PR DESCRIPTION
https://github.com/matrix-org/matrix-ios-sdk/issues/113

I try to keep the same behaviour we had with the previous AFNetworking version. Specifically for media upload when the app goes in background.

I tested SSL in different situations but I failed to enter in this code https://github.com/matrix-org/matrix-ios-sdk/blob/1feaa3ddc4c1a49f9fb7438ac202721024dbc732/MatrixSDK/Utils/MXHTTPClient.m#L455-L471.
As I cannot understand how we can enter in this else block, I have removed it.

There is an API break in MXRestClient with the introduction of NSProgress.
