### PR TITLE
MXRestClient: Add the completionQueue property

### DIFF
--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -132,6 +132,13 @@ typedef enum : NSUInteger
 @property (nonatomic, readonly) NSData* allowedCertificate;
 
 /**
+ The queue on which asynchronous response blocks are called.
+ Default is dispatch_get_main_queue().
+ */
+@property (nonatomic, strong) dispatch_queue_t completionQueue;
+
+
+/**
  Create an instance based on homeserver url.
 
  @param homeserver the homeserver URL.

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -134,7 +134,9 @@ MXAuthAction;
         
         // By default, use the same address for the identity server
         self.identityServer = homeserver;
-        
+
+        completionQueue = dispatch_get_main_queue();
+
         processingQueue = dispatch_queue_create("MXRestClient", DISPATCH_QUEUE_SERIAL);
     }
     return self;

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -244,7 +244,11 @@ MXAuthAction;
                                              }
                                              else if (failure)
                                              {
-                                                 failure(error);
+                                                 dispatch_async(processingQueue, ^{
+                                                     dispatch_async(completionQueue, ^{
+                                                         failure(error);
+                                                     });
+                                                 });
                                              }
                                              
                                          });
@@ -267,7 +271,11 @@ MXAuthAction;
 {
     if (![loginType isEqualToString:kMXLoginFlowTypePassword] && ![loginType isEqualToString:kMXLoginFlowTypeDummy])
     {
-        failure(nil);
+        dispatch_async(processingQueue, ^{
+            dispatch_async(completionQueue, ^{
+                failure(nil);
+            });
+        });
         return nil;
     }
 
@@ -351,7 +359,11 @@ MXAuthAction;
                                      
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                      
                                  }];
@@ -370,7 +382,11 @@ MXAuthAction;
 {
     if (![loginType isEqualToString:kMXLoginFlowTypePassword])
     {
-        failure(nil);
+        dispatch_async(processingQueue, ^{
+            dispatch_async(completionQueue, ^{
+                failure(nil);
+            });
+        });
         return nil;
     }
 
@@ -424,11 +440,16 @@ MXAuthAction;
     if (!parameters)
     {
         NSError* error = [NSError errorWithDomain:@"Invalid params" code:500 userInfo:nil];
-        
-        failure(error);
+
+        dispatch_async(processingQueue, ^{
+            dispatch_async(completionQueue, ^{
+                failure(error);
+            });
+        });
+
         return nil;
     }
-    
+
     return [httpClient requestWithMethod:@"POST"
                                     path:[NSString stringWithFormat:@"%@/account/password", apiPathPrefix]
                               parameters:parameters
@@ -442,7 +463,11 @@ MXAuthAction;
 
                                  }
                                  failure:^(NSError *error) {
-                                     failure(error);
+                                     dispatch_async(processingQueue, ^{
+                                         dispatch_async(completionQueue, ^{
+                                             failure(error);
+                                         });
+                                     });
                                  }];
 }
 
@@ -455,10 +480,15 @@ MXAuthAction;
     {
         NSError* error = [NSError errorWithDomain:@"Invalid params" code:500 userInfo:nil];
         
-        failure(error);
+        dispatch_async(processingQueue, ^{
+            dispatch_async(completionQueue, ^{
+                failure(error);
+            });
+        });
+
         return nil;
     }
-    
+
     NSDictionary *parameters = @{
                                  @"auth": @{
                                              @"type": kMXLoginFlowTypePassword,
@@ -481,7 +511,11 @@ MXAuthAction;
 
                                  }
                                  failure:^(NSError *error) {
-                                     failure(error);
+                                     dispatch_async(processingQueue, ^{
+                                         dispatch_async(completionQueue, ^{
+                                             failure(error);
+                                         });
+                                     });
                                  }];
 }
 
@@ -536,7 +570,11 @@ MXAuthAction;
                                      
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                      
                                  }];
@@ -563,7 +601,11 @@ MXAuthAction;
                                      
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                      
                                  }];
@@ -600,7 +642,11 @@ MXAuthAction;
                                  failure:^(NSError *error) {
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                  }];
 }
@@ -624,10 +670,15 @@ MXAuthAction;
     {
         NSError* error = [NSError errorWithDomain:@"Invalid params" code:500 userInfo:nil];
         
-        failure(error);
+        dispatch_async(processingQueue, ^{
+            dispatch_async(completionQueue, ^{
+                failure(error);
+            });
+        });
+
         return nil;
     }
-    
+
     // Fill the request parameters on demand
     // Caution: parameters are JSON serialized in http body, we must use a NSNumber created with a boolean for append value.
     NSDictionary *parameters = @{
@@ -655,7 +706,11 @@ MXAuthAction;
 
                                  }
                                  failure:^(NSError *error) {
-                                     failure(error);
+                                     dispatch_async(processingQueue, ^{
+                                         dispatch_async(completionQueue, ^{
+                                             failure(error);
+                                         });
+                                     });
                                  }];
 }
 
@@ -678,7 +733,11 @@ MXAuthAction;
                                      }
                                  }
                                  failure:^(NSError *error) {
-                                     failure(error);
+                                     dispatch_async(processingQueue, ^{
+                                         dispatch_async(completionQueue, ^{
+                                             failure(error);
+                                         });
+                                     });
                                  }];
 }
 
@@ -733,7 +792,11 @@ MXAuthAction;
                                  failure:^(NSError *error) {
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                  }];
 }
@@ -780,7 +843,11 @@ MXAuthAction;
                                  failure:^(NSError *error) {
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                  }];
 }
@@ -865,7 +932,11 @@ MXAuthAction;
                                      failure:^(NSError *error) {
                                          if (failure)
                                          {
-                                             failure(error);
+                                             dispatch_async(processingQueue, ^{
+                                                 dispatch_async(completionQueue, ^{
+                                                     failure(error);
+                                                 });
+                                             });
                                          }
                                      }];
     }
@@ -873,7 +944,11 @@ MXAuthAction;
     {
         if (failure)
         {
-            failure([NSError errorWithDomain:kMXRestClientErrorDomain code:0 userInfo:@{@"error": @"Invalid argument"}]);
+            dispatch_async(processingQueue, ^{
+                dispatch_async(completionQueue, ^{
+                    failure([NSError errorWithDomain:kMXRestClientErrorDomain code:0 userInfo:@{@"error": @"Invalid argument"}]);
+                });
+            });
         }
         return nil;
     }
@@ -912,7 +987,11 @@ MXAuthAction;
                                  failure:^(NSError *error) {
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                  }];
 }
@@ -945,7 +1024,11 @@ MXAuthAction;
                                  failure:^(NSError *error) {
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                  }];
 }
@@ -1012,7 +1095,11 @@ MXAuthAction;
                                  failure:^(NSError *error) {
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                  }];
 }
@@ -1057,7 +1144,11 @@ MXAuthAction;
                                  failure:^(NSError *error) {
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                  }];
 }
@@ -1096,7 +1187,11 @@ MXAuthAction;
                                  failure:^(NSError *error) {
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                  }];
 }
@@ -1337,7 +1432,11 @@ MXAuthAction;
                                  failure:^(NSError *error) {
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                  }];
 }
@@ -1365,7 +1464,11 @@ MXAuthAction;
                                  failure:^(NSError *error) {
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                  }];
 }
@@ -1397,7 +1500,11 @@ MXAuthAction;
                                  failure:^(NSError *error) {
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                  }];
 }
@@ -1426,7 +1533,11 @@ MXAuthAction;
                                  failure:^(NSError *error) {
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                  }];
 }
@@ -1514,7 +1625,11 @@ MXAuthAction;
                                  failure:^(NSError *error) {
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                  }];
 }
@@ -1564,8 +1679,12 @@ MXAuthAction;
     {
         if (failure)
         {
-            MXError *error = [[MXError alloc] initWithErrorCode:kMXSDKErrCodeStringMissingParameters error:@"No supplied identity server URL"];
-            failure([error createNSError]);
+            dispatch_async(processingQueue, ^{
+                dispatch_async(completionQueue, ^{
+                    MXError *error = [[MXError alloc] initWithErrorCode:kMXSDKErrCodeStringMissingParameters error:@"No supplied identity server URL"];
+                    failure([error createNSError]);
+                });
+            });
         }
         return nil;
     }
@@ -1606,7 +1725,11 @@ MXAuthAction;
                                  failure:^(NSError *error) {
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                  }];
 }
@@ -1648,7 +1771,11 @@ MXAuthAction;
                                  failure:^(NSError *error) {
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                  }];
 }
@@ -1799,7 +1926,11 @@ MXAuthAction;
                                  failure:^(NSError *error) {
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                  }];
 }
@@ -1860,7 +1991,11 @@ MXAuthAction;
                                  failure:^(NSError *error) {
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                  }];
 }
@@ -1900,7 +2035,11 @@ MXAuthAction;
                                  failure:^(NSError *error) {
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                  }];
 }
@@ -1932,7 +2071,11 @@ MXAuthAction;
                                  failure:^(NSError *error) {
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                  }];
 }
@@ -1975,7 +2118,11 @@ MXAuthAction;
                                                        failure:^(NSError *error) {
                                                            if (failure)
                                                            {
-                                                               failure(error);
+                                                               dispatch_async(processingQueue, ^{
+                                                                   dispatch_async(completionQueue, ^{
+                                                                       failure(error);
+                                                                   });
+                                                               });
                                                            }
                                                        }];
     
@@ -2021,7 +2168,11 @@ MXAuthAction;
                                  failure:^(NSError *error) {
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                  }];
 }
@@ -2065,7 +2216,11 @@ MXAuthAction;
                                  failure:^(NSError *error) {
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                  }];
 }
@@ -2102,7 +2257,11 @@ MXAuthAction;
                                  failure:^(NSError *error) {
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                  }];
 }
@@ -2140,7 +2299,11 @@ MXAuthAction;
                                  failure:^(NSError *error) {
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                  }];
 }
@@ -2180,7 +2343,11 @@ MXAuthAction;
                                  failure:^(NSError *error) {
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                  }];
 }
@@ -2219,7 +2386,11 @@ MXAuthAction;
                                  failure:^(NSError *error) {
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                  }];
 }
@@ -2246,7 +2417,11 @@ MXAuthAction;
                                  failure:^(NSError *error) {
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                  }];
 }
@@ -2281,7 +2456,11 @@ MXAuthAction;
                                  failure:^(NSError *error) {
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                  }];
 }
@@ -2321,7 +2500,11 @@ MXAuthAction;
                                  failure:^(NSError *error) {
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                  }];
 }
@@ -2354,7 +2537,11 @@ MXAuthAction;
                                  failure:^(NSError *error) {
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                  }];
 }
@@ -2392,7 +2579,11 @@ MXAuthAction;
                                  failure:^(NSError *error) {
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                  }];
 }
@@ -2430,7 +2621,11 @@ MXAuthAction;
                                  failure:^(NSError *error) {
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                  }];
 }
@@ -2462,7 +2657,11 @@ MXAuthAction;
                                  failure:^(NSError *error) {
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                  }];
 }
@@ -2503,7 +2702,11 @@ MXAuthAction;
                                  failure:^(NSError *error) {
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                  }];
 }
@@ -2541,7 +2744,11 @@ MXAuthAction;
                                  failure:^(NSError *error) {
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                  }];
 }
@@ -2573,7 +2780,11 @@ MXAuthAction;
                                  failure:^(NSError *error) {
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                  }];
 }
@@ -2608,7 +2819,11 @@ MXAuthAction;
                                  failure:^(NSError *error) {
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                  }];
 }
@@ -2674,7 +2889,11 @@ MXAuthAction;
                                                        failure:^(NSError *error) {
                                                            if (failure)
                                                            {
-                                                               failure(error);
+                                                               dispatch_async(processingQueue, ^{
+                                                                   dispatch_async(completionQueue, ^{
+                                                                       failure(error);
+                                                                   });
+                                                               });
                                                            }
                                                        }];
     
@@ -2711,8 +2930,12 @@ MXAuthAction;
                                  }
                                  failure:^(NSError *error) {
                                      
-                                     failure(error);
-                                     
+                                     dispatch_async(processingQueue, ^{
+                                         dispatch_async(completionQueue, ^{
+                                             failure(error);
+                                         });
+                                     });
+
                                  }];
     
 }
@@ -2748,7 +2971,11 @@ MXAuthAction;
                                  failure:^(NSError *error) {
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                  }];
 }
@@ -2782,7 +3009,11 @@ MXAuthAction;
                                  failure:^(NSError *error) {
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                  }];
 }
@@ -2937,7 +3168,11 @@ MXAuthAction;
                                          failure:^(NSError *error) {
                                              if (failure)
                                              {
-                                                 failure(error);
+                                                 dispatch_async(processingQueue, ^{
+                                                     dispatch_async(completionQueue, ^{
+                                                         failure(error);
+                                                     });
+                                                 });
                                              }
                                          }];
 }
@@ -2986,7 +3221,11 @@ MXAuthAction;
             
         } failure:^(NSError *error) {
             if (failure) {
-                failure(error);
+                dispatch_async(processingQueue, ^{
+                    dispatch_async(completionQueue, ^{
+                        failure(error);
+                    });
+                });
             }
         }];
     }
@@ -3051,7 +3290,11 @@ MXAuthAction;
                                          failure:^(NSError *error) {
                                              if (failure)
                                              {
-                                                 failure(error);
+                                                 dispatch_async(processingQueue, ^{
+                                                     dispatch_async(completionQueue, ^{
+                                                         failure(error);
+                                                     });
+                                                 });
                                              }
                                          }];
 }
@@ -3087,15 +3330,23 @@ MXAuthAction;
                                                  // Build the error from the JSON data
                                                  if (failure && JSONResponse[@"errcode"] && JSONResponse[@"error"])
                                                  {
-                                                     MXError *error = [[MXError alloc] initWithErrorCode:JSONResponse[@"errcode"] error:JSONResponse[@"error"]];
-                                                     failure([error createNSError]);
+                                                     dispatch_async(processingQueue, ^{
+                                                         dispatch_async(completionQueue, ^{
+                                                             MXError *error = [[MXError alloc] initWithErrorCode:JSONResponse[@"errcode"] error:JSONResponse[@"error"]];
+                                                             failure([error createNSError]);
+                                                         });
+                                                     });
                                                  }
                                              }
                                          }
                                          failure:^(NSError *error) {
                                              if (failure)
                                              {
-                                                 failure(error);
+                                                 dispatch_async(processingQueue, ^{
+                                                     dispatch_async(completionQueue, ^{
+                                                         failure(error);
+                                                     });
+                                                 });
                                              }
                                          }];
 }
@@ -3126,7 +3377,11 @@ MXAuthAction;
                                          failure:^(NSError *error) {
                                              if (failure)
                                              {
-                                                 failure(error);
+                                                 dispatch_async(processingQueue, ^{
+                                                     dispatch_async(completionQueue, ^{
+                                                         failure(error);
+                                                     });
+                                                 });
                                              }
                                          }];
 }
@@ -3155,7 +3410,11 @@ MXAuthAction;
                                  failure:^(NSError *error) {
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                  }];
 }
@@ -3383,7 +3642,11 @@ MXAuthAction;
                                  failure:^(NSError *error) {
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                  }];
 }
@@ -3417,7 +3680,11 @@ MXAuthAction;
                                      
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                      
                                  }];
@@ -3452,7 +3719,11 @@ MXAuthAction;
                                      
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                      
                                  }];
@@ -3490,7 +3761,11 @@ MXAuthAction;
                                  } failure:^(NSError *error) {
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                  }];
 }
@@ -3539,7 +3814,11 @@ MXAuthAction;
                                              }
                                              else if (failure)
                                              {
-                                                 failure(error);
+                                                 dispatch_async(processingQueue, ^{
+                                                     dispatch_async(completionQueue, ^{
+                                                         failure(error);
+                                                     });
+                                                 });
                                              }
                                              
                                          });
@@ -3581,7 +3860,11 @@ MXAuthAction;
                                      
                                      if (failure)
                                      {
-                                         failure(error);
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
                                      }
                                      
                                  }];

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -95,7 +95,7 @@ MXAuthAction;
 @end
 
 @implementation MXRestClient
-@synthesize homeserver, homeserverSuffix, credentials, apiPathPrefix;
+@synthesize homeserver, homeserverSuffix, credentials, apiPathPrefix, completionQueue;
 
 -(id)initWithHomeServer:(NSString *)inHomeserver andOnUnrecognizedCertificateBlock:(MXHTTPClientOnUnrecognizedCertificate)onUnrecognizedCertBlock
 {
@@ -111,7 +111,9 @@ MXAuthAction;
         
         // By default, use the same address for the identity server
         self.identityServer = homeserver;
-        
+
+        completionQueue = dispatch_get_main_queue();
+
         processingQueue = dispatch_queue_create("MXRestClient", DISPATCH_QUEUE_SERIAL);
     }
     return self;
@@ -526,7 +528,7 @@ MXAuthAction;
                                          // Use here the processing queue in order to keep the server response order
                                          dispatch_async(processingQueue, ^{
                                              
-                                             dispatch_async(dispatch_get_main_queue(), ^{
+                                             dispatch_async(completionQueue, ^{
                                                  
                                                  success();
                                                  
@@ -814,7 +816,7 @@ MXAuthAction;
                                          // Use here the processing queue in order to keep the server response order
                                          dispatch_async(processingQueue, ^{
                                              
-                                             dispatch_async(dispatch_get_main_queue(), ^{
+                                             dispatch_async(completionQueue, ^{
 
                                                  NSString *eventId;
                                                  MXJSONModelSetString(eventId, JSONResponse[@"event_id"]);
@@ -850,7 +852,7 @@ MXAuthAction;
                                          // Use here the processing queue in order to keep the server response order
                                          dispatch_async(processingQueue, ^{
                                              
-                                             dispatch_async(dispatch_get_main_queue(), ^{
+                                             dispatch_async(completionQueue, ^{
                                                  
                                                  NSString *eventId;
                                                  MXJSONModelSetString(eventId, JSONResponse[@"event_id"]);
@@ -919,7 +921,7 @@ MXAuthAction;
                                          // Use here the processing queue in order to keep the server response order
                                          dispatch_async(processingQueue, ^{
                                              
-                                             dispatch_async(dispatch_get_main_queue(), ^{
+                                             dispatch_async(completionQueue, ^{
                                                  
                                                  success();
                                                  
@@ -964,7 +966,7 @@ MXAuthAction;
                                          // Use here the processing queue in order to keep the server response order
                                          dispatch_async(processingQueue, ^{
 
-                                             dispatch_async(dispatch_get_main_queue(), ^{
+                                             dispatch_async(completionQueue, ^{
 
                                                  success();
 
@@ -1004,7 +1006,7 @@ MXAuthAction;
                                      // Use here the processing queue in order to keep the server response order
                                      dispatch_async(processingQueue, ^{
 
-                                         dispatch_async(dispatch_get_main_queue(), ^{
+                                         dispatch_async(completionQueue, ^{
 
                                              success(JSONResponse);
 
@@ -1208,7 +1210,7 @@ MXAuthAction;
                                          // Use here the processing queue in order to keep the server response order
                                          dispatch_async(processingQueue, ^{
 
-                                             dispatch_async(dispatch_get_main_queue(), ^{
+                                             dispatch_async(completionQueue, ^{
 
                                                  success();
 
@@ -1237,7 +1239,7 @@ MXAuthAction;
                                      // Use here the processing queue in order to keep the server response order
                                      dispatch_async(processingQueue, ^{
 
-                                         dispatch_async(dispatch_get_main_queue(), ^{
+                                         dispatch_async(completionQueue, ^{
 
                                              MXRoomDirectoryVisibility directoryVisibility;
                                              MXJSONModelSetString(directoryVisibility, JSONResponse[@"visibility"]);
@@ -1274,7 +1276,7 @@ MXAuthAction;
                                          // Use here the processing queue in order to keep the server response order
                                          dispatch_async(processingQueue, ^{
                                              
-                                             dispatch_async(dispatch_get_main_queue(), ^{
+                                             dispatch_async(completionQueue, ^{
                                                  
                                                  success();
                                                  
@@ -1307,7 +1309,7 @@ MXAuthAction;
                                          // Use here the processing queue in order to keep the server response order
                                          dispatch_async(processingQueue, ^{
                                              
-                                             dispatch_async(dispatch_get_main_queue(), ^{
+                                             dispatch_async(completionQueue, ^{
                                                  
                                                  success();
                                                  
@@ -1384,7 +1386,7 @@ MXAuthAction;
                                          // Use here the processing queue in order to keep the server response order
                                          dispatch_async(processingQueue, ^{
                                              
-                                             dispatch_async(dispatch_get_main_queue(), ^{
+                                             dispatch_async(completionQueue, ^{
                                                  
                                                  NSString *roomId;
                                                  MXJSONModelSetString(roomId, JSONResponse[@"room_id"]);
@@ -1481,7 +1483,7 @@ MXAuthAction;
                                          // Use here the processing queue in order to keep the server response order
                                          dispatch_async(processingQueue, ^{
 
-                                             dispatch_async(dispatch_get_main_queue(), ^{
+                                             dispatch_async(completionQueue, ^{
 
                                                  success(JSONResponse);
 
@@ -1523,7 +1525,7 @@ MXAuthAction;
                                          // Use here the processing queue in order to keep the server response order
                                          dispatch_async(processingQueue, ^{
                                              
-                                             dispatch_async(dispatch_get_main_queue(), ^{
+                                             dispatch_async(completionQueue, ^{
                                                  
                                                  success();
                                                  
@@ -1674,7 +1676,7 @@ MXAuthAction;
                                              
                                              MXCreateRoomResponse *response = [MXCreateRoomResponse modelFromJSON:JSONResponse];
                                              
-                                             dispatch_async(dispatch_get_main_queue(), ^{
+                                             dispatch_async(completionQueue, ^{
                                                  
                                                  success(response);
                                                  
@@ -1735,7 +1737,7 @@ MXAuthAction;
                                              
                                              MXPaginationResponse *paginatedResponse = [MXPaginationResponse modelFromJSON:JSONResponse];
                                              
-                                             dispatch_async(dispatch_get_main_queue(), ^{
+                                             dispatch_async(completionQueue, ^{
                                                  
                                                  success(paginatedResponse);
                                                  
@@ -1775,7 +1777,7 @@ MXAuthAction;
                                                  [roomMemberEvents addObject:roomMemberEvent];
                                              }
                                              
-                                             dispatch_async(dispatch_get_main_queue(), ^{
+                                             dispatch_async(completionQueue, ^{
                                                  
                                                  success(roomMemberEvents);
                                                  
@@ -1807,7 +1809,7 @@ MXAuthAction;
                                          // Use here the processing queue in order to keep the server response order
                                          dispatch_async(processingQueue, ^{
                                              
-                                             dispatch_async(dispatch_get_main_queue(), ^{
+                                             dispatch_async(completionQueue, ^{
                                                  
                                                  success(JSONResponse);
                                                  
@@ -1850,7 +1852,7 @@ MXAuthAction;
                                                                // Use here the processing queue in order to keep the server response order
                                                                dispatch_async(processingQueue, ^{
                                                                    
-                                                                   dispatch_async(dispatch_get_main_queue(), ^{
+                                                                   dispatch_async(completionQueue, ^{
                                                                        
                                                                        success();
                                                                        
@@ -1896,7 +1898,7 @@ MXAuthAction;
                                          // Use here the processing queue in order to keep the server response order
                                          dispatch_async(processingQueue, ^{
                                              
-                                             dispatch_async(dispatch_get_main_queue(), ^{
+                                             dispatch_async(completionQueue, ^{
                                                  
                                                  success();
                                                  
@@ -1940,7 +1942,7 @@ MXAuthAction;
                                          // Use here the processing queue in order to keep the server response order
                                          dispatch_async(processingQueue, ^{
 
-                                             dispatch_async(dispatch_get_main_queue(), ^{
+                                             dispatch_async(completionQueue, ^{
 
                                                  success();
 
@@ -1977,7 +1979,7 @@ MXAuthAction;
                                              
                                              MXRoomInitialSync *roomInitialSync = [MXRoomInitialSync modelFromJSON:JSONResponse];
                                              
-                                             dispatch_async(dispatch_get_main_queue(), ^{
+                                             dispatch_async(completionQueue, ^{
                                                  
                                                  success(roomInitialSync);
                                                  
@@ -2015,7 +2017,7 @@ MXAuthAction;
 
                                              MXEventContext *eventContext = [MXEventContext modelFromJSON:JSONResponse];
 
-                                             dispatch_async(dispatch_get_main_queue(), ^{
+                                             dispatch_async(completionQueue, ^{
 
                                                  success(eventContext);
 
@@ -2056,7 +2058,7 @@ MXAuthAction;
                                                  [tags addObject:tag];
                                              }
 
-                                             dispatch_async(dispatch_get_main_queue(), ^{
+                                             dispatch_async(completionQueue, ^{
 
                                                  success(tags);
 
@@ -2094,7 +2096,7 @@ MXAuthAction;
                                          // Use here the processing queue in order to keep the server response order
                                          dispatch_async(processingQueue, ^{
 
-                                             dispatch_async(dispatch_get_main_queue(), ^{
+                                             dispatch_async(completionQueue, ^{
 
                                                  success();
 
@@ -2152,7 +2154,7 @@ MXAuthAction;
                                          // Use here the processing queue in order to keep the server response order
                                          dispatch_async(processingQueue, ^{
                                              
-                                             dispatch_async(dispatch_get_main_queue(), ^{
+                                             dispatch_async(completionQueue, ^{
                                                  
                                                  success();
                                                  
@@ -2190,7 +2192,7 @@ MXAuthAction;
                                              
                                              NSDictionary *cleanedJSONResponse = [MXJSONModel removeNullValuesInJSON:JSONResponse];
                                              
-                                             dispatch_async(dispatch_get_main_queue(), ^{
+                                             dispatch_async(completionQueue, ^{
 
                                                  NSString *displayname;
                                                  MXJSONModelSetString(displayname, cleanedJSONResponse[@"displayname"]);
@@ -2225,7 +2227,7 @@ MXAuthAction;
                                          // Use here the processing queue in order to keep the server response order
                                          dispatch_async(processingQueue, ^{
                                              
-                                             dispatch_async(dispatch_get_main_queue(), ^{
+                                             dispatch_async(completionQueue, ^{
                                                  
                                                  success();
                                                  
@@ -2263,7 +2265,7 @@ MXAuthAction;
                                              
                                              NSDictionary *cleanedJSONResponse = [MXJSONModel removeNullValuesInJSON:JSONResponse];
                                              
-                                             dispatch_async(dispatch_get_main_queue(), ^{
+                                             dispatch_async(completionQueue, ^{
                                                  
                                                  NSString *avatarUrl;
                                                  MXJSONModelSetString(avatarUrl, cleanedJSONResponse[@"avatar_url"]);
@@ -2329,7 +2331,7 @@ MXAuthAction;
                                          // Use here the processing queue in order to keep the server response order
                                          dispatch_async(processingQueue, ^{
 
-                                             dispatch_async(dispatch_get_main_queue(), ^{
+                                             dispatch_async(completionQueue, ^{
 
                                                  NSArray<MXThirdPartyIdentifier*> *threePIDs;
                                                  MXJSONModelSetMXJSONModelArray(threePIDs, MXThirdPartyIdentifier, JSONResponse[@"threepids"]);
@@ -2372,7 +2374,7 @@ MXAuthAction;
                                          // Use here the processing queue in order to keep the server response order
                                          dispatch_async(processingQueue, ^{
                                              
-                                             dispatch_async(dispatch_get_main_queue(), ^{
+                                             dispatch_async(completionQueue, ^{
                                                  
                                                  success();
                                                  
@@ -2410,7 +2412,7 @@ MXAuthAction;
                                              
                                              MXPresenceResponse *presence = [MXPresenceResponse modelFromJSON:JSONResponse];
                                              
-                                             dispatch_async(dispatch_get_main_queue(), ^{
+                                             dispatch_async(completionQueue, ^{
                                                  
                                                  success(presence);
                                                  
@@ -2442,7 +2444,7 @@ MXAuthAction;
                                              
                                              MXPresenceResponse *presence = [MXPresenceResponse modelFromJSON:JSONResponse];
                                              
-                                             dispatch_async(dispatch_get_main_queue(), ^{
+                                             dispatch_async(completionQueue, ^{
                                                  
                                                  success(presence);
                                                  
@@ -2477,7 +2479,7 @@ MXAuthAction;
                                          // Use here the processing queue in order to keep the server response order
                                          dispatch_async(processingQueue, ^{
                                              
-                                             dispatch_async(dispatch_get_main_queue(), ^{
+                                             dispatch_async(completionQueue, ^{
                                                  
                                                  success();
                                                  
@@ -2543,7 +2545,7 @@ MXAuthAction;
                                                                    
                                                                    MXSyncResponse *syncResponse = [MXSyncResponse modelFromJSON:JSONResponse];
                                                                    
-                                                                   dispatch_async(dispatch_get_main_queue(), ^{
+                                                                   dispatch_async(completionQueue, ^{
                                                                        
                                                                        success(syncResponse);
                                                                        
@@ -2581,7 +2583,7 @@ MXAuthAction;
                                      // Use here the processing queue in order to keep the server response order
                                      dispatch_async(processingQueue, ^{
                                          
-                                         dispatch_async(dispatch_get_main_queue(), ^{
+                                         dispatch_async(completionQueue, ^{
                                              
                                              success(eventId);
                                              
@@ -2616,7 +2618,7 @@ MXAuthAction;
                                                  NSArray *publicRooms;
                                                  MXJSONModelSetMXJSONModelArray(publicRooms, MXPublicRoom, JSONResponse[@"chunk"]);
 
-                                                 dispatch_async(dispatch_get_main_queue(), ^{
+                                                 dispatch_async(completionQueue, ^{
 
                                                      success(publicRooms);
 
@@ -2650,7 +2652,7 @@ MXAuthAction;
                                          // Use here the processing queue in order to keep the server response order
                                          dispatch_async(processingQueue, ^{
                                              
-                                             dispatch_async(dispatch_get_main_queue(), ^{
+                                             dispatch_async(completionQueue, ^{
 
                                                  NSString *roomId;
                                                  MXJSONModelSetString(roomId, JSONResponse[@"room_id"]);
@@ -2968,7 +2970,7 @@ MXAuthAction;
                                                  // Use here the processing queue in order to keep the server response order
                                                  dispatch_async(processingQueue, ^{
 
-                                                     dispatch_async(dispatch_get_main_queue(), ^{
+                                                     dispatch_async(completionQueue, ^{
 
                                                          success(JSONResponse);
 
@@ -3054,7 +3056,7 @@ MXAuthAction;
                                      // Use here the processing queue in order to keep the server response order
                                      dispatch_async(processingQueue, ^{
 
-                                         dispatch_async(dispatch_get_main_queue(), ^{
+                                         dispatch_async(completionQueue, ^{
 
                                              MXSearchResponse *searchResponse = [MXSearchResponse modelFromJSON:JSONResponse];
 
@@ -3118,7 +3120,7 @@ MXAuthAction;
 
                                         MXKeysUploadResponse *keysUploadResponse =  [MXKeysUploadResponse modelFromJSON:JSONResponse];
 
-                                         dispatch_async(dispatch_get_main_queue(), ^{
+                                         dispatch_async(completionQueue, ^{
 
                                              if (success)
                                              {
@@ -3155,7 +3157,7 @@ MXAuthAction;
 
                                          MXKeysQueryResponse *keysQueryResponse = [MXKeysQueryResponse modelFromJSON:JSONResponse];
 
-                                         dispatch_async(dispatch_get_main_queue(), ^{
+                                         dispatch_async(completionQueue, ^{
 
                                              if (success)
                                              {
@@ -3185,7 +3187,7 @@ MXAuthAction;
 
                                          MXKeysClaimResponse *keysClaimResponse = [MXKeysClaimResponse modelFromJSON:JSONResponse];
 
-                                         dispatch_async(dispatch_get_main_queue(), ^{
+                                         dispatch_async(completionQueue, ^{
 
                                              if (success)
                                              {
@@ -3219,7 +3221,7 @@ MXAuthAction;
                                          // Use here the processing queue in order to keep the server response order
                                          dispatch_async(processingQueue, ^{
 
-                                             dispatch_async(dispatch_get_main_queue(), ^{
+                                             dispatch_async(completionQueue, ^{
 
                                                  success();
 
@@ -3252,7 +3254,7 @@ MXAuthAction;
                                              NSArray<MXDevice *> *devices;
                                              MXJSONModelSetMXJSONModelArray(devices, MXDevice, JSONResponse[@"devices"]);
                                              
-                                             dispatch_async(dispatch_get_main_queue(), ^{
+                                             dispatch_async(completionQueue, ^{
                                                  
                                                  success(devices);
                                                  
@@ -3287,7 +3289,7 @@ MXAuthAction;
                                              MXDevice *device;
                                              MXJSONModelSetMXJSONModel(device, MXDevice, JSONResponse);
                                              
-                                             dispatch_async(dispatch_get_main_queue(), ^{
+                                             dispatch_async(completionQueue, ^{
                                                  
                                                  success(device);
                                                  
@@ -3326,7 +3328,7 @@ MXAuthAction;
                                          // Use here the processing queue in order to keep the server response order
                                          dispatch_async(processingQueue, ^{
                                              
-                                             dispatch_async(dispatch_get_main_queue(), ^{
+                                             dispatch_async(completionQueue, ^{
                                                  
                                                  success();
                                                  

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -321,12 +321,30 @@ MXAuthAction;
                 });
             });
 
-        } failure:failure];
+        } failure:^(NSError *error) {
+            if (failure)
+            {
+                dispatch_async(processingQueue, ^{
+                    dispatch_async(completionQueue, ^{
+                        failure(error);
+                    });
+                });
+            }
+        }];
 
         // Mutate MXHTTPOperation so that the user can cancel this new operation
         [operation mutateTo:operation2];
 
-    } failure:failure];
+    } failure:^(NSError *error) {
+        if (failure)
+        {
+            dispatch_async(processingQueue, ^{
+                dispatch_async(completionQueue, ^{
+                    failure(error);
+                });
+            });
+        }
+    }];
 
     return operation;
 }
@@ -423,7 +441,16 @@ MXAuthAction;
                        });
                    });
                    
-               } failure:failure];
+               } failure:^(NSError *error) {
+                   if (failure)
+                   {
+                       dispatch_async(processingQueue, ^{
+                           dispatch_async(completionQueue, ^{
+                               failure(error);
+                           });
+                       });
+                   }
+               }];
 }
 
 - (NSString*)loginFallback;
@@ -3062,7 +3089,16 @@ MXAuthAction;
 
                                      }
                                  }
-                                 failure:failure];
+                                 failure:^(NSError *error) {
+                                     if (failure)
+                                     {
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
+                                     }
+                                 }];
 }
 
 - (NSString*)urlOfContent:(NSString*)mxcContentURI
@@ -3481,7 +3517,16 @@ MXAuthAction;
                                      });
 
                                  }
-                                 failure:failure];
+                                 failure:^(NSError *error) {
+                                     if (failure)
+                                     {
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
+                                     }
+                                 }];
 }
 
 // Shorcut for calling [self search] without needing to manage top hierarchy parameters
@@ -3541,7 +3586,16 @@ MXAuthAction;
                                          });
                                      });
                                  }
-                                 failure:failure];
+                                 failure:^(NSError *error) {
+                                     if (failure)
+                                     {
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
+                                     }
+                                 }];
 }
 
 - (MXHTTPOperation*)downloadKeysForUsers:(NSArray<NSString*>*)userIds
@@ -3578,7 +3632,16 @@ MXAuthAction;
                                          });
                                      });
                                  }
-                                 failure:failure];
+                                 failure:^(NSError *error) {
+                                     if (failure)
+                                     {
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
+                                     }
+                                 }];
 }
 
 - (MXHTTPOperation *)claimOneTimeKeysForUsersDevices:(MXUsersDevicesMap<NSString *> *)usersDevicesKeyTypesMap success:(void (^)(MXKeysClaimResponse *))success failure:(void (^)(NSError *))failure
@@ -3608,7 +3671,16 @@ MXAuthAction;
                                          });
                                      });
                                  }
-                                 failure:failure];
+                                 failure:^(NSError *error) {
+                                     if (failure)
+                                     {
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
+                                         });
+                                     }
+                                 }];
 }
 
 

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -273,11 +273,15 @@ MXAuthAction;
 {
     if (![loginType isEqualToString:kMXLoginFlowTypePassword] && ![loginType isEqualToString:kMXLoginFlowTypeDummy])
     {
-        dispatch_async(processingQueue, ^{
-            dispatch_async(completionQueue, ^{
-                failure(nil);
+        if (failure)
+        {
+            dispatch_async(processingQueue, ^{
+                dispatch_async(completionQueue, ^{
+                    failure(nil);
+                });
             });
-        });
+
+        }
         return nil;
     }
 
@@ -362,17 +366,20 @@ MXAuthAction;
                                     path:[self authActionPath:MXAuthActionLogin]
                               parameters:nil
                                  success:^(NSDictionary *JSONResponse) {
-                                     
-                                     dispatch_async(processingQueue, ^{
 
-                                         MXAuthenticationSession *authSession = [MXAuthenticationSession modelFromJSON:JSONResponse];
+                                     if (success)
+                                     {
+                                         dispatch_async(processingQueue, ^{
 
-                                         dispatch_async(completionQueue, ^{
+                                             MXAuthenticationSession *authSession = [MXAuthenticationSession modelFromJSON:JSONResponse];
 
-                                             success(authSession);
-                                             
+                                             dispatch_async(completionQueue, ^{
+
+                                                 success(authSession);
+                                                 
+                                             });
                                          });
-                                     });
+                                     }
                                      
                                  }
                                  failure:^(NSError *error) {
@@ -402,11 +409,14 @@ MXAuthAction;
 {
     if (![loginType isEqualToString:kMXLoginFlowTypePassword])
     {
-        dispatch_async(processingQueue, ^{
-            dispatch_async(completionQueue, ^{
-                failure(nil);
+        if (failure)
+        {
+            dispatch_async(processingQueue, ^{
+                dispatch_async(completionQueue, ^{
+                    failure(nil);
+                });
             });
-        });
+        }
         return nil;
     }
 
@@ -470,11 +480,14 @@ MXAuthAction;
     {
         NSError* error = [NSError errorWithDomain:@"Invalid params" code:500 userInfo:nil];
 
-        dispatch_async(processingQueue, ^{
-            dispatch_async(completionQueue, ^{
-                failure(error);
+        if (failure)
+        {
+            dispatch_async(processingQueue, ^{
+                dispatch_async(completionQueue, ^{
+                    failure(error);
+                });
             });
-        });
+        }
 
         return nil;
     }
@@ -483,20 +496,24 @@ MXAuthAction;
                                     path:[NSString stringWithFormat:@"%@/account/password", apiPathPrefix]
                               parameters:parameters
                                  success:^(NSDictionary *JSONResponse) {
-
-                                     dispatch_async(processingQueue, ^{
-                                         dispatch_async(completionQueue, ^{
-                                             success();
+                                     if (success)
+                                     {
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 success();
+                                             });
                                          });
-                                     });
-
+                                     }
                                  }
                                  failure:^(NSError *error) {
-                                     dispatch_async(processingQueue, ^{
-                                         dispatch_async(completionQueue, ^{
-                                             failure(error);
+                                     if (failure)
+                                     {
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
                                          });
-                                     });
+                                     }
                                  }];
 }
 
@@ -508,12 +525,15 @@ MXAuthAction;
     if (!oldPassword || !newPassword)
     {
         NSError* error = [NSError errorWithDomain:@"Invalid params" code:500 userInfo:nil];
-        
-        dispatch_async(processingQueue, ^{
-            dispatch_async(completionQueue, ^{
-                failure(error);
+
+        if (failure)
+        {
+            dispatch_async(processingQueue, ^{
+                dispatch_async(completionQueue, ^{
+                    failure(error);
+                });
             });
-        });
+        }
 
         return nil;
     }
@@ -531,20 +551,24 @@ MXAuthAction;
                                     path:[NSString stringWithFormat:@"%@/account/password", apiPathPrefix]
                               parameters:parameters
                                  success:^(NSDictionary *JSONResponse) {
-
-                                     dispatch_async(processingQueue, ^{
-                                         dispatch_async(completionQueue, ^{
-                                             success();
+                                     if (success)
+                                     {
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 success();
+                                             });
                                          });
-                                     });
-
+                                     }
                                  }
                                  failure:^(NSError *error) {
-                                     dispatch_async(processingQueue, ^{
-                                         dispatch_async(completionQueue, ^{
-                                             failure(error);
+                                     if (failure)
+                                     {
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
                                          });
-                                     });
+                                     }
                                  }];
 }
 
@@ -698,12 +722,15 @@ MXAuthAction;
     if (!pushkey || !kind || !appDisplayName || !deviceDisplayName || !profileTag || !lang || !data)
     {
         NSError* error = [NSError errorWithDomain:@"Invalid params" code:500 userInfo:nil];
-        
-        dispatch_async(processingQueue, ^{
-            dispatch_async(completionQueue, ^{
-                failure(error);
+
+        if (failure)
+        {
+            dispatch_async(processingQueue, ^{
+                dispatch_async(completionQueue, ^{
+                    failure(error);
+                });
             });
-        });
+        }
 
         return nil;
     }
@@ -726,20 +753,24 @@ MXAuthAction;
                                     path:[NSString stringWithFormat:@"%@/pushers/set", apiPathPrefix]
                               parameters:parameters
                                  success:^(NSDictionary *JSONResponse) {
-
-                                     dispatch_async(processingQueue, ^{
-                                         dispatch_async(completionQueue, ^{
-                                             success();
+                                     if (success)
+                                     {
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 success();
+                                             });
                                          });
-                                     });
-
+                                     }
                                  }
                                  failure:^(NSError *error) {
-                                     dispatch_async(processingQueue, ^{
-                                         dispatch_async(completionQueue, ^{
-                                             failure(error);
+                                     if (failure)
+                                     {
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
                                          });
-                                     });
+                                     }
                                  }];
 }
 
@@ -749,24 +780,30 @@ MXAuthAction;
                                     path:[NSString stringWithFormat:@"%@/pushrules/", apiPathPrefix]
                               parameters:nil
                                  success:^(NSDictionary *JSONResponse) {
-                                     @autoreleasepool
+                                     if (success)
                                      {
-                                         dispatch_async(processingQueue, ^{
+                                         @autoreleasepool
+                                         {
+                                             dispatch_async(processingQueue, ^{
 
-                                             MXPushRulesResponse *pushRules = [MXPushRulesResponse modelFromJSON:JSONResponse];
+                                                 MXPushRulesResponse *pushRules = [MXPushRulesResponse modelFromJSON:JSONResponse];
 
-                                             dispatch_async(completionQueue, ^{
-                                                 success(pushRules);
+                                                 dispatch_async(completionQueue, ^{
+                                                     success(pushRules);
+                                                 });
                                              });
-                                         });
+                                         }
                                      }
                                  }
                                  failure:^(NSError *error) {
-                                     dispatch_async(processingQueue, ^{
-                                         dispatch_async(completionQueue, ^{
-                                             failure(error);
+                                     if (failure)
+                                     {
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
                                          });
-                                     });
+                                     }
                                  }];
 }
 
@@ -1202,16 +1239,19 @@ MXAuthAction;
                                     path:path
                               parameters:nil
                                  success:^(NSDictionary *JSONResponse) {
-                                     // Use here the processing queue in order to keep the server response order
-                                     dispatch_async(processingQueue, ^{
+                                     if (success)
+                                     {
+                                         // Use here the processing queue in order to keep the server response order
+                                         dispatch_async(processingQueue, ^{
 
-                                         dispatch_async(completionQueue, ^{
+                                             dispatch_async(completionQueue, ^{
 
-                                             success(JSONResponse);
+                                                 success(JSONResponse);
 
+                                             });
+                                             
                                          });
-                                         
-                                     });
+                                     }
                                  }
                                  failure:^(NSError *error) {
                                      if (failure)
@@ -1245,17 +1285,18 @@ MXAuthAction;
     return [self valueOfStateEvent:kMXEventTypeStringRoomTopic
                             inRoom:roomId
                            success:^(NSDictionary *JSONResponse) {
+                               if (success)
+                               {
+                                   dispatch_async(processingQueue, ^{
 
-                               dispatch_async(processingQueue, ^{
+                                       NSString *topic;
+                                       MXJSONModelSetString(topic, JSONResponse[@"topic"]);
 
-                                   NSString *topic;
-                                   MXJSONModelSetString(topic, JSONResponse[@"topic"]);
-
-                                   dispatch_async(completionQueue, ^{
-                                       success(topic);
+                                       dispatch_async(completionQueue, ^{
+                                           success(topic);
+                                       });
                                    });
-                               });
-
+                               }
                            } failure:failure];
 }
 
@@ -1280,16 +1321,18 @@ MXAuthAction;
     return [self valueOfStateEvent:kMXEventTypeStringRoomAvatar
                             inRoom:roomId
                            success:^(NSDictionary *JSONResponse) {
+                               if (success)
+                               {
+                                   dispatch_async(processingQueue, ^{
 
-                               dispatch_async(processingQueue, ^{
+                                       NSString *url;
+                                       MXJSONModelSetString(url, JSONResponse[@"url"]);
 
-                                   NSString *url;
-                                   MXJSONModelSetString(url, JSONResponse[@"url"]);
-
-                                   dispatch_async(completionQueue, ^{
-                                       success(url);
+                                       dispatch_async(completionQueue, ^{
+                                           success(url);
+                                       });
                                    });
-                               });
+                               }
 
                            } failure:failure];
 }
@@ -1314,16 +1357,18 @@ MXAuthAction;
     return [self valueOfStateEvent:kMXEventTypeStringRoomName
                             inRoom:roomId
                            success:^(NSDictionary *JSONResponse) {
+                               if (success)
+                               {
+                                   dispatch_async(processingQueue, ^{
 
-                               dispatch_async(processingQueue, ^{
+                                       NSString *name;
+                                       MXJSONModelSetString(name, JSONResponse[@"name"]);
 
-                                   NSString *name;
-                                   MXJSONModelSetString(name, JSONResponse[@"name"]);
-
-                                   dispatch_async(completionQueue, ^{
-                                       success(name);
+                                       dispatch_async(completionQueue, ^{
+                                           success(name);
+                                       });
                                    });
-                               });
+                               }
 
                            } failure:failure];
 }
@@ -1348,16 +1393,18 @@ MXAuthAction;
     return [self valueOfStateEvent:kMXEventTypeStringRoomHistoryVisibility
                             inRoom:roomId
                            success:^(NSDictionary *JSONResponse) {
+                               if (success)
+                               {
+                                   dispatch_async(processingQueue, ^{
 
-                               dispatch_async(processingQueue, ^{
+                                       NSString *historyVisibility;
+                                       MXJSONModelSetString(historyVisibility, JSONResponse[@"history_visibility"]);
 
-                                   NSString *historyVisibility;
-                                   MXJSONModelSetString(historyVisibility, JSONResponse[@"history_visibility"]);
-
-                                   dispatch_async(completionQueue, ^{
-                                       success(historyVisibility);
+                                       dispatch_async(completionQueue, ^{
+                                           success(historyVisibility);
+                                       });
                                    });
-                               });
+                               }
 
                            } failure:failure];
 }
@@ -1382,16 +1429,18 @@ MXAuthAction;
     return [self valueOfStateEvent:kMXEventTypeStringRoomJoinRules
                             inRoom:roomId
                            success:^(NSDictionary *JSONResponse) {
+                               if (success)
+                               {
+                                   dispatch_async(processingQueue, ^{
 
-                               dispatch_async(processingQueue, ^{
+                                       MXRoomJoinRule joinRule;
+                                       MXJSONModelSetString(joinRule, JSONResponse[@"join_rule"]);
 
-                                   MXRoomJoinRule joinRule;
-                                   MXJSONModelSetString(joinRule, JSONResponse[@"join_rule"]);
-
-                                   dispatch_async(completionQueue, ^{
-                                       success(joinRule);
+                                       dispatch_async(completionQueue, ^{
+                                           success(joinRule);
+                                       });
                                    });
-                               });
+                               }
 
                            } failure:failure];
 }
@@ -1416,16 +1465,18 @@ MXAuthAction;
     return [self valueOfStateEvent:kMXEventTypeStringRoomGuestAccess
                             inRoom:roomId
                            success:^(NSDictionary *JSONResponse) {
+                               if (success)
+                               {
+                                   dispatch_async(processingQueue, ^{
 
-                               dispatch_async(processingQueue, ^{
+                                       MXRoomGuestAccess guestAccess;
+                                       MXJSONModelSetString(guestAccess, JSONResponse[@"guest_access"]);
 
-                                   MXRoomGuestAccess guestAccess;
-                                   MXJSONModelSetString(guestAccess, JSONResponse[@"guest_access"]);
-
-                                   dispatch_async(completionQueue, ^{
-                                       success(guestAccess);
+                                       dispatch_async(completionQueue, ^{
+                                           success(guestAccess);
+                                       });
                                    });
-                               });
+                               }
 
                            } failure:failure];
 }
@@ -1479,16 +1530,18 @@ MXAuthAction;
                                     path:path
                               parameters:nil
                                  success:^(NSDictionary *JSONResponse) {
-                                 
-                                     dispatch_async(processingQueue, ^{
+                                     if (success)
+                                     {
+                                         dispatch_async(processingQueue, ^{
 
-                                         MXRoomDirectoryVisibility directoryVisibility;
-                                         MXJSONModelSetString(directoryVisibility, JSONResponse[@"visibility"]);
+                                             MXRoomDirectoryVisibility directoryVisibility;
+                                             MXJSONModelSetString(directoryVisibility, JSONResponse[@"visibility"]);
 
-                                         dispatch_async(completionQueue, ^{
-                                             success(directoryVisibility);
+                                             dispatch_async(completionQueue, ^{
+                                                 success(directoryVisibility);
+                                             });
                                          });
-                                     });
+                                     }
                                  }
                                  failure:^(NSError *error) {
                                      if (failure)
@@ -1591,16 +1644,18 @@ MXAuthAction;
     return [self valueOfStateEvent:kMXEventTypeStringRoomCanonicalAlias
                             inRoom:roomId
                            success:^(NSDictionary *JSONResponse) {
-                               
-                               dispatch_async(processingQueue, ^{
+                               if (success)
+                               {
+                                   dispatch_async(processingQueue, ^{
 
-                                   NSString * alias;
-                                   MXJSONModelSetString(alias, JSONResponse[@"alias"]);
+                                       NSString * alias;
+                                       MXJSONModelSetString(alias, JSONResponse[@"alias"]);
 
-                                   dispatch_async(completionQueue, ^{
-                                       success(alias);
+                                       dispatch_async(completionQueue, ^{
+                                           success(alias);
+                                       });
                                    });
-                               });
+                               }
 
                            } failure:failure];
 }
@@ -2944,27 +2999,29 @@ MXAuthAction;
                                     path: [NSString stringWithFormat:@"%@/rooms/%@/receipt/m.read/%@", apiPathPrefix, roomId, eventId]
                               parameters:[[NSDictionary alloc] init]
                                  success:^(NSDictionary *JSONResponse) {
-                                     
-                                     // Use here the processing queue in order to keep the server response order
-                                     dispatch_async(processingQueue, ^{
-                                         
-                                         dispatch_async(completionQueue, ^{
+                                     if (success)
+                                     {
+                                         // Use here the processing queue in order to keep the server response order
+                                         dispatch_async(processingQueue, ^{
                                              
-                                             success(eventId);
+                                             dispatch_async(completionQueue, ^{
+                                                 
+                                                 success(eventId);
+                                                 
+                                             });
                                              
                                          });
-                                         
-                                     });
-                                     
+                                     }
                                  }
                                  failure:^(NSError *error) {
-                                     
-                                     dispatch_async(processingQueue, ^{
-                                         dispatch_async(completionQueue, ^{
-                                             failure(error);
+                                     if (failure)
+                                     {
+                                         dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
+                                                 failure(error);
+                                             });
                                          });
-                                     });
-
+                                     }
                                  }];
     
 }
@@ -3500,22 +3557,23 @@ MXAuthAction;
                                     path: path
                               parameters:parameters
                                  success:^(NSDictionary *JSONResponse) {
+                                     if (success)
+                                     {
+                                         // Use here the processing queue in order to keep the server response order
+                                         dispatch_async(processingQueue, ^{
 
-                                     // Use here the processing queue in order to keep the server response order
-                                     dispatch_async(processingQueue, ^{
+                                             dispatch_async(completionQueue, ^{
 
-                                         dispatch_async(completionQueue, ^{
+                                                 MXSearchResponse *searchResponse = [MXSearchResponse modelFromJSON:JSONResponse];
 
-                                             MXSearchResponse *searchResponse = [MXSearchResponse modelFromJSON:JSONResponse];
+                                                 if (success)
+                                                 {
+                                                     success(searchResponse.searchCategories.roomEvents);
+                                                 }
+                                             });
 
-                                             if (success)
-                                             {
-                                                 success(searchResponse.searchCategories.roomEvents);
-                                             }
                                          });
-
-                                     });
-
+                                     }
                                  }
                                  failure:^(NSError *error) {
                                      if (failure)
@@ -3571,20 +3629,22 @@ MXAuthAction;
                                     path: path
                               parameters:parameters
                                  success:^(NSDictionary *JSONResponse) {
+                                     if (success)
+                                     {
+                                         // Use here the processing queue in order to keep the server response order
+                                         dispatch_async(processingQueue, ^{
 
-                                     // Use here the processing queue in order to keep the server response order
-                                     dispatch_async(processingQueue, ^{
+                                            MXKeysUploadResponse *keysUploadResponse =  [MXKeysUploadResponse modelFromJSON:JSONResponse];
 
-                                        MXKeysUploadResponse *keysUploadResponse =  [MXKeysUploadResponse modelFromJSON:JSONResponse];
+                                             dispatch_async(completionQueue, ^{
 
-                                         dispatch_async(completionQueue, ^{
-
-                                             if (success)
-                                             {
-                                                 success(keysUploadResponse);
-                                             }
+                                                 if (success)
+                                                 {
+                                                     success(keysUploadResponse);
+                                                 }
+                                             });
                                          });
-                                     });
+                                     }
                                  }
                                  failure:^(NSError *error) {
                                      if (failure)
@@ -3618,19 +3678,21 @@ MXAuthAction;
                                     path: path
                               parameters:parameters
                                  success:^(NSDictionary *JSONResponse) {
+                                     if (success)
+                                     {
+                                         dispatch_async(processingQueue, ^{
 
-                                     dispatch_async(processingQueue, ^{
+                                             MXKeysQueryResponse *keysQueryResponse = [MXKeysQueryResponse modelFromJSON:JSONResponse];
 
-                                         MXKeysQueryResponse *keysQueryResponse = [MXKeysQueryResponse modelFromJSON:JSONResponse];
+                                             dispatch_async(completionQueue, ^{
 
-                                         dispatch_async(completionQueue, ^{
-
-                                             if (success)
-                                             {
-                                                 success(keysQueryResponse);
-                                             }
+                                                 if (success)
+                                                 {
+                                                     success(keysQueryResponse);
+                                                 }
+                                             });
                                          });
-                                     });
+                                     }
                                  }
                                  failure:^(NSError *error) {
                                      if (failure)
@@ -3657,19 +3719,21 @@ MXAuthAction;
                                     path: path
                               parameters:parameters
                                  success:^(NSDictionary *JSONResponse) {
+                                     if (success)
+                                     {
+                                         dispatch_async(processingQueue, ^{
 
-                                     dispatch_async(processingQueue, ^{
+                                             MXKeysClaimResponse *keysClaimResponse = [MXKeysClaimResponse modelFromJSON:JSONResponse];
 
-                                         MXKeysClaimResponse *keysClaimResponse = [MXKeysClaimResponse modelFromJSON:JSONResponse];
+                                             dispatch_async(completionQueue, ^{
 
-                                         dispatch_async(completionQueue, ^{
-
-                                             if (success)
-                                             {
-                                                 success(keysClaimResponse);
-                                             }
+                                                 if (success)
+                                                 {
+                                                     success(keysClaimResponse);
+                                                 }
+                                             });
                                          });
-                                     });
+                                     }
                                  }
                                  failure:^(NSError *error) {
                                      if (failure)


### PR DESCRIPTION
in order to make response blocks called from another thread than the main one.

The PR contains also these fixes:
- some apis did not do processing on the processing queue
- some apis did not do sanity checks on optional failure and success blocks