### PR TITLE
MXCallStackCall: Do not force the main speaker on video call.

### DIFF
--- a/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallStackCall.m
+++ b/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallStackCall.m
@@ -165,15 +165,30 @@
             // Report this sdp back to libjingle
             [peerConnection setLocalDescription:sdp completionHandler:^(NSError * _Nullable error) {
 
-                if (!error)
-                {
-                    success(sdp.sdp);
-                }
+                // Return on main thread
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    
+                    if (!error)
+                    {
+                        success(sdp.sdp);
+                    }
+                    else
+                    {
+                        failure(error);
+                    }
+                    
+                });
+                
             }];
         }
         else
         {
-            failure(error);
+            // Return on main thread
+            dispatch_async(dispatch_get_main_queue(), ^{
+                
+                failure(error);
+                
+            });
         }
     }];
 }
@@ -189,15 +204,29 @@
             // Report this sdp back to libjingle
             [peerConnection setLocalDescription:sdp completionHandler:^(NSError * _Nullable error) {
 
-                if (!error)
-                {
-                    success(sdp.sdp);
-                }
+                // Return on main thread
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    
+                    if (!error)
+                    {
+                        success(sdp.sdp);
+                    }
+                    else
+                    {
+                        failure(error);
+                    }
+                    
+                });
             }];
         }
         else
         {
-            failure(error);
+            // Return on main thread
+            dispatch_async(dispatch_get_main_queue(), ^{
+                
+                failure(error);
+                
+            });
         }
     }];
 }
@@ -207,14 +236,20 @@
     RTCSessionDescription *sessionDescription = [[RTCSessionDescription alloc] initWithType:RTCSdpTypeAnswer sdp:sdp];
     [peerConnection setRemoteDescription:sessionDescription completionHandler:^(NSError * _Nullable error) {
 
-        if (!error)
-        {
-            success();
-        }
-        else
-        {
-            failure(error);
-        }
+        // Return on main thread
+        dispatch_async(dispatch_get_main_queue(), ^{
+            
+            if (!error)
+            {
+                success();
+            }
+            else
+            {
+                failure(error);
+            }
+            
+        });
+        
     }];
 }
 
@@ -293,6 +328,7 @@ didChangeIceConnectionState:(RTCIceConnectionState)newState
             dispatch_async(dispatch_get_main_queue(), ^{
 
                 [delegate callStackCall:self onError:nil];
+                
             });
             break;
         }
@@ -315,7 +351,9 @@ didGenerateIceCandidate:(RTCIceCandidate *)candidate
 {
     // Forward found ICE candidates
     dispatch_async(dispatch_get_main_queue(), ^{
+        
         [delegate callStackCall:self onICECandidateWithSdpMid:candidate.sdpMid sdpMLineIndex:candidate.sdpMLineIndex candidate:candidate.sdp];
+        
     });
 }
 

--- a/MatrixSDK/VoIP/CallStack/MXCallStackCall.h
+++ b/MatrixSDK/VoIP/CallStack/MXCallStackCall.h
@@ -149,10 +149,8 @@
 @property (nonatomic) BOOL videoMuted;
 
 /**
- If YES, the inbound audio is sent to the main speaker, else it is routed to the
- ear speaker.
- By default, video calls are routed to the main speaker and voice call, to the ear
- speaker.
+ NO by default, the inbound audio is then routed to the default audio outputs.
+ If YES, the inbound audio is sent to the main speaker.
  */
 @property (nonatomic) BOOL audioToSpeaker;
 

--- a/MatrixSDK/VoIP/MXCall.h
+++ b/MatrixSDK/VoIP/MXCall.h
@@ -175,10 +175,8 @@ extern NSString *const kMXCallStateDidChange;
 @property (nonatomic) BOOL videoMuted;
 
 /**
- If YES, the inbound audio is sent to the main speaker, else it is routed to the
- ear speaker.
- By default, video calls are routed to the main speaker and voice call, to the ear
- speaker.
+ NO by default, the inbound audio is then routed to the default audio outputs.
+ If YES, the inbound audio is sent to the main speaker.
  */
 @property (nonatomic) BOOL audioToSpeaker;
 

--- a/MatrixSDK/VoIP/MXCall.m
+++ b/MatrixSDK/VoIP/MXCall.m
@@ -139,8 +139,8 @@ NSString *const kMXCallStateDidChange = @"kMXCallStateDidChange";
                 // Store if it is voice or video call
                 _isVideoCall = callInviteEventContent.isVideoCall;
 
-                // Set up the default audio route for this call type
-                callStackCall.audioToSpeaker = _isVideoCall;
+                // Set up the default audio route
+                callStackCall.audioToSpeaker = NO;
                 
                 [callStackCall startCapturingMediaWithVideo:self.isVideoCall success:^{
                     [callStackCall handleOffer:callInviteEventContent.offer.sdp];
@@ -243,8 +243,8 @@ NSString *const kMXCallStateDidChange = @"kMXCallStateDidChange";
 
     [self setState:MXCallStateWaitLocalMedia reason:nil];
 
-    // Set up the default audio route for this call type
-    callStackCall.audioToSpeaker = video;
+    // Set up the default audio route
+    callStackCall.audioToSpeaker = NO;
 
     [callStackCall startCapturingMediaWithVideo:video success:^() {
 


### PR DESCRIPTION
Let the Application handle the audio route. It is useful in case of headset use.

MXJingleCallStackCall: Run callbacks on the main thread.