### PR TITLE
Xcode framework support

### DIFF
--- a/MatrixSDK/Crypto/MXOlmDevice.m
+++ b/MatrixSDK/Crypto/MXOlmDevice.m
@@ -99,7 +99,7 @@
 
 - (NSString *)olmVersion
 {
-    return OLMKitVersionString();
+    return [OLMKit versionString];
 }
 
 - (NSString *)signMessage:(NSData*)message

--- a/Podfile
+++ b/Podfile
@@ -9,8 +9,10 @@ pod 'AFNetworking', '~> 3.1.0'
 pod 'OLMKit'
 #pod 'OLMKit', :path => '../olm/OLMKit.podspec'
 
-# This fork of OLMKit includes only trivial changes that enable it to run on macOS.
-#pod 'OLMKit', :git => 'https://github.com/aapierce0/OLMKit.git', :branch => 'macOS_port'
+# This fork of OLMKit changes the way the OLMKitVersionString is exposed.
+# This change is necessary to work around a compiler error that occurs when
+# both MatrixSDK and OLMKit pods are included in a project with use_frameworks! enabled.
+#pod 'OLMKit', :git => 'https://github.com/aapierce0/OLMKit.git', :branch => 'OLMKit-xcode-framework-compatibility'
 
 pod 'Realm', '~> 2.1.1'
 


### PR DESCRIPTION
This should resolve #219, but it depends on a change in OLMKit that moves the `OLMKitVersionString` function to a class method. See here: 

https://github.com/aapierce0/OLMKit/tree/OLMKit-xcode-framework-compatibility

The only reason I haven't submitted this change to the olm repository is because this is *technically* a breaking change (albeit an incredibly small one). Here's the patch file, though: [olm_patch.txt](https://github.com/matrix-org/matrix-ios-sdk/files/712987/olm_patch.txt)

Signed-off-by: Avery Pierce <aapierce0@gmail.com>