### PR TITLE
Bug Fix - MXHTTPClient: Handle correctly the case where the homeserve…

### DIFF
--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -46,7 +46,7 @@ FOUNDATION_EXPORT NSString *const kMXIdentityAPIPrefixPath;
  */
 FOUNDATION_EXPORT NSString *const kMXContentUriScheme;
 /**
- Matrix content respository path.
+ A constant representing the prefix of the Matrix content repository path.
  */
 FOUNDATION_EXPORT NSString *const kMXContentPrefixPath;
 
@@ -115,9 +115,15 @@ typedef enum : NSUInteger
 
 /**
  The Client-Server API prefix to use.
- By default, it is '/_matrix/client/r0'. See kMXAPIPrefixPathR0 and kMXAPIPrefixPathUnstable for constants.
+ By default, it is '_matrix/client/r0'. See kMXAPIPrefixPathR0 and kMXAPIPrefixPathUnstable for constants.
  */
 @property (nonatomic) NSString *apiPathPrefix;
+
+/**
+ The Matrix content repository prefix to use.
+ By default, it is defined by the constant kMXContentPrefixPath.
+ */
+@property (nonatomic) NSString *contentPathPrefix;
 
 /**
  The identity server.

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -3118,7 +3118,7 @@ MXAuthAction;
                     uploadProgress:(void (^)(NSProgress *uploadProgress))uploadProgress
 {
     // Define an absolute path based on Matrix content respository path instead of the base url
-    NSString* path = [NSString stringWithFormat:@"%@/upload", kMXContentPrefixPath];
+    NSString* path = [NSString stringWithFormat:@"%@/upload", contentPathPrefix];
     NSDictionary *headers = @{@"Content-Type": mimeType};
 
     if (filename.length)
@@ -3168,7 +3168,7 @@ MXAuthAction;
     // Replace the "mxc://" scheme by the absolute http location of the content
     if ([mxcContentURI hasPrefix:kMXContentUriScheme])
     {
-        NSString *mxMediaPrefix = [NSString stringWithFormat:@"%@/%@/download/", homeserver, kMXContentPrefixPath];
+        NSString *mxMediaPrefix = [NSString stringWithFormat:@"%@/%@/download/", homeserver, contentPathPrefix];
         contentURL = [mxcContentURI stringByReplacingOccurrencesOfString:kMXContentUriScheme withString:mxMediaPrefix];
         
         // Remove the auto generated image tag from the URL
@@ -3191,7 +3191,7 @@ MXAuthAction;
         CGSize sizeInPixels = CGSizeMake(viewSize.width * scale, viewSize.height * scale);
         
         // Replace the "mxc://" scheme by the absolute http location for the content thumbnail
-        NSString *mxThumbnailPrefix = [NSString stringWithFormat:@"%@/%@/thumbnail/", homeserver, kMXContentPrefixPath];
+        NSString *mxThumbnailPrefix = [NSString stringWithFormat:@"%@/%@/thumbnail/", homeserver, contentPathPrefix];
         thumbnailURL = [mxcContentURI stringByReplacingOccurrencesOfString:kMXContentUriScheme withString:mxThumbnailPrefix];
         
         // Convert MXThumbnailingMethod to parameter string
@@ -3222,7 +3222,7 @@ MXAuthAction;
 
 - (NSString *)urlOfIdenticon:(NSString *)identiconString
 {
-    return [NSString stringWithFormat:@"%@/%@/identicon/%@", homeserver, kMXContentPrefixPath, [identiconString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLHostAllowedCharacterSet]]];
+    return [NSString stringWithFormat:@"%@/%@/identicon/%@", homeserver, contentPathPrefix, [identiconString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLHostAllowedCharacterSet]]];
 }
 
 

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -24,19 +24,19 @@
 /**
  Prefix used in path of home server API requests.
  */
-NSString *const kMXAPIPrefixPathR0 = @"/_matrix/client/r0";
-NSString *const kMXAPIPrefixPathUnstable = @"/_matrix/client/unstable";
+NSString *const kMXAPIPrefixPathR0 = @"_matrix/client/r0";
+NSString *const kMXAPIPrefixPathUnstable = @"_matrix/client/unstable";
 
 /**
  Prefix used in path of identity server API requests.
  */
-NSString *const kMXIdentityAPIPrefixPath = @"/_matrix/identity/api/v1";
+NSString *const kMXIdentityAPIPrefixPath = @"_matrix/identity/api/v1";
 
 /**
  Matrix content respository path
  */
 NSString *const kMXContentUriScheme  = @"mxc://";
-NSString *const kMXContentPrefixPath = @"/_matrix/media/v1";
+NSString *const kMXContentPrefixPath = @"_matrix/media/v1";
 
 /**
  Account data types
@@ -95,7 +95,7 @@ MXAuthAction;
 @end
 
 @implementation MXRestClient
-@synthesize homeserver, homeserverSuffix, credentials, apiPathPrefix, completionQueue;
+@synthesize homeserver, homeserverSuffix, credentials, apiPathPrefix, contentPathPrefix, completionQueue;
 
 -(id)initWithHomeServer:(NSString *)inHomeserver andOnUnrecognizedCertificateBlock:(MXHTTPClientOnUnrecognizedCertificate)onUnrecognizedCertBlock
 {
@@ -104,6 +104,7 @@ MXAuthAction;
     {
         homeserver = inHomeserver;
         apiPathPrefix = kMXAPIPrefixPathR0;
+        contentPathPrefix = kMXContentPrefixPath;
         
         httpClient = [[MXHTTPClient alloc] initWithBaseURL:homeserver
                                                accessToken:nil
@@ -126,6 +127,8 @@ MXAuthAction;
     {
         homeserver = inCredentials.homeServer;
         apiPathPrefix = kMXAPIPrefixPathR0;
+        contentPathPrefix = kMXContentPrefixPath;
+        
         self.credentials = inCredentials;
         
         httpClient = [[MXHTTPClient alloc] initWithBaseURL:homeserver
@@ -3165,7 +3168,7 @@ MXAuthAction;
     // Replace the "mxc://" scheme by the absolute http location of the content
     if ([mxcContentURI hasPrefix:kMXContentUriScheme])
     {
-        NSString *mxMediaPrefix = [NSString stringWithFormat:@"%@%@/download/", homeserver, kMXContentPrefixPath];
+        NSString *mxMediaPrefix = [NSString stringWithFormat:@"%@/%@/download/", homeserver, kMXContentPrefixPath];
         contentURL = [mxcContentURI stringByReplacingOccurrencesOfString:kMXContentUriScheme withString:mxMediaPrefix];
         
         // Remove the auto generated image tag from the URL
@@ -3188,7 +3191,7 @@ MXAuthAction;
         CGSize sizeInPixels = CGSizeMake(viewSize.width * scale, viewSize.height * scale);
         
         // Replace the "mxc://" scheme by the absolute http location for the content thumbnail
-        NSString *mxThumbnailPrefix = [NSString stringWithFormat:@"%@%@/thumbnail/", homeserver, kMXContentPrefixPath];
+        NSString *mxThumbnailPrefix = [NSString stringWithFormat:@"%@/%@/thumbnail/", homeserver, kMXContentPrefixPath];
         thumbnailURL = [mxcContentURI stringByReplacingOccurrencesOfString:kMXContentUriScheme withString:mxThumbnailPrefix];
         
         // Convert MXThumbnailingMethod to parameter string
@@ -3219,7 +3222,7 @@ MXAuthAction;
 
 - (NSString *)urlOfIdenticon:(NSString *)identiconString
 {
-    return [NSString stringWithFormat:@"%@%@/identicon/%@", homeserver, kMXContentPrefixPath, [identiconString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLHostAllowedCharacterSet]]];
+    return [NSString stringWithFormat:@"%@/%@/identicon/%@", homeserver, kMXContentPrefixPath, [identiconString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLHostAllowedCharacterSet]]];
 }
 
 
@@ -3227,7 +3230,7 @@ MXAuthAction;
 - (void)setIdentityServer:(NSString *)identityServer
 {
     _identityServer = [identityServer copy];
-    identityHttpClient = [[MXHTTPClient alloc] initWithBaseURL:[NSString stringWithFormat:@"%@%@", identityServer, kMXIdentityAPIPrefixPath]
+    identityHttpClient = [[MXHTTPClient alloc] initWithBaseURL:[NSString stringWithFormat:@"%@/%@", identityServer, kMXIdentityAPIPrefixPath]
                              andOnUnrecognizedCertificateBlock:nil];
 
     // The identity server accepts parameters in form data form not in JSON

--- a/MatrixSDK/Utils/MXHTTPClient.m
+++ b/MatrixSDK/Utils/MXHTTPClient.m
@@ -204,11 +204,6 @@ NSString * const MXHTTPClientErrorResponseDataKey = @"com.matrixsdk.httpclient.e
         path = [path stringByAppendingString:[NSString stringWithFormat:@"%@access_token=%@", urlSeparator, accessToken]];
     }
     
-    // Remove the potential leading slash for the provided path, so that NSURL +URLWithString:relativeToURL: works as expected.
-    if ([path hasPrefix:@"/"] && path.length > 1)
-    {
-        path = [path substringFromIndex:1];
-    }
     NSString *URLString = [[NSURL URLWithString:path relativeToURL:httpManager.baseURL] absoluteString];
     
     NSMutableURLRequest *request;

--- a/MatrixSDK/Utils/MXHTTPClient.m
+++ b/MatrixSDK/Utils/MXHTTPClient.m
@@ -204,6 +204,11 @@ NSString * const MXHTTPClientErrorResponseDataKey = @"com.matrixsdk.httpclient.e
         path = [path stringByAppendingString:[NSString stringWithFormat:@"%@access_token=%@", urlSeparator, accessToken]];
     }
     
+    // Remove the potential leading slash for the provided path, so that NSURL +URLWithString:relativeToURL: works as expected.
+    if ([path hasPrefix:@"/"] && path.length > 1)
+    {
+        path = [path substringFromIndex:1];
+    }
     NSString *URLString = [[NSURL URLWithString:path relativeToURL:httpManager.baseURL] absoluteString];
     
     NSMutableURLRequest *request;


### PR DESCRIPTION
…r url is a subdirectory.

In MXHTTPClient try request method, remove the potential leading slash for the provided path, so that NSURL +URLWithString:relativeToURL: works as expected.

This should fix "Content prefix path" #213.