### PR TITLE
Self-signed homeserver: Fix: Avatars (and probably other media) do no…

### DIFF
--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -44,6 +44,8 @@
 		322A51C81D9BBD3C00C8536D /* MXOlmDevice.m in Sources */ = {isa = PBXBuildFile; fileRef = 322A51C61D9BBD3C00C8536D /* MXOlmDevice.m */; };
 		322A51D81D9E846800C8536D /* MXCryptoTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 322A51D71D9E846800C8536D /* MXCryptoTests.m */; };
 		32322A481E57264E005DD155 /* MXSelfSignedHomeserverTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 32322A471E57264E005DD155 /* MXSelfSignedHomeserverTests.m */; };
+		32322A4B1E575F65005DD155 /* MXAllowedCertificates.h in Headers */ = {isa = PBXBuildFile; fileRef = 32322A491E575F65005DD155 /* MXAllowedCertificates.h */; };
+		32322A4C1E575F65005DD155 /* MXAllowedCertificates.m in Sources */ = {isa = PBXBuildFile; fileRef = 32322A4A1E575F65005DD155 /* MXAllowedCertificates.m */; };
 		3233606F1A403A0D0071A488 /* MXFileStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 3233606D1A403A0D0071A488 /* MXFileStore.h */; };
 		323360701A403A0D0071A488 /* MXFileStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 3233606E1A403A0D0071A488 /* MXFileStore.m */; };
 		323B2ACF1BCD3EF000B11F34 /* MXCoreDataStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 323B2ACB1BCD3EF000B11F34 /* MXCoreDataStore.h */; };
@@ -275,6 +277,8 @@
 		322A51C61D9BBD3C00C8536D /* MXOlmDevice.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXOlmDevice.m; sourceTree = "<group>"; };
 		322A51D71D9E846800C8536D /* MXCryptoTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXCryptoTests.m; sourceTree = "<group>"; };
 		32322A471E57264E005DD155 /* MXSelfSignedHomeserverTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXSelfSignedHomeserverTests.m; sourceTree = "<group>"; };
+		32322A491E575F65005DD155 /* MXAllowedCertificates.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXAllowedCertificates.h; sourceTree = "<group>"; };
+		32322A4A1E575F65005DD155 /* MXAllowedCertificates.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXAllowedCertificates.m; sourceTree = "<group>"; };
 		3233606D1A403A0D0071A488 /* MXFileStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXFileStore.h; sourceTree = "<group>"; };
 		3233606E1A403A0D0071A488 /* MXFileStore.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXFileStore.m; sourceTree = "<group>"; };
 		323B2ACB1BCD3EF000B11F34 /* MXCoreDataStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXCoreDataStore.h; sourceTree = "<group>"; };
@@ -554,6 +558,8 @@
 				329FB1781A0A74B100A5E88E /* MXTools.m */,
 				327E37B41A974F75007F026F /* MXLogger.h */,
 				327E37B51A974F75007F026F /* MXLogger.m */,
+				32322A491E575F65005DD155 /* MXAllowedCertificates.h */,
+				32322A4A1E575F65005DD155 /* MXAllowedCertificates.m */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -986,6 +992,7 @@
 				32114A8F1A262ECB00FF2EC4 /* MXNoStore.h in Headers */,
 				3259CD531DF860C300186944 /* MXRealmCryptoStore.h in Headers */,
 				32D776811A27877300FC4AA2 /* MXMemoryRoomStore.h in Headers */,
+				32322A4B1E575F65005DD155 /* MXAllowedCertificates.h in Headers */,
 				32A1515B1DB525DA00400192 /* NSObject+sortedKeys.h in Headers */,
 				32DC15CF1A8CF7AE006F9AD3 /* MXPushRuleConditionChecker.h in Headers */,
 				327187851DA7D0220071C818 /* MXOlmDecryption.h in Headers */,
@@ -1307,6 +1314,7 @@
 				32A151471DAF7C0C00400192 /* MXDeviceInfo.m in Sources */,
 				32A1515C1DB525DA00400192 /* NSObject+sortedKeys.m in Sources */,
 				F03EF5091DF071D5009DF592 /* MXEncryptedAttachments.m in Sources */,
+				32322A4C1E575F65005DD155 /* MXAllowedCertificates.m in Sources */,
 				F03EF5051DF01596009DF592 /* MXLRUCache.m in Sources */,
 				71DE22E01BC7C51200284153 /* MXReceiptData.m in Sources */,
 				327E37B71A974F75007F026F /* MXLogger.m in Sources */,

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -20,6 +20,8 @@
 #import "MXTools.h"
 #import "MXError.h"
 
+#import "MXAllowedCertificates.h"
+
 #pragma mark - Constants definitions
 /**
  Prefix used in path of home server API requests.
@@ -138,6 +140,8 @@ MXAuthAction;
                              // Check whether the provided certificate is the already trusted by the user.
                              if (inCredentials.allowedCertificate && [inCredentials.allowedCertificate isEqualToData:certificate])
                              {
+                                 // Store the allowed certificate for further requests (from MXMediaManager)
+                                 [[MXAllowedCertificates sharedInstance] addCertificate:certificate];
                                  return YES;
                              }
 
@@ -150,7 +154,15 @@ MXAuthAction;
                              // Let the app ask the end user to verify it
                              if (onUnrecognizedCertBlock)
                              {
-                                 return onUnrecognizedCertBlock(certificate);
+                                 BOOL allowed = onUnrecognizedCertBlock(certificate);
+
+                                 if (allowed)
+                                 {
+                                     // Store the allowed certificate for further requests (from MXMediaManager)
+                                     [[MXAllowedCertificates sharedInstance] addCertificate:certificate];
+                                 }
+
+                                 return allowed;
                              }
                              else
                              {

--- a/MatrixSDK/Utils/MXAllowedCertificates.h
+++ b/MatrixSDK/Utils/MXAllowedCertificates.h
@@ -1,0 +1,45 @@
+/*
+ Copyright 2017 Vector Creations Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+/**
+ The `MXAllowedCertificates` singleton stores certificates allowed by the user.
+ We need this static object because of the staticness of `MXMediaManager`.
+ */
+@interface MXAllowedCertificates : NSObject
+
+/**
+ The `MXAllowedCertificates` singleton.
+ */
++ (id)sharedInstance;
+
+/**
+ Add a certificate in the allowed list.
+ 
+ @param certificate the certificate to add.
+ */
+- (void)addCertificate:(NSData*)certificate;
+
+/**
+ Check if a certificate is allowed.
+ 
+ @param certificate the certificate to check.
+ @return YES if allowed.
+ */
+- (BOOL)isCertificateAllowed:(NSData*)certificate;
+
+@end

--- a/MatrixSDK/Utils/MXAllowedCertificates.m
+++ b/MatrixSDK/Utils/MXAllowedCertificates.m
@@ -1,0 +1,74 @@
+/*
+ Copyright 2017 Vector Creations Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXAllowedCertificates.h"
+
+@interface MXAllowedCertificates ()
+{
+    NSMutableSet<NSData*> *certificates;
+}
+
+@end
+
+@implementation MXAllowedCertificates
+
++ (MXAllowedCertificates *)sharedInstance
+{
+    static MXAllowedCertificates *sharedOnceInstance;
+
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sharedOnceInstance = [[MXAllowedCertificates alloc] init];
+    });
+
+    return sharedOnceInstance;
+}
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self)
+    {
+        certificates = [NSMutableSet set];
+    }
+    return self;
+}
+
+- (void)addCertificate:(NSData *)certificate
+{
+    if (![self isCertificateAllowed:certificate])
+    {
+        [certificates addObject:certificate];
+    }
+}
+
+- (BOOL)isCertificateAllowed:(NSData *)certificate
+{
+    BOOL allowed = NO;
+
+    for (NSData *allowedCertificate in certificates)
+    {
+        if ([allowedCertificate isEqualToData:certificate])
+        {
+            allowed = YES;
+            break;
+        }
+    }
+
+    return allowed;
+}
+
+@end

--- a/MatrixSDK/Utils/Media/MXMediaLoader.h
+++ b/MatrixSDK/Utils/Media/MXMediaLoader.h
@@ -92,7 +92,7 @@ extern NSString *const kMXMediaUploadIdPrefix;
 /**
  `MXMediaLoader` defines a class to download/upload media. It provides progress information during the operation.
  */
-@interface MXMediaLoader : NSObject <NSURLConnectionDataDelegate>
+@interface MXMediaLoader : NSObject <NSURLConnectionDataDelegate, NSURLConnectionDelegate>
 {    
     blockMXMediaLoader_onSuccess onSuccess;
     blockMXMediaLoader_onError onError;

--- a/MatrixSDK/Utils/Media/MXMediaLoader.m
+++ b/MatrixSDK/Utils/Media/MXMediaLoader.m
@@ -19,6 +19,8 @@
 #import "MXSession.h"
 #import "MXHTTPOperation.h"
 
+#import "MXAllowedCertificates.h"
+
 NSString *const kMXMediaDownloadProgressNotification = @"kMXMediaDownloadProgressNotification";
 NSString *const kMXMediaDownloadDidFinishNotification = @"kMXMediaDownloadDidFinishNotification";
 NSString *const kMXMediaDownloadDidFailNotification = @"kMXMediaDownloadDidFailNotification";
@@ -221,6 +223,33 @@ NSString *const kMXMediaUploadIdPrefix = @"upload-";
     
     downloadData = nil;
     downloadConnection = nil;
+}
+
+#pragma mark - NSURLConnectionDelegate
+
+- (void)connection:(NSURLConnection *)connection willSendRequestForAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge
+{
+    NSURLProtectionSpace *protectionSpace = [challenge protectionSpace];
+    if ([protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust])
+    {
+        SecTrustRef trust = [protectionSpace serverTrust];
+        if (SecTrustGetCertificateCount(trust) > 0)
+        {
+            // Consider here the leaf certificate (the one at index 0).
+            SecCertificateRef certif = SecTrustGetCertificateAtIndex(trust, 0);
+
+            NSData *certificate = (__bridge NSData*)SecCertificateCopyData(certif);
+            if ([[MXAllowedCertificates sharedInstance] isCertificateAllowed:certificate])
+            {
+                NSURLCredential *credential = [NSURLCredential credentialForTrust:protectionSpace.serverTrust];
+                [[challenge sender] useCredential:credential forAuthenticationChallenge:challenge];
+            }
+            else
+            {
+                NSLog(@"[MXMediaLoader] Certificate check failed for %@", protectionSpace);
+            }
+        }
+    }
 }
 
 #pragma mark - Upload


### PR DESCRIPTION
…t display with account on a self-signed server (https://github.com/vector-im/riot-ios/issues/816)

Handle this by storing allowed certificates into a singleton that the static MXMediaManager can use.