### PR TITLE
Converting existing rooms to/from DMs

### DIFF
--- a/MatrixSDK/MXSession.h
+++ b/MatrixSDK/MXSession.h
@@ -593,6 +593,13 @@ typedef void (^MXOnBackgroundSyncFail)(NSError *error);
 - (NSArray<MXRoom*>*)rooms;
 
 /**
+ Return the first joined direct chat listed in account data for this user.
+ 
+ @return the MXRoom instance (nil if no room exists yet).
+ */
+- (MXRoom *)directJoinedRoomWithUserId:(NSString*)userId;
+
+/**
  The list of the direct rooms by user identifiers.
  
  A dictionary where the keys are the user IDs and values are lists of room ID strings.

--- a/MatrixSDK/MXSession.h
+++ b/MatrixSDK/MXSession.h
@@ -593,13 +593,6 @@ typedef void (^MXOnBackgroundSyncFail)(NSError *error);
 - (NSArray<MXRoom*>*)rooms;
 
 /**
- Get the existing private OneToOne room with this user.
-
- @return the MXRoom instance (nil if the room does not exist yet).
- */
-- (MXRoom *)privateOneToOneRoomWithUserId:(NSString*)userId;
-
-/**
  The list of the direct rooms by user identifiers.
  
  A dictionary where the keys are the user IDs and values are lists of room ID strings.
@@ -665,11 +658,6 @@ typedef void (^MXOnBackgroundSyncFail)(NSError *error);
  @return an array of MXUsers.
  */
 - (NSArray<MXUser*> *)users;
-
-/**
- List all the user ids for whom a 1:1 room exists.
- */
-- (NSArray<NSString*> *)privateOneToOneUsers;
 
 /**
  The list of ignored users.

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -1480,6 +1480,28 @@ typedef void (^MXOnResumeDone)();
     return [rooms allValues];
 }
 
+- (MXRoom *)directJoinedRoomWithUserId:(NSString*)userId
+{
+    // Retrieve the existing direct chats
+    NSArray *directRoomIds = self.directRooms[userId];
+    
+    // Check whether the room is still existing
+    for (NSString* directRoomId in directRoomIds)
+    {
+        MXRoom *directRoom = [self roomWithRoomId:directRoomId];
+        if (directRoom)
+        {
+            // Check whether the user membership is joined
+            if (directRoom.state.membership == MXMembershipJoin)
+            {
+                return directRoom;
+            }
+        }
+    }
+    
+    return nil;
+}
+
 - (MXHTTPOperation*)uploadDirectRooms:(void (^)())success
                               failure:(void (^)(NSError *error))failure
 {


### PR DESCRIPTION
https://github.com/vector-im/vector-ios/issues/715

Remove `privateOneToOneRoomWithUserId:` and `privateOneToOneUsers` (the developer must use the `directRooms` property instread).