### PR TITLE
Improve disk usage: Do not use NSURLCache. The SDK does not need this cache

### DIFF
--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
@@ -1,5 +1,6 @@
 /*
  Copyright 2014 OpenMarket Ltd
+ Copyright 2017 Vector Creations Ltd
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
@@ -182,6 +182,13 @@ NSString *const kMXFileStoreRoomReadReceiptsFile = @"readReceipts";
             else if (kMXFileVersion != metaData.version)
             {
                 NSLog(@"[MXFileStore] New MXFileStore version detected");
+
+                if (metaData.version <= 35)
+                {
+                    NSLog(@"[MXFileStore] Matrix SDK until the version of 35 of MXFileStore caches all NSURLRequests unnecessarily. Clear NSURLCache");
+                    [[NSURLCache sharedURLCache] removeAllCachedResponses];
+                }
+
                 [self deleteAllData];
             }
             // Check credentials

--- a/MatrixSDK/Utils/MXHTTPClient.m
+++ b/MatrixSDK/Utils/MXHTTPClient.m
@@ -1,6 +1,7 @@
 /*
  Copyright 2014 OpenMarket Ltd
- 
+ Copyright 2017 Vector Creations Ltd
+
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at

--- a/MatrixSDK/Utils/MXHTTPClient.m
+++ b/MatrixSDK/Utils/MXHTTPClient.m
@@ -116,7 +116,10 @@ NSString * const MXHTTPClientErrorResponseDataKey = @"com.matrixsdk.httpclient.e
 #if TARGET_OS_IPHONE
         backgroundTaskIdentifier = UIBackgroundTaskInvalid;
 #endif
-        
+
+        // No need for caching. The sdk caches the data it needs
+        [httpManager.requestSerializer setCachePolicy:NSURLRequestReloadIgnoringLocalCacheData];
+
         // Send requests parameters in JSON format by default
         self.requestParametersInJSON = YES;
 


### PR DESCRIPTION
This will just save hundreds of MB of the app usage.