### PR TITLE
Fix: MXCrypto: app may crash on clear cache because of the periodic u…

### DIFF
--- a/MatrixSDK/Crypto/MXCrypto.h
+++ b/MatrixSDK/Crypto/MXCrypto.h
@@ -78,11 +78,9 @@
  
  @param success A block object called when the operation succeeds.
  @param failure A block object called when the operation fails.
- 
- @return a MXHTTPOperation instance.
  */
-- (MXHTTPOperation*)start:(void (^)())onComplete
-                  failure:(void (^)(NSError *error))failure;
+- (void)start:(void (^)())onComplete
+      failure:(void (^)(NSError *error))failure;
 
 /**
  Stop and release crypto objects.

--- a/MatrixSDK/MXSession.h
+++ b/MatrixSDK/MXSession.h
@@ -1,6 +1,7 @@
 /*
  Copyright 2014 OpenMarket Ltd
- 
+ Copyright 2017 Vector Creations Ltd
+
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
@@ -454,10 +455,8 @@ typedef void (^MXOnBackgroundSyncFail)(NSError *error);
 
  @param success A block object called when the operation succeeds.
  @param failure A block object called when the operation fails.
- 
- @return the HTTP operation that may be required. Can be nil.
  */
-- (MXHTTPOperation*)enableCrypto:(BOOL)enableCrypto success:(void (^)())success failure:(void (^)(NSError *error))failure;
+- (void)enableCrypto:(BOOL)enableCrypto success:(void (^)())success failure:(void (^)(NSError *error))failure;
 
 
 #pragma mark - Rooms operations

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -1196,10 +1196,8 @@ typedef void (^MXOnResumeDone)();
     _callManager = [[MXCallManager alloc] initWithMatrixSession:self andCallStack:callStack];
 }
 
-- (MXHTTPOperation *)enableCrypto:(BOOL)enableCrypto success:(void (^)())success failure:(void (^)(NSError *))failure
+- (void)enableCrypto:(BOOL)enableCrypto success:(void (^)())success failure:(void (^)(NSError *))failure
 {
-    MXHTTPOperation *operation;
-
     NSLog(@"[MXSesion] enableCrypto: %@", @(enableCrypto));
 
     if (enableCrypto && !_crypto)
@@ -1208,7 +1206,7 @@ typedef void (^MXOnResumeDone)();
 
         if (_state == MXSessionStateRunning)
         {
-            operation = [_crypto start:success failure:failure];
+            [_crypto start:success failure:failure];
         }
         else
         {
@@ -1239,8 +1237,6 @@ typedef void (^MXOnResumeDone)();
             success();
         }
     }
-
-    return operation;
 }
 
 
@@ -2144,24 +2140,20 @@ typedef void (^MXOnResumeDone)();
 
  @param complete a block called in any case when the operation completes.
  */
-- (MXHTTPOperation*)startCrypto:(void (^)())success
-                        failure:(void (^)(NSError *error))failure
+- (void)startCrypto:(void (^)())success
+            failure:(void (^)(NSError *error))failure
 {
-    MXHTTPOperation *operation;
-
     NSLog(@"[MXSession] Start crypto");
 
     if (_crypto)
     {
-        operation = [_crypto start:success failure:failure];
+        [_crypto start:success failure:failure];
     }
     else
     {
         NSLog(@"[MXSession] Start crypto -> No crypto");
         success();
     }
-
-    return operation;
 }
 
 - (BOOL)decryptEvent:(MXEvent*)event inTimeline:(NSString*)timeline

--- a/MatrixSDKTests/MXCryptoTests.m
+++ b/MatrixSDKTests/MXCryptoTests.m
@@ -231,7 +231,7 @@
 
         XCTAssertFalse([mxSession.crypto.store.class hasDataForCredentials:mxSession.matrixRestClient.credentials]);
 
-        MXHTTPOperation *operation = [mxSession enableCrypto:YES success:^{
+        [mxSession enableCrypto:YES success:^{
 
             XCTAssert(mxSession.crypto);
             XCTAssert([mxSession.crypto.store.class hasDataForCredentials:mxSession.matrixRestClient.credentials]);
@@ -254,9 +254,6 @@
             XCTFail(@"The request should not fail - NSError: %@", error);
             [expectation fulfill];
         }];
-
-        XCTAssert(operation, @"HTTP operations must be done when initialising crypto for the first time");
-
     }];
 }
 


### PR DESCRIPTION
…ploadKeys #234

Do not return anymore a MXHTTPOperation from [MXCrypto start] because it is not used but handle this MXHTTPOperation internally to be able to cancel it on [MXCrypto close].