### PR TITLE
Feature - Converting existing rooms to/from DMs

### DIFF
--- a/MatrixSDK/Data/MXRoom.h
+++ b/MatrixSDK/Data/MXRoom.h
@@ -133,13 +133,17 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidUpdateUnreadNotification;
 /**
  Tag this room as a direct one, or remove the direct tag.
 
- @discussion: When a group chat is tagged as direct, the room becomes a direct chat with the oldest joined member.
+ @discussion: When a room is tagged as direct without mentioning the concerned userId,
+ the room becomes a direct chat with the oldest joined member. If no member has joined yet,
+ the room becomes direct with the oldest invited member.
 
  @param isDirect Tell whether the room is direct or not.
+ @param userId (optional) the identifier of the user for whom the room becomes direct.
  @param success A block object called when the operation succeeds.
  @param failure A block object called when the operation fails.
  */
 - (MXHTTPOperation*)setIsDirect:(BOOL)isDirect
+                     withUserId:(NSString*)userId
                         success:(void (^)())success
                         failure:(void (^)(NSError *error))failure;
 

--- a/MatrixSDK/MXSession.h
+++ b/MatrixSDK/MXSession.h
@@ -455,6 +455,9 @@ typedef void (^MXOnBackgroundSyncFail)(NSError *error);
  @param success A block object called when the operation succeeds. It provides the MXRoom
                 instance of the joined room.
  @param failure A block object called when the operation fails.
+ 
+ @discussion When the flag isDirect is turned on, only one user id is expected in the inviteArray. The room will be considered
+ as direct only for the first mentioned user in case of several user ids.
 
  @return a MXHTTPOperation instance.
  */


### PR DESCRIPTION
https://github.com/vector-im/vector-ios/issues/715

- Room creation: When the flag isDirect is turned on, only one user id is expected in the inviteArray. The room will be considered as direct only for the first mentioned user in case of several user ids.