### PR TITLE
MXRoom: add eventDeviceInfo API

### DIFF
--- a/MatrixSDK/Data/MXRoom.h
+++ b/MatrixSDK/Data/MXRoom.h
@@ -769,6 +769,13 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidUpdateUnreadNotification;
                                           success:(void (^)())success
                                           failure:(void (^)(NSError *error))failure;
 
+/**
+ Return the device information for an encrypted event.
+ 
+ @param event The event.
+ @return the device info if any.
+ */
+- (MXDeviceInfo*)eventDeviceInfo:(MXEvent*)event;
 
 #pragma mark - Utils
 

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -1107,6 +1107,17 @@ NSString *const kMXRoomDidUpdateUnreadNotification = @"kMXRoomDidUpdateUnreadNot
     return operation;
 }
 
+- (MXDeviceInfo*)eventDeviceInfo:(MXEvent*)event
+{
+#ifdef MX_CRYPTO
+    if (mxSession.crypto && event.isEncrypted)
+    {
+        return [mxSession.crypto deviceWithIdentityKey:event.senderKey forUser:event.sender andAlgorithm:self.state.encryptionAlgorithm];
+    }
+#endif
+    
+    return nil;
+}
 
 #pragma mark - Utils
 - (NSComparisonResult)compareOriginServerTs:(MXRoom *)otherRoom


### PR DESCRIPTION
Return the device information related to an encrypted event.