### PR TITLE
BF: e2e: Sometimes some events are not decrypted when importing keys #261

### DIFF
--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -410,7 +410,9 @@ NSTimeInterval kMXCryptoUploadOneTimeKeysPeriod = 60.0; // one minute
 
     __block BOOL result = NO;
 
-    // @TODO: dispatch_async
+    // TODO: dispatch_async (https://github.com/matrix-org/matrix-ios-sdk/issues/205)
+    // At the moment, we lock the main thread while decrypting events.
+    // Fortunately, decrypting is far quicker that encrypting.
     dispatch_sync(_decryptionQueue, ^{
         id<MXDecrypting> alg = [self getRoomDecryptor:event.roomId algorithm:event.content[@"algorithm"]];
         if (!alg)


### PR DESCRIPTION
Fix race conditions by doing the retry is the same threads conditions as [MXCrypto decryptEvent].

The retry is done in 2 cases:
- a late room key
- after keys import

