### PR TITLE
App crashes when we start a chat during initial sync

### DIFF
--- a/MatrixSDK/Data/MXUser.h
+++ b/MatrixSDK/Data/MXUser.h
@@ -92,7 +92,6 @@
  */
 - (void)updateWithRoomMemberEvent:(MXEvent*)roomMemberEvent roomMember:(MXRoomMember *)roomMember inMatrixSession:(MXSession*)mxSession;
 
-
 /**
  Update the MXUser data with a m.presence event.
  
@@ -100,6 +99,15 @@
  @param mxSession the mxSession to the home server.
  */
 - (void)updateWithPresenceEvent:(MXEvent*)presenceEvent inMatrixSession:(MXSession*)mxSession;
+
+/**
+ Make a request to the homeserver to update the MXUser.
+
+ @param mxSession the mxSession to the home server.
+ @param success a block when the operation succeeds.
+ @param failure a block when the operation fails.
+ */
+- (void)updateFromHomeserverOfMatrixSession:(MXSession*)mxSession success:(void (^)())success failure:(void (^)(NSError *error))failure;
 
 
 #pragma mark - Events listeners

--- a/MatrixSDK/Data/MXUser.m
+++ b/MatrixSDK/Data/MXUser.m
@@ -122,6 +122,31 @@
     [self notifyListeners:presenceEvent];
 }
 
+- (void)updateFromHomeserverOfMatrixSession:(MXSession *)mxSession success:(void (^)())success failure:(void (^)(NSError *))failure
+{
+    [mxSession.matrixRestClient displayNameForUser:_userId success:^(NSString *displayname) {
+
+        [mxSession.matrixRestClient avatarUrlForUser:_userId success:^(NSString *avatarUrl) {
+
+            self.displayname = displayname;
+            self.avatarUrl = avatarUrl;
+
+            success();
+
+            [self notifyListeners:nil];
+
+        } failure:^(NSError *error) {
+
+            NSLog(@"[MXUser] updateFromHomeserverOfMatrixSession. Error when getting avatar: %@", error);
+            failure(error);
+        }];
+    } failure:^(NSError *error) {
+
+        NSLog(@"[MXUser] updateFromHomeserverOfMatrixSession. Error when getting avatar: %@", error);
+        failure(error);
+    }];
+}
+
 - (NSUInteger)lastActiveAgo
 {
     NSUInteger lastActiveAgo = -1;


### PR DESCRIPTION
https://github.com/vector-im/vector-ios/issues/623

MXSession: In case of initialSync, mxsession.myUser.userId must be available before changing the state to MXSessionStateStoreDataReady.
