### PR TITLE
MXEvent: Add isLocalEvent property.

### DIFF
--- a/MatrixSDK/Data/MXRoom.h
+++ b/MatrixSDK/Data/MXRoom.h
@@ -34,8 +34,6 @@
 #import "MXEventsEnumerator.h"
 #import "MXCryptoConstants.h"
 
-extern NSString *const kMXRoomLocalEventIdPrefix;
-
 @class MXRoom;
 @class MXSession;
 
@@ -248,7 +246,7 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidUpdateUnreadNotification;
                   When the event type is `kMXEventTypeStringRoomMessage`, this pointer
                   is set to an actual MXEvent object containing the local created event which should be used
                   to echo the message in the messages list until the resulting event come through the server sync.
-                  For information, the identifier of the created local event has the prefix: `kMXRoomLocalEventIdPrefix`.
+                  For information, the identifier of the created local event has the prefix: `kMXEventLocalEventIdPrefix`.
                   You may specify nil for this parameter if you do not want this information.
                   You may provide your own MXEvent object, in this case only its send state is updated.
                   When the event type is `kMXEventTypeStringRoomEncrypted`, no local event is created.
@@ -288,7 +286,7 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidUpdateUnreadNotification;
  @param localEcho a pointer to a MXEvent object. This pointer is set to an actual MXEvent object
                   containing the local created event which should be used to echo the message in
                   the messages list until the resulting event come through the server sync.
-                  For information, the identifier of the created local event has the prefix: `kMXRoomLocalEventIdPrefix`.
+                  For information, the identifier of the created local event has the prefix: `kMXEventLocalEventIdPrefix`.
                   You may specify nil for this parameter if you do not want this information.
                   You may provide your own MXEvent object, in this case only its send state is updated.
  @param success A block object called when the operation succeeds. It returns
@@ -753,7 +751,7 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidUpdateUnreadNotification;
 /**
  Create a temporary message event for the room.
  
- @param eventId the event id. A globally unique string with kMXRoomLocalEventIdPrefix prefix is defined when this param is nil.
+ @param eventId the event id. A globally unique string with kMXEventLocalEventIdPrefix prefix is defined when this param is nil.
  @param content the event content.
  @return the created event.
  */

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -27,8 +27,6 @@
 
 #import "MXError.h"
 
-NSString *const kMXRoomLocalEventIdPrefix = @"kMXRoomLocalId_";
-
 NSString *const kMXRoomDidFlushDataNotification = @"kMXRoomDidFlushDataNotification";
 NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotification";
 NSString *const kMXRoomDidUpdateUnreadNotification = @"kMXRoomDidUpdateUnreadNotification";
@@ -1314,7 +1312,7 @@ NSString *const kMXRoomDidUpdateUnreadNotification = @"kMXRoomDidUpdateUnreadNot
 {
     if (!eventId)
     {
-        eventId = [NSString stringWithFormat:@"%@%@", kMXRoomLocalEventIdPrefix, [[NSProcessInfo processInfo] globallyUniqueString]];
+        eventId = [NSString stringWithFormat:@"%@%@", kMXEventLocalEventIdPrefix, [[NSProcessInfo processInfo] globallyUniqueString]];
     }
     
     MXEvent *event = [[MXEvent alloc] init];

--- a/MatrixSDK/JSONModels/MXEvent.h
+++ b/MatrixSDK/JSONModels/MXEvent.h
@@ -108,6 +108,11 @@ FOUNDATION_EXPORT NSString *const kMXMessageTypeLocation;
 FOUNDATION_EXPORT NSString *const kMXMessageTypeFile;
 
 /**
+ Prefix used for id of temporary local event.
+ */
+FOUNDATION_EXPORT NSString *const kMXEventLocalEventIdPrefix;
+
+/**
  Membership definitions
  */
 typedef enum : NSUInteger
@@ -320,6 +325,11 @@ FOUNDATION_EXPORT NSString *const kMXEventDidDecryptNotification;
  Indicates if the event hosts state data.
  */
 - (BOOL)isState;
+
+/**
+ Indicates if the event is a local one.
+ */
+- (BOOL)isLocalEvent;
 
 /**
  Indicates if the event has been redacted.

--- a/MatrixSDK/JSONModels/MXEvent.m
+++ b/MatrixSDK/JSONModels/MXEvent.m
@@ -59,6 +59,8 @@ NSString *const kMXMessageTypeVideo     = @"m.video";
 NSString *const kMXMessageTypeLocation  = @"m.location";
 NSString *const kMXMessageTypeFile      = @"m.file";
 
+NSString *const kMXEventLocalEventIdPrefix = @"kMXEventLocalId_";
+
 NSString *const kMXMembershipStringInvite = @"invite";
 NSString *const kMXMembershipStringJoin   = @"join";
 NSString *const kMXMembershipStringLeave  = @"leave";
@@ -251,6 +253,11 @@ NSString *const kMXEventDidDecryptNotification = @"kMXEventDidDecryptNotificatio
 {
     // The event is a state event if has a state_key
     return (nil != self.stateKey);
+}
+
+- (BOOL)isLocalEvent
+{
+    return [_eventId hasPrefix:kMXEventLocalEventIdPrefix];
 }
 
 - (BOOL)isRedactedEvent


### PR DESCRIPTION
API break: kMXRoomLocalEventIdPrefix has been renamed to kMXEventLocalEventIdPrefix