### PR TITLE
Http retry policy

### DIFF
--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
@@ -498,9 +498,8 @@ NSString *const kMXFileStoreRoomReadReceiptsFile = @"readReceipts";
             [[UIApplication sharedApplication] endBackgroundTask:backgroundTaskIdentifier];
             backgroundTaskIdentifier = UIBackgroundTaskInvalid;
         }];
-#if DEBUG
+
         NSLog(@"[MXFileStore commit] Background task #%tu started", backgroundTaskIdentifier);
-#endif // DEBUG
 #endif // TARGET_OS_IPHONE
 
         [self saveRoomsDeletion];

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -1040,7 +1040,7 @@ typedef void (^MXOnResumeDone)();
                     // Relaunch the request in a random near futur.
                     // Random time it used to avoid all Matrix clients to retry all in the same time
                     // if there is server side issue like server restart
-                    dispatch_time_t delayTime = dispatch_time(DISPATCH_TIME_NOW, [MXHTTPClient jitterTimeForRetry] * NSEC_PER_MSEC);
+                    dispatch_time_t delayTime = dispatch_time(DISPATCH_TIME_NOW, [MXHTTPClient timeForRetry:eventStreamRequest] * NSEC_PER_MSEC);
                     dispatch_after(delayTime, dispatch_get_main_queue(), ^(void) {
                         
                         if (eventStreamRequest)

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -1,6 +1,7 @@
 /*
  Copyright 2014 OpenMarket Ltd
- 
+ Copyright 2017 Vector Creations Ltd
+
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at

--- a/MatrixSDK/Utils/MXHTTPClient.h
+++ b/MatrixSDK/Utils/MXHTTPClient.h
@@ -1,6 +1,7 @@
 /*
  Copyright 2014 OpenMarket Ltd
- 
+ Copyright 2017 Vector Creations Ltd
+
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at

--- a/MatrixSDK/Utils/MXHTTPClient.h
+++ b/MatrixSDK/Utils/MXHTTPClient.h
@@ -140,13 +140,13 @@ typedef BOOL (^MXHTTPClientOnUnrecognizedCertificate)(NSData *certificate);
                           failure:(void (^)(NSError *error))failure;
 
 /**
- Return a random time to retry a request.
+ Return the amount of time to wait before retrying a request.
  
- a jitter is used to prevent all Matrix clients from retrying all in the same time
- if there is server side issue like server restart.
+ The time is based on an exponential backoff plus a jitter in order to prevent all Matrix clients 
+ from retrying all in the same time if there is server side issue like server restart.
  
- @return a random time in milliseconds between 5s and 8s.
+ @return a time in milliseconds like [2000, 4000, 8000, 16000, ...] + a jitter of 3000ms.
  */
-+ (NSUInteger)jitterTimeForRetry;
++ (NSUInteger)timeForRetry:(MXHTTPOperation*)httpOperation;
 
 @end

--- a/MatrixSDK/Utils/MXHTTPOperation.h
+++ b/MatrixSDK/Utils/MXHTTPOperation.h
@@ -1,5 +1,6 @@
 /*
  Copyright 2015 OpenMarket Ltd
+ Copyright 2017 Vector Creations Ltd
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/MatrixSDK/Utils/MXHTTPOperation.h
+++ b/MatrixSDK/Utils/MXHTTPOperation.h
@@ -44,7 +44,7 @@
 
 /**
  Max number of times the request can be retried.
- Default is 3.
+ Default is 4.
  */
 @property (nonatomic) NSUInteger maxNumberOfTries;
 

--- a/MatrixSDK/Utils/MXHTTPOperation.m
+++ b/MatrixSDK/Utils/MXHTTPOperation.m
@@ -1,5 +1,6 @@
 /*
  Copyright 2015 OpenMarket Ltd
+ Copyright 2017 Vector Creations Ltd
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/MatrixSDK/Utils/MXHTTPOperation.m
+++ b/MatrixSDK/Utils/MXHTTPOperation.m
@@ -22,7 +22,7 @@
 /**
  The default max attempts.
  */
-#define MXHTTPOPERATION_DEFAULT_MAX_RETRIES 3
+#define MXHTTPOPERATION_DEFAULT_MAX_RETRIES 4
 
 /**
  The default max time a request can be retried.

--- a/MatrixSDKTests/MXHTTPClientTests.m
+++ b/MatrixSDKTests/MXHTTPClientTests.m
@@ -1,6 +1,7 @@
 /*
  Copyright 2014 OpenMarket Ltd
- 
+ Copyright 2017 Vector Creations Ltd
+
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at

--- a/MatrixSDKTests/MXHTTPClientTests.m
+++ b/MatrixSDKTests/MXHTTPClientTests.m
@@ -136,9 +136,9 @@
     [self waitForExpectationsWithTimeout:10 handler:nil];
 }
 
-- (void)testJitterTimeForRetry
+- (void)testTimeForRetry
 {
-    XCTAssertNotEqual([MXHTTPClient jitterTimeForRetry], [MXHTTPClient jitterTimeForRetry], @"[MXHTTPClient jitterTimeForRetry] cannot return the same value twice");
+    XCTAssertNotEqual([MXHTTPClient timeForRetry:nil], [MXHTTPClient timeForRetry:nil], @"[MXHTTPClient timeForRetry] cannot return the same value twice");
 }
 
 @end


### PR DESCRIPTION
#245.

We keep a gitter as discussed here: https://matrix.to/#/!HCXfdvrfksxuYnIFiJ:matrix.org/$1487167061111kLtnV:jki.re
