### PR TITLE
Feature - Support `m.direct` event in account_data

### DIFF
--- a/MatrixSDK/Data/MXRoom.h
+++ b/MatrixSDK/Data/MXRoom.h
@@ -126,6 +126,11 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidUpdateUnreadNotification;
 @property (nonatomic, readonly) BOOL isDirect;
 
 /**
+ Indicate whether the room looks like a direct room ("heuritic method").
+ */
+@property (nonatomic, readonly) BOOL looksLikeDirect;
+
+/**
  Tag this room as a direct one, or remove the direct tag.
 
  @discussion: When a group chat is tagged as direct, the room becomes a direct chat with the oldest joined member.

--- a/MatrixSDK/MXSession.h
+++ b/MatrixSDK/MXSession.h
@@ -175,7 +175,7 @@ FOUNDATION_EXPORT NSString *const kMXSessionNotificationEventKey;
 FOUNDATION_EXPORT NSString *const kMXSessionIgnoredUsersDidChangeNotification;
 
 /**
- Posted when MXSession has detected a change in the `directRooms` property.
+ Posted when the `directRooms` property is updated from homeserver.
  
  The notification object is the concerned session (MXSession instance).
  */
@@ -554,23 +554,21 @@ typedef void (^MXOnBackgroundSyncFail)(NSError *error);
 /**
  The list of the direct rooms by user identifiers.
  
- @return a dictionary where the keys are the user IDs and values are lists of room ID strings.
- of the 'direct' rooms for that user ID. nil if the direct rooms have not been yet fetched from the homeserver.
+ A dictionary where the keys are the user IDs and values are lists of room ID strings.
+ of the 'direct' rooms for that user ID.
  */
-@property (nonatomic, readonly) NSDictionary<NSString*, NSArray<NSString*>*> *directRooms;
+@property (nonatomic, readonly) NSMutableDictionary<NSString*, NSArray<NSString*>*> *directRooms;
 
 /**
- Update the direct rooms list on homeserver side.
+ Update the direct rooms list on homeserver side with the current value of the `directRooms` property.
  
- @param directRooms a dictionary where the keys are the user IDs and values are lists of room ID strings
  @param success A block object called when the operation succeeds.
  @param failure A block object called when the operation fails.
  
  @return a MXHTTPOperation instance.
  */
-- (MXHTTPOperation*)setDirectRooms:(NSDictionary<NSString*, NSArray<NSString*>*> *)directRooms
-                        success:(void (^)())success
-                        failure:(void (^)(NSError *error))failure;
+- (MXHTTPOperation*)uploadDirectRooms:(void (^)())success
+                              failure:(void (^)(NSError *error))failure;
 
 #pragma mark - Room peeking
 /**

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -1006,17 +1006,11 @@ typedef void (^MXOnResumeDone)();
             {
                 didDefineDirectChats = YES;
                 
-                if ([event[@"content"] isKindOfClass:NSDictionary.class])
-                {
-                    @synchronized (self.directRooms)
-                    {
-                        _directRooms = [NSMutableDictionary dictionaryWithDictionary:event[@"content"]];
-                    }
-                    
-                    [[NSNotificationCenter defaultCenter] postNotificationName:kMXSessionDirectRoomsDidChangeNotification
-                                                                        object:self
-                                                                      userInfo:nil];
-                }
+                MXJSONModelSetDictionary(_directRooms, event[@"content"]);
+                
+                [[NSNotificationCenter defaultCenter] postNotificationName:kMXSessionDirectRoomsDidChangeNotification
+                                                                    object:self
+                                                                  userInfo:nil];
             }
 
             // Update the corresponding part of account data
@@ -1335,14 +1329,7 @@ typedef void (^MXOnResumeDone)();
                               failure:(void (^)(NSError *error))failure
 {
     // Push the current direct rooms dictionary to the homeserver.
-    MXHTTPOperation *operation;
-    
-    @synchronized (self.directRooms)
-    {
-        operation = [matrixRestClient setAccountData:_directRooms forType:kMXAccountDataTypeDirect success:success failure:failure];
-    }
-    
-    return operation;
+    return [matrixRestClient setAccountData:_directRooms forType:kMXAccountDataTypeDirect success:success failure:failure];
 }
 
 - (MXRoom *)getOrCreateRoom:(NSString *)roomId notify:(BOOL)notify

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -139,6 +139,7 @@ typedef void (^MXOnResumeDone)();
         matrixRestClient = mxRestClient;
         rooms = [NSMutableDictionary dictionary];
         oneToOneRooms = [NSMutableDictionary dictionary];
+        _directRooms = [NSMutableDictionary dictionary];
         globalEventListeners = [NSMutableArray array];
         syncMessagesLimit = -1;
         _notificationCenter = [[MXNotificationCenter alloc] initWithMatrixSession:self];
@@ -952,9 +953,10 @@ typedef void (^MXOnResumeDone)();
 
 - (void)handleAccountData:(NSDictionary*)accountDataUpdate
 {
-    if (accountDataUpdate && accountDataUpdate[@"events"])
+    if (accountDataUpdate && accountDataUpdate[@"events"] && ((NSArray*)accountDataUpdate[@"events"]).count)
     {
         BOOL isInitialSync = !_store.eventStreamToken || _state == MXSessionStateInitialised;
+        BOOL didDefineDirectChats = NO;
 
         for (NSDictionary *event in accountDataUpdate[@"events"])
         {
@@ -1002,11 +1004,19 @@ typedef void (^MXOnResumeDone)();
             }
             else if ([event[@"type"] isEqualToString:kMXAccountDataTypeDirect])
             {
-                MXJSONModelSetDictionary(_directRooms, event[@"content"]);
+                didDefineDirectChats = YES;
                 
-                [[NSNotificationCenter defaultCenter] postNotificationName:kMXSessionDirectRoomsDidChangeNotification
-                                                                    object:self
-                                                                  userInfo:nil];
+                if ([event[@"content"] isKindOfClass:NSDictionary.class])
+                {
+                    @synchronized (self.directRooms)
+                    {
+                        _directRooms = [NSMutableDictionary dictionaryWithDictionary:event[@"content"]];
+                    }
+                    
+                    [[NSNotificationCenter defaultCenter] postNotificationName:kMXSessionDirectRoomsDidChangeNotification
+                                                                        object:self
+                                                                      userInfo:nil];
+                }
             }
 
             // Update the corresponding part of account data
@@ -1014,6 +1024,22 @@ typedef void (^MXOnResumeDone)();
         }
 
         _store.userAccountData = accountData.accountData;
+        
+        if (!didDefineDirectChats)
+        {
+            // When no direct chat is listed in account data, we synthesize them from the current heuristics of what counts as a 1:1 room.
+            NSArray *rooms = self.rooms;
+            
+            for (MXRoom *room in rooms)
+            {
+                if (room.looksLikeDirect)
+                {
+                    [room setIsDirect:YES success:nil failure:^(NSError *error) {
+                        NSLog(@"[MXSession] Failed to tag the room (%@) as a direct chat", room.roomId);
+                    }];
+                }
+            }
+        }
     }
 }
 
@@ -1305,12 +1331,18 @@ typedef void (^MXOnResumeDone)();
     return nil;
 }
 
-- (MXHTTPOperation*)setDirectRooms:(NSDictionary<NSString*, NSArray<NSString*>*> *)directRooms
-                           success:(void (^)())success
-                           failure:(void (^)(NSError *error))failure
+- (MXHTTPOperation*)uploadDirectRooms:(void (^)())success
+                              failure:(void (^)(NSError *error))failure
 {
-    // Report the new dictionary to the homeserver, the local dictionary will be updated at the next sync in case of success.
-    return [matrixRestClient setAccountData:directRooms forType:kMXAccountDataTypeDirect success:success failure:failure];
+    // Push the current direct rooms dictionary to the homeserver.
+    MXHTTPOperation *operation;
+    
+    @synchronized (self.directRooms)
+    {
+        operation = [matrixRestClient setAccountData:_directRooms forType:kMXAccountDataTypeDirect success:success failure:failure];
+    }
+    
+    return operation;
 }
 
 - (MXRoom *)getOrCreateRoom:(NSString *)roomId notify:(BOOL)notify

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -1006,7 +1006,14 @@ typedef void (^MXOnResumeDone)();
             {
                 didDefineDirectChats = YES;
                 
-                MXJSONModelSetDictionary(_directRooms, event[@"content"]);
+                if ([event[@"content"] isKindOfClass:NSDictionary.class])
+                {
+                    _directRooms = [NSMutableDictionary dictionaryWithDictionary:event[@"content"]];
+                }
+                else
+                {
+                    [_directRooms removeAllObjects];
+                }
                 
                 [[NSNotificationCenter defaultCenter] postNotificationName:kMXSessionDirectRoomsDidChangeNotification
                                                                     object:self


### PR DESCRIPTION
#149

When no direct chat is listed in account data, we synthesize them from the current heuristics of what counts as a 1:1 room.