### PR TITLE
MXRestClient: Support the filter parameter during a messages request.

### DIFF
--- a/MatrixSDK/Data/MXEventTimeline.h
+++ b/MatrixSDK/Data/MXEventTimeline.h
@@ -17,6 +17,7 @@
 #import <Foundation/Foundation.h>
 
 #import "MXEvent.h"
+#import "MXRoomEventFilter.h"
 #import "MXJSONModels.h"
 #import "MXRoomState.h"
 #import "MXHTTPOperation.h"
@@ -65,6 +66,11 @@ typedef void (^MXOnRoomEvent)(MXEvent *event, MXTimelineDirection direction, MXR
  Indicate if this timeline is a live one.
  */
 @property (nonatomic, readonly) BOOL isLiveTimeline;
+
+/**
+ The room events filter which is applied during the history pagination.
+ */
+@property (nonatomic, readonly) MXRoomEventFilter *roomEventFilter;
 
 /**
  The state of the room at the top most recent event of the timeline.

--- a/MatrixSDK/Data/MXEventTimeline.m
+++ b/MatrixSDK/Data/MXEventTimeline.m
@@ -98,6 +98,8 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
         }
 
         _state = [[MXRoomState alloc] initWithRoomId:room.roomId andMatrixSession:room.mxSession andDirection:YES];
+        
+        _roomEventFilter = [[MXRoomEventFilter alloc] init];
     }
     return self;
 }
@@ -290,7 +292,7 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
 
     NSLog(@"[MXEventTimeline] paginate : request %tu messages from the server", numItems);
 
-    operation = [room.mxSession.matrixRestClient messagesForRoom:_state.roomId from:paginationToken direction:direction limit:numItems success:^(MXPaginationResponse *paginatedResponse) {
+    operation = [room.mxSession.matrixRestClient messagesForRoom:_state.roomId from:paginationToken direction:direction limit:numItems filter:_roomEventFilter success:^(MXPaginationResponse *paginatedResponse) {
 
         NSLog(@"[MXEventTimeline] paginate : get %tu messages from the server", paginatedResponse.chunk.count);
 

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -918,6 +918,7 @@ typedef enum : NSUInteger
  @param from the token to start getting results from.
  @param direction `MXTimelineDirectionForwards` or `MXTimelineDirectionBackwards`
  @param limit (optional, use -1 to not defined this value) the maximum nuber of messages to return.
+ @param filter to filter returned events with.
 
  @param success A block object called when the operation succeeds. It provides a `MXPaginationResponse` object.
  @param failure A block object called when the operation fails.
@@ -928,6 +929,7 @@ typedef enum : NSUInteger
                                from:(NSString*)from
                           direction:(MXTimelineDirection)direction
                               limit:(NSUInteger)limit
+                             filter:(MXRoomEventFilter*)roomEventFilter
                             success:(void (^)(MXPaginationResponse *paginatedResponse))success
                             failure:(void (^)(NSError *error))failure;
 

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -1599,6 +1599,7 @@ MXAuthAction;
                                from:(NSString*)from
                           direction:(MXTimelineDirection)direction
                               limit:(NSUInteger)limit
+                             filter:(MXRoomEventFilter*)roomEventFilter
                             success:(void (^)(MXPaginationResponse *paginatedResponse))success
                             failure:(void (^)(NSError *error))failure
 {
@@ -1620,6 +1621,11 @@ MXAuthAction;
     if (-1 != limit)
     {
         parameters[@"limit"] = [NSNumber numberWithUnsignedInteger:limit];
+    }
+    
+    if (roomEventFilter.dictionary.count)
+    {
+        parameters[@"filter"] = roomEventFilter.dictionary;
     }
     
     return [httpClient requestWithMethod:@"GET"

--- a/MatrixSDKTests/MXEventTests.m
+++ b/MatrixSDKTests/MXEventTests.m
@@ -53,7 +53,7 @@
 {
     [matrixSDKTestsData doMXRestClientTestWithBobAndARoomWithMessages:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
-        [bobRestClient messagesForRoom:roomId from:nil direction:MXTimelineDirectionBackwards limit:100 success:^(MXPaginationResponse *paginatedResponse) {
+        [bobRestClient messagesForRoom:roomId from:nil direction:MXTimelineDirectionBackwards limit:100 filter:nil success:^(MXPaginationResponse *paginatedResponse) {
 
             NSAssert(0 < paginatedResponse.chunk.count, @"Cannot set up intial test conditions");
 

--- a/MatrixSDKTests/MXRestClientTests.m
+++ b/MatrixSDKTests/MXRestClientTests.m
@@ -645,7 +645,7 @@
 {
     [matrixSDKTestsData  doMXRestClientTestWithBobAndARoomWithMessages:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
         
-        [bobRestClient messagesForRoom:roomId from:nil direction:MXTimelineDirectionBackwards limit:-1 success:^(MXPaginationResponse *paginatedResponse) {
+        [bobRestClient messagesForRoom:roomId from:nil direction:MXTimelineDirectionBackwards limit:-1 filter:nil success:^(MXPaginationResponse *paginatedResponse) {
             
             XCTAssertNotNil(paginatedResponse);
             XCTAssertNotNil(paginatedResponse.start);
@@ -667,7 +667,7 @@
 {
     [matrixSDKTestsData  doMXRestClientTestWithBobAndARoomWithMessages:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
-        [bobRestClient messagesForRoom:roomId from:nil direction:MXTimelineDirectionBackwards limit:100 success:^(MXPaginationResponse *paginatedResponse) {
+        [bobRestClient messagesForRoom:roomId from:nil direction:MXTimelineDirectionBackwards limit:100 filter:nil success:^(MXPaginationResponse *paginatedResponse) {
 
             XCTAssertNotNil(paginatedResponse);
             XCTAssertNotNil(paginatedResponse.start);


### PR DESCRIPTION
to filter returned events