### PR TITLE
Bug Fix - App crashes while the app stores user.

### DIFF
--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -347,6 +347,12 @@ typedef void (^MXOnResumeDone)();
         // Get data from the home server
         // First of all, retrieve the user's profile information
         [_myUser updateFromHomeserverOfMatrixSession:self success:^{
+            
+            // Stop here if [MXSession close] has been triggered.
+            if (nil == _myUser)
+            {
+                return;
+            }
 
             // And store him as a common MXUser
             [_store storeUser:_myUser];


### PR DESCRIPTION
*** -[__NSDictionaryM removeObjectForKey:]: key cannot be nil

Main thread: YES
(
	0   CoreFoundation                      0x00000001849371d0 <redacted> + 148
	1   libobjc.A.dylib                     0x000000018336c55c objc_exception_throw + 56
	2   CoreFoundation                      0x00000001848347a4 <redacted> + 692
	3   Vector                              0x00000001002dc6b8 Vector + 2377400
 -> -[MXMemoryStore storeUser:] (in Vector) (MXMemoryStore.m:298)
	4   Vector                              0x00000001002b34e0 Vector + 2208992
 -> -[MXFileStore storeUser:] (in Vector) (MXFileStore.m:449)
	5   Vector                              0x000000010030e244 Vector + 2581060
 -> __61-[MXSession startWithMessagesLimit:onServerSyncDone:failure:]_block_invoke132 (in Vector) (MXSession.m:355)
	6   Vector                              0x000000010031a490 Vector + 2630800
 -> __62-[MXUser updateFromHomeserverOfMatrixSession:success:failure:]_block_invoke_2 (in Vector) (MXUser.m:136)
[...]