### PR TITLE
API break - MXRoom:`sendMessageOfType` is deprecated.

### DIFF
--- a/MatrixSDK/Data/MXRoom.h
+++ b/MatrixSDK/Data/MXRoom.h
@@ -268,7 +268,6 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidUpdateUnreadNotification;
 /**
  Send a room message to a room.
 
- @param msgType the type of the message. @see MXMessageType.
  @param content the message content that will be sent to the server as a JSON object.
  @param success A block object called when the operation succeeds. It returns
                 the event id of the event generated on the home server
@@ -276,10 +275,9 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidUpdateUnreadNotification;
 
  @return a MXHTTPOperation instance.
  */
-- (MXHTTPOperation*)sendMessageOfType:(MXMessageType)msgType
-                              content:(NSDictionary*)content
-                              success:(void (^)(NSString *eventId))success
-                              failure:(void (^)(NSError *error))failure;
+- (MXHTTPOperation*)sendMessageWithContent:(NSDictionary*)content
+                                   success:(void (^)(NSString *eventId))success
+                                   failure:(void (^)(NSError *error))failure;
 
 /**
  Send a text message to a room

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -328,7 +328,6 @@ NSString *const kMXRoomDidUpdateUnreadNotification = @"kMXRoomDidUpdateUnreadNot
     return [mxSession.matrixRestClient sendEventToRoom:self.roomId eventType:eventTypeString content:content success:success failure:failure];
 }
 
-
 - (MXHTTPOperation*)sendStateEventOfType:(MXEventTypeString)eventTypeString
                                  content:(NSDictionary*)content
                                  success:(void (^)(NSString *eventId))success
@@ -337,27 +336,22 @@ NSString *const kMXRoomDidUpdateUnreadNotification = @"kMXRoomDidUpdateUnreadNot
     return [mxSession.matrixRestClient sendStateEventToRoom:self.roomId eventType:eventTypeString content:content success:success failure:failure];
 }
 
-- (MXHTTPOperation*)sendMessageOfType:(MXMessageType)msgType
-                              content:(NSDictionary*)content
-                              success:(void (^)(NSString *eventId))success
-                              failure:(void (^)(NSError *error))failure
+- (MXHTTPOperation*)sendMessageWithContent:(NSDictionary*)content
+                                   success:(void (^)(NSString *eventId))success
+                                   failure:(void (^)(NSError *error))failure
 {
-    // Add the messsage type to the data to send
-    NSMutableDictionary *eventContent = [NSMutableDictionary dictionaryWithDictionary:content];
-    eventContent[@"msgtype"] = msgType;
-
-    return [self sendEventOfType:kMXEventTypeStringRoomMessage content:eventContent success:success failure:failure];
+    return [self sendEventOfType:kMXEventTypeStringRoomMessage content:content success:success failure:failure];
 }
 
 - (MXHTTPOperation*)sendTextMessage:(NSString*)text
                             success:(void (^)(NSString *eventId))success
                             failure:(void (^)(NSError *error))failure
 {
-    return [self sendMessageOfType:kMXMessageTypeText
-                           content:@{
-                                     @"body": text
-                                     }
-                           success:success failure:failure];
+    return [self sendMessageWithContent:@{
+                                          @"msgtype": kMXMessageTypeText,
+                                          @"body": text
+                                          }
+                                success:success failure:failure];
 }
 
 - (MXHTTPOperation*)setTopic:(NSString*)topic


### PR DESCRIPTION
[sendMessageOfType:content:success:failure:] is replaced with [sendMessageWithContent:success:failure:] where the message type is defined in the provided content.