### PR TITLE
Implement [MXCryptoRealmStore storeDevicesForUser]  correctly & add timing logs

### DIFF
--- a/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmEncryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmEncryption.m
@@ -125,8 +125,12 @@
     queuedEncryption.failure = failure;
     [pendingEncryptions addObject:queuedEncryption];
 
+    NSDate *startDate = [NSDate date];
+
     return [self ensureOutboundSessionInRoom:room success:^(MXOutboundSessionInfo *session) {
 
+        NSLog(@"[MXMegolmEncryption] ensureOutboundSessionInRoom took %.0fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+        
         [self processPendingEncryptionsInSession:session withError:nil];
 
     } failure:^(NSError *error) {

--- a/MatrixSDK/Crypto/Data/MXUsersDevicesMap.h
+++ b/MatrixSDK/Crypto/Data/MXUsersDevicesMap.h
@@ -32,6 +32,10 @@
  */
 @property (nonatomic, readonly) NSDictionary<NSString* /* userId */,
                                     NSDictionary<NSString* /* deviceId */, ObjectType>*> *map;
+/**
+ Number of stored objects.
+ */
+@property (nonatomic, readonly) NSUInteger count;
 
 /**
  Helper methods to extract information from 'map'.

--- a/MatrixSDK/Crypto/Data/MXUsersDevicesMap.m
+++ b/MatrixSDK/Crypto/Data/MXUsersDevicesMap.m
@@ -40,6 +40,18 @@
     return self;
 }
 
+- (NSUInteger)count
+{
+    NSUInteger count = 0;
+
+    for (NSString *userId in _map)
+    {
+        count += _map[userId].count;
+    }
+
+    return count;
+}
+
 - (NSArray<NSString *> *)userIds
 {
     return _map.allKeys;

--- a/MatrixSDK/Crypto/Data/Store/MXFileCryptoStore/MXFileCryptoStore.m
+++ b/MatrixSDK/Crypto/Data/Store/MXFileCryptoStore/MXFileCryptoStore.m
@@ -238,8 +238,10 @@ NSString *const kMXFileCryptoStoreInboundGroupSessionsFile = @"inboundGroupSessi
 {
     olmAccount = account;
 
+    NSDate *startDate = [NSDate date];
     NSString *filePath = [storePath stringByAppendingPathComponent:kMXFileCryptoStoreAccountFile];
     [NSKeyedArchiver archiveRootObject:olmAccount toFile:filePath];
+    NSLog(@"##### [MXFileCryptoStore] storeAccount in %.0fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 }
 
 - (OLMAccount *)account
@@ -262,8 +264,10 @@ NSString *const kMXFileCryptoStoreInboundGroupSessionsFile = @"inboundGroupSessi
 {
     [usersDevicesInfoMap setObject:device forUser:userId andDevice:device.deviceId];
 
+    NSDate *startDate = [NSDate date];
     NSString *filePath = [storePath stringByAppendingPathComponent:kMXFileCryptoStoreDevicesFile];
     [NSKeyedArchiver archiveRootObject:usersDevicesInfoMap toFile:filePath];
+    NSLog(@"##### [MXFileCryptoStore] storeAccount in %.0fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 }
 
 - (MXDeviceInfo *)deviceWithDeviceId:(NSString *)deviceId forUser:(NSString *)userId
@@ -275,8 +279,10 @@ NSString *const kMXFileCryptoStoreInboundGroupSessionsFile = @"inboundGroupSessi
 {
     [usersDevicesInfoMap setObjects:devices forUser:userId];
 
+    NSDate *startDate = [NSDate date];
     NSString *filePath = [storePath stringByAppendingPathComponent:kMXFileCryptoStoreDevicesFile];
     [NSKeyedArchiver archiveRootObject:usersDevicesInfoMap toFile:filePath];
+    NSLog(@"##### [MXFileCryptoStore] storeDevicesForUser in %.0fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 }
 
 - (NSDictionary<NSString *,MXDeviceInfo *> *)devicesForUser:(NSString *)userId
@@ -288,8 +294,10 @@ NSString *const kMXFileCryptoStoreInboundGroupSessionsFile = @"inboundGroupSessi
 {
     roomsAlgorithms[roomId] = algorithm;
 
+    NSDate *startDate = [NSDate date];
     NSString *filePath = [storePath stringByAppendingPathComponent:kMXFileCryptoStoreRoomsAlgorithmsFile];
     [NSKeyedArchiver archiveRootObject:roomsAlgorithms toFile:filePath];
+    NSLog(@"##### [MXFileCryptoStore] storeAlgorithmForRoom in %.0fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 }
 
 - (NSString *)algorithmForRoom:(NSString *)roomId
@@ -306,8 +314,10 @@ NSString *const kMXFileCryptoStoreInboundGroupSessionsFile = @"inboundGroupSessi
 
     olmSessions[deviceKey][session.sessionIdentifier] = session;
 
+    NSDate *startDate = [NSDate date];
     NSString *filePath = [storePath stringByAppendingPathComponent:kMXFileCryptoStoreSessionsFile];
     [NSKeyedArchiver archiveRootObject:olmSessions toFile:filePath];
+    NSLog(@"##### [MXFileCryptoStore] storeSession in %.0fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 }
 
 - (NSDictionary<NSString *,OLMSession *> *)sessionsWithDevice:(NSString *)deviceKey
@@ -324,8 +334,10 @@ NSString *const kMXFileCryptoStoreInboundGroupSessionsFile = @"inboundGroupSessi
 
     inboundGroupSessions[session.senderKey][session.session.sessionIdentifier] = session;
 
+    NSDate *startDate = [NSDate date];
     NSString *filePath = [storePath stringByAppendingPathComponent:kMXFileCryptoStoreInboundGroupSessionsFile];
     [NSKeyedArchiver archiveRootObject:inboundGroupSessions toFile:filePath];
+    NSLog(@"##### [MXFileCryptoStore] storeInboundGroupSession in %.0fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 }
 
 - (MXOlmInboundGroupSession *)inboundGroupSessionWithId:(NSString *)sessionId andSenderKey:(NSString *)senderKey
@@ -339,8 +351,10 @@ NSString *const kMXFileCryptoStoreInboundGroupSessionsFile = @"inboundGroupSessi
 {
     [inboundGroupSessions[senderKey] removeObjectForKey:sessionId];
 
+    NSDate *startDate = [NSDate date];
     NSString *filePath = [storePath stringByAppendingPathComponent:kMXFileCryptoStoreInboundGroupSessionsFile];
     [NSKeyedArchiver archiveRootObject:inboundGroupSessions toFile:filePath];
+    NSLog(@"##### [MXFileCryptoStore] removeInboundGroupSessionWithId in %.0fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 }
 
 

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -591,8 +591,11 @@
 
     MXUsersDevicesMap<MXOlmSessionResult*> *results = [[MXUsersDevicesMap alloc] init];
 
+    NSUInteger count = 0;
     for (NSString *userId in devicesByUser)
     {
+        count += devicesByUser[userId].count;
+
         for (MXDeviceInfo *deviceInfo in devicesByUser[userId])
         {
             NSString *deviceId = deviceInfo.deviceId;
@@ -608,6 +611,8 @@
             [results setObject:olmSessionResult forUser:userId andDevice:deviceId];
         }
     }
+
+    NSLog(@"[MXCrypto] ensureOlmSessionsForDevices (users count: %lu - devices: %tu)", devicesByUser.count, count);
 
     if (devicesWithoutSession.count == 0)
     {
@@ -630,11 +635,13 @@
     //
     // That should eventually resolve itself, but it's poor form.
 
-    NSLog(@"### claimOneTimeKeysForUsersDevices (count: %@", usersDevicesToClaim);
+    NSLog(@"[MXCrypto] ensureOlmSessionsForDevices: claimOneTimeKeysForUsersDevices (users count: %lu - devices: %tu)",
+          usersDevicesToClaim.map.count, usersDevicesToClaim.count);
 
     return [mxSession.matrixRestClient claimOneTimeKeysForUsersDevices:usersDevicesToClaim success:^(MXKeysClaimResponse *keysClaimResponse) {
 
-        NSLog(@"### keysClaimResponse.oneTimeKeys: %@", keysClaimResponse.oneTimeKeys);
+        NSLog(@"[MXCrypto] keysClaimResponse.oneTimeKeys (users count: %lu - devices: %tu): %@",
+              keysClaimResponse.oneTimeKeys.map.count, keysClaimResponse.oneTimeKeys.count, keysClaimResponse.oneTimeKeys);
 
         for (NSString *userId in devicesByUser)
         {


### PR DESCRIPTION
storeDevicesForUser is now 10 times faster.
The timing logs are supposed to be temporary.

I pause the storage optimisation. Now, there is more things to save by threading the whole crypto.