### PR TITLE
Add threading in crypto to avoid blocking UI

### DIFF
--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		3256E3821DCB91EB003C9718 /* MXCryptoConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 3256E3801DCB91EB003C9718 /* MXCryptoConstants.m */; };
 		3259CD531DF860C300186944 /* MXRealmCryptoStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 3259CD511DF860C300186944 /* MXRealmCryptoStore.h */; };
 		3259CD541DF860C300186944 /* MXRealmCryptoStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 3259CD521DF860C300186944 /* MXRealmCryptoStore.m */; };
+		325D1C261DFECE0D0070B8BF /* MXCrypto_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 325D1C251DFECE0D0070B8BF /* MXCrypto_Private.h */; };
 		326056851C76FDF2009D44AD /* MXEventTimeline.h in Headers */ = {isa = PBXBuildFile; fileRef = 326056831C76FDF1009D44AD /* MXEventTimeline.h */; };
 		326056861C76FDF2009D44AD /* MXEventTimeline.m in Sources */ = {isa = PBXBuildFile; fileRef = 326056841C76FDF1009D44AD /* MXEventTimeline.m */; };
 		3264DB911CEC528D00B99881 /* MXAccountData.h in Headers */ = {isa = PBXBuildFile; fileRef = 3264DB8F1CEC528D00B99881 /* MXAccountData.h */; };
@@ -304,6 +305,7 @@
 		3256E3801DCB91EB003C9718 /* MXCryptoConstants.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXCryptoConstants.m; sourceTree = "<group>"; };
 		3259CD511DF860C300186944 /* MXRealmCryptoStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXRealmCryptoStore.h; sourceTree = "<group>"; };
 		3259CD521DF860C300186944 /* MXRealmCryptoStore.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXRealmCryptoStore.m; sourceTree = "<group>"; };
+		325D1C251DFECE0D0070B8BF /* MXCrypto_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXCrypto_Private.h; sourceTree = "<group>"; };
 		326056831C76FDF1009D44AD /* MXEventTimeline.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXEventTimeline.h; sourceTree = "<group>"; };
 		326056841C76FDF1009D44AD /* MXEventTimeline.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXEventTimeline.m; sourceTree = "<group>"; };
 		3264DB8F1CEC528D00B99881 /* MXAccountData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXAccountData.h; sourceTree = "<group>"; };
@@ -567,6 +569,7 @@
 				32A1513B1DAF768D00400192 /* Data */,
 				322A51B41D9AB15900C8536D /* MXCrypto.h */,
 				322A51B51D9AB15900C8536D /* MXCrypto.m */,
+				325D1C251DFECE0D0070B8BF /* MXCrypto_Private.h */,
 				322A51C51D9BBD3C00C8536D /* MXOlmDevice.h */,
 				322A51C61D9BBD3C00C8536D /* MXOlmDevice.m */,
 			);
@@ -978,6 +981,7 @@
 				32481A841C03572900782AD3 /* MXRoomAccountData.h in Headers */,
 				3284A5AE1DB7CFA800A09972 /* MXFileCryptoStoreMetaData.h in Headers */,
 				3281E8B919E42DFE00976E1A /* MXJSONModels.h in Headers */,
+				325D1C261DFECE0D0070B8BF /* MXCrypto_Private.h in Headers */,
 				32A151521DAF8A7200400192 /* MXQueuedEncryption.h in Headers */,
 				323B2AFE1BCE9B6700B11F34 /* MXCoreDataEvent+CoreDataProperties.h in Headers */,
 				3284A5AC1DB7CFA800A09972 /* MXFileCryptoStore.h in Headers */,

--- a/MatrixSDK/Crypto/Algorithms/MXDecrypting.h
+++ b/MatrixSDK/Crypto/Algorithms/MXDecrypting.h
@@ -19,7 +19,7 @@
 #import "MXEvent.h"
 #import "MXDecryptionResult.h"
 
-@class MXSession;
+@class MXCrypto;
 
 
 @protocol MXDecrypting <NSObject>
@@ -27,9 +27,9 @@
 /**
  Constructor.
 
- @param matrixSession the related 'MXSession'.
- */
-- (instancetype)initWithMatrixSession:(MXSession*)matrixSession;
+ @param crypto the related 'MXCrypto'.
+*/
+- (instancetype)initWithCrypto:(MXCrypto*)crypto;
 
 /**
  Decrypt a message.

--- a/MatrixSDK/Crypto/Algorithms/MXEncrypting.h
+++ b/MatrixSDK/Crypto/Algorithms/MXEncrypting.h
@@ -16,7 +16,8 @@
 
 #import <Foundation/Foundation.h>
 
-#import "MXRoom.h"
+#import "MXHTTPOperation.h"
+#import "MXEvent.h"
 #import "MXDeviceInfo.h"
 
 @class MXCrypto;
@@ -36,14 +37,15 @@
 
  @param eventContent the content of the event.
  @param eventType the type of the event.
- @param room the room the event will be sent.
+ @param users the room members the event will be sent to.
 
  @param success A block object called when the operation succeeds.
  @param failure A block object called when the operation fails.
 
  @return a MXHTTPOperation instance. May be nil if all required materials is already in place.
  */
-- (MXHTTPOperation*)encryptEventContent:(NSDictionary*)eventContent eventType:(MXEventTypeString)eventType inRoom:(MXRoom*)room
+- (MXHTTPOperation*)encryptEventContent:(NSDictionary*)eventContent eventType:(MXEventTypeString)eventType
+                               forUsers:(NSArray<NSString*>*)users
                                 success:(void (^)(NSDictionary *encryptedContent))success
                                 failure:(void (^)(NSError *error))failure;
 

--- a/MatrixSDK/Crypto/Algorithms/MXEncrypting.h
+++ b/MatrixSDK/Crypto/Algorithms/MXEncrypting.h
@@ -50,11 +50,11 @@
 /**
  Called when the membership of a member of the room changes.
 
- @param event the event causing the change.
- @param member the user whose membership changed.
+ @param userId the user whose membership changed.
  @param oldMembership the previous membership.
+ @param newMembership the new membership.
  */
-- (void)onRoomMembership:(MXEvent*)event member:(MXRoomMember*)member oldMembership:(MXMembership)oldMembership;
+- (void)onRoomMembership:(NSString*)userId oldMembership:(MXMembership)oldMembership newMembership:(MXMembership)newMembership;
 
 /**
  Called when the verification status of a device changes.

--- a/MatrixSDK/Crypto/Algorithms/MXEncrypting.h
+++ b/MatrixSDK/Crypto/Algorithms/MXEncrypting.h
@@ -16,18 +16,20 @@
 
 #import <Foundation/Foundation.h>
 
-#include "MXRoom.h"
+#import "MXRoom.h"
 #import "MXDeviceInfo.h"
+
+@class MXCrypto;
 
 @protocol MXEncrypting <NSObject>
 
 /**
  Constructor.
 
- @param matrixSession the related 'MXSession'.
+ @param crypto the related 'MXCrypto'.
  @param roomId the id of the room we will be sending to.
  */
-- (instancetype)initWithMatrixSession:(MXSession*)matrixSession andRoom:(NSString*)roomId;
+- (instancetype)initWithCrypto:(MXCrypto*)crypto andRoom:(NSString*)roomId;
 
 /**
  Encrypt an event content according to the configuration of the room.

--- a/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmDecryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmDecryption.m
@@ -75,7 +75,11 @@
     if (result)
     {
         MXEvent *clearedEvent = [MXEvent modelFromJSON:result.payload];
-        [event setClearData:clearedEvent keysProved:result.keysProved keysClaimed:result.keysClaimed];
+
+        // @TODO
+        //dispatch_async(dispatch_get_main_queue(), ^{
+            [event setClearData:clearedEvent keysProved:result.keysProved keysClaimed:result.keysClaimed];
+        //});
     }
     else
     {

--- a/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmDecryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmDecryption.m
@@ -19,7 +19,6 @@
 #ifdef MX_CRYPTO
 
 #import "MXCryptoAlgorithms.h"
-#import "MXSession.h"
 #import "MXCrypto_Private.h"
 
 @interface MXMegolmDecryption ()
@@ -43,12 +42,12 @@
 }
 
 #pragma mark - MXDecrypting
-- (instancetype)initWithMatrixSession:(MXSession *)matrixSession
+- (instancetype)initWithCrypto:(MXCrypto *)crypto
 {
     self = [super init];
     if (self)
     {
-        olmDevice = matrixSession.crypto.olmDevice;
+        olmDevice = crypto.olmDevice;
         pendingEvents = [NSMutableDictionary dictionary];
     }
     return self;

--- a/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmDecryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmDecryption.m
@@ -20,6 +20,7 @@
 
 #import "MXCryptoAlgorithms.h"
 #import "MXSession.h"
+#import "MXCrypto_Private.h"
 
 @interface MXMegolmDecryption ()
 {

--- a/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmEncryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmEncryption.m
@@ -136,18 +136,15 @@
     }];
 }
 
-- (void)onRoomMembership:(MXEvent *)event member:(MXRoomMember *)member oldMembership:(MXMembership)oldMembership
+- (void)onRoomMembership:(NSString*)userId oldMembership:(MXMembership)oldMembership newMembership:(MXMembership)newMembership;
 {
-
-    MXMembership newMembership = member.membership;
-
     if (newMembership == MXMembershipJoin || newMembership == MXMembershipInvite)
     {
         return;
     }
 
     // Otherwise we assume the user is leaving, and start a new outbound session.
-    NSLog(@"[MXMegolmEncryption] Discarding outbound megolm session in %@ due to change in membership of %@ (%tu -> %tu)", roomId, member.userId, oldMembership, newMembership);
+    NSLog(@"[MXMegolmEncryption] Discarding outbound megolm session in %@ due to change in membership of %@ (%tu -> %tu)", roomId, userId, oldMembership, newMembership);
 
     // This ensures that we will start a new session on the next message.
     outboundSession = nil;

--- a/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmEncryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmEncryption.m
@@ -21,7 +21,6 @@
 #import "MXMegolmEncryption.h"
 
 #import "MXCryptoAlgorithms.h"
-#import "MXSession.h"
 #import "MXCrypto_Private.h"
 #import "MXQueuedEncryption.h"
 
@@ -60,7 +59,6 @@
 
 @interface MXMegolmEncryption ()
 {
-    MXSession *mxSession;
     MXCrypto *crypto;
 
     // The id of the room we will be sending to.
@@ -93,13 +91,12 @@
 
 
 #pragma mark - MXEncrypting
-- (instancetype)initWithMatrixSession:(MXSession *)matrixSession andRoom:(NSString *)theRoomId
+- (instancetype)initWithCrypto:(MXCrypto *)theCrypto andRoom:(NSString *)theRoomId
 {
     self = [super init];
     if (self)
     {
-        mxSession = matrixSession;
-        crypto = matrixSession.crypto;
+        crypto = theCrypto;
         roomId = theRoomId;
         deviceId = crypto.store.deviceId;
 
@@ -343,7 +340,7 @@
         {
             NSLog(@"[MXMegolEncryption] shareKey. Actually share with %@", contentMap);
 
-            MXHTTPOperation *operation2 = [mxSession.matrixRestClient sendToDevice:kMXEventTypeStringRoomEncrypted contentMap:contentMap success:^{
+            MXHTTPOperation *operation2 = [crypto.matrixRestClient sendToDevice:kMXEventTypeStringRoomEncrypted contentMap:contentMap success:^{
 
                 // Add the devices we have shared with to session.sharedWithDevices.
                 //

--- a/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmEncryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmEncryption.m
@@ -110,9 +110,10 @@
     return self;
 }
 
-- (MXHTTPOperation *)encryptEventContent:(NSDictionary *)eventContent eventType:(MXEventTypeString)eventType inRoom:(MXRoom *)room
-                                 success:(void (^)(NSDictionary *))success
-                                 failure:(void (^)(NSError *))failure
+- (MXHTTPOperation*)encryptEventContent:(NSDictionary*)eventContent eventType:(MXEventTypeString)eventType
+                               forUsers:(NSArray<NSString*>*)users
+                                success:(void (^)(NSDictionary *encryptedContent))success
+                                failure:(void (^)(NSError *error))failure
 {
     // Queue the encryption request
     // It will be processed when everything is set up
@@ -125,7 +126,7 @@
 
     NSDate *startDate = [NSDate date];
 
-    return [self ensureOutboundSessionInRoom:room success:^(MXOutboundSessionInfo *session) {
+    return [self ensureOutboundSessionWithUsers:users success:^(MXOutboundSessionInfo *session) {
 
         NSLog(@"[MXMegolmEncryption] ensureOutboundSessionInRoom took %.0fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
         
@@ -173,16 +174,16 @@
  * @return {module:client.Promise} Promise which resolves to the megolm
  *   sessionId when setup is complete.
  */
-- (MXHTTPOperation *)ensureOutboundSessionInRoom:(MXRoom*)room
-                                         success:(void (^)(MXOutboundSessionInfo *session))success
-                                         failure:(void (^)(NSError *))failure
+- (MXHTTPOperation *)ensureOutboundSessionWithUsers:(NSArray<NSString*>*)users
+                                            success:(void (^)(MXOutboundSessionInfo *session))success
+                                            failure:(void (^)(NSError *))failure
 {
     MXOutboundSessionInfo *session = outboundSession;
 
     // Need to make a brand new session?
     if (!session || [session needsRotation:sessionRotationPeriodMsgs rotationPeriodMs:sessionRotationPeriodMs])
     {
-        outboundSession = session = [self prepareNewSessionInRoom:room];
+        outboundSession = session = [self prepareNewSession];
    }
 
     if (session.shareOperation)
@@ -192,7 +193,13 @@
     }
 
     // No share in progress: check if we need to share with any devices
-    session.shareOperation = [self devicesInRoom:room success:^(MXUsersDevicesMap<MXDeviceInfo *> *devicesInRoom) {
+
+    // Get all keys of all users devices
+    // We are happy to use a cached version here: we assume that if we already
+    // have a list of the user's devices, then we already share an e2e room
+    // with them, which means that they will have announced any new devices via
+    // an m.new_device.
+    session.shareOperation = [crypto downloadKeys:users forceDownload:NO success:^(MXUsersDevicesMap<MXDeviceInfo *> *devicesInRoom) {
 
         NSMutableDictionary<NSString* /* userId */, NSMutableArray<MXDeviceInfo*>*> *shareMap = [NSMutableDictionary dictionary];
 
@@ -252,7 +259,7 @@
     return session.shareOperation;
 }
 
-- (MXOutboundSessionInfo*)prepareNewSessionInRoom:(MXRoom*)room
+- (MXOutboundSessionInfo*)prepareNewSession
 {
     NSString *sessionId = [crypto.olmDevice createOutboundGroupSession];
 
@@ -410,27 +417,6 @@
     }
 
     [pendingEncryptions removeAllObjects];
-}
-
-/**
- Get the list of devices for all users in the room.
- */
-- (MXHTTPOperation*)devicesInRoom:(MXRoom*)room
-                          success:(void (^)(MXUsersDevicesMap<MXDeviceInfo*> *usersDevicesInfoMap))success
-                          failure:(void (^)(NSError *error))failure
-{
-    // XXX what about rooms where invitees can see the content?
-    NSMutableArray *roomMembers = [NSMutableArray array];
-    for (MXRoomMember *roomMember in room.state.joinedMembers)
-    {
-        [roomMembers addObject:roomMember.userId];
-    }
-
-    // We are happy to use a cached version here: we assume that if we already
-    // have a list of the user's devices, then we already share an e2e room
-    // with them, which means that they will have announced any new devices via
-    // an m.new_device.
-    return [crypto downloadKeys:roomMembers forceDownload:NO success:success failure:failure];
 }
 
 @end

--- a/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmEncryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmEncryption.m
@@ -22,6 +22,7 @@
 
 #import "MXCryptoAlgorithms.h"
 #import "MXSession.h"
+#import "MXCrypto_Private.h"
 #import "MXQueuedEncryption.h"
 
 @interface MXOutboundSessionInfo : NSObject

--- a/MatrixSDK/Crypto/Algorithms/Olm/MXOlmDecryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Olm/MXOlmDecryption.m
@@ -19,7 +19,6 @@
 #ifdef MX_CRYPTO
 
 #import "MXCryptoAlgorithms.h"
-#import "MXSession.h"
 #import "MXCrypto_Private.h"
 
 @interface MXOlmDecryption ()
@@ -43,13 +42,13 @@
 
 
 #pragma mark - MXDecrypting
-- (instancetype)initWithMatrixSession:(MXSession *)matrixSession
+- (instancetype)initWithCrypto:(MXCrypto *)crypto
 {
     self = [super init];
     if (self)
     {
-        olmDevice = matrixSession.crypto.olmDevice;
-        userId = matrixSession.myUser.userId;
+        olmDevice = crypto.olmDevice;
+        userId = crypto.matrixRestClient.credentials.userId;
     }
     return self;
 }

--- a/MatrixSDK/Crypto/Algorithms/Olm/MXOlmDecryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Olm/MXOlmDecryption.m
@@ -20,6 +20,7 @@
 
 #import "MXCryptoAlgorithms.h"
 #import "MXSession.h"
+#import "MXCrypto_Private.h"
 
 @interface MXOlmDecryption ()
 {

--- a/MatrixSDK/Crypto/Algorithms/Olm/MXOlmDecryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Olm/MXOlmDecryption.m
@@ -190,11 +190,15 @@
     }
 
     MXEvent *clearedEvent = [MXEvent modelFromJSON:payload];
-    [event setClearData:clearedEvent
-             keysProved:@{
-                          @"curve25519": deviceKey
-                          }
-            keysClaimed:payload[@"keys"]];
+
+    // @TODO
+    //dispatch_async(dispatch_get_main_queue(), ^{
+        [event setClearData:clearedEvent
+                 keysProved:@{
+                              @"curve25519": deviceKey
+                              }
+                keysClaimed:payload[@"keys"]];
+    //});
 
     return YES;
 }

--- a/MatrixSDK/Crypto/Algorithms/Olm/MXOlmEncryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Olm/MXOlmEncryption.m
@@ -17,7 +17,6 @@
 #import "MXOlmEncryption.h"
 
 #import "MXCryptoAlgorithms.h"
-#import "MXSession.h"
 #import "MXCrypto_Private.h"
 
 #ifdef MX_CRYPTO
@@ -43,12 +42,12 @@
 
 
 #pragma mark - MXEncrypting
-- (instancetype)initWithMatrixSession:(MXSession *)matrixSession andRoom:(NSString *)theRoomId
+- (instancetype)initWithCrypto:(MXCrypto *)theCrypto andRoom:(NSString *)theRoomId
 {
     self = [super init];
     if (self)
     {
-        crypto = matrixSession.crypto;
+        crypto = theCrypto;
         roomId = theRoomId;
     }
     return self;

--- a/MatrixSDK/Crypto/Algorithms/Olm/MXOlmEncryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Olm/MXOlmEncryption.m
@@ -104,7 +104,7 @@
     } failure:failure];
 }
 
-- (void)onRoomMembership:(MXEvent *)event member:(MXRoomMember *)member oldMembership:(MXMembership)oldMembership
+- (void)onRoomMembership:(NSString*)userId oldMembership:(MXMembership)oldMembership newMembership:(MXMembership)newMembership;
 {
     // No impact for olm
 }

--- a/MatrixSDK/Crypto/Algorithms/Olm/MXOlmEncryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Olm/MXOlmEncryption.m
@@ -18,6 +18,7 @@
 
 #import "MXCryptoAlgorithms.h"
 #import "MXSession.h"
+#import "MXCrypto_Private.h"
 
 #ifdef MX_CRYPTO
 

--- a/MatrixSDK/Crypto/Algorithms/Olm/MXOlmEncryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Olm/MXOlmEncryption.m
@@ -53,21 +53,11 @@
     return self;
 }
 
-- (MXHTTPOperation *)encryptEventContent:(NSDictionary *)eventContent eventType:(MXEventTypeString)eventType inRoom:(MXRoom *)room
-                                 success:(void (^)(NSDictionary *))success
-                                 failure:(void (^)(NSError *))failure
+- (MXHTTPOperation*)encryptEventContent:(NSDictionary*)eventContent eventType:(MXEventTypeString)eventType
+                               forUsers:(NSArray<NSString*>*)users
+                                success:(void (^)(NSDictionary *encryptedContent))success
+                                failure:(void (^)(NSError *error))failure
 {
-    // pick the list of recipients based on the membership list.
-    //
-    // TODO: there is a race condition here! What if a new user turns up
-    // just as you are sending a secret message?
-
-    NSMutableArray <NSString*> *users = [NSMutableArray array];
-    for (MXRoomMember *member in room.state.joinedMembers)
-    {
-        [users addObject:member.userId];
-    }
-
     return [self ensureSession:users success:^{
 
         NSMutableArray *participantDevices = [NSMutableArray array];
@@ -94,7 +84,7 @@
         }
 
         NSDictionary *encryptedMessage = [crypto encryptMessage:@{
-                                                                  @"room_id": room.roomId,
+                                                                  @"room_id": roomId,
                                                                   @"type": eventType,
                                                                   @"content": eventContent
                                                                   }

--- a/MatrixSDK/Crypto/MXCrypto.h
+++ b/MatrixSDK/Crypto/MXCrypto.h
@@ -139,6 +139,20 @@
                       failure:(void (^)(NSError *error))failure;
 
 /**
+ Download the device keys for a list of users and stores them into the crypto store.
+
+ @param userIds The users to fetch.
+
+ @param success A block object called when the operation succeeds.
+ @param failure A block object called when the operation fails.
+
+ @return a MXHTTPOperation instance. May be nil if the data is already in the store.
+ */
+- (MXHTTPOperation*)downloadKeys:(NSArray<NSString*>*)userIds
+                        success:(void (^)(MXUsersDevicesMap<MXDeviceInfo*> *usersDevicesInfoMap))success
+                        failure:(void (^)(NSError *error))failure;
+
+/**
  Reset replay attack data for the given timeline.
 
  @param the id of the timeline.
@@ -151,11 +165,6 @@
  @param credentials the credentials of the account.
  */
 + (void)deleteStoreWithCredentials:(MXCredentials*)credentials;
-
-
-- (MXHTTPOperation*)downloadKeys:(NSArray<NSString*>*)userIds forceDownload:(BOOL)forceDownload
-                         success:(void (^)(MXUsersDevicesMap<MXDeviceInfo*> *usersDevicesInfoMap))success
-                         failure:(void (^)(NSError *error))failure;
 
 @end
 

--- a/MatrixSDK/Crypto/MXCrypto.h
+++ b/MatrixSDK/Crypto/MXCrypto.h
@@ -20,9 +20,6 @@
 
 #import "MXDeviceInfo.h"
 
-#ifdef MX_CRYPTO
-
-#import "MXCryptoStore.h"
 #import "MXRestClient.h"
 
 @class MXSession;
@@ -55,13 +52,20 @@
 @property (nonatomic, readonly) NSString *olmVersion;
 
 /**
- Create the `MXCrypto` instance.
-
- @param mxSession the mxSession to the home server.
- @param store the storage module for crypto data.
- @return the newly created MXCrypto instance.
+ Create a new crypto instance and data for the given user.
+ 
+ @param mxSession the session on which to enable crypto.
+ @return the fresh crypto instance.
  */
-- (instancetype)initWithMatrixSession:(MXSession*)mxSession andStore:(id<MXCryptoStore>)store;
++ (MXCrypto *)createCryptoWithMatrixSession:(MXSession*)mxSession;
+
+/**
+ Check if the user has previously enabled crypto.
+ If yes, init the crypto module.
+
+ @param complete a block called in any case when the operation completes.
+ */
++ (void)checkCryptoWithMatrixSession:(MXSession*)mxSession complete:(void (^)(MXCrypto *crypto))complete;
 
 /**
  Start the crypto module.
@@ -139,12 +143,13 @@
  */
 - (void)resetReplayAttackCheckInTimeline:(NSString*)timeline;
 
+/**
+ Delete the crypto store for the passed credentials.
+
+ @param credentials the credentials of the account.
+ */
++ (void)deleteStoreWithCredentials:(MXCredentials*)credentials;
+
 @end
 
-#else
-
-@interface MXCrypto : NSObject
-@end
-
-#endif
 

--- a/MatrixSDK/Crypto/MXCrypto.h
+++ b/MatrixSDK/Crypto/MXCrypto.h
@@ -24,10 +24,6 @@
 
 #import "MXCryptoStore.h"
 #import "MXRestClient.h"
-#import "MXOlmDevice.h"
-#import "MXCryptoAlgorithms.h"
-#import "MXUsersDevicesMap.h"
-#import "MXOlmSessionResult.h"
 
 @class MXSession;
 
@@ -42,6 +38,21 @@
  Specially, it tracks all room membership changes events in order to do keys updates.
  */
 @interface MXCrypto : NSObject
+
+/**
+ Curve25519 key for the account.
+ */
+@property (nonatomic, readonly) NSString *deviceCurve25519Key;
+
+/**
+ Ed25519 key for the account.
+ */
+@property (nonatomic, readonly) NSString *deviceEd25519Key;
+
+/**
+ The olm library version.
+ */
+@property (nonatomic, readonly) NSString *olmVersion;
 
 /**
  Create the `MXCrypto` instance.
@@ -73,56 +84,38 @@
 - (void)close;
 
 /**
- The store for crypto data.
- */
-@property (nonatomic, readonly) id<MXCryptoStore> store;
-
-/**
-  The libolm wrapper.
- */
-@property (nonatomic, readonly) MXOlmDevice *olmDevice;
-
-/**
- Upload the device keys to the homeserver and ensure that the
- homeserver has enough one-time keys.
-
- @param maxKeys The maximum number of keys to generate.
+ Encrypt an event content according to the configuration of the room.
  
+ @param eventContent the content of the event.
+ @param eventType the type of the event.
+ @param room the room the event will be sent.
+ *
  @param success A block object called when the operation succeeds.
  @param failure A block object called when the operation fails.
 
- @return a MXHTTPOperation instance.
+ @return a MXHTTPOperation instance. May be nil if all required materials is already in place.
  */
-- (MXHTTPOperation*)uploadKeys:(NSUInteger)maxKeys
-                       success:(void (^)())success
-                       failure:(void (^)(NSError *))failure;
+- (MXHTTPOperation*)encryptEventContent:(NSDictionary*)eventContent withType:(MXEventTypeString)eventType inRoom:(MXRoom*)room
+                                success:(void (^)(NSDictionary *encryptedContent, NSString *encryptedEventType))success
+                                failure:(void (^)(NSError *error))failure;
 
 /**
- Download the device keys for a list of users and stores the keys in the MXStore.
-
- @param userIds The users to fetch.
- @param forceDownload Always download the keys even if cached.
+ Decrypt a received event.
  
- @param success A block object called when the operation succeeds.
- @param failure A block object called when the operation fails.
+ In case of success, the event is updated with clear data.
+ In case of failure, event.decryptionError contains the error.
+
+ @param event the raw event.
+ @param timeline the id of the timeline where the event is decrypted. It is used
+                 to prevent replay attack.
  
- @return a MXHTTPOperation instance. May be nil if the data is already in the store.
+ @return YES if the decryption was successful.
  */
-- (MXHTTPOperation*)downloadKeys:(NSArray<NSString*>*)userIds forceDownload:(BOOL)forceDownload
-                         success:(void (^)(MXUsersDevicesMap<MXDeviceInfo*> *usersDevicesInfoMap))success
-                         failure:(void (^)(NSError *error))failure;
-
-/**
- Get the stored device keys for a user.
-
- @param userId the user to list keys for.
- @return the list of devices.
- */
-- (NSArray<MXDeviceInfo*>*)storedDevicesForUser:(NSString*)userId;
+- (BOOL)decryptEvent:(MXEvent*)event inTimeline:(NSString*)timeline;
 
 /**
  Find a device by curve25519 identity key
- 
+
  @param userId the owner of the device.
  @param algorithm the encryption algorithm.
  @param senderKey the curve25519 key to match.
@@ -140,87 +133,11 @@
 - (void)setDeviceVerification:(MXDeviceVerification)verificationStatus forDevice:(NSString*)deviceId ofUser:(NSString*)userId;
 
 /**
- Get the device which sent an event.
+ Reset replay attack data for the given timeline.
 
- @param event the event to be checked.
- @return device info.
+ @param the id of the timeline.
  */
-- (MXDeviceInfo*)eventSenderDeviceOfEvent:(MXEvent*)event;
-
-/**
- Configure a room to use encryption.
-
- @param roomId the room id to enable encryption in.
- @param algorithm the encryption config for the room.
- @return YES if the operation succeeds.
- */
-- (BOOL)setEncryptionInRoom:(NSString*)roomId withAlgorithm:(NSString*)algorithm;
-
-/**
- Try to make sure we have established olm sessions for the given users.
-
- @param users a list of user ids.
-
- @param success A block object called when the operation succeeds.
- @param failure A block object called when the operation fails.
-
- @return a MXHTTPOperation instance. May be nil if the data is already in the store.
- */
-- (MXHTTPOperation*)ensureOlmSessionsForUsers:(NSArray*)users
-                                      success:(void (^)(MXUsersDevicesMap<MXOlmSessionResult*> *results))success
-                                      failure:(void (^)(NSError *error))failure;
-
-/**
- Try to make sure we have established olm sessions for the given devices.
-
- @param devicesByUser a map from userid to list of devices.
-
- @param success A block object called when the operation succeeds.
- @param failure A block object called when the operation fails.
- */
-- (MXHTTPOperation*)ensureOlmSessionsForDevices:(NSDictionary<NSString* /* userId */, NSArray<MXDeviceInfo*>*>*)devicesByUser
-                                      success:(void (^)(MXUsersDevicesMap<MXOlmSessionResult*> *results))success
-                                      failure:(void (^)(NSError *error))failure;
-
-/**
- Encrypt an event content according to the configuration of the room.
- 
- @param eventContent the content of the event.
- @param eventType the type of the event.
- @param room the room the event will be sent.
- *
- @param success A block object called when the operation succeeds.
- @param failure A block object called when the operation fails.
-
- @return a MXHTTPOperation instance. May be nil if all required materials is already in place.
- */
-- (MXHTTPOperation*)encryptEventContent:(NSDictionary*)eventContent withType:(MXEventTypeString)eventType inRoom:(MXRoom*)room
-                                success:(void (^)(NSDictionary *encryptedContent, NSString *encryptedEventType))success
-                                failure:(void (^)(NSError *error))failure;
-
-/**
- Encrypt an event payload for a list of devices.
-
- @param payloadFields fields to include in the encrypted payload.
- @param deviceInfos the list of the recipient devices.
-
- @return the content for an m.room.encrypted event.
- */
-- (NSDictionary*)encryptMessage:(NSDictionary*)payloadFields forDevices:(NSArray<MXDeviceInfo*>*)devices;
-
-/**
- Decrypt a received event.
- 
- In case of success, the event is updated with clear data.
- In case of failure, event.decryptionError contains the error.
-
- @param event the raw event.
- @param timeline the id of the timeline where the event is decrypted. It is used
-                 to prevent replay attack.
- 
- @return YES if the decryption was successful.
- */
-- (BOOL)decryptEvent:(MXEvent*)event inTimeline:(NSString*)timeline;
+- (void)resetReplayAttackCheckInTimeline:(NSString*)timeline;
 
 @end
 

--- a/MatrixSDK/Crypto/MXCrypto.h
+++ b/MatrixSDK/Crypto/MXCrypto.h
@@ -128,6 +128,14 @@
 - (MXDeviceInfo*)deviceWithIdentityKey:(NSString*)senderKey forUser:(NSString*)userId andAlgorithm:(NSString*)algorithm;
 
 /**
+ Get the stored device keys for a user.
+
+ @param userId the user to list keys for.
+ @param complete a block called with the list of devices.
+ */
+- (void)devicesForUser:(NSString*)userId complete:(void (^)(NSArray<MXDeviceInfo*> *devices))complete;
+
+/**
  Update the blocked/verified state of the given device
 
  @param verificationStatus the new verification status.

--- a/MatrixSDK/Crypto/MXCrypto.h
+++ b/MatrixSDK/Crypto/MXCrypto.h
@@ -134,7 +134,9 @@
  @param deviceId the unique identifier for the device.
  @param userId the owner of the device.
  */
-- (void)setDeviceVerification:(MXDeviceVerification)verificationStatus forDevice:(NSString*)deviceId ofUser:(NSString*)userId;
+- (void)setDeviceVerification:(MXDeviceVerification)verificationStatus forDevice:(NSString*)deviceId ofUser:(NSString*)userId
+                      success:(void (^)())success
+                      failure:(void (^)(NSError *error))failure;
 
 /**
  Reset replay attack data for the given timeline.
@@ -149,6 +151,11 @@
  @param credentials the credentials of the account.
  */
 + (void)deleteStoreWithCredentials:(MXCredentials*)credentials;
+
+
+- (MXHTTPOperation*)downloadKeys:(NSArray<NSString*>*)userIds forceDownload:(BOOL)forceDownload
+                         success:(void (^)(MXUsersDevicesMap<MXDeviceInfo*> *usersDevicesInfoMap))success
+                         failure:(void (^)(NSError *error))failure;
 
 @end
 

--- a/MatrixSDK/Crypto/MXCrypto.h
+++ b/MatrixSDK/Crypto/MXCrypto.h
@@ -118,14 +118,12 @@
 - (BOOL)decryptEvent:(MXEvent*)event inTimeline:(NSString*)timeline;
 
 /**
- Find a device by curve25519 identity key
+ Return the device information for an encrypted event.
 
- @param userId the owner of the device.
- @param algorithm the encryption algorithm.
- @param senderKey the curve25519 key to match.
- @return the device info.
+ @param event The event.
+ @return the device if any.
  */
-- (MXDeviceInfo*)deviceWithIdentityKey:(NSString*)senderKey forUser:(NSString*)userId andAlgorithm:(NSString*)algorithm;
+- (MXDeviceInfo *)eventDeviceInfo:(MXEvent*)event;
 
 /**
  Get the stored device keys for a user.

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -404,8 +404,9 @@
 
         _olmDevice = [[MXOlmDevice alloc] initWithStore:_store];
 
-        // Use our own rest client that answers on the crypto thread
+        // Use our own REST client that answers on the crypto thread
         _matrixRestClient = [[MXRestClient alloc] initWithCredentials:mxSession.matrixRestClient.credentials andOnUnrecognizedCertificateBlock:nil];
+        _matrixRestClient.completionQueue = cryptoQueue;
 
         roomEncryptors = [NSMutableDictionary dictionary];
         roomDecryptors = [NSMutableDictionary dictionary];

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -250,8 +250,20 @@
 {
 #ifdef MX_CRYPTO
 
-    // Create an empty operation that will be mutated later 
+    // Create an empty operation that will be mutated later
     MXHTTPOperation *operation = [[MXHTTPOperation alloc] init];
+
+    // Pick the list of recipients based on the membership list.
+
+    // TODO: there is a race condition here! What if a new user turns up
+    // just as you are sending a secret message?
+
+    // XXX what about rooms where invitees can see the content?
+    NSMutableArray *roomMembers = [NSMutableArray array];
+    for (MXRoomMember *roomMember in room.state.joinedMembers)
+    {
+        [roomMembers addObject:roomMember.userId];
+    }
 
     dispatch_async(_cryptoQueue, ^{
 
@@ -282,7 +294,7 @@
             NSLog(@"[MXCrypto] encryptEventContent with %@: %@", algorithm, eventContent);
 #endif
 
-            MXHTTPOperation *operation2 =  [alg encryptEventContent:eventContent eventType:eventType inRoom:room success:^(NSDictionary *encryptedContent) {
+            MXHTTPOperation *operation2 = [alg encryptEventContent:eventContent eventType:eventType forUsers:roomMembers success:^(NSDictionary *encryptedContent) {
 
                 dispatch_async(dispatch_get_main_queue(), ^{
                     success(encryptedContent, kMXEventTypeStringRoomEncrypted);

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -329,7 +329,7 @@
     __block BOOL result = NO;
 
     // @TODO: dispatch_ssync
-    dispatch_sync(_cryptoQueue, ^{
+    dispatch_sync(_cryptoLessBusyQueue, ^{
         id<MXDecrypting> alg = [self getRoomDecryptor:event.roomId algorithm:event.content[@"algorithm"]];
         if (!alg)
         {
@@ -363,7 +363,7 @@
 - (void)resetReplayAttackCheckInTimeline:(NSString*)timeline
 {
 #ifdef MX_CRYPTO
-    dispatch_async(_cryptoQueue, ^{
+    dispatch_async(_cryptoLessBusyQueue, ^{
         [_olmDevice resetReplayAttackCheckInTimeline:timeline];
     });
 #else
@@ -411,6 +411,8 @@
         mxSession = matrixSession;
         _cryptoQueue = theCryptoQueue;
         _store = store;
+
+        _cryptoLessBusyQueue = dispatch_queue_create("MXCryptoLessBusy", DISPATCH_QUEUE_SERIAL);
 
         _olmDevice = [[MXOlmDevice alloc] initWithStore:_store];
 

--- a/MatrixSDK/Crypto/MXCrypto_Private.h
+++ b/MatrixSDK/Crypto/MXCrypto_Private.h
@@ -52,9 +52,18 @@
 @property (nonatomic, readonly) MXRestClient *matrixRestClient;
 
 /**
- The queue used for all crypto processing.
+ The queue used for almost all crypto processing.
  */
 @property (nonatomic, readonly) dispatch_queue_t cryptoQueue;
+
+/**
+ A less busy queue that can respond quicker to the UI.
+ 
+ The best example is the event decryption.
+ Encrypting an event is a long task (like 20s). We do not want the UI to wait the end of
+ the encryption before being able to decrypt and display other messages of the room history.
+ */
+@property (nonatomic, readonly) dispatch_queue_t cryptoLessBusyQueue;
 
 /**
  Upload the device keys to the homeserver and ensure that the
@@ -82,9 +91,9 @@
  
  @return a MXHTTPOperation instance. May be nil if the data is already in the store.
  */
-- (MXHTTPOperation*)downloadKeys:(NSArray<NSString*>*)userIds forceDownload:(BOOL)forceDownload
-                         success:(void (^)(MXUsersDevicesMap<MXDeviceInfo*> *usersDevicesInfoMap))success
-                         failure:(void (^)(NSError *error))failure;
+//- (MXHTTPOperation*)downloadKeys:(NSArray<NSString*>*)userIds forceDownload:(BOOL)forceDownload
+//                         success:(void (^)(MXUsersDevicesMap<MXDeviceInfo*> *usersDevicesInfoMap))success
+//                         failure:(void (^)(NSError *error))failure;
 
 /**
  Get the stored device keys for a user.

--- a/MatrixSDK/Crypto/MXCrypto_Private.h
+++ b/MatrixSDK/Crypto/MXCrypto_Private.h
@@ -52,15 +52,6 @@
 @property (nonatomic, readonly) MXRestClient *matrixRestClient;
 
 /**
- Create the `MXCrypto` instance.
-
- @param mxSession the mxSession to the home server.
- @param store the storage module for crypto data.
- @return the newly created MXCrypto instance.
- */
-- (instancetype)initWithMatrixSession:(MXSession*)mxSession andStore:(id<MXCryptoStore>)store;
-
-/**
  Upload the device keys to the homeserver and ensure that the
  homeserver has enough one-time keys.
 

--- a/MatrixSDK/Crypto/MXCrypto_Private.h
+++ b/MatrixSDK/Crypto/MXCrypto_Private.h
@@ -57,13 +57,18 @@
 @property (nonatomic, readonly) dispatch_queue_t cryptoQueue;
 
 /**
+ The queue used for decryption.
+
  A less busy queue that can respond quicker to the UI.
+
+ Encrypting the 1st event in a room is a long task (like 20s). We do not want the UI to
+ wait the end of the encryption before being able to decrypt and display other messages
+ of the room history.
  
- The best example is the event decryption.
- Encrypting an event is a long task (like 20s). We do not want the UI to wait the end of
- the encryption before being able to decrypt and display other messages of the room history.
+ We might miss a room key which is handled on cryptoQueue but the event will be decoded
+ later once available. kMXEventDidDecryptNotification will then be sent. 
  */
-@property (nonatomic, readonly) dispatch_queue_t cryptoLessBusyQueue;
+@property (nonatomic, readonly) dispatch_queue_t decryptionQueue;
 
 /**
  Upload the device keys to the homeserver and ensure that the

--- a/MatrixSDK/Crypto/MXCrypto_Private.h
+++ b/MatrixSDK/Crypto/MXCrypto_Private.h
@@ -47,6 +47,15 @@
 @property (nonatomic, readonly) MXOlmDevice *olmDevice;
 
 /**
+ Create the `MXCrypto` instance.
+
+ @param mxSession the mxSession to the home server.
+ @param store the storage module for crypto data.
+ @return the newly created MXCrypto instance.
+ */
+- (instancetype)initWithMatrixSession:(MXSession*)mxSession andStore:(id<MXCryptoStore>)store;
+
+/**
  Upload the device keys to the homeserver and ensure that the
  homeserver has enough one-time keys.
 

--- a/MatrixSDK/Crypto/MXCrypto_Private.h
+++ b/MatrixSDK/Crypto/MXCrypto_Private.h
@@ -1,0 +1,143 @@
+/*
+ Copyright 2016 OpenMarket Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "MXSDKOptions.h"
+
+#ifdef MX_CRYPTO
+
+#import "MXCryptoStore.h"
+#import "MXRestClient.h"
+#import "MXOlmDevice.h"
+#import "MXCryptoAlgorithms.h"
+#import "MXUsersDevicesMap.h"
+#import "MXOlmSessionResult.h"
+
+#import "MXCrypto.h"
+
+/**
+ The `MXCrypto_Private` extension exposes internal operations.
+ 
+ These methods run on a dedicated thread and must be called with the corresponding care.
+ */
+@interface MXCrypto ()
+
+/**
+ The store for crypto data.
+ */
+@property (nonatomic, readonly) id<MXCryptoStore> store;
+
+/**
+  The libolm wrapper.
+ */
+@property (nonatomic, readonly) MXOlmDevice *olmDevice;
+
+/**
+ Upload the device keys to the homeserver and ensure that the
+ homeserver has enough one-time keys.
+
+ @param maxKeys The maximum number of keys to generate.
+ 
+ @param success A block object called when the operation succeeds.
+ @param failure A block object called when the operation fails.
+
+ @return a MXHTTPOperation instance.
+ */
+- (MXHTTPOperation*)uploadKeys:(NSUInteger)maxKeys
+                       success:(void (^)())success
+                       failure:(void (^)(NSError *))failure;
+
+/**
+ Download the device keys for a list of users and stores the keys in the MXStore.
+
+ @param userIds The users to fetch.
+ @param forceDownload Always download the keys even if cached.
+ 
+ @param success A block object called when the operation succeeds.
+ @param failure A block object called when the operation fails.
+ 
+ @return a MXHTTPOperation instance. May be nil if the data is already in the store.
+ */
+- (MXHTTPOperation*)downloadKeys:(NSArray<NSString*>*)userIds forceDownload:(BOOL)forceDownload
+                         success:(void (^)(MXUsersDevicesMap<MXDeviceInfo*> *usersDevicesInfoMap))success
+                         failure:(void (^)(NSError *error))failure;
+
+/**
+ Get the stored device keys for a user.
+
+ @param userId the user to list keys for.
+ @return the list of devices.
+ */
+- (NSArray<MXDeviceInfo*>*)storedDevicesForUser:(NSString*)userId;
+
+/**
+ Get the device which sent an event.
+
+ @param event the event to be checked.
+ @return device info.
+ */
+- (MXDeviceInfo*)eventSenderDeviceOfEvent:(MXEvent*)event;
+
+/**
+ Configure a room to use encryption.
+
+ @param roomId the room id to enable encryption in.
+ @param algorithm the encryption config for the room.
+ @return YES if the operation succeeds.
+ */
+- (BOOL)setEncryptionInRoom:(NSString*)roomId withAlgorithm:(NSString*)algorithm;
+
+/**
+ Try to make sure we have established olm sessions for the given users.
+
+ @param users a list of user ids.
+
+ @param success A block object called when the operation succeeds.
+ @param failure A block object called when the operation fails.
+
+ @return a MXHTTPOperation instance. May be nil if the data is already in the store.
+ */
+- (MXHTTPOperation*)ensureOlmSessionsForUsers:(NSArray*)users
+                                      success:(void (^)(MXUsersDevicesMap<MXOlmSessionResult*> *results))success
+                                      failure:(void (^)(NSError *error))failure;
+
+/**
+ Try to make sure we have established olm sessions for the given devices.
+
+ @param devicesByUser a map from userid to list of devices.
+
+ @param success A block object called when the operation succeeds.
+ @param failure A block object called when the operation fails.
+ */
+- (MXHTTPOperation*)ensureOlmSessionsForDevices:(NSDictionary<NSString* /* userId */, NSArray<MXDeviceInfo*>*>*)devicesByUser
+                                      success:(void (^)(MXUsersDevicesMap<MXOlmSessionResult*> *results))success
+                                      failure:(void (^)(NSError *error))failure;
+
+/**
+ Encrypt an event payload for a list of devices.
+
+ @param payloadFields fields to include in the encrypted payload.
+ @param deviceInfos the list of the recipient devices.
+
+ @return the content for an m.room.encrypted event.
+ */
+- (NSDictionary*)encryptMessage:(NSDictionary*)payloadFields forDevices:(NSArray<MXDeviceInfo*>*)devices;
+
+
+@end
+
+#endif

--- a/MatrixSDK/Crypto/MXCrypto_Private.h
+++ b/MatrixSDK/Crypto/MXCrypto_Private.h
@@ -91,9 +91,9 @@
  
  @return a MXHTTPOperation instance. May be nil if the data is already in the store.
  */
-//- (MXHTTPOperation*)downloadKeys:(NSArray<NSString*>*)userIds forceDownload:(BOOL)forceDownload
-//                         success:(void (^)(MXUsersDevicesMap<MXDeviceInfo*> *usersDevicesInfoMap))success
-//                         failure:(void (^)(NSError *error))failure;
+- (MXHTTPOperation*)downloadKeys:(NSArray<NSString*>*)userIds forceDownload:(BOOL)forceDownload
+                         success:(void (^)(MXUsersDevicesMap<MXDeviceInfo*> *usersDevicesInfoMap))success
+                         failure:(void (^)(NSError *error))failure;
 
 /**
  Get the stored device keys for a user.

--- a/MatrixSDK/Crypto/MXCrypto_Private.h
+++ b/MatrixSDK/Crypto/MXCrypto_Private.h
@@ -52,6 +52,11 @@
 @property (nonatomic, readonly) MXRestClient *matrixRestClient;
 
 /**
+ The queue used for all crypto processing.
+ */
+@property (nonatomic, readonly) dispatch_queue_t cryptoQueue;
+
+/**
  Upload the device keys to the homeserver and ensure that the
  homeserver has enough one-time keys.
 

--- a/MatrixSDK/Crypto/MXCrypto_Private.h
+++ b/MatrixSDK/Crypto/MXCrypto_Private.h
@@ -109,6 +109,16 @@
 - (NSArray<MXDeviceInfo*>*)storedDevicesForUser:(NSString*)userId;
 
 /**
+ Find a device by curve25519 identity key
+
+ @param userId the owner of the device.
+ @param algorithm the encryption algorithm.
+ @param senderKey the curve25519 key to match.
+ @return the device info.
+ */
+- (MXDeviceInfo*)deviceWithIdentityKey:(NSString*)senderKey forUser:(NSString*)userId andAlgorithm:(NSString*)algorithm;
+
+/**
  Get the device which sent an event.
 
  @param event the event to be checked.

--- a/MatrixSDK/Crypto/MXCrypto_Private.h
+++ b/MatrixSDK/Crypto/MXCrypto_Private.h
@@ -47,6 +47,11 @@
 @property (nonatomic, readonly) MXOlmDevice *olmDevice;
 
 /**
+  The instance used to make requests to the homeserver.
+ */
+@property (nonatomic, readonly) MXRestClient *matrixRestClient;
+
+/**
  Create the `MXCrypto` instance.
 
  @param mxSession the mxSession to the home server.

--- a/MatrixSDK/Crypto/MXOlmDevice.h
+++ b/MatrixSDK/Crypto/MXOlmDevice.h
@@ -34,7 +34,7 @@
 /**
  Create the `MXOlmDevice` instance.
 
- @param mxSession the mxSession to the home server.
+ @param store the crypto data storage.
  @return the newly created MXOlmDevice instance.
  */
 - (instancetype)initWithStore:(id<MXCryptoStore>)store;

--- a/MatrixSDK/Data/MXRoom.h
+++ b/MatrixSDK/Data/MXRoom.h
@@ -779,14 +779,6 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidUpdateUnreadNotification;
                                           success:(void (^)())success
                                           failure:(void (^)(NSError *error))failure;
 
-/**
- Return the device information for an encrypted event.
- 
- @param event The event.
- @return the device info if any.
- */
-- (MXDeviceInfo*)eventDeviceInfo:(MXEvent*)event;
-
 #pragma mark - Utils
 
 /**

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -1140,16 +1140,6 @@ NSString *const kMXRoomDidUpdateUnreadNotification = @"kMXRoomDidUpdateUnreadNot
     return operation;
 }
 
-- (MXDeviceInfo*)eventDeviceInfo:(MXEvent*)event
-{
-    if (mxSession.crypto && event.isEncrypted)
-    {
-        return [mxSession.crypto deviceWithIdentityKey:event.senderKey forUser:event.sender andAlgorithm:self.state.encryptionAlgorithm];
-    }
-    
-    return nil;
-}
-
 #pragma mark - Utils
 - (NSComparisonResult)compareOriginServerTs:(MXRoom *)otherRoom
 {

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -292,7 +292,6 @@ NSString *const kMXRoomDidUpdateUnreadNotification = @"kMXRoomDidUpdateUnreadNot
                             success:(void (^)(NSString *eventId))success
                             failure:(void (^)(NSError *error))failure
 {
-#ifdef MX_CRYPTO
     if (mxSession.crypto && self.state.isEncrypted)
     {
         // Encrypt the content before sending
@@ -314,7 +313,6 @@ NSString *const kMXRoomDidUpdateUnreadNotification = @"kMXRoomDidUpdateUnreadNot
         return operation;
     }
     else
-#endif
     {
         return [self _sendEventOfType:eventTypeString content:content success:success failure:failure];
     }
@@ -550,8 +548,7 @@ NSString *const kMXRoomDidUpdateUnreadNotification = @"kMXRoomDidUpdateUnreadNot
     event.originServerTs = (uint64_t) ([[NSDate date] timeIntervalSince1970] * 1000);
     event.sender = mxSession.myUser.userId;
     event.wireContent = content;
-    
-#ifdef MX_CRYPTO
+
     if (mxSession.crypto && self.state.isEncrypted)
     {
         // Encapsulate the resulting event in a fake encrypted event
@@ -569,7 +566,6 @@ NSString *const kMXRoomDidUpdateUnreadNotification = @"kMXRoomDidUpdateUnreadNot
         
         event = encryptedEvent;
     }
-#endif
     
     return event;
 }
@@ -1110,7 +1106,6 @@ NSString *const kMXRoomDidUpdateUnreadNotification = @"kMXRoomDidUpdateUnreadNot
 {
     MXHTTPOperation *operation;
 
-#ifdef MX_CRYPTO
     if (mxSession.crypto)
     {
         // Send the information to the homeserver
@@ -1134,7 +1129,6 @@ NSString *const kMXRoomDidUpdateUnreadNotification = @"kMXRoomDidUpdateUnreadNot
         }];
     }
     else
-#endif
     {
         failure([NSError errorWithDomain:MXDecryptingErrorDomain
                                     code:MXDecryptingErrorEncryptionNotEnabledCode
@@ -1148,12 +1142,10 @@ NSString *const kMXRoomDidUpdateUnreadNotification = @"kMXRoomDidUpdateUnreadNot
 
 - (MXDeviceInfo*)eventDeviceInfo:(MXEvent*)event
 {
-#ifdef MX_CRYPTO
     if (mxSession.crypto && event.isEncrypted)
     {
         return [mxSession.crypto deviceWithIdentityKey:event.senderKey forUser:event.sender andAlgorithm:self.state.encryptionAlgorithm];
     }
-#endif
     
     return nil;
 }

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -564,7 +564,7 @@ NSString *const kMXRoomDidUpdateUnreadNotification = @"kMXRoomDidUpdateUnreadNot
         encryptedEvent.sender = mxSession.myUser.userId;
 
         [encryptedEvent setClearData:event
-                          keysProved:@{@"curve25519":mxSession.crypto.olmDevice.deviceCurve25519Key}
+                          keysProved:@{@"curve25519":mxSession.crypto.deviceCurve25519Key}
                          keysClaimed:nil];
         
         event = encryptedEvent;

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -2173,7 +2173,7 @@ typedef void (^MXOnResumeDone)();
 #ifdef MX_CRYPTO
     if (_crypto)
     {
-        [_crypto.olmDevice resetReplayAttackCheckInTimeline:timeline];
+        [_crypto resetReplayAttackCheckInTimeline:timeline];
     }
 #endif
 }

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -27,8 +27,6 @@
 #import "MXFileStore.h"
 
 #import "MXDecryptionResult.h"
-#import "MXFileCryptoStore.h"
-#import "MXRealmCryptoStore.h"
 
 #import "MXAccountData.h"
 
@@ -55,11 +53,6 @@ NSString *const kMXSessionNoRoomTag = @"m.recent";  // Use the same value as mat
 #define SERVER_TIMEOUT_MS 30000
 #define CLIENT_TIMEOUT_MS 120000
 
-/**
- The store to use for crypto.
- */
-//#define MXCryptoStoreClass MXFileCryptoStore
-#define MXCryptoStoreClass MXRealmCryptoStore
 
 // Block called when MSSession resume is complete
 typedef void (^MXOnResumeDone)();
@@ -221,7 +214,8 @@ typedef void (^MXOnResumeDone)();
     [_store openWithCredentials:matrixRestClient.credentials onComplete:^{
 
         // Check if the user has enabled crypto
-        [self checkCrypto:^{
+        [MXCrypto checkCryptoWithMatrixSession:self complete:^(MXCrypto *crypto) {
+            _crypto = crypto;
 
             // Sanity check: The session may be closed before the end of store opening.
             if (!matrixRestClient)
@@ -566,14 +560,12 @@ typedef void (^MXOnResumeDone)();
         _callManager = nil;
     }
 
-#ifdef MX_CRYPTO
     // Stop crypto
     if (_crypto)
     {
         [_crypto close];
         _crypto = nil;
     }
-#endif
 
     // Stop background task
     if (backgroundTaskIdentifier != UIBackgroundTaskInvalid)
@@ -1130,11 +1122,9 @@ typedef void (^MXOnResumeDone)();
 
     NSLog(@"[MXSesion] enableCrypto: %@", @(enableCrypto));
 
-#ifdef MX_CRYPTO
     if (enableCrypto && !_crypto)
     {
-        MXCryptoStoreClass *cryptoStore = [MXCryptoStoreClass createStoreWithCredentials:self.matrixRestClient.credentials];
-        _crypto = [[MXCrypto alloc] initWithMatrixSession:self andStore:cryptoStore];
+        _crypto = [MXCrypto createCryptoWithMatrixSession:self];
 
         if (_state == MXSessionStateRunning)
         {
@@ -1156,7 +1146,7 @@ typedef void (^MXOnResumeDone)();
         _crypto = nil;
 
         // Erase all crypto data of this user
-        [MXFileCryptoStore deleteStoreWithCredentials:matrixRestClient.credentials];
+        [MXCrypto deleteStoreWithCredentials:matrixRestClient.credentials];
         if (success)
         {
             success();
@@ -1169,15 +1159,6 @@ typedef void (^MXOnResumeDone)();
             success();
         }
     }
-
-#else
-
-    if (failure)
-    {
-        failure(nil);
-    }
-
-#endif
 
     return operation;
 }
@@ -2079,47 +2060,6 @@ typedef void (^MXOnResumeDone)();
 #pragma mark - Crypto
 
 /**
- Check if the user has previously enabled crypto.
- If yes, init the crypto module.
- 
- @param complete a block called in any case when the operation completes.
- */
-- (void)checkCrypto:(void (^)())complete
-{
-#ifdef MX_CRYPTO
-    if ([MXCryptoStoreClass hasDataForCredentials:matrixRestClient.credentials])
-    {
-        // If it already exists, open and init crypto
-        MXCryptoStoreClass *cryptoStore = [[MXCryptoStoreClass alloc] initWithCredentials:self.matrixRestClient.credentials];
-
-        [cryptoStore open:^{
-
-            _crypto = [[MXCrypto alloc] initWithMatrixSession:self andStore:cryptoStore];
-
-            complete();
-
-        } failure:^(NSError *error) {
-            complete();
-        }];
-    }
-    else if ([MXSDKOptions sharedInstance].enableCryptoWhenStartingMXSession
-        // Without the device id provided by the hs, the crypto does not work
-        && matrixRestClient.credentials.deviceId)
-    {
-        // Create it
-        MXCryptoStoreClass *cryptoStore = [MXCryptoStoreClass createStoreWithCredentials:self.matrixRestClient.credentials];
-        _crypto = [[MXCrypto alloc] initWithMatrixSession:self andStore:cryptoStore];
-        complete();
-    }
-    else
-#endif
-    {
-        // Else do not enable crypto
-        complete();
-    }
-}
-
-/**
  If any, start the crypto module.
 
  @param complete a block called in any case when the operation completes.
@@ -2129,13 +2069,11 @@ typedef void (^MXOnResumeDone)();
 {
     MXHTTPOperation *operation;
 
-#ifdef MX_CRYPTO
     if (_crypto)
     {
         operation = [_crypto start:success failure:failure];
     }
     else
-#endif
     {
         success();
     }
@@ -2148,13 +2086,11 @@ typedef void (^MXOnResumeDone)();
     BOOL result = NO;
     if (event.eventType == MXEventTypeRoomEncrypted)
     {
-#ifdef MX_CRYPTO
         if (_crypto)
         {
             result = [_crypto decryptEvent:event inTimeline:timeline];
         }
         else
-#endif
         {
             // Encryption not enabled
             event.decryptionError = [NSError errorWithDomain:MXDecryptingErrorDomain
@@ -2170,12 +2106,10 @@ typedef void (^MXOnResumeDone)();
 
 - (void)resetReplayAttackCheckInTimeline:(NSString*)timeline
 {
-#ifdef MX_CRYPTO
     if (_crypto)
     {
         [_crypto resetReplayAttackCheckInTimeline:timeline];
     }
-#endif
 }
 
 

--- a/MatrixSDKTests/MXCryptoTests.m
+++ b/MatrixSDKTests/MXCryptoTests.m
@@ -19,6 +19,7 @@
 #import "MatrixSDKTestsData.h"
 
 #import "MXSession.h"
+#import "MXCrypto_Private.h"
 #import "MXFileStore.h"
 
 #import "MXSDKOptions.h"

--- a/MatrixSDKTests/MXCryptoTests.m
+++ b/MatrixSDKTests/MXCryptoTests.m
@@ -248,7 +248,7 @@
             [expectation fulfill];
         }];
 
-        XCTAssert(operation, @"HTTP operations must be done when initialising crypto for the first tume");
+        XCTAssert(operation, @"HTTP operations must be done when initialising crypto for the first time");
 
     }];
 }
@@ -372,7 +372,7 @@
 
                     XCTAssertEqual([usersDevicesInfoMap deviceIdsForUser:aliceSession.myUser.userId].count, 1);
 
-                    MXDeviceInfo *aliceDeviceFromBobPOV = [usersDevicesInfoMap objectForDevice:aliceSession.matrixRestClient.credentials.deviceId forUser:aliceSession.myUser.userId];
+                    __block MXDeviceInfo *aliceDeviceFromBobPOV = [usersDevicesInfoMap objectForDevice:aliceSession.matrixRestClient.credentials.deviceId forUser:aliceSession.myUser.userId];
                     XCTAssert(aliceDeviceFromBobPOV);
                     XCTAssertEqualObjects(aliceDeviceFromBobPOV.fingerprint, aliceSession.crypto.olmDevice.deviceEd25519Key);
 
@@ -381,47 +381,53 @@
 
                     XCTAssertEqual(aliceDeviceFromBobPOV.verified, MXDeviceUnverified);
 
-                    [mxSession.crypto setDeviceVerification:MXDeviceBlocked forDevice:aliceDeviceFromBobPOV.deviceId ofUser:aliceSession.myUser.userId];
+                    [mxSession.crypto setDeviceVerification:MXDeviceBlocked forDevice:aliceDeviceFromBobPOV.deviceId ofUser:aliceSession.myUser.userId success:^{
 
-                    aliceDeviceFromBobPOV = [mxSession.crypto.store deviceWithDeviceId:aliceDeviceFromBobPOV.deviceId forUser:aliceSession.myUser.userId];
-                    XCTAssertEqual(aliceDeviceFromBobPOV.verified, MXDeviceBlocked);
+                        aliceDeviceFromBobPOV = [mxSession.crypto.store deviceWithDeviceId:aliceDeviceFromBobPOV.deviceId forUser:aliceSession.myUser.userId];
+                        XCTAssertEqual(aliceDeviceFromBobPOV.verified, MXDeviceBlocked);
 
-                    MXRestClient *bobRestClient = mxSession.matrixRestClient;
-                    [mxSession close];
+                        MXRestClient *bobRestClient = mxSession.matrixRestClient;
+                        [mxSession close];
 
 
-                    // Test storage: Reopen the session
-                    MXFileStore *store = [[MXFileStore alloc] init];
+                        // Test storage: Reopen the session
+                        MXFileStore *store = [[MXFileStore alloc] init];
 
-                    MXSession *mxSession2 = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
-                    [mxSession2 setStore:store success:^{
+                        MXSession *mxSession2 = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+                        [mxSession2 setStore:store success:^{
 
-                        MXDeviceInfo *aliceDeviceFromBobPOV2 = [mxSession2.crypto deviceWithIdentityKey:aliceSession.crypto.olmDevice.deviceCurve25519Key forUser:aliceSession.myUser.userId andAlgorithm:kMXCryptoOlmAlgorithm];
+                            MXDeviceInfo *aliceDeviceFromBobPOV2 = [mxSession2.crypto deviceWithIdentityKey:aliceSession.crypto.olmDevice.deviceCurve25519Key forUser:aliceSession.myUser.userId andAlgorithm:kMXCryptoOlmAlgorithm];
 
-                        XCTAssert(aliceDeviceFromBobPOV2);
-                        XCTAssertEqualObjects(aliceDeviceFromBobPOV2.fingerprint, aliceSession.crypto.olmDevice.deviceEd25519Key);
-                        XCTAssertEqual(aliceDeviceFromBobPOV2.verified, MXDeviceBlocked, @"AliceDevice must still be blocked");
+                            XCTAssert(aliceDeviceFromBobPOV2);
+                            XCTAssertEqualObjects(aliceDeviceFromBobPOV2.fingerprint, aliceSession.crypto.olmDevice.deviceEd25519Key);
+                            XCTAssertEqual(aliceDeviceFromBobPOV2.verified, MXDeviceBlocked, @"AliceDevice must still be blocked");
 
-                        // Download again alice device
-                        [mxSession2.crypto downloadKeys:@[aliceSession.myUser.userId] forceDownload:YES success:^(MXUsersDevicesMap<MXDeviceInfo *> *usersDevicesInfoMap2) {
+                            // Download again alice device
+                            [mxSession2.crypto downloadKeys:@[aliceSession.myUser.userId] forceDownload:YES success:^(MXUsersDevicesMap<MXDeviceInfo *> *usersDevicesInfoMap2) {
 
-                            MXDeviceInfo *aliceDeviceFromBobPOV3 = [mxSession2.crypto deviceWithIdentityKey:aliceSession.crypto.olmDevice.deviceCurve25519Key forUser:aliceSession.myUser.userId andAlgorithm:kMXCryptoOlmAlgorithm];
+                                MXDeviceInfo *aliceDeviceFromBobPOV3 = [mxSession2.crypto deviceWithIdentityKey:aliceSession.crypto.olmDevice.deviceCurve25519Key forUser:aliceSession.myUser.userId andAlgorithm:kMXCryptoOlmAlgorithm];
 
-                            XCTAssert(aliceDeviceFromBobPOV3);
-                            XCTAssertEqualObjects(aliceDeviceFromBobPOV3.fingerprint, aliceSession.crypto.olmDevice.deviceEd25519Key);
-                            XCTAssertEqual(aliceDeviceFromBobPOV3.verified, MXDeviceBlocked, @"AliceDevice must still be blocked.");
+                                XCTAssert(aliceDeviceFromBobPOV3);
+                                XCTAssertEqualObjects(aliceDeviceFromBobPOV3.fingerprint, aliceSession.crypto.olmDevice.deviceEd25519Key);
+                                XCTAssertEqual(aliceDeviceFromBobPOV3.verified, MXDeviceBlocked, @"AliceDevice must still be blocked.");
 
-                            [expectation fulfill];
+                                [expectation fulfill];
 
+                            } failure:^(NSError *error) {
+                                XCTFail(@"The request should not fail - NSError: %@", error);
+                                [expectation fulfill];
+                            }];
                         } failure:^(NSError *error) {
-                            XCTFail(@"The request should not fail - NSError: %@", error);
+                            XCTFail(@"Cannot set up intial test conditions - error: %@", error);
                             [expectation fulfill];
                         }];
+
                     } failure:^(NSError *error) {
-                        XCTFail(@"Cannot set up intial test conditions - error: %@", error);
+                        XCTFail(@"The request should not fail - NSError: %@", error);
                         [expectation fulfill];
                     }];
-                } failure:^(NSError *error) {
+
+                 } failure:^(NSError *error) {
                     XCTFail(@"The request should not fail - NSError: %@", error);
                     [expectation fulfill];
                 }];
@@ -1220,12 +1226,19 @@
                     // Make Alice block Bob
                     [aliceSession.crypto setDeviceVerification:MXDeviceBlocked
                                                      forDevice:bobSession.matrixRestClient.credentials.deviceId
-                                                        ofUser:bobSession.myUser.userId];
+                                                        ofUser:bobSession.myUser.userId
+                                                       success:
+                     ^{
 
-                    [roomFromAlicePOV sendTextMessage:aliceMessages[1] success:nil failure:^(NSError *error) {
-                        XCTFail(@"Cannot set up intial test conditions - error: %@", error);
-                        [expectation fulfill];
-                    }];
+                         [roomFromAlicePOV sendTextMessage:aliceMessages[1] success:nil failure:^(NSError *error) {
+                             XCTFail(@"Cannot set up intial test conditions - error: %@", error);
+                             [expectation fulfill];
+                         }];
+
+                     } failure:^(NSError *error) {
+                         XCTFail(@"Cannot set up intial test conditions - error: %@", error);
+                         [expectation fulfill];
+                     }];
 
                     break;
                 }
@@ -1240,12 +1253,17 @@
                     // Make Alice unblock Bob
                     [aliceSession.crypto setDeviceVerification:MXDeviceUnverified
                                                      forDevice:bobSession.matrixRestClient.credentials.deviceId
-                                                        ofUser:bobSession.myUser.userId];
+                                                        ofUser:bobSession.myUser.userId success:
+                     ^{
+                         [roomFromAlicePOV sendTextMessage:aliceMessages[2] success:nil failure:^(NSError *error) {
+                             XCTFail(@"Cannot set up intial test conditions - error: %@", error);
+                             [expectation fulfill];
+                         }];
 
-                    [roomFromAlicePOV sendTextMessage:aliceMessages[2] success:nil failure:^(NSError *error) {
-                        XCTFail(@"Cannot set up intial test conditions - error: %@", error);
-                        [expectation fulfill];
-                    }];
+                     } failure:^(NSError *error) {
+                         XCTFail(@"Cannot set up intial test conditions - error: %@", error);
+                         [expectation fulfill];
+                     }];
 
                     break;
                 }
@@ -1406,6 +1424,8 @@
 
             // The event must be decrypted once we reinject the m.room_key event
             __block __weak id observer = [[NSNotificationCenter defaultCenter] addObserverForName:kMXEventDidDecryptNotification object:event queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *note) {
+
+                XCTAssert([NSThread currentThread].isMainThread);
 
                 [[NSNotificationCenter defaultCenter] removeObserver:observer];
 


### PR DESCRIPTION
Well, this modification actually makes the crypto code runs on a pool of threads because this is how dispatch_async works when running on a queue which is not the main one.

Well, the code actually uses 2 queues: a main one and another one dedicated to the decryption because we want to be able to read the room history while sending a message to the room (sending our 1st message in a room can take seconds).

I have also removed #ifdef MX_CRYPTO from code outside the crypto module. MXCrypto stubs public methods if MX_CRYPTO is not defined.

Note that message decryption still blocks UI but it is not noticeable for the end-user. Making it asynchronous requires too much refactoring. Plus this refactoring is on the same path than the event storage improvement.

