### PR TITLE
Bug Fix - Chat screen: New message(s) notification

### DIFF
--- a/MatrixSDK/Data/MXRoom.h
+++ b/MatrixSDK/Data/MXRoom.h
@@ -99,10 +99,12 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidUpdateUnreadNotification;
 @property (nonatomic, readonly) NSArray *typingUsers;
 
 /**
- Tell whether the room has unread events.
- This value depends on unreadEventTypes.
+ The number of unread events wrote in the store which have their type listed in the 'unreadEventTypes' array.
+ 
+ @discussion: The returned count is relative to the local storage. The actual unread messages
+ for a room may be higher than the returned value.
  */
-@property (nonatomic, readonly) BOOL hasUnreadEvents;
+@property (nonatomic, readonly) NSUInteger localUnreadEventCount;
 
 /**
  The number of unread messages that match the push notification rules.
@@ -700,6 +702,18 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidUpdateUnreadNotification;
  @param
  */
 - (BOOL)handleReceiptEvent:(MXEvent *)event direction:(MXTimelineDirection)direction;
+
+/**
+ If the event was not acknowledged yet, this method acknowlegdes it by sending a receipt event.
+ This will indicate to the homeserver that the user has read up to this event.
+ 
+ @discussion If the type of the provided event is not defined in acknowledgableEventTypes,
+ this method acknowlegdes the first prior event of type defined in acknowledgableEventTypes.
+ 
+ @param event the event to acknowlegde.
+ @return true if there is an update
+ */
+- (BOOL)acknowledgeEvent:(MXEvent*)event;
 
 /**
  Acknowlegde the latest event of type defined in acknowledgableEventTypes.

--- a/MatrixSDK/Data/Store/MXCoreDataStore/MXCoreDataStore.m
+++ b/MatrixSDK/Data/Store/MXCoreDataStore/MXCoreDataStore.m
@@ -354,10 +354,10 @@ NSString *const kMXCoreDataStoreFolder = @"MXCoreDataStore";
     return nil;
 }
 
-- (BOOL)hasUnreadEvents:(NSString*)roomId withTypeIn:(NSArray*)types
+- (NSUInteger)localUnreadEventCount:(NSString*)roomId withTypeIn:(NSArray*)types
 {
     // TODO
-    return NO;
+    return 0;
 }
 
 - (BOOL)isPermanent

--- a/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryStore.m
+++ b/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryStore.m
@@ -174,7 +174,6 @@
     return roomStore.partialTextMessage;
 }
 
-
 - (NSArray*)getEventReceipts:(NSString*)roomId eventId:(NSString*)eventId sorted:(BOOL)sort
 {
     NSMutableArray* receipts = [[NSMutableArray alloc] init];
@@ -252,10 +251,11 @@
     return nil;
 }
 
-- (BOOL)hasUnreadEvents:(NSString*)roomId withTypeIn:(NSArray*)types
+- (NSUInteger)localUnreadEventCount:(NSString*)roomId withTypeIn:(NSArray*)types
 {
     MXMemoryRoomStore* store = [roomStores valueForKey:roomId];
     NSMutableDictionary* receipsByUserId = [receiptsByRoomId objectForKey:roomId];
+    NSUInteger count = 0;
     
     if (store && receipsByUserId)
     {
@@ -271,14 +271,13 @@
             {
                 if (event.redactedBecause == nil)
                 {
-                    // There is at least one unread event - Done
-                    return YES;
+                    count ++;
                 }
             }
         }
     }
    
-    return NO;
+    return count;
 }
 
 - (BOOL)isPermanent

--- a/MatrixSDK/Data/Store/MXNoStore/MXNoStore.m
+++ b/MatrixSDK/Data/Store/MXNoStore/MXNoStore.m
@@ -253,9 +253,9 @@
     return nil;
 }
 
-- (BOOL)hasUnreadEvents:(NSString*)roomId withTypeIn:(NSArray*)types
+- (NSUInteger)localUnreadEventCount:(NSString*)roomId withTypeIn:(NSArray*)types
 {
-    return NO;
+    return 0;
 }
 
 

--- a/MatrixSDK/Data/Store/MXStore.h
+++ b/MatrixSDK/Data/Store/MXStore.h
@@ -193,13 +193,16 @@
 - (MXReceiptData *)getReceiptInRoom:(NSString*)roomId forUserId:(NSString*)userId;
 
 /**
- Check whether a room has some unread events.
+ Count the unread events wrote in the store.
+ 
+ @discussion: The returned count is relative to the local storage. The actual unread messages
+ for a room may be higher than the returned value.
  
  @param roomId the room id.
  @param types an array of event types strings (MXEventTypeString).
- @return YES if at least one stored event has its type listed in provided array.
+ @return The number of unread events which have their type listed in the provided array.
  */
-- (BOOL)hasUnreadEvents:(NSString*)roomId withTypeIn:(NSArray*)types;
+- (NSUInteger)localUnreadEventCount:(NSString*)roomId withTypeIn:(NSArray*)types;
 
 /**
  Indicate if the MXStore implementation stores data permanently.


### PR DESCRIPTION
https://github.com/vector-im/vector-ios/issues/532

MXRoom Changes:
- Define 'localUnreadEventCount' property: The number of unread events wrote in the store.
- Add API [acknowledgeEvent:]: If the event was not acknowledged yet, this method acknowlegdes it by sending a receipt event. This will indicate to the homeserver that the user has read up to this event.