### PR TITLE
Bug Fix: App crash on "setObjectForKey: key cannot be nil"

### DIFF
--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -228,12 +228,19 @@ typedef void (^MXOnResumeDone)();
     NSDate *startDate = [NSDate date];
 
     [_store openWithCredentials:matrixRestClient.credentials onComplete:^{
+        
+        // Sanity check: The session may be closed before the end of store opening.
+        if (!matrixRestClient)
+        {
+            return;
+        }
 
         // Check if the user has enabled crypto
         [MXCrypto checkCryptoWithMatrixSession:self complete:^(MXCrypto *crypto) {
+            
             _crypto = crypto;
 
-            // Sanity check: The session may be closed before the end of store opening.
+            // Sanity check: The session may be closed before the end of this operation.
             if (!matrixRestClient)
             {
                 return;


### PR DESCRIPTION
Logs:
[MXCrypto] checkCryptoWithMatrixSession for (null)
[MXCrypto] Create dispatch queue for (null)'s crypto

Crash log:
Main thread: YES
(
	0   CoreFoundation                      0x000000018acfd1d0 <redacted> + 148
	1   libobjc.A.dylib                     0x000000018973455c objc_exception_throw + 56
	2   CoreFoundation                      0x000000018abdda0c <redacted> + 0
	3   Vector                              0x00000001002a3060 Vector + 2125920
 -> +[MXCrypto dispatchQueueForUser:] (in Vector) (MXCrypto.m:1225)
	4   Vector                              0x000000010029c004 Vector + 2097156
 -> +[MXCrypto checkCryptoWithMatrixSession:complete:] (in Vector) (MXCrypto.m:100)
	5   Vector                              0x0000000100332da4 Vector + 2715044
 -> __38-[MXSession setStore:success:failure:]_block_invoke (in Vector) (MXSession.m:306)