### PR TITLE
Bug Fix - Use contains_url filter for navigating files and showing a …

### DIFF
--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -149,6 +149,8 @@
 		71DE22E11BC7C51200284153 /* MXReceiptData.h in Headers */ = {isa = PBXBuildFile; fileRef = 71DE22DD1BC7C51200284153 /* MXReceiptData.h */; };
 		A23A8594855481FEFA0E9A22 /* libPods-MatrixSDK.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E1674C6FF8BBF074E7F76059 /* libPods-MatrixSDK.a */; };
 		D123DC2791F0EAF08F70C207 /* libPods-MatrixSDKTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3ABDD5D65684E6B7F52FB94E /* libPods-MatrixSDKTests.a */; };
+		F0AC734E1DA4F53B0011DAEE /* MXRoomEventFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = F0AC734C1DA4F53B0011DAEE /* MXRoomEventFilter.h */; };
+		F0AC734F1DA4F53B0011DAEE /* MXRoomEventFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = F0AC734D1DA4F53B0011DAEE /* MXRoomEventFilter.m */; };
 		F0C34CBB1C18C93700C36F09 /* MXSDKOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = F0C34CBA1C18C93700C36F09 /* MXSDKOptions.m */; };
 /* End PBXBuildFile section */
 
@@ -328,6 +330,8 @@
 		71DE22DD1BC7C51200284153 /* MXReceiptData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXReceiptData.h; sourceTree = "<group>"; };
 		B1F1AE550CF4C15B653DDE6E /* Pods-MatrixSDKTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MatrixSDKTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MatrixSDKTests/Pods-MatrixSDKTests.debug.xcconfig"; sourceTree = "<group>"; };
 		E1674C6FF8BBF074E7F76059 /* libPods-MatrixSDK.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-MatrixSDK.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		F0AC734C1DA4F53B0011DAEE /* MXRoomEventFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXRoomEventFilter.h; sourceTree = "<group>"; };
+		F0AC734D1DA4F53B0011DAEE /* MXRoomEventFilter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXRoomEventFilter.m; sourceTree = "<group>"; };
 		F0C34CB91C18C80000C36F09 /* MXSDKOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXSDKOptions.h; sourceTree = "<group>"; };
 		F0C34CBA1C18C93700C36F09 /* MXSDKOptions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXSDKOptions.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -395,6 +399,8 @@
 				326056841C76FDF1009D44AD /* MXEventTimeline.m */,
 				3220094319EFBF30008DE41D /* MXSessionEventListener.h */,
 				3220094419EFBF30008DE41D /* MXSessionEventListener.m */,
+				F0AC734C1DA4F53B0011DAEE /* MXRoomEventFilter.h */,
+				F0AC734D1DA4F53B0011DAEE /* MXRoomEventFilter.m */,
 				329FB1731A0A3A1600A5E88E /* MXRoomMember.h */,
 				329FB1741A0A3A1600A5E88E /* MXRoomMember.m */,
 				327F8DB01C6112BA00581CA3 /* MXRoomThirdPartyInvite.h */,
@@ -718,6 +724,7 @@
 				32114A851A262CE000FF2EC4 /* MXStore.h in Headers */,
 				3264E2A41BDF8D1500F89A86 /* MXCoreDataRoomState+CoreDataProperties.h in Headers */,
 				329FB1791A0A74B100A5E88E /* MXTools.h in Headers */,
+				F0AC734E1DA4F53B0011DAEE /* MXRoomEventFilter.h in Headers */,
 				323B2B001BCE9B6700B11F34 /* MXCoreDataEvent.h in Headers */,
 				32481A841C03572900782AD3 /* MXRoomAccountData.h in Headers */,
 				3281E8B919E42DFE00976E1A /* MXJSONModels.h in Headers */,
@@ -965,6 +972,7 @@
 				32CE6FB91A409B1F00317F1E /* MXFileStoreMetaData.m in Sources */,
 				3264DB921CEC528D00B99881 /* MXAccountData.m in Sources */,
 				329B2AC21D3FB01D002D546F /* MXJingleCallStackCall.m in Sources */,
+				F0AC734F1DA4F53B0011DAEE /* MXRoomEventFilter.m in Sources */,
 				323E0C5C1A306D7A00A31D73 /* MXEvent.m in Sources */,
 				323B2AFF1BCE9B6700B11F34 /* MXCoreDataEvent+CoreDataProperties.m in Sources */,
 				32CAB10C1A925B41008C5BB9 /* MXHTTPOperation.m in Sources */,

--- a/MatrixSDK/Data/MXRoomEventFilter.h
+++ b/MatrixSDK/Data/MXRoomEventFilter.h
@@ -1,0 +1,75 @@
+/*
+ Copyright 2016 OpenMarket Ltd
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+/**
+ `MXRoomEventFilter` defines a room event filter which may be used during Matrix requests
+ (see the property 'dictionary' for the resulting dictionary).
+ */
+@interface MXRoomEventFilter : NSObject
+
+/**
+ If YES, includes only events with a url key in their content. If NO, excludes those events.
+ */
+@property (nonatomic) BOOL containsURL;
+
+/**
+ A list of event types to include. If this list is absent then all event types are included.
+ A '*' can be used as a wildcard to match any sequence of characters.
+ */
+@property (nonatomic) NSArray<NSString*> *types;
+
+/**
+ A list of event types to exclude. If this list is absent then no event types are excluded.
+ A matching type will be excluded even if it is listed in the 'types' filter.
+ A '*' can be used as a wildcard to match any sequence of characters.
+ */
+@property (nonatomic) NSArray<NSString*> *notTypes;
+
+/**
+ A list of room IDs to include. If this list is absent then all rooms are included.
+ */
+@property (nonatomic) NSArray<NSString*> *rooms;
+
+/**
+ A list of room IDs to exclude. If this list is absent then no rooms are excluded.
+ A matching room will be excluded even if it is listed in the 'rooms' filter.
+ */
+@property (nonatomic) NSArray<NSString*> *notRooms;
+
+/**
+ A list of senders IDs to include. If this list is absent then all senders are included.
+ */
+@property (nonatomic) NSArray<NSString*> *senders;
+
+/**
+ A list of sender IDs to exclude. If this list is absent then no senders are excluded.
+ A matching sender will be excluded even if it is listed in the 'senders' filter.
+ */
+@property (nonatomic) NSArray<NSString*> *notSenders;
+
+/**
+ The maximum number of events to return.
+ */
+@property (nonatomic) NSUInteger limit;
+
+/**
+ The resulting dictionary.
+ */
+@property (nonatomic, readonly) NSDictionary *dictionary;
+
+@end

--- a/MatrixSDK/Data/MXRoomEventFilter.m
+++ b/MatrixSDK/Data/MXRoomEventFilter.m
@@ -1,0 +1,89 @@
+/*
+ Copyright 2016 OpenMarket Ltd
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXRoomEventFilter.h"
+
+@interface MXRoomEventFilter()
+{
+    NSMutableDictionary *dictionary;
+}
+@end
+
+@implementation MXRoomEventFilter
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self)
+    {
+        dictionary = [NSMutableDictionary dictionary];
+    }
+    return self;
+}
+
+- (void)setContainsURL:(BOOL)containsURL
+{
+    dictionary[@"contains_url"] = [NSNumber numberWithBool:containsURL];
+    _containsURL = containsURL;
+}
+
+- (void)setTypes:(NSArray<NSString *> *)types
+{
+    dictionary[@"types"] = types;
+    _types = types;
+}
+
+- (void)setNotTypes:(NSArray<NSString *> *)notTypes
+{
+    dictionary[@"not_types"] = notTypes;
+    _notTypes = notTypes;
+}
+
+- (void)setRooms:(NSArray<NSString *> *)rooms
+{
+    dictionary[@"rooms"] = rooms;
+    _rooms = rooms;
+}
+
+- (void)setNotRooms:(NSArray<NSString *> *)notRooms
+{
+    dictionary[@"not_rooms"] = notRooms;
+    _notRooms = notRooms;
+}
+
+- (void)setSenders:(NSArray<NSString *> *)senders
+{
+    dictionary[@"senders"] = senders;
+    _senders = senders;
+}
+
+- (void)setNotSenders:(NSArray<NSString *> *)notSenders
+{
+    dictionary[@"not_senders"] = notSenders;
+    _notSenders = notSenders;
+}
+
+- (void)setLimit:(NSUInteger)limit
+{
+    dictionary[@"limit"] = [NSNumber numberWithUnsignedInteger:limit];
+}
+
+- (NSDictionary*)dictionary
+{
+    return dictionary;
+}
+
+@end

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -87,28 +87,6 @@ typedef enum : NSUInteger
 } MXThumbnailingMethod;
 
 /**
- List the filtering options used during the messages search. This option concerns the attachments handling.
- */
-typedef enum : NSUInteger
-{
-    /**
-     Default value. No limitation.
-     */
-    MXMessagesSearchMediaFilterUndefined,
-    
-    /**
-     Only the messages which contain an URL are concerned by the search request.
-     */
-    MXMessagesSearchMediaFilterLimitedToAttachments,
-    
-    /**
-     The messages which contain an URL are not concerned by the search request.
-     */
-    MXMessagesSearchMediaFilterExcludeAttachments
-} MXMessagesSearchMediaFilter;
-
-
-/**
  `MXRestClient` makes requests to Matrix servers.
 
  It is the single point to send requests to Matrix servers which are:

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -19,6 +19,7 @@
 
 #import "MXHTTPClient.h"
 #import "MXEvent.h"
+#import "MXRoomEventFilter.h"
 #import "MXEventTimeline.h"
 #import "MXJSONModels.h"
 
@@ -1498,11 +1499,10 @@ typedef enum : NSUInteger
  Search a text in room messages.
 
  @param textPattern the text to search for in message body.
- @param rooms a list of rooms to search in. nil means all rooms the user is in.
+ @param roomEventFilter a nullable dictionary which defines the room event filtering during the search request.
  @param beforeLimit the number of events to get before the matching results.
  @param afterLimit the number of events to get after the matching results.
  @param nextBatch the token to pass for doing pagination from a previous response.
- @param mediaFilter tells whether the messages with url (the attachments) are filtered or not.
 
  @param success A block object called when the operation succeeds.
  @param failure A block object called when the operation fails.
@@ -1510,11 +1510,10 @@ typedef enum : NSUInteger
  @return a MXHTTPOperation instance.
  */
 - (MXHTTPOperation*)searchMessagesWithText:(NSString*)textPattern
-                                   inRooms:(NSArray<NSString*>*)rooms
+                           roomEventFilter:(MXRoomEventFilter*)roomEventFilter
                                beforeLimit:(NSUInteger)beforeLimit
                                 afterLimit:(NSUInteger)afterLimit
                                  nextBatch:(NSString*)nextBatch
-                               mediaFilter:(MXMessagesSearchMediaFilter)mediaFilter
                                    success:(void (^)(MXSearchRoomEventResults *roomEventResults))success
                                    failure:(void (^)(NSError *error))failure;
 

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -71,19 +71,40 @@ FOUNDATION_EXPORT NSString *const kMXRestClientErrorDomain;
 typedef enum : NSUInteger
 {
     /**
-     "scale" trys to return an image where either the width or the height is smaller than the
+     "scale" tries to return an image where either the width or the height is smaller than the
      requested size. The client should then scale and letterbox the image if it needs to
      fit within a given rectangle.
      */
     MXThumbnailingMethodScale,
 
     /**
-     "crop" trys to return an image where the width and height are close to the requested size
+     "crop" tries to return an image where the width and height are close to the requested size
      and the aspect matches the requested size. The client should scale the image if it needs to
      fit within a given rectangle.
      */
     MXThumbnailingMethodCrop
 } MXThumbnailingMethod;
+
+/**
+ List the filtering options used during the messages search. This option concerns the attachments handling.
+ */
+typedef enum : NSUInteger
+{
+    /**
+     Default value. No limitation.
+     */
+    MXMessagesSearchMediaFilterUndefined,
+    
+    /**
+     Only the messages which contain an URL are concerned by the search request.
+     */
+    MXMessagesSearchMediaFilterLimitedToAttachments,
+    
+    /**
+     The messages which contain an URL are not concerned by the search request.
+     */
+    MXMessagesSearchMediaFilterExcludeAttachments
+} MXMessagesSearchMediaFilter;
 
 
 /**
@@ -1481,7 +1502,7 @@ typedef enum : NSUInteger
  @param beforeLimit the number of events to get before the matching results.
  @param afterLimit the number of events to get after the matching results.
  @param nextBatch the token to pass for doing pagination from a previous response.
- @param containsURl tells whether only the messages with url (the attachments) are concerned.
+ @param mediaFilter tells whether the messages with url (the attachments) are filtered or not.
 
  @param success A block object called when the operation succeeds.
  @param failure A block object called when the operation fails.
@@ -1493,7 +1514,7 @@ typedef enum : NSUInteger
                                beforeLimit:(NSUInteger)beforeLimit
                                 afterLimit:(NSUInteger)afterLimit
                                  nextBatch:(NSString*)nextBatch
-                               containsURL:(BOOL)containsURL
+                               mediaFilter:(MXMessagesSearchMediaFilter)mediaFilter
                                    success:(void (^)(MXSearchRoomEventResults *roomEventResults))success
                                    failure:(void (^)(NSError *error))failure;
 

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -2887,11 +2887,10 @@ MXAuthAction;
 
 #pragma mark - Search
 - (MXHTTPOperation*)searchMessagesWithText:(NSString*)textPattern
-                                   inRooms:(NSArray<NSString*>*)rooms
+                           roomEventFilter:(MXRoomEventFilter*)roomEventFilter
                                beforeLimit:(NSUInteger)beforeLimit
                                 afterLimit:(NSUInteger)afterLimit
                                  nextBatch:(NSString*)nextBatch
-                               mediaFilter:(MXMessagesSearchMediaFilter)mediaFilter
                                    success:(void (^)(MXSearchRoomEventResults *roomEventResults))success
                                    failure:(void (^)(NSError *error))failure
 {
@@ -2906,25 +2905,9 @@ MXAuthAction;
                                                            }
                                                    }];
     
-    // Prepare potential filtering option
-    NSMutableDictionary *filter = [NSMutableDictionary dictionary];
-    if (rooms)
+    if (roomEventFilter.dictionary.count)
     {
-         filter[@"rooms"] = rooms;
-    }
-    
-    if (mediaFilter == MXMessagesSearchMediaFilterLimitedToAttachments)
-    {
-        filter[@"contains_url"] = @(YES);
-    }
-    else if (mediaFilter == MXMessagesSearchMediaFilterExcludeAttachments)
-    {
-        filter[@"contains_url"] = @(NO);
-    }
-    
-    if (filter.count)
-    {
-        roomEventsParameters[@"filter"] = filter;
+        roomEventsParameters[@"filter"] = roomEventFilter.dictionary;
     }
 
     return [self searchRoomEvents:roomEventsParameters nextBatch:nextBatch success:success failure:failure];

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -2891,7 +2891,7 @@ MXAuthAction;
                                beforeLimit:(NSUInteger)beforeLimit
                                 afterLimit:(NSUInteger)afterLimit
                                  nextBatch:(NSString*)nextBatch
-                               containsURL:(BOOL)containsURL
+                               mediaFilter:(MXMessagesSearchMediaFilter)mediaFilter
                                    success:(void (^)(MXSearchRoomEventResults *roomEventResults))success
                                    failure:(void (^)(NSError *error))failure
 {
@@ -2905,18 +2905,26 @@ MXAuthAction;
                                                            @"include_profile": @(YES)
                                                            }
                                                    }];
+    
+    // Prepare potential filtering option
+    NSMutableDictionary *filter = [NSMutableDictionary dictionary];
     if (rooms)
     {
-        roomEventsParameters[@"filter"] = @{
-                                            @"rooms": rooms,
-                                            @"contains_url": [NSNumber numberWithBool:containsURL]
-                                            };
+         filter[@"rooms"] = rooms;
     }
-    else if (containsURL)
+    
+    if (mediaFilter == MXMessagesSearchMediaFilterLimitedToAttachments)
     {
-        roomEventsParameters[@"filter"] = @{
-                                            @"contains_url": @(YES)
-                                            };
+        filter[@"contains_url"] = @(YES);
+    }
+    else if (mediaFilter == MXMessagesSearchMediaFilterExcludeAttachments)
+    {
+        filter[@"contains_url"] = @(NO);
+    }
+    
+    if (filter.count)
+    {
+        roomEventsParameters[@"filter"] = filter;
     }
 
     return [self searchRoomEvents:roomEventsParameters nextBatch:nextBatch success:success failure:failure];


### PR DESCRIPTION
…file index for a room.

vector-im/vector-ios#652

MXRestClient: Support 3 filtering modes on attachments during the messages search (see `MXMessagesSearchMediaFilter`):
- Default value. No limitation.
- Only the messages which contain an URL are concerned by the search request.
- The messages which contain an URL are not concerned by the search request.