### PR TITLE
Self-signed homeserver: Fix regression on media hosted by server with CA certificate

### DIFF
--- a/MatrixSDK/Utils/MXAllowedCertificates.h
+++ b/MatrixSDK/Utils/MXAllowedCertificates.h
@@ -42,4 +42,9 @@
  */
 - (BOOL)isCertificateAllowed:(NSData*)certificate;
 
+/**
+ Forget all allowed certificates.
+ */
+- (void)reset;
+
 @end

--- a/MatrixSDK/Utils/MXAllowedCertificates.m
+++ b/MatrixSDK/Utils/MXAllowedCertificates.m
@@ -71,4 +71,9 @@
     return allowed;
 }
 
+- (void)reset
+{
+    [certificates removeAllObjects];
+}
+
 @end

--- a/MatrixSDK/Utils/MXHTTPClient.m
+++ b/MatrixSDK/Utils/MXHTTPClient.m
@@ -359,7 +359,8 @@ NSString * const MXHTTPClientErrorResponseDataKey = @"com.matrixsdk.httpclient.e
                 }
                 else if (mxHTTPOperation.numberOfTries < mxHTTPOperation.maxNumberOfTries
                          && mxHTTPOperation.age < mxHTTPOperation.maxRetriesTime
-                         && response.statusCode != 400 && response.statusCode != 401 && response.statusCode != 403 // No amount of retrying will save you now
+                         && !([error.domain isEqualToString:NSURLErrorDomain] && error.code == kCFURLErrorCancelled)    // No need to retry a cancelation (which can also happen on SSL error)
+                         && response.statusCode != 400 && response.statusCode != 401 && response.statusCode != 403      // No amount of retrying will save you now
                          )
                 {
                     // Check if it is a network connectivity issue

--- a/MatrixSDK/Utils/Media/MXMediaLoader.m
+++ b/MatrixSDK/Utils/Media/MXMediaLoader.m
@@ -254,6 +254,7 @@ NSString *const kMXMediaUploadIdPrefix = @"upload-";
                 {
                     NSURLCredential *credential = [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust];
                     [challenge.sender useCredential:credential forAuthenticationChallenge:challenge];
+                    break;
                 }
 
                 default:

--- a/MatrixSDK/Utils/Media/MXMediaLoader.m
+++ b/MatrixSDK/Utils/Media/MXMediaLoader.m
@@ -233,20 +233,53 @@ NSString *const kMXMediaUploadIdPrefix = @"upload-";
     if ([protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust])
     {
         SecTrustRef trust = [protectionSpace serverTrust];
-        if (SecTrustGetCertificateCount(trust) > 0)
-        {
-            // Consider here the leaf certificate (the one at index 0).
-            SecCertificateRef certif = SecTrustGetCertificateAtIndex(trust, 0);
 
-            NSData *certificate = (__bridge NSData*)SecCertificateCopyData(certif);
-            if ([[MXAllowedCertificates sharedInstance] isCertificateAllowed:certificate])
+        // Re-evaluate the trust policy
+        SecTrustResultType secresult = kSecTrustResultInvalid;
+        if (SecTrustEvaluate(trust, &secresult) != errSecSuccess)
+        {
+            // Trust evaluation failed
+            [connection cancel];
+
+            // Generate same kind of error as AFNetworking
+            NSError *error = [NSError errorWithDomain:NSURLErrorDomain code:kCFURLErrorCancelled userInfo:nil];
+            [self connection:connection didFailWithError:error];
+        }
+        else
+        {
+            switch (secresult)
             {
-                NSURLCredential *credential = [NSURLCredential credentialForTrust:protectionSpace.serverTrust];
-                [[challenge sender] useCredential:credential forAuthenticationChallenge:challenge];
-            }
-            else
-            {
-                NSLog(@"[MXMediaLoader] Certificate check failed for %@", protectionSpace);
+                case kSecTrustResultUnspecified:    // The OS trusts this certificate implicitly.
+                case kSecTrustResultProceed:        // The user explicitly told the OS to trust it.
+                {
+                    NSURLCredential *credential = [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust];
+                    [challenge.sender useCredential:credential forAuthenticationChallenge:challenge];
+                }
+
+                default:
+                {
+                    // Consider here the leaf certificate (the one at index 0).
+                    SecCertificateRef certif = SecTrustGetCertificateAtIndex(trust, 0);
+
+                    NSData *certificate = (__bridge NSData*)SecCertificateCopyData(certif);
+
+                    // Was it already trusted by the user ?
+                    if ([[MXAllowedCertificates sharedInstance] isCertificateAllowed:certificate])
+                    {
+                        NSURLCredential *credential = [NSURLCredential credentialForTrust:protectionSpace.serverTrust];
+                        [[challenge sender] useCredential:credential forAuthenticationChallenge:challenge];
+                    }
+                    else
+                    {
+                        NSLog(@"[MXMediaLoader] Certificate check failed for %@", protectionSpace);
+                        [connection cancel];
+
+                        // Generate same kind of error as AFNetworking
+                        NSError *error = [NSError errorWithDomain:NSURLErrorDomain code:kCFURLErrorCancelled userInfo:nil];
+                        [self connection:connection didFailWithError:error];
+                    }
+                    break;
+                }
             }
         }
     }


### PR DESCRIPTION
Plus:
- improve the SSL error handling. Previously, requests silently died. Now, they call their failure block.
- add more tests