### PR TITLE
Bug Fix - Profile changes shouldn't reorder the room list

### DIFF
--- a/MatrixSDK/Data/MXRoom.h
+++ b/MatrixSDK/Data/MXRoom.h
@@ -99,9 +99,11 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidUpdateUnreadNotification;
 
 /**
  The last message of the requested types.
+ This value depends on mxSession.ignoreProfileChangesDuringLastMessageProcessing.
 
  @param types an array of event types strings (MXEventTypeString).
  @return the last event of the requested types or the true last event if no event of the requested type is found.
+ (CAUTION: All rooms must have a last message. For this reason, the returned event may be a profile change even if it should be ignored).
  */
 - (MXEvent*)lastMessageWithTypeIn:(NSArray*)type;
 
@@ -697,6 +699,7 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidUpdateUnreadNotification;
 
 /**
  Comparator to use to order array of rooms by their lastest originServerTs value.
+ This sorting is based on the last message of the room.
  
  Arrays are then sorting so that the oldest room is set at position 0.
  

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -139,7 +139,8 @@ NSString *const kMXRoomDidUpdateUnreadNotification = @"kMXRoomDidUpdateUnreadNot
 
 - (MXEvent *)lastMessageWithTypeIn:(NSArray*)types
 {
-    return [mxSession.store lastMessageOfRoom:self.state.roomId withTypeIn:types];
+    // Retrieve the last message from the store by considering the mxSession settings.
+    return [mxSession.store lastMessageOfRoom:self.state.roomId withTypeIn:types ignoreMemberProfileChanges:mxSession.ignoreProfileChangesDuringLastMessageProcessing];
 }
 
 #pragma mark - Sync
@@ -597,7 +598,7 @@ NSString *const kMXRoomDidUpdateUnreadNotification = @"kMXRoomDidUpdateUnreadNot
 
 - (BOOL)acknowledgeLatestEvent:(BOOL)sendReceipt;
 {    
-    MXEvent* event =[mxSession.store lastMessageOfRoom:self.state.roomId withTypeIn:_acknowledgableEventTypes];
+    MXEvent* event =[mxSession.store lastMessageOfRoom:self.state.roomId withTypeIn:_acknowledgableEventTypes ignoreMemberProfileChanges:NO];
     // Sanity check on event id: Do not send read receipt on event without id
     if (event.eventId && ([event.eventId hasPrefix:kMXRoomInviteStateEventIdPrefix] == NO))
     {

--- a/MatrixSDK/Data/Store/MXCoreDataStore/MXCoreDataRoom.h
+++ b/MatrixSDK/Data/Store/MXCoreDataStore/MXCoreDataRoom.h
@@ -93,7 +93,7 @@ NS_ASSUME_NONNULL_BEGIN
  The last message of the room.
 
  An optional array of event types may be provided to filter room events. When this array is not nil,
- the type of the returned last event matches with one of the provided types.
+ the type of the returned last event should match with one of the provided types.
 
  CAUTION: All rooms must have a last message. If no event matches with the provided event types, the
  first event is returned whatever its type.

--- a/MatrixSDK/Data/Store/MXCoreDataStore/MXCoreDataStore.m
+++ b/MatrixSDK/Data/Store/MXCoreDataStore/MXCoreDataStore.m
@@ -342,9 +342,11 @@ NSString *const kMXCoreDataStoreFolder = @"MXCoreDataStore";
     return [room remainingMessagesForPagination];
 }
 
-- (MXEvent*)lastMessageOfRoom:(NSString*)roomId withTypeIn:(NSArray*)types;
+- (MXEvent*)lastMessageOfRoom:(NSString*)roomId withTypeIn:(NSArray*)types ignoreMemberProfileChanges:(BOOL)ignoreProfileChanges
 {
     MXCoreDataRoom *room = [self getOrCreateRoomEntity:roomId];
+    
+    // TODO handle ignoreProfileChanges flag
     return [room lastMessageWithTypeIn:types];
 }
 

--- a/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryRoomStore.h
+++ b/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryRoomStore.h
@@ -109,15 +109,17 @@
  The last message of the room.
  
  An optional array of event types may be provided to filter room events. When this array is not nil,
- the type of the returned last event matches with one of the provided types.
+ the type of the returned last event should match with one of the provided types.
  
  CAUTION: All rooms must have a last message. If no event matches with the provided event types, the 
- first event is returned whatever its type.
+ last event is returned whatever its type. The returned event may then be a profile change even if
+ it should be ignored.
  
  @param types an array of event types strings (MXEventTypeString) to filter room's events.
+ @param ignoreProfileChanges tell whether the profile changes should be ignored.
  @return a MXEvent instance.
  */
-- (MXEvent*)lastMessageWithTypeIn:(NSArray*)types;
+- (MXEvent*)lastMessageWithTypeIn:(NSArray*)types ignoreMemberProfileChanges:(BOOL)ignoreProfileChanges;
 
 /**
  Get all events newer than the event with the passed id.

--- a/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryRoomStore.m
+++ b/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryRoomStore.m
@@ -116,17 +116,21 @@
     return paginationPosition;
 }
 
-- (MXEvent*)lastMessageWithTypeIn:(NSArray*)types
+- (MXEvent*)lastMessageWithTypeIn:(NSArray*)types ignoreMemberProfileChanges:(BOOL)ignoreProfileChanges
 {
     MXEvent *lastMessage = [messages lastObject];
+    
     for (NSInteger i = messages.count - 1; 0 <= i; i--)
     {
         MXEvent *event = messages[i];
 
         if (event.eventId && (!types || (NSNotFound != [types indexOfObject:event.type])))
         {
-            lastMessage = event;
-            break;
+            if (!ignoreProfileChanges || !event.isUserProfileChange)
+            {
+                lastMessage = event;
+                break;
+            }
         }
     }
     

--- a/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryStore.m
+++ b/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryStore.m
@@ -169,10 +169,10 @@
 }
 
 
-- (MXEvent*)lastMessageOfRoom:(NSString*)roomId withTypeIn:(NSArray*)types
+- (MXEvent*)lastMessageOfRoom:(NSString*)roomId withTypeIn:(NSArray*)types ignoreMemberProfileChanges:(BOOL)ignoreProfileChanges
 {
     MXMemoryRoomStore *roomStore = [self getOrCreateRoomStore:roomId];
-    return [roomStore lastMessageWithTypeIn:types];
+    return [roomStore lastMessageWithTypeIn:types ignoreMemberProfileChanges:ignoreProfileChanges];
 }
 
 

--- a/MatrixSDK/Data/Store/MXNoStore/MXNoStore.m
+++ b/MatrixSDK/Data/Store/MXNoStore/MXNoStore.m
@@ -212,7 +212,7 @@
 }
 
 
-- (MXEvent*)lastMessageOfRoom:(NSString*)roomId withTypeIn:(NSArray*)types
+- (MXEvent*)lastMessageOfRoom:(NSString*)roomId withTypeIn:(NSArray*)types ignoreMemberProfileChanges:(BOOL)ignoreProfileChanges
 {
     // MXNoStore stores only the last event whatever its type
     NSLog(@"[MXNoStore] Warning: MXNoStore implementation of lastMessageOfRoom is limited");

--- a/MatrixSDK/Data/Store/MXStore.h
+++ b/MatrixSDK/Data/Store/MXStore.h
@@ -159,13 +159,13 @@
  The last message of a room.
 
  @param roomId the id of the room.
- @param types an array of event types strings (MXEventTypeString). The last message
-        type should be among `types`. If no event matches `type`, the implementation
-        must return the true last event of the room whatever its type is.
- @return the MXEvent object corresponding to the last message.
+ @param types an array of event types strings (MXEventTypeString).
+        The last message type should be among `types`.
+ @param ignoreProfileChanges tell whether the profile changes should be ignored.
+ @return the MXEvent object corresponding to the last message. A room must have a last message. If no event matches `type`, the implementation
+ must return the true last event of the room whatever its type is. Even if it is an ignored profile change.
  */
-- (MXEvent*)lastMessageOfRoom:(NSString*)roomId withTypeIn:(NSArray*)types;
-
+- (MXEvent*)lastMessageOfRoom:(NSString*)roomId withTypeIn:(NSArray*)types ignoreMemberProfileChanges:(BOOL)ignoreProfileChanges;
 
 /**
  Store the text message partially typed by the user but not yet sent.

--- a/MatrixSDK/JSONModels/MXEvent.h
+++ b/MatrixSDK/JSONModels/MXEvent.h
@@ -231,6 +231,11 @@ FOUNDATION_EXPORT uint64_t const kMXUndefinedTimestamp;
 - (BOOL)isEmote;
 
 /**
+ Return YES when the event corresponds to a user profile change.
+ */
+- (BOOL)isUserProfileChange;
+
+/**
  Returns the event IDs for which a read receipt is defined in this event.
  
  This property is relevant only for events with 'kMXEventTypeStringReceipt' type.

--- a/MatrixSDK/JSONModels/MXEvent.m
+++ b/MatrixSDK/JSONModels/MXEvent.m
@@ -235,13 +235,31 @@ uint64_t const kMXUndefinedTimestamp = (uint64_t)-1;
 {
     if (self.eventType == MXEventTypeRoomMessage)
     {
-        NSString *msgtype = self.content[@"msgtype"];
-        if ([msgtype isEqualToString:kMXMessageTypeEmote])
+        NSString *msgtype;
+        MXJSONModelSetString(msgtype, self.content[@"msgtype"]);
+        
+        if (msgtype && [msgtype isEqualToString:kMXMessageTypeEmote])
         {
             return YES;
         }
     }
     return NO;
+}
+
+- (BOOL)isUserProfileChange
+{
+    // Retrieve membership
+    NSString* membership;
+    MXJSONModelSetString(membership, self.content[@"membership"]);
+    
+    NSString *prevMembership = nil;
+    if (self.prevContent)
+    {
+        MXJSONModelSetString(prevMembership, self.prevContent[@"membership"]);
+    }
+    
+    // Check whether the sender has updated his profile (the membership is then unchanged)
+    return (prevMembership && membership && [membership isEqualToString:prevMembership]);
 }
 
 - (NSArray *)readReceiptEventIds

--- a/MatrixSDK/MXSession.h
+++ b/MatrixSDK/MXSession.h
@@ -336,6 +336,17 @@ typedef void (^MXOnBackgroundSyncFail)(NSError *error);
          failure:(void (^)(NSError *error))failure;
 
 /**
+ Tell whether the profiles changes of the room members should be ignored in the last message processing.
+ NO by default.
+ 
+ @discussion An event (with MXEventTypeRoomMember type) is added in room history each time a room member changes his profile.
+ This event replaces the last message of all the rooms to which the member belongs.
+ This impacts the rooms ordering based on their last message.
+ Ignoring the profile changes in last message handling prevents an irrelevant reordering of the room list.
+ */
+@property (nonatomic) BOOL ignoreProfileChangesDuringLastMessageProcessing;
+
+/**
  Enable VoIP by setting the external VoIP stack to use.
  
  @param callStack the VoIP call stack to use.


### PR DESCRIPTION
https://github.com/vector-im/vector-ios/issues/494

- Ignore members profile changes during last message handling.