### PR TITLE
Delay otk generation

### DIFF
--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -231,13 +231,13 @@ NSTimeInterval kMXCryptoUploadOneTimeKeysPeriod = 60.0; // one minute
 
                 // Once keys are uploaded, announce ourselves
                 MXHTTPOperation *operation2 = [self makeAnnoucement:roomsByUser success:^{
+
+                    // Make sure we are refreshing devices lists right instead
+                    // of waiting for the next /sync that may occur in 30s.
+                    [_deviceList refreshOutdatedDeviceLists];
+
                     dispatch_async(dispatch_get_main_queue(), ^{
                         startOperation = nil;
-
-                        // Make sure we are refreshing devices lists right instead
-                        // of waiting for the next /sync that may occur in 30s.
-                        [_deviceList refreshOutdatedDeviceLists];
-
                         success();
                     });
 

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -233,6 +233,11 @@ NSTimeInterval kMXCryptoUploadOneTimeKeysPeriod = 60.0; // one minute
                 MXHTTPOperation *operation2 = [self makeAnnoucement:roomsByUser success:^{
                     dispatch_async(dispatch_get_main_queue(), ^{
                         startOperation = nil;
+
+                        // Make sure we are refreshing devices lists right instead
+                        // of waiting for the next /sync that may occur in 30s.
+                        [_deviceList refreshOutdatedDeviceLists];
+
                         success();
                     });
 

--- a/MatrixSDK/Crypto/MXCrypto_Private.h
+++ b/MatrixSDK/Crypto/MXCrypto_Private.h
@@ -76,20 +76,6 @@
  */
 @property (nonatomic, readonly) dispatch_queue_t decryptionQueue;
 
-/**
- Upload the device keys to the homeserver and ensure that the
- homeserver has enough one-time keys.
-
- @param maxKeys The maximum number of keys to generate.
- 
- @param success A block object called when the operation succeeds.
- @param failure A block object called when the operation fails.
-
- @return a MXHTTPOperation instance.
- */
-- (MXHTTPOperation*)uploadKeys:(NSUInteger)maxKeys
-                       success:(void (^)())success
-                       failure:(void (^)(NSError *))failure;
 
 /**
  Get the device which sent an event.

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -895,6 +895,12 @@ typedef void (^MXOnResumeDone)();
         {
             [_store commit];
         }
+
+        // Do a loop of /syncs until catching up is done
+        if (nextServerTimeout == 0)
+        {
+            [self serverSyncWithServerTimeout:nextServerTimeout success:success failure:failure clientTimeout:CLIENT_TIMEOUT_MS setPresence:nil];
+        }
         
         // there is a pending backgroundSync
         if (onBackgroundSyncDone)

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -696,7 +696,11 @@ typedef void (^MXOnResumeDone)();
                         setPresence:(NSString*)setPresence
 {
     NSDate *startDate = [NSDate date];
-    NSLog(@"[MXSession] Do a server sync");
+
+    // Determine if we are catching up
+    _catchingUp = (0 == serverTimeout);
+
+    NSLog(@"[MXSession] Do a server sync%@", _catchingUp ? @" (catching up)" : @"");
 
     NSString *inlineFilter;
     if (-1 != syncMessagesLimit)
@@ -704,9 +708,6 @@ typedef void (^MXOnResumeDone)();
         // If requested by the app, use a limit for /sync.
         inlineFilter = [NSString stringWithFormat:@"{\"room\":{\"timeline\":{\"limit\":%tu}}}", syncMessagesLimit];
     }
-
-    // Determine if we are catching up
-    _catchingUp = (0 == serverTimeout);
 
     eventStreamRequest = [matrixRestClient syncFromToken:_store.eventStreamToken serverTimeout:serverTimeout clientTimeout:clientTimeout setPresence:setPresence filter:inlineFilter success:^(MXSyncResponse *syncResponse) {
         

--- a/MatrixSDKTests/MXCryptoTests.m
+++ b/MatrixSDKTests/MXCryptoTests.m
@@ -258,7 +258,7 @@
     XCTAssert(event.eventId);
     XCTAssertEqualObjects(event.roomId, roomId);
     XCTAssertEqual(event.eventType, MXEventTypeRoomMessage);
-    XCTAssertLessThan(event.age, 2000);
+    XCTAssertLessThan(event.age, 10000);
     XCTAssertEqualObjects(event.content[@"body"], clearMessage);
     XCTAssertEqualObjects(event.sender, senderSession.myUser.userId);
     XCTAssertNil(event.decryptionError);

--- a/MatrixSDKTests/MXCryptoTests.m
+++ b/MatrixSDKTests/MXCryptoTests.m
@@ -402,92 +402,6 @@
             XCTFail(@"The request should not fail - NSError: %@", error);
             [expectation fulfill];
         }];
-    }];
-}
-
-- (void)testKeysUploadAndDownload
-{
-    [MXSDKOptions sharedInstance].enableCryptoWhenStartingMXSession = YES;
-
-    [matrixSDKTestsData doMXSessionTestWithAlice:self readyToTest:^(MXSession *aliceSession, XCTestExpectation *expectation) {
-
-        [aliceSession.crypto uploadKeys:10 success:^{
-
-            [matrixSDKTestsData doMXSessionTestWithBob:nil readyToTest:^(MXSession *mxSession, XCTestExpectation *expectation2) {
-
-                [MXSDKOptions sharedInstance].enableCryptoWhenStartingMXSession = NO;
-
-                [mxSession.crypto.deviceList downloadKeys:@[mxSession.myUser.userId, aliceSession.myUser.userId] forceDownload:NO success:^(MXUsersDevicesMap<MXDeviceInfo *> *usersDevicesInfoMap) {
-
-                    XCTAssertEqual(usersDevicesInfoMap.userIds.count, 2, @"BobDevice must be obtain from the cache and AliceDevice from the hs");
-
-                    XCTAssertEqual([usersDevicesInfoMap deviceIdsForUser:aliceSession.myUser.userId].count, 1);
-
-                    __block MXDeviceInfo *aliceDeviceFromBobPOV = [usersDevicesInfoMap objectForDevice:aliceSession.matrixRestClient.credentials.deviceId forUser:aliceSession.myUser.userId];
-                    XCTAssert(aliceDeviceFromBobPOV);
-                    XCTAssertEqualObjects(aliceDeviceFromBobPOV.fingerprint, aliceSession.crypto.olmDevice.deviceEd25519Key);
-
-                    // Continue testing other methods
-                    XCTAssertEqualObjects([mxSession.crypto.deviceList deviceWithIdentityKey:aliceSession.crypto.olmDevice.deviceCurve25519Key forUser:aliceSession.myUser.userId andAlgorithm:kMXCryptoOlmAlgorithm].description, aliceDeviceFromBobPOV.description);
-
-                    XCTAssertEqual(aliceDeviceFromBobPOV.verified, MXDeviceUnknown, @"This is the first time Alice sees this device");
-
-                    [mxSession.crypto setDeviceVerification:MXDeviceBlocked forDevice:aliceDeviceFromBobPOV.deviceId ofUser:aliceSession.myUser.userId success:^{
-
-                        aliceDeviceFromBobPOV = [mxSession.crypto.store deviceWithDeviceId:aliceDeviceFromBobPOV.deviceId forUser:aliceSession.myUser.userId];
-                        XCTAssertEqual(aliceDeviceFromBobPOV.verified, MXDeviceBlocked);
-
-                        MXRestClient *bobRestClient = mxSession.matrixRestClient;
-                        [mxSession close];
-
-
-                        // Test storage: Reopen the session
-                        MXFileStore *store = [[MXFileStore alloc] init];
-
-                        MXSession *mxSession2 = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
-                        [mxSession2 setStore:store success:^{
-
-                            MXDeviceInfo *aliceDeviceFromBobPOV2 = [mxSession2.crypto.deviceList deviceWithIdentityKey:aliceSession.crypto.olmDevice.deviceCurve25519Key forUser:aliceSession.myUser.userId andAlgorithm:kMXCryptoOlmAlgorithm];
-
-                            XCTAssert(aliceDeviceFromBobPOV2);
-                            XCTAssertEqualObjects(aliceDeviceFromBobPOV2.fingerprint, aliceSession.crypto.olmDevice.deviceEd25519Key);
-                            XCTAssertEqual(aliceDeviceFromBobPOV2.verified, MXDeviceBlocked, @"AliceDevice must still be blocked");
-
-                            // Download again alice device
-                            [mxSession2.crypto.deviceList downloadKeys:@[aliceSession.myUser.userId] forceDownload:YES success:^(MXUsersDevicesMap<MXDeviceInfo *> *usersDevicesInfoMap2) {
-
-                                MXDeviceInfo *aliceDeviceFromBobPOV3 = [mxSession2.crypto.deviceList deviceWithIdentityKey:aliceSession.crypto.olmDevice.deviceCurve25519Key forUser:aliceSession.myUser.userId andAlgorithm:kMXCryptoOlmAlgorithm];
-
-                                XCTAssert(aliceDeviceFromBobPOV3);
-                                XCTAssertEqualObjects(aliceDeviceFromBobPOV3.fingerprint, aliceSession.crypto.olmDevice.deviceEd25519Key);
-                                XCTAssertEqual(aliceDeviceFromBobPOV3.verified, MXDeviceBlocked, @"AliceDevice must still be blocked.");
-
-                                [expectation fulfill];
-
-                            } failure:^(NSError *error) {
-                                XCTFail(@"The request should not fail - NSError: %@", error);
-                                [expectation fulfill];
-                            }];
-                        } failure:^(NSError *error) {
-                            XCTFail(@"Cannot set up intial test conditions - error: %@", error);
-                            [expectation fulfill];
-                        }];
-
-                    } failure:^(NSError *error) {
-                        XCTFail(@"The request should not fail - NSError: %@", error);
-                        [expectation fulfill];
-                    }];
-
-                 } failure:^(NSError *error) {
-                    XCTFail(@"The request should not fail - NSError: %@", error);
-                    [expectation fulfill];
-                }];
-
-            }];
-        } failure:^(NSError *error) {
-            XCTFail(@"The request should not fail - NSError: %@", error);
-            [expectation fulfill];
-        }];
 
     }];
 }
@@ -592,81 +506,6 @@
             [expectation fulfill];
         }];
 
-    }];
-}
-
-- (void)testEnsureOlmSessionsForUsers
-{
-    [MXSDKOptions sharedInstance].enableCryptoWhenStartingMXSession = YES;
-
-    [matrixSDKTestsData doMXSessionTestWithAlice:self readyToTest:^(MXSession *aliceSession, XCTestExpectation *expectation) {
-
-        [aliceSession.crypto uploadKeys:10 success:^{
-
-            [matrixSDKTestsData doMXSessionTestWithBob:nil readyToTest:^(MXSession *mxSession, XCTestExpectation *expectation2) {
-
-                [MXSDKOptions sharedInstance].enableCryptoWhenStartingMXSession = NO;
-
-                [mxSession.crypto.deviceList downloadKeys:@[mxSession.myUser.userId, aliceSession.myUser.userId] forceDownload:NO success:^(MXUsersDevicesMap<MXDeviceInfo *> *usersDevicesInfoMap) {
-
-
-                    // Start the test
-                    MXHTTPOperation *httpOperation = [mxSession.crypto ensureOlmSessionsForUsers:@[mxSession.myUser.userId, aliceSession.myUser.userId] success:^(MXUsersDevicesMap<MXOlmSessionResult *> *results) {
-
-                        XCTAssertEqual(results.userIds.count, 1, @"Only a session with Alice must be created. No mean to create on with oneself(Bob)");
-
-                        MXOlmSessionResult *sessionWithAliceDevice = [results objectForDevice:aliceSession.matrixRestClient.credentials.deviceId forUser:aliceSession.myUser.userId];
-                        XCTAssert(sessionWithAliceDevice);
-                        XCTAssert(sessionWithAliceDevice.sessionId);
-                        XCTAssertEqualObjects(sessionWithAliceDevice.device.deviceId, aliceSession.matrixRestClient.credentials.deviceId);
-
-
-                        // Test persistence
-                        MXRestClient *bobRestClient = mxSession.matrixRestClient;
-                        [mxSession close];
-
-                        MXSession *mxSession2 = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
-                        [mxSession2 setStore:[[MXFileStore alloc] init] success:^{
-
-                            MXHTTPOperation *httpOperation2 = [mxSession2.crypto ensureOlmSessionsForUsers:@[mxSession2.myUser.userId, aliceSession.myUser.userId] success:^(MXUsersDevicesMap<MXOlmSessionResult *> *results) {
-
-                                XCTAssertEqual(results.userIds.count, 1, @"Only a session with Alice must be created. No mean to create on with oneself(Bob)");
-
-                                MXOlmSessionResult *sessionWithAliceDevice = [results objectForDevice:aliceSession.matrixRestClient.credentials.deviceId forUser:aliceSession.myUser.userId];
-                                XCTAssert(sessionWithAliceDevice);
-                                XCTAssert(sessionWithAliceDevice.sessionId);
-                                XCTAssertEqualObjects(sessionWithAliceDevice.device.deviceId, aliceSession.matrixRestClient.credentials.deviceId);
-
-                                [expectation fulfill];
-
-                            } failure:^(NSError *error) {
-                                XCTFail(@"The request should not fail - NSError: %@", error);
-                                [expectation fulfill];
-                            }];
-
-                            XCTAssertNil(httpOperation2, @"The session must be in cache. No need to make a request");
-
-                        } failure:^(NSError *error) {
-                            XCTFail(@"Cannot set up intial test conditions - error: %@", error);
-                            [expectation fulfill];
-                        }];
-
-                    } failure:^(NSError *error) {
-                        XCTFail(@"The request should not fail - NSError: %@", error);
-                        [expectation fulfill];
-                    }];
-
-                    XCTAssert(httpOperation);
-
-                } failure:^(NSError *error) {
-                    XCTFail(@"Cannot set up intial test conditions - error: %@", error);
-                    [expectation fulfill];
-                }];
-            }];
-        } failure:^(NSError *error) {
-            XCTFail(@"Cannot set up intial test conditions - error: %@", error);
-            [expectation fulfill];
-        }];
     }];
 }
 
@@ -1175,7 +1014,6 @@
 - (void)testAliceWithNewDeviceAndBob
 {
     [self doE2ETestWithAliceAndBobInARoomWithCryptedMessages:self cryptedBob:YES readyToTest:^(MXSession *aliceSession, MXSession *bobSession, NSString *roomId, XCTestExpectation *expectation) {
-//    [self doE2ETestWithAliceAndBobInARoom:self cryptedBob:YES readyToTest:^(MXSession *aliceSession, MXSession *bobSession, NSString *roomId, XCTestExpectation *expectation) {
 
         // Relog alice to simulate a new device
         [MXSDKOptions sharedInstance].enableCryptoWhenStartingMXSession = YES;


### PR DESCRIPTION
Equivalent of https://github.com/matrix-org/matrix-js-sdk/pull/376.

With some differences / improvements due to the ios sdk behaviour:
- MXSession does a loop of /sync requests until catching up is done. This ensures that we start crypto in the right condition
- Upload OTK before sending the to-device announcement.

