### PR TITLE
Converting existing rooms to/from DMs

### DIFF
--- a/MatrixSDK/Data/MXRoom.h
+++ b/MatrixSDK/Data/MXRoom.h
@@ -121,6 +121,11 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidUpdateUnreadNotification;
 @property (nonatomic, readonly) NSUInteger highlightCount;
 
 /**
+ Indicate if the room is tagged as a direct room.
+ */
+@property (nonatomic, readonly) BOOL isDirect;
+
+/**
  Create a `MXRoom` instance.
 
  @param roomId the id of the room.

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -764,6 +764,24 @@ NSString *const kMXRoomDidUpdateUnreadNotification = @"kMXRoomDidUpdateUnreadNot
     return [mxSession.store highlightCountOfRoom:self.roomId];
 }
 
+- (BOOL)isDirect
+{
+    // Retrieve a joined member from the  members list.
+    NSArray* roomMembers = self.state.members;
+    MXRoomMember* member;
+    
+    for (member in roomMembers)
+    {
+        if (member.membership == MXMembershipJoin && ![member.userId isEqualToString:mxSession.myUser.userId])
+        {
+            // Check whether the provided room id belong to the direct rooms related to this member
+            return ([mxSession.directRooms[member.userId] indexOfObject:self.roomId] != NSNotFound);
+        }
+    }
+    
+    return NO;
+}
+
 - (NSArray*)getEventReceipts:(NSString*)eventId sorted:(BOOL)sort
 {
     NSArray *receipts = [mxSession.store getEventReceipts:self.roomId eventId:eventId sorted:sort];

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -775,7 +775,10 @@ NSString *const kMXRoomDidUpdateUnreadNotification = @"kMXRoomDidUpdateUnreadNot
         if (member.membership == MXMembershipJoin && ![member.userId isEqualToString:mxSession.myUser.userId])
         {
             // Check whether the provided room id belong to the direct rooms related to this member
-            return ([mxSession.directRooms[member.userId] indexOfObject:self.roomId] != NSNotFound);
+            if (mxSession.directRooms[member.userId])
+            {
+                return ([mxSession.directRooms[member.userId] indexOfObject:self.roomId] != NSNotFound);
+            }
         }
     }
     

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -52,7 +52,8 @@ FOUNDATION_EXPORT NSString *const kMXContentPrefixPath;
 /**
  Account data types
  */
-FOUNDATION_EXPORT NSString *const kMXAccountDataPushRules;
+FOUNDATION_EXPORT NSString *const kMXAccountDataTypeDirect;
+FOUNDATION_EXPORT NSString *const kMXAccountDataTypePushRules;
 FOUNDATION_EXPORT NSString *const kMXAccountDataTypeIgnoredUserList;
 
 /**

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -42,7 +42,8 @@ NSString *const kMXContentPrefixPath = @"/_matrix/media/v1";
  Account data types
  */
 NSString *const kMXAccountDataTypeIgnoredUserList = @"m.ignored_user_list";
-NSString *const kMXAccountDataPushRules = @"m.push_rules";
+NSString *const kMXAccountDataTypePushRules = @"m.push_rules";
+NSString *const kMXAccountDataTypeDirect = @"m.direct";
 
 /**
  Account data keys

--- a/MatrixSDK/MXSession.h
+++ b/MatrixSDK/MXSession.h
@@ -175,6 +175,13 @@ FOUNDATION_EXPORT NSString *const kMXSessionNotificationEventKey;
 FOUNDATION_EXPORT NSString *const kMXSessionIgnoredUsersDidChangeNotification;
 
 /**
+ Posted when MXSession has detected a change in the `directRooms` property.
+ 
+ The notification object is the concerned session (MXSession instance).
+ */
+FOUNDATION_EXPORT NSString *const kMXSessionDirectRoomsDidChangeNotification;
+
+/**
  Posted when MXSession data have been corrupted. The listener must reload the session data with a full server sync.
  
  The notification object is the concerned session (MXSession instance).
@@ -517,6 +524,22 @@ typedef void (^MXOnBackgroundSyncFail)(NSError *error);
  */
 - (MXRoom *)privateOneToOneRoomWithUserId:(NSString*)userId;
 
+/**
+ The list of the direct rooms by user identifiers.
+ 
+ @return a dictionary where the keys are the user IDs and values are lists of room ID strings
+ of the 'direct' rooms for that user ID. nil if the direct rooms have not been yet fetched from the homeserver.
+ */
+@property (nonatomic, readonly) NSDictionary<NSString*, NSArray<NSString*>*> *directRooms;
+
+/**
+ Indicate if a room is a direct one.
+ 
+ @param roomId the id of the room.
+ @return YES if the room is direct.
+ */
+- (BOOL)isDirectRoom:(NSString*)roomId;
+
 
 #pragma mark - Room peeking
 /**
@@ -663,7 +686,7 @@ typedef void (^MXOnBackgroundSyncFail)(NSError *error);
  Note: rooms with no tags are returned under the fake tag. The corresponding returned
  array is not ordered.
 
- @return a dictionary where the key is the tag name and value, an array of
+ @return a dictionary where the key is the tag name and the value is an array of
          room tagged with this tag. The array order is the same as [MXSession roomsWithTag:]
  */
 - (NSDictionary<NSString*, NSArray<MXRoom*>*>*)roomsByTags;

--- a/MatrixSDK/MXSession.h
+++ b/MatrixSDK/MXSession.h
@@ -532,15 +532,6 @@ typedef void (^MXOnBackgroundSyncFail)(NSError *error);
  */
 @property (nonatomic, readonly) NSDictionary<NSString*, NSArray<NSString*>*> *directRooms;
 
-/**
- Indicate if a room is a direct one.
- 
- @param roomId the id of the room.
- @return YES if the room is direct.
- */
-- (BOOL)isDirectRoom:(NSString*)roomId;
-
-
 #pragma mark - Room peeking
 /**
  Start peeking a room.

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -40,6 +40,7 @@ NSString *const kMXSessionInvitedRoomsDidChangeNotification = @"kMXSessionInvite
 NSString *const kMXSessionNotificationRoomIdKey = @"roomId";
 NSString *const kMXSessionNotificationEventKey = @"event";
 NSString *const kMXSessionIgnoredUsersDidChangeNotification = @"kMXSessionIgnoredUsersDidChangeNotification";
+NSString *const kMXSessionDirectRoomsDidChangeNotification = @"kMXSessionDirectRoomsDidChangeNotification";
 NSString *const kMXSessionDidCorruptDataNotification = @"kMXSessionDidCorruptDataNotification";
 NSString *const kMXSessionNoRoomTag = @"m.recent";  // Use the same value as matrix-react-sdk
 
@@ -957,7 +958,7 @@ typedef void (^MXOnResumeDone)();
 
         for (NSDictionary *event in accountDataUpdate[@"events"])
         {
-            if ([event[@"type"] isEqualToString:kMXAccountDataPushRules])
+            if ([event[@"type"] isEqualToString:kMXAccountDataTypePushRules])
             {
                 // Handle push rules
                 MXPushRulesResponse *pushRules = [MXPushRulesResponse modelFromJSON:event[@"content"]];
@@ -998,6 +999,14 @@ typedef void (^MXOnResumeDone)();
                                                                           userInfo:nil];
                     }
                 }
+            }
+            else if ([event[@"type"] isEqualToString:kMXAccountDataTypeDirect])
+            {
+                MXJSONModelSetDictionary(_directRooms, event[@"content"]);
+                
+                [[NSNotificationCenter defaultCenter] postNotificationName:kMXSessionDirectRoomsDidChangeNotification
+                                                                    object:self
+                                                                  userInfo:nil];
             }
 
             // Update the corresponding part of account data
@@ -1421,6 +1430,27 @@ typedef void (^MXOnResumeDone)();
     }
 }
 
+- (BOOL)isDirectRoom:(NSString*)roomId
+{
+    MXRoom *room = [self roomWithRoomId:roomId];
+    if (room)
+    {
+        // Retrieve a joined member from the  members list.
+        NSArray* roomMembers = room.state.members;
+        MXRoomMember* member;
+        
+        for (member in roomMembers)
+        {
+            if (member.membership == MXMembershipJoin && ![member.userId isEqualToString:self.myUser.userId])
+            {
+                // Check whether the provided room id belong to the direct rooms related to this member
+                return ([self.directRooms[member.userId] indexOfObject:roomId] != NSNotFound);
+            }
+        }
+    }
+    
+    return NO;
+}
 
 #pragma mark - Room peeking
 - (void)peekInRoomWithRoomId:(NSString*)roomId

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -1430,28 +1430,6 @@ typedef void (^MXOnResumeDone)();
     }
 }
 
-- (BOOL)isDirectRoom:(NSString*)roomId
-{
-    MXRoom *room = [self roomWithRoomId:roomId];
-    if (room)
-    {
-        // Retrieve a joined member from the  members list.
-        NSArray* roomMembers = room.state.members;
-        MXRoomMember* member;
-        
-        for (member in roomMembers)
-        {
-            if (member.membership == MXMembershipJoin && ![member.userId isEqualToString:self.myUser.userId])
-            {
-                // Check whether the provided room id belong to the direct rooms related to this member
-                return ([self.directRooms[member.userId] indexOfObject:roomId] != NSNotFound);
-            }
-        }
-    }
-    
-    return NO;
-}
-
 #pragma mark - Room peeking
 - (void)peekInRoomWithRoomId:(NSString*)roomId
                      success:(void (^)(MXPeekingRoom *peekingRoom))success


### PR DESCRIPTION
https://github.com/vector-im/vector-ios/issues/715

MXRestClient: support `m.direct` event in `account_data` at session level.