### PR TITLE
API break: MXRestClient: Remove registerWithUser and loginWithUser methods

### DIFF
--- a/MatrixSDK/JSONModels/MXJSONModels.h
+++ b/MatrixSDK/JSONModels/MXJSONModels.h
@@ -93,11 +93,13 @@ FOUNDATION_EXPORT NSString *const kMX3PIDMediumMSISDN;
  */
 typedef NSString* MXLoginFlowType;
 FOUNDATION_EXPORT NSString *const kMXLoginFlowTypePassword;
-FOUNDATION_EXPORT NSString *const kMXLoginFlowTypeOAuth2;
-FOUNDATION_EXPORT NSString *const kMXLoginFlowTypeEmailCode;
-FOUNDATION_EXPORT NSString *const kMXLoginFlowTypeEmailUrl;
-FOUNDATION_EXPORT NSString *const kMXLoginFlowTypeEmailIdentity;
 FOUNDATION_EXPORT NSString *const kMXLoginFlowTypeRecaptcha;
+FOUNDATION_EXPORT NSString *const kMXLoginFlowTypeOAuth2;
+FOUNDATION_EXPORT NSString *const kMXLoginFlowTypeEmailIdentity;
+FOUNDATION_EXPORT NSString *const kMXLoginFlowTypeToken;
+FOUNDATION_EXPORT NSString *const kMXLoginFlowTypeDummy;
+
+FOUNDATION_EXPORT NSString *const kMXLoginFlowTypeEmailCode; // Deprecated
 
 /**
  `MXLoginFlow` represents a login or a register flow supported by the home server.

--- a/MatrixSDK/JSONModels/MXJSONModels.m
+++ b/MatrixSDK/JSONModels/MXJSONModels.m
@@ -69,11 +69,12 @@
 
 
 NSString *const kMXLoginFlowTypePassword = @"m.login.password";
-NSString *const kMXLoginFlowTypeOAuth2 = @"m.login.oauth2";
-NSString *const kMXLoginFlowTypeEmailCode = @"m.login.email.code";
-NSString *const kMXLoginFlowTypeEmailUrl = @"m.login.email.url";
-NSString *const kMXLoginFlowTypeEmailIdentity = @"m.login.email.identity";
 NSString *const kMXLoginFlowTypeRecaptcha = @"m.login.recaptcha";
+NSString *const kMXLoginFlowTypeOAuth2 = @"m.login.oauth2";
+NSString *const kMXLoginFlowTypeEmailIdentity = @"m.login.email.identity";
+NSString *const kMXLoginFlowTypeToken = @"m.login.token";
+NSString *const kMXLoginFlowTypeDummy = @"m.login.dummy";
+NSString *const kMXLoginFlowTypeEmailCode = @"m.login.email.code";
 
 @implementation MXLoginFlow
 

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -175,7 +175,7 @@ typedef enum : NSUInteger
 /**
  Generic registration action request.
 
- As described in http://matrix.org/docs/spec/#registration-and-login some registration flows require to
+ As described in http://matrix.org/docs/spec/client_server/r0.2.0.html#client-authentication some registration flows require to
  complete several stages in order to complete user registration.
  This can lead to make several requests to the home server with different kinds of parameters.
  This generic method with open parameters and response exists to handle any kind of registration flow stage.
@@ -195,21 +195,21 @@ typedef enum : NSUInteger
                                    failure:(void (^)(NSError *error))failure;
 
 /**
- Register a user with the password-based flow.
+ Register a user.
+ 
+ This method manages the full flow for simple login types and returns the credentials of the newly created matrix user.
 
- It implements the password-based registration flow described at
- http://matrix.org/docs/spec/#password-based
-
- @param user the user id (ex: "@bob:matrix.org") or the user id localpart (ex: "bob") of the user to register.
+ @param loginType the login type. Only kMXLoginFlowTypePassword and kMXLoginFlowTypeDummy (m.login.password and m.login.dummy) are supported.
+ @param username the user id (ex: "@bob:matrix.org") or the user id localpart (ex: "bob") of the user to register. Can be nil.
  @param password his password.
  @param success A block object called when the operation succeeds. It provides credentials to use to create a MXRestClient.
  @param failure A block object called when the operation fails.
 
  @return a MXHTTPOperation instance.
  */
-- (MXHTTPOperation*)registerWithUser:(NSString*)user andPassword:(NSString*)password
-                             success:(void (^)(MXCredentials *credentials))success
-                             failure:(void (^)(NSError *error))failure;
+- (MXHTTPOperation*)registerWithLoginType:(NSString*)loginType username:(NSString*)username password:(NSString*)password
+                                  success:(void (^)(MXCredentials *credentials))success
+                                  failure:(void (^)(NSError *error))failure;
 
 /**
  Get the register fallback page to make registration via a web browser or a web view.
@@ -250,21 +250,21 @@ typedef enum : NSUInteger
                   failure:(void (^)(NSError *error))failure;
 
 /**
- Log a user in with the password-based flow.
+ Log a user in.
 
- It implements the password-based registration flow described at
- http://matrix.org/docs/spec/#password-based
+ This method manages the full flow for simple login types and returns the credentials of the logged matrix user.
 
- @param user the user id (ex: "@bob:matrix.org") or the user id localpart (ex: "bob") of the user to log in.
+ @param loginType the login type. Only kMXLoginFlowTypePassword (m.login.password) is supported.
+ @param username the user id (ex: "@bob:matrix.org") or the user id localpart (ex: "bob") of the user to register.
  @param password his password.
  @param success A block object called when the operation succeeds. It provides credentials to use to create a MXRestClient.
  @param failure A block object called when the operation fails.
 
  @return a MXHTTPOperation instance.
  */
-- (MXHTTPOperation*)loginWithUser:(NSString*)user andPassword:(NSString*)password
-                          success:(void (^)(MXCredentials *credentials))success
-                          failure:(void (^)(NSError *error))failure;
+- (MXHTTPOperation*)loginWithLoginType:(NSString*)loginType username:(NSString*)username password:(NSString*)password
+                               success:(void (^)(MXCredentials *credentials))success
+                               failure:(void (^)(NSError *error))failure;
 
 /**
  Get the login fallback page to make login via a web browser or a web view.

--- a/MatrixSDKTests/MatrixSDKTestsData.m
+++ b/MatrixSDKTests/MatrixSDKTestsData.m
@@ -78,11 +78,8 @@ NSMutableArray *roomsToClean;
         NSString *bobUniqueUser = [NSString stringWithFormat:@"%@-%@", MXTESTS_BOB, [[NSUUID UUID] UUIDString]];
 
         // First, try register the user
-        // @TODO: Update the registration code to support r0 registration and
-        // remove this patch that redirects the registration to a deprecated CS API.
-        mxRestClient.apiPathPrefix = @"/_matrix/client/api/v1";
-        [mxRestClient registerWithUser:bobUniqueUser andPassword:MXTESTS_BOB_PWD success:^(MXCredentials *credentials) {
-            
+        [mxRestClient registerWithLoginType:kMXLoginFlowTypeDummy username:bobUniqueUser password:MXTESTS_BOB success:^(MXCredentials *credentials) {
+
             _bobCredentials = credentials;
             success();
             
@@ -92,8 +89,7 @@ NSMutableArray *roomsToClean;
             {
                 // The user already exists. This error is normal.
                 // Log Bob in to get his keys
-                mxRestClient.apiPathPrefix = @"/_matrix/client/api/v1";
-                [mxRestClient loginWithUser:bobUniqueUser andPassword:MXTESTS_BOB_PWD success:^(MXCredentials *credentials) {
+                [mxRestClient loginWithLoginType:kMXLoginFlowTypeDummy username:bobUniqueUser password:MXTESTS_BOB_PWD success:^(MXCredentials *credentials) {
                     
                     _bobCredentials = credentials;
                     success();
@@ -101,14 +97,12 @@ NSMutableArray *roomsToClean;
                 } failure:^(NSError *error) {
                     NSAssert(NO, @"Cannot log mxBOB in");
                 }];
-                mxRestClient.apiPathPrefix = kMXAPIPrefixPathR0;
             }
             else
             {
                 NSAssert(NO, @"Cannot create mxBOB account. Make sure the homeserver at %@ is running", mxRestClient.homeserver);
             }
         }];
-        mxRestClient.apiPathPrefix = kMXAPIPrefixPathR0;
     }
 }
 
@@ -424,11 +418,8 @@ NSMutableArray *roomsToClean;
         // Use a different Alice each time so that tests are independent
         NSString *aliceUniqueUser = [NSString stringWithFormat:@"%@-%@", MXTESTS_ALICE, [[NSUUID UUID] UUIDString]];
 
-        // @TODO: Update the registration code to support r0 registration and
-        // remove this patch that redirects the registration to a deprecated CS API.
-        mxRestClient.apiPathPrefix = @"/_matrix/client/api/v1";
         // First, try register the user
-        [mxRestClient registerWithUser:aliceUniqueUser andPassword:MXTESTS_ALICE_PWD success:^(MXCredentials *credentials) {
+        [mxRestClient registerWithLoginType:kMXLoginFlowTypeDummy username:aliceUniqueUser password:MXTESTS_ALICE success:^(MXCredentials *credentials) {
             
             _aliceCredentials = credentials;
             success();
@@ -438,24 +429,21 @@ NSMutableArray *roomsToClean;
             if (mxError && [mxError.errcode isEqualToString:@"M_USER_IN_USE"])
             {
                 // The user already exists. This error is normal.
-                // Log Bob in to get his keys
-        		mxRestClient.apiPathPrefix = @"/_matrix/client/api/v1";
-                [mxRestClient loginWithUser:aliceUniqueUser andPassword:MXTESTS_ALICE_PWD success:^(MXCredentials *credentials) {
-                    
+                // Log Alice in to get his keys
+                [mxRestClient loginWithLoginType:kMXLoginFlowTypeDummy username:aliceUniqueUser password:MXTESTS_ALICE_PWD success:^(MXCredentials *credentials) {
+
                     _aliceCredentials = credentials;
                     success();
                     
                 } failure:^(NSError *error) {
                     NSAssert(NO, @"Cannot log mxAlice in");
                 }];
-                mxRestClient.apiPathPrefix = kMXAPIPrefixPathR0;
             }
             else
             {
                 NSAssert(NO, @"Cannot create mxAlice account");
             }
         }];
-        mxRestClient.apiPathPrefix = kMXAPIPrefixPathR0;
     }
 }
 


### PR DESCRIPTION
which worked only with old CS auth API.

Add registerWithLoginType and loginWithLoginType which do the job with new CS auth api for dummy and password flows.

Tests have been updated.