### PR TITLE
Vector 443

### DIFF
--- a/MatrixSDK/Data/MXEventTimeline.m
+++ b/MatrixSDK/Data/MXEventTimeline.m
@@ -19,6 +19,8 @@
 #import "MXSession.h"
 #import "MXMemoryStore.h"
 
+#import "MXEvent+MatrixKit.h"
+
 #import "MXError.h"
 
 NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
@@ -47,6 +49,11 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
     // past timelines is managed locally.
     NSString *forwardsPaginationToken;
     BOOL hasReachedHomeServerForwardsPaginationEnd;
+    
+    /**
+     The current pending request.
+     */
+    MXHTTPOperation *httpOperation;
 }
 @end
 
@@ -102,6 +109,13 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
 
 - (void)destroy
 {
+    if (httpOperation)
+    {
+        // Cancel the current server request
+        [httpOperation cancel];
+        httpOperation = nil;
+    }
+    
     if (!_isLiveTimeline)
     {
         // Release past timeline events stored in memory
@@ -409,7 +423,7 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
     else if (roomSync.timeline.limited)
     {
         // The room has been resync with a limited timeline - Post notification
-        [[NSNotificationCenter defaultCenter] postNotificationName:kMXRoomSyncWithLimitedTimelineNotification
+        [[NSNotificationCenter defaultCenter] postNotificationName:kMXRoomDidFlushMessagesNotification
                                                             object:room
                                                           userInfo:nil];
     }
@@ -537,7 +551,9 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
 #pragma mark - Specific events Handling
 - (void)handleRedaction:(MXEvent*)redactionEvent
 {
-    // Check whether the redacted event has been already processed
+    NSLog(@"[MXEventTimeline] handle an event redaction");
+    
+    // Check whether the redacted event is stored in room messages
     MXEvent *redactedEvent = [store eventWithEventId:redactionEvent.redacts inRoom:_state.roomId];
     if (redactedEvent)
     {
@@ -545,15 +561,133 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
         redactedEvent = [redactedEvent prune];
         redactedEvent.redactedBecause = redactionEvent.JSONDictionary;
 
-        if (redactedEvent.isState) {
-            // FIXME: The room state must be refreshed here since this redacted event.
-        }
-
-        // Store the event
+        // Store the updated event
         [store replaceEvent:redactedEvent inRoom:_state.roomId];
+    }
+    
+    // Check whether the current room state depends on this redacted event.
+    if (!redactedEvent || redactedEvent.isState)
+    {
+        // FIXME: Is @autoreleasepool block required or not here?
+        NSArray *stateEvents = _state.stateEvents;
+        
+        for (MXEvent *stateEvent in stateEvents)
+        {
+            if ([stateEvent.eventId isEqualToString:redactionEvent.redacts])
+            {
+                NSLog(@"[MXEventTimeline] the current room state has been modified by the event redaction.");
+                
+                // Redact the stored event
+                redactedEvent = [stateEvent prune];
+                redactedEvent.redactedBecause = redactionEvent.JSONDictionary;
+                
+                // Reset the room state. //FIXME: is it possible to handle only the redacted event?
+                _state = [[MXRoomState alloc] initWithRoomId:room.roomId andMatrixSession:room.mxSession andDirection:YES];
+                [self initialiseState:stateEvents];
+                
+                // Update store with new room state when all state event have been processed
+                if ([store respondsToSelector:@selector(storeStateForRoom:stateEvents:)])
+                {
+                    [store storeStateForRoom:_state.roomId stateEvents:_state.stateEvents];
+                }
+                
+                // Reset the current pagination
+                // FIXME: Shall we let the kMXRoomStateHasBeenRedactedNotification listener trigger this reset? (like [MXKRoomDataSource reload] do)
+                [self resetPagination];
+                
+                // Notify that room history has been flushed
+                [[NSNotificationCenter defaultCenter] postNotificationName:kMXRoomDidFlushMessagesNotification
+                                                                    object:room
+                                                                  userInfo:nil];
+                return;
+            }
+        }
+    }
+    
+    // Re-sync the room in case of redacted state event from the past.
+    // Indeed, redacted information shouldn't spontaneously appear when you backpaginate...
+    if (!redactedEvent)
+    {
+        // Use a /context request to check whether the redacted event is a state event or not.
+        httpOperation = [room.mxSession.matrixRestClient contextOfEvent:redactionEvent.redacts inRoom:room.roomId limit:1 success:^(MXEventContext *eventContext) {
+            
+            if (!httpOperation)
+            {
+                return;
+            }
+            httpOperation = nil;
+            
+            if (eventContext.event.isState)
+            {
+                NSLog(@"[MXEventTimeline] the redacted event is a state event from the past");
+                [self forceRoomServerSync];
+            }
+            
+        } failure:^(NSError *error) {
+            
+            if (!httpOperation)
+            {
+                return;
+            }
+            httpOperation = nil;
+            
+            NSLog(@"[MXEventTimeline] handleRedaction: failed to retrieved the redacted event");
+            [self forceRoomServerSync];
+        }];
+    }
+    else if (redactedEvent.isState)
+    {
+        NSLog(@"[MXEventTimeline] the redacted event is a former state event");
+        [self forceRoomServerSync];
     }
 }
 
+- (void)forceRoomServerSync
+{
+    // Reset the storage of this room. Re-sync it from the server
+    NSLog(@"[MXEventTimeline] re-sync room (%@) from the server.", room.roomId);
+    [store deleteRoom:room.roomId];
+    
+    // Make an /initialSync request to get data
+    // Use a 0 messages limit for now because:
+    //    - /initialSync is marked as obsolete in the spec
+    //    - MXEventTimeline does not have methods to handle /initialSync responses
+    // So, avoid to write temparary code and let the user uses [MXEventTimeline paginate]
+    // to get room messages.
+    httpOperation = [room.mxSession.matrixRestClient initialSyncOfRoom:room.roomId withLimit:0 success:^(MXRoomInitialSync *roomInitialSync) {
+        
+        if (!httpOperation)
+        {
+            return;
+        }
+        httpOperation = nil;
+        
+        _state = [[MXRoomState alloc] initWithRoomId:room.roomId andMatrixSession:room.mxSession andDirection:YES];
+        [self initialiseState:roomInitialSync.state];
+        
+        // Update store with new room state when all state event have been processed
+        if ([store respondsToSelector:@selector(storeStateForRoom:stateEvents:)])
+        {
+            [store storeStateForRoom:_state.roomId stateEvents:_state.stateEvents];
+        }
+        
+        [self resetPagination];
+        
+        // Notify that room history has been flushed
+        [[NSNotificationCenter defaultCenter] postNotificationName:kMXRoomDidFlushMessagesNotification
+                                                            object:room
+                                                          userInfo:nil];
+        
+    } failure:^(NSError *error) {
+        
+        NSLog(@"[MXEventTimeline] forceRoomServerSync failed.");
+        
+        // FIXME: Reload entirely the app?
+//        [[NSNotificationCenter defaultCenter] postNotificationName:kMXSessionIgnoredUsersDidChangeNotification
+//                                                            object:room.mxSession
+//                                                          userInfo:nil];
+    }];
+}
 
 #pragma mark - State events handling
 - (void)cloneState:(MXTimelineDirection)direction
@@ -584,8 +718,8 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
         // Forwards events update the current state of the room
         [_state handleStateEvent:event];
 
-        // Special handling for presence
-        if (_isLiveTimeline && MXEventTypeRoomMember == event.eventType)
+        // Special handling for presence (CAUTION: ignore redacted state event here)
+        if (_isLiveTimeline && MXEventTypeRoomMember == event.eventType && !event.isRedactedEvent)
         {
             // Update MXUser data
             MXUser *user = [room.mxSession getOrCreateUser:event.sender];

--- a/MatrixSDK/Data/MXEventTimeline.m
+++ b/MatrixSDK/Data/MXEventTimeline.m
@@ -568,7 +568,6 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
     // Check whether the current room state depends on this redacted event.
     if (!redactedEvent || redactedEvent.isState)
     {
-        // FIXME: Is @autoreleasepool block required or not here?
         NSMutableArray *stateEvents = [NSMutableArray arrayWithArray:_state.stateEvents];
         
         for (NSInteger index = 0; index < stateEvents.count; index++)
@@ -585,7 +584,7 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
                 
                 [stateEvents replaceObjectAtIndex:index withObject:redactedEvent];
                 
-                // Reset the room state. //FIXME: is it possible to handle only the redacted event?
+                // Reset the room state.
                 _state = [[MXRoomState alloc] initWithRoomId:room.roomId andMatrixSession:room.mxSession andDirection:YES];
                 [self initialiseState:stateEvents];
                 
@@ -596,7 +595,7 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
                 }
                 
                 // Reset the current pagination
-                // FIXME: Shall we let the kMXRoomStateHasBeenRedactedNotification listener trigger this reset? (like [MXKRoomDataSource reload] do)
+                // FIXME: Shall we let the kMXRoomDidFlushMessagesNotification listener trigger this reset? (like [MXKRoomDataSource reload] do)
                 [self resetPagination];
                 
                 // Notify that room history has been flushed
@@ -686,10 +685,10 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
         
         NSLog(@"[MXEventTimeline] forceRoomServerSync failed.");
         
-        // FIXME: Reload entirely the app?
-//        [[NSNotificationCenter defaultCenter] postNotificationName:kMXSessionIgnoredUsersDidChangeNotification
-//                                                            object:room.mxSession
-//                                                          userInfo:nil];
+        // Reload entirely the app
+        [[NSNotificationCenter defaultCenter] postNotificationName:kMXSessionDidCorruptDataNotification
+                                                            object:room.mxSession
+                                                          userInfo:nil];
     }];
 }
 

--- a/MatrixSDK/Data/MXEventTimeline.m
+++ b/MatrixSDK/Data/MXEventTimeline.m
@@ -569,10 +569,12 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
     if (!redactedEvent || redactedEvent.isState)
     {
         // FIXME: Is @autoreleasepool block required or not here?
-        NSArray *stateEvents = _state.stateEvents;
+        NSMutableArray *stateEvents = [NSMutableArray arrayWithArray:_state.stateEvents];
         
-        for (MXEvent *stateEvent in stateEvents)
+        for (NSInteger index = 0; index < stateEvents.count; index++)
         {
+            MXEvent *stateEvent = stateEvents[index];
+            
             if ([stateEvent.eventId isEqualToString:redactionEvent.redacts])
             {
                 NSLog(@"[MXEventTimeline] the current room state has been modified by the event redaction.");
@@ -580,6 +582,8 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
                 // Redact the stored event
                 redactedEvent = [stateEvent prune];
                 redactedEvent.redactedBecause = redactionEvent.JSONDictionary;
+                
+                [stateEvents replaceObjectAtIndex:index withObject:redactedEvent];
                 
                 // Reset the room state. //FIXME: is it possible to handle only the redacted event?
                 _state = [[MXRoomState alloc] initWithRoomId:room.roomId andMatrixSession:room.mxSession andDirection:YES];

--- a/MatrixSDK/Data/MXRoom.h
+++ b/MatrixSDK/Data/MXRoom.h
@@ -45,7 +45,7 @@ FOUNDATION_EXPORT NSString *const kMXRoomInitialSyncNotification;
  
  The notification object is the concerned room (MXRoom instance).
  */
-FOUNDATION_EXPORT NSString *const kMXRoomDidFlushMessagesNotification;
+FOUNDATION_EXPORT NSString *const kMXRoomDidFlushDataNotification;
 
 /**
  Posted when the number of unread notifications ('notificationCount' and 'highlightCount' properties) are updated.

--- a/MatrixSDK/Data/MXRoom.h
+++ b/MatrixSDK/Data/MXRoom.h
@@ -39,13 +39,13 @@
 FOUNDATION_EXPORT NSString *const kMXRoomInitialSyncNotification;
 
 /**
- Posted when a limited timeline is observed for an existing room during server sync.
- All the existing messages have been removed from the room storage. Only the messages received during this sync are available.
+ Posted when the messages of an existing room has been flushed during server sync.
+ This flush may be due to a limited timeline in the room sync, or the redaction of a state event.
  The token where to start back pagination has been updated.
  
  The notification object is the concerned room (MXRoom instance).
  */
-FOUNDATION_EXPORT NSString *const kMXRoomSyncWithLimitedTimelineNotification;
+FOUNDATION_EXPORT NSString *const kMXRoomDidFlushMessagesNotification;
 
 /**
  Posted when the number of unread notifications ('notificationCount' and 'highlightCount' properties) are updated.

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -21,7 +21,7 @@
 
 #import "MXError.h"
 
-NSString *const kMXRoomDidFlushMessagesNotification = @"kMXRoomDidFlushMessagesNotification";
+NSString *const kMXRoomDidFlushDataNotification = @"kMXRoomDidFlushDataNotification";
 NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotification";
 NSString *const kMXRoomDidUpdateUnreadNotification = @"kMXRoomDidUpdateUnreadNotification";
 

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -21,7 +21,7 @@
 
 #import "MXError.h"
 
-NSString *const kMXRoomSyncWithLimitedTimelineNotification = @"kMXRoomSyncWithLimitedTimelineNotification";
+NSString *const kMXRoomDidFlushMessagesNotification = @"kMXRoomDidFlushMessagesNotification";
 NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotification";
 NSString *const kMXRoomDidUpdateUnreadNotification = @"kMXRoomDidUpdateUnreadNotification";
 

--- a/MatrixSDK/Data/MXRoomState.m
+++ b/MatrixSDK/Data/MXRoomState.m
@@ -462,8 +462,7 @@
                     membersWithThirdPartyInviteTokenCache[roomMember.thirdPartyInviteToken] = roomMember;
                 }
             }
-            else// FIXME: In case of redacted membership event (prev_content is missing see SYN-724),
-                // the room member is then nil: the client considers by mistake the user is no more part of the room...
+            else
             {
                 // The user is no more part of the room. Remove him.
                 // This case happens during back pagination: we remove here users when they are not in the room yet.
@@ -568,17 +567,13 @@
         
         if (!member)
         {
-            // FIXME: In case of redacted membership event (prev_content is missing see SYN-724),
-            // the client considers by mistake that some users are no more part of the room.
-            // PATCH: we comment the following, else some redacted information re-appear spontaneously.
-            
-//            // The user may not have joined the room yet. So try to resolve display name from presence data
-//            // Note: This data may not be available
-//            MXUser* user = [mxSession userWithUserId:userId];
-//            if (user && user.displayname.length)
-//            {
-//                displayName = user.displayname;
-//            }
+            // The user may not have joined the room yet. So try to resolve display name from presence data
+            // Note: This data may not be available
+            MXUser* user = [mxSession userWithUserId:userId];
+            if (user && user.displayname.length)
+            {
+                displayName = user.displayname;
+            }
         }
         else if (member.displayname.length)
         {

--- a/MatrixSDK/Data/MXRoomState.m
+++ b/MatrixSDK/Data/MXRoomState.m
@@ -450,7 +450,8 @@
                     membersWithThirdPartyInviteTokenCache[roomMember.thirdPartyInviteToken] = roomMember;
                 }
             }
-            else
+            else// FIXME: In case of redacted membership event (prev_content is missing see SYN-724),
+                // the room member is then nil: the client considers by mistake the user is no more part of the room...
             {
                 // The user is no more part of the room. Remove him.
                 // This case happens during back pagination: we remove here users when they are not in the room yet.
@@ -550,13 +551,17 @@
         
         if (!member)
         {
-            // The user may not have joined the room yet. So try to resolve display name from presence data
-            // Note: This data may not be available
-            MXUser* user = [mxSession userWithUserId:userId];
-            if (user && user.displayname.length)
-            {
-                displayName = user.displayname;
-            }
+            // FIXME: In case of redacted membership event (prev_content is missing see SYN-724),
+            // the client considers by mistake that some users are no more part of the room.
+            // PATCH: we comment the following, else some redacted information re-appear spontaneously.
+            
+//            // The user may not have joined the room yet. So try to resolve display name from presence data
+//            // Note: This data may not be available
+//            MXUser* user = [mxSession userWithUserId:userId];
+//            if (user && user.displayname.length)
+//            {
+//                displayName = user.displayname;
+//            }
         }
         else if (member.displayname.length)
         {

--- a/MatrixSDK/JSONModels/MXEvent.h
+++ b/MatrixSDK/JSONModels/MXEvent.h
@@ -216,9 +216,19 @@ FOUNDATION_EXPORT uint64_t const kMXUndefinedTimestamp;
 - (MXEventType)eventType;
 
 /**
- Indicates if the event hosts state data
+ Indicates if the event hosts state data.
  */
 - (BOOL)isState;
+
+/**
+ Indicates if the event has been redacted.
+ */
+- (BOOL)isRedactedEvent;
+
+/**
+ Return YES if the event is an emote event
+ */
+- (BOOL)isEmote;
 
 /**
  Returns the event IDs for which a read receipt is defined in this event.

--- a/MatrixSDK/JSONModels/MXEvent.m
+++ b/MatrixSDK/JSONModels/MXEvent.m
@@ -225,6 +225,25 @@ uint64_t const kMXUndefinedTimestamp = (uint64_t)-1;
     return (nil != self.stateKey);
 }
 
+- (BOOL)isRedactedEvent
+{
+    // The event is redacted if its redactedBecause is filed (with a redaction event id)
+    return (self.redactedBecause != nil);
+}
+
+- (BOOL)isEmote
+{
+    if (self.eventType == MXEventTypeRoomMessage)
+    {
+        NSString *msgtype = self.content[@"msgtype"];
+        if ([msgtype isEqualToString:kMXMessageTypeEmote])
+        {
+            return YES;
+        }
+    }
+    return NO;
+}
+
 - (NSArray *)readReceiptEventIds
 {
     NSMutableArray* list = nil;

--- a/MatrixSDK/MXSession.h
+++ b/MatrixSDK/MXSession.h
@@ -161,9 +161,17 @@ FOUNDATION_EXPORT NSString *const kMXSessionNotificationEventKey;
 
 /**
  Posted when MXSession has detected a change in the `ignoredUsers` property.
+ 
+ The notification object is the concerned session (MXSession instance).
  */
 FOUNDATION_EXPORT NSString *const kMXSessionIgnoredUsersDidChangeNotification;
 
+/**
+ Posted when MXSession data have been corrupted. The listener must reload the session data with a full server sync.
+ 
+ The notification object is the concerned session (MXSession instance).
+ */
+FOUNDATION_EXPORT NSString *const kMXSessionDidCorruptDataNotification;
 
 #pragma mark - Other constants
 /**

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -40,6 +40,7 @@ NSString *const kMXSessionInvitedRoomsDidChangeNotification = @"kMXSessionInvite
 NSString *const kMXSessionNotificationRoomIdKey = @"roomId";
 NSString *const kMXSessionNotificationEventKey = @"event";
 NSString *const kMXSessionIgnoredUsersDidChangeNotification = @"kMXSessionIgnoredUsersDidChangeNotification";
+NSString *const kMXSessionDidCorruptDataNotification = @"kMXSessionDidCorruptDataNotification";
 NSString *const kMXSessionNoRoomTag = @"m.recent";  // Use the same value as matrix-react-sdk
 
 /**


### PR DESCRIPTION
Redacting membership events should immediately reset the displayname & avatar of room members.
