### PR TITLE
Crypto: message-replay mitigation

### DIFF
--- a/MatrixSDK/Crypto/Algorithms/MXDecryptionResult.h
+++ b/MatrixSDK/Crypto/Algorithms/MXDecryptionResult.h
@@ -33,6 +33,7 @@ typedef enum : NSUInteger
     MXDecryptingErrorForwardedMessageCode,
     MXDecryptingErrorBadRoomCode,
     MXDecryptingErrorBadEncryptedMessageCode,
+    MXDecryptingErrorDuplicateMessageIndexCode,
 } MXDecryptingErrorCode;
 
 FOUNDATION_EXPORT NSString* const MXDecryptingErrorEncryptionNotEnabledReason;
@@ -48,6 +49,7 @@ FOUNDATION_EXPORT NSString* const MXDecryptingErrorBadRecipientKeyReason;
 FOUNDATION_EXPORT NSString* const MXDecryptingErrorForwardedMessageReason;
 FOUNDATION_EXPORT NSString* const MXDecryptingErrorBadRoomReason;
 FOUNDATION_EXPORT NSString* const MXDecryptingErrorBadEncryptedMessageReason;
+FOUNDATION_EXPORT NSString* const MXDecryptingErrorDuplicateMessageIndexReason;
 
 /**
  Result of a decryption.

--- a/MatrixSDK/Crypto/Algorithms/MXDecryptionResult.m
+++ b/MatrixSDK/Crypto/Algorithms/MXDecryptionResult.m
@@ -31,6 +31,7 @@ NSString* const MXDecryptingErrorBadRecipientKeyReason              = @"Message 
 NSString* const MXDecryptingErrorForwardedMessageReason             = @"Message forwarded from %@";
 NSString* const MXDecryptingErrorBadRoomReason                      = @"Message intended for room %@";
 NSString* const MXDecryptingErrorBadEncryptedMessageReason          = @"Bad Encrypted Message";
+NSString* const MXDecryptingErrorDuplicateMessageIndexReason        = @"Duplicate message index, possible replay attack %@";
 
 @implementation MXDecryptionResult
 


### PR DESCRIPTION
There is however an issue: it breaks permalinks or reloading events from a store.
The reason is that a permalink is opened in a separate window with its own timeline. And this timeline decodes events for a second time.