### PR TITLE
Bug Fix: Riot looks to me like I'm sending the same message twice.

### DIFF
--- a/MatrixSDK/Data/MXEventTimeline.m
+++ b/MatrixSDK/Data/MXEventTimeline.m
@@ -819,6 +819,20 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
             [listener notify:event direction:direction andCustomObject:roomState];
         }
     }
+    
+    if (_isLiveTimeline)
+    {
+        // Check for local echo suppression
+        if (room.outgoingMessages.count && [event.sender isEqualToString:room.mxSession.myUser.userId])
+        {
+            MXEvent *localEcho = [room pendingLocalEchoRelatedToEvent:event];
+            if (localEcho)
+            {
+                // Remove the event from the pending local echo list
+                [room removePendingLocalEcho:localEcho.eventId];
+            }
+        }
+    }
 }
 
 @end


### PR DESCRIPTION
https://github.com/vector-im/riot-ios/issues/894

Move the local echo suppression from `MXKRoomDataSource` to `MXEventTimeline` class.