### PR TITLE
Feature - Converting existing rooms to/from DMs

### DIFF
--- a/MatrixSDK/MXEnumConstants.h
+++ b/MatrixSDK/MXEnumConstants.h
@@ -98,6 +98,26 @@ FOUNDATION_EXPORT NSString *const kMXRoomJoinRuleInvite;
 FOUNDATION_EXPORT NSString *const kMXRoomJoinRulePrivate;
 FOUNDATION_EXPORT NSString *const kMXRoomJoinRuleKnock;
 
+/**
+ Room presets
+ Define a set of state events applied during a new room creation.
+ */
+typedef NSString* MXRoomPreset;
+
+/**
+ join_rules is set to invite. history_visibility is set to shared.
+ */
+FOUNDATION_EXPORT NSString *const kMXRoomPresetPrivateChat;
+
+/**
+ join_rules is set to invite. history_visibility is set to shared. All invitees are given the same power level as the room creator.
+ */
+FOUNDATION_EXPORT NSString *const kMXRoomPresetTrustedPrivateChat;
+
+/**
+ join_rules is set to public. history_visibility is set to shared.
+ */
+FOUNDATION_EXPORT NSString *const kMXRoomPresetPublicChat;
 
 /**
  Room guest access.

--- a/MatrixSDK/MXEnumConstants.m
+++ b/MatrixSDK/MXEnumConstants.m
@@ -39,6 +39,13 @@ NSString *const kMXRoomJoinRulePrivate = @"private";
 NSString *const kMXRoomJoinRuleKnock   = @"knock";
 
 /**
+ Room presets
+ */
+NSString *const kMXRoomPresetPrivateChat = @"private_chat";
+NSString *const kMXRoomPresetTrustedPrivateChat = @"trusted_private_chat";
+NSString *const kMXRoomPresetPublicChat = @"public_chat";
+
+/**
  Room guest access.
  */
 NSString *const kMXRoomGuestAccessCanJoin   = @"can_join";

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -919,6 +919,7 @@ typedef enum : NSUInteger
  @param inviteArray (optional) A list of user IDs to invite to the room. This will tell the server to invite everyone in the list to the newly created room.
  @param invite3PIDArray (optional) A list of objects representing third party IDs to invite into the room.
  @param isDirect This flag makes the server set the is_direct flag on the m.room.member events sent to the users in invite and invite_3pid (Use NO by default).
+ @param preset (optional) Convenience parameter for setting various default state events based on a preset.
 
  @param success A block object called when the operation succeeds. It provides a MXCreateRoomResponse object.
  @param failure A block object called when the operation fails.
@@ -932,6 +933,7 @@ typedef enum : NSUInteger
                         invite:(NSArray<NSString*>*)inviteArray
                     invite3PID:(NSArray<MXInvite3PID*>*)invite3PIDArray
                       isDirect:(BOOL)isDirect
+                        preset:(MXRoomPreset)preset
                        success:(void (^)(MXCreateRoomResponse *response))success
                        failure:(void (^)(NSError *error))failure;
 

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -1592,6 +1592,7 @@ MXAuthAction;
                         invite:(NSArray<NSString*>*)inviteArray
                     invite3PID:(NSArray<MXInvite3PID*>*)invite3PIDArray
                       isDirect:(BOOL)isDirect
+                        preset:(MXRoomPreset)preset
                        success:(void (^)(MXCreateRoomResponse *response))success
                        failure:(void (^)(NSError *error))failure
 {
@@ -1633,6 +1634,10 @@ MXAuthAction;
         {
             parameters[@"invite_3pid"] = invite3PIDArray2;
         }
+    }
+    if (preset)
+    {
+        parameters[@"preset"] = preset;
     }
     
     parameters[@"is_direct"] = [NSNumber numberWithBool:isDirect];

--- a/MatrixSDK/MXSession.h
+++ b/MatrixSDK/MXSession.h
@@ -451,6 +451,7 @@ typedef void (^MXOnBackgroundSyncFail)(NSError *error);
  @param inviteArray (optional) A list of user IDs to invite to the room. This will tell the server to invite everyone in the list to the newly created room.
  @param invite3PIDArray (optional) A list of objects representing third party IDs to invite into the room.
  @param isDirect tells whether the resulting room must be tagged as a direct room.
+ @param preset (optional) Convenience parameter for setting various default state events based on a preset.
 
  @param success A block object called when the operation succeeds. It provides the MXRoom
                 instance of the joined room.
@@ -468,6 +469,7 @@ typedef void (^MXOnBackgroundSyncFail)(NSError *error);
                         invite:(NSArray<NSString*>*)inviteArray
                     invite3PID:(NSArray<MXInvite3PID*>*)invite3PIDArray
                       isDirect:(BOOL)isDirect
+                        preset:(MXRoomPreset)preset
                        success:(void (^)(MXRoom *room))success
                        failure:(void (^)(NSError *error))failure;
 

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -1173,10 +1173,11 @@ typedef void (^MXOnResumeDone)();
                         invite:(NSArray<NSString*>*)inviteArray
                     invite3PID:(NSArray<MXInvite3PID*>*)invite3PIDArray
                       isDirect:(BOOL)isDirect
+                        preset:(MXRoomPreset)preset
                        success:(void (^)(MXRoom *room))success
                        failure:(void (^)(NSError *error))failure
 {
-    return [matrixRestClient createRoom:name visibility:visibility roomAlias:roomAlias topic:topic invite:inviteArray invite3PID:invite3PIDArray isDirect:isDirect success:^(MXCreateRoomResponse *response) {
+    return [matrixRestClient createRoom:name visibility:visibility roomAlias:roomAlias topic:topic invite:inviteArray invite3PID:invite3PIDArray isDirect:isDirect preset:preset success:^(MXCreateRoomResponse *response) {
 
         if (isDirect)
         {

--- a/MatrixSDKTests/MXRestClientTests.m
+++ b/MatrixSDKTests/MXRestClientTests.m
@@ -648,7 +648,7 @@
         [matrixSDKTestsData doMXRestClientTestWithAlice:nil readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation2) {
             
             // Create a random room by inviting alice
-            [bobRestClient createRoom:nil visibility:nil roomAlias:nil topic:nil invite:@[matrixSDKTestsData.aliceCredentials.userId] invite3PID:nil isDirect:NO success:^(MXCreateRoomResponse *response) {
+            [bobRestClient createRoom:nil visibility:nil roomAlias:nil topic:nil invite:@[matrixSDKTestsData.aliceCredentials.userId] invite3PID:nil isDirect:NO preset:nil success:^(MXCreateRoomResponse *response) {
                 
                 XCTAssertNotNil(response);
                 XCTAssertNotNil(response.roomId, "The home server should have allocated a room id");

--- a/MatrixSDKTests/MXSessionTests.m
+++ b/MatrixSDKTests/MXSessionTests.m
@@ -681,7 +681,7 @@
             mxSession = mxSession2;
             
             // Create a random room with no params
-            [mxSession createRoom:nil visibility:nil roomAlias:nil topic:nil invite:@[matrixSDKTestsData.aliceCredentials.userId] invite3PID:nil isDirect:NO success:^(MXRoom *room) {
+            [mxSession createRoom:nil visibility:nil roomAlias:nil topic:nil invite:@[matrixSDKTestsData.aliceCredentials.userId] invite3PID:nil isDirect:NO preset:nil success:^(MXRoom *room) {
                 
                 XCTAssertNotNil(room);
                 
@@ -733,7 +733,7 @@
             mxSession = mxSession2;
             
             // Create a random room with no params
-            [mxSession createRoom:nil visibility:nil roomAlias:nil topic:nil invite:@[matrixSDKTestsData.aliceCredentials.userId] invite3PID:nil isDirect:YES success:^(MXRoom *room) {
+            [mxSession createRoom:nil visibility:nil roomAlias:nil topic:nil invite:@[matrixSDKTestsData.aliceCredentials.userId] invite3PID:nil isDirect:YES preset:kMXRoomPresetTrustedPrivateChat success:^(MXRoom *room) {
                 
                 XCTAssertNotNil(room);
                 
@@ -758,6 +758,8 @@
                     }
                     
                     XCTAssertTrue(succeed);
+                    
+                    // TODO Check whether both members have the same power level (trusted_private_chat preset)
                     
                     // Force sync to get direct rooms list
                     [mxSession startWithMessagesLimit:0 onServerSyncDone:^{

--- a/MatrixSDKTests/MXSessionTests.m
+++ b/MatrixSDKTests/MXSessionTests.m
@@ -759,12 +759,18 @@
                     
                     XCTAssertTrue(succeed);
                     
-                    // TODO Check whether both members have the same power level (trusted_private_chat preset)
-                    
                     // Force sync to get direct rooms list
                     [mxSession startWithMessagesLimit:0 onServerSyncDone:^{
                         
                         XCTAssertTrue(room.isDirect);
+                        
+                        // Check whether both members have the same power level (trusted_private_chat preset)
+                        MXRoomPowerLevels *roomPowerLevels = room.state.powerLevels;
+                        
+                        XCTAssertNotNil(roomPowerLevels);
+                        NSUInteger powerlLevel1 = [roomPowerLevels powerLevelOfUserWithUserID:mxSession.myUser.userId];
+                        NSUInteger powerlLevel2 = [roomPowerLevels powerLevelOfUserWithUserID:matrixSDKTestsData.aliceCredentials.userId];
+                        XCTAssertEqual(powerlLevel1, powerlLevel2, @"The members must have the same power level");
                         
                         [expectation fulfill];
                         


### PR DESCRIPTION
https://github.com/vector-im/vector-ios/issues/715

Ensure 1:1 rooms are created with equal ops on both sides (the trusted_private_chat preset)