### PR TITLE
VoIP: ensure e2e is ready in the room before answering a call

### DIFF
--- a/MatrixSDK/Crypto/Algorithms/MXEncrypting.h
+++ b/MatrixSDK/Crypto/Algorithms/MXEncrypting.h
@@ -49,4 +49,19 @@
                                 success:(void (^)(NSDictionary *encryptedContent))success
                                 failure:(void (^)(NSError *error))failure;
 
+/**
+ Ensure the set up of the session.
+ 
+ @param users the room members events will be sent to.
+
+ @param success A block object called when the operation succeeds. 
+                sessionInfo is an internal object, specific to the algorithm.
+ @param failure A block object called when the operation fails.
+
+ @return a MXHTTPOperation instance. May be nil if all required materials is already in place.
+ */
+- (MXHTTPOperation*)ensureSessionForUsers:(NSArray<NSString*>*)users
+                                  success:(void (^)(NSObject *sessionInfo))success
+                                  failure:(void (^)(NSError *error))failure;
+
 @end

--- a/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmEncryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmEncryption.m
@@ -134,6 +134,20 @@
     queuedEncryption.failure = failure;
     [pendingEncryptions addObject:queuedEncryption];
 
+    return [self ensureSessionForUsers:users success:^(NSObject *sessionInfo) {
+
+        MXOutboundSessionInfo *session = (MXOutboundSessionInfo*)sessionInfo;
+        [self processPendingEncryptionsInSession:session withError:nil];
+
+    } failure:^(NSError *error) {
+        [self processPendingEncryptionsInSession:nil withError:error];
+    }];
+}
+
+- (MXHTTPOperation*)ensureSessionForUsers:(NSArray<NSString*>*)users
+                                  success:(void (^)(NSObject *sessionInfo))success
+                                  failure:(void (^)(NSError *error))failure
+{
     NSDate *startDate = [NSDate date];
 
     MXHTTPOperation *operation;
@@ -141,22 +155,21 @@
 
         MXHTTPOperation *operation2 = [self ensureOutboundSession:devicesInRoom success:^(MXOutboundSessionInfo *session) {
 
-            NSLog(@"[MXMegolmEncryption] ensureOutboundSessionInRoom took %.0fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+            NSLog(@"[MXMegolmEncryption] ensureSessionForUsers took %.0fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 
-            [self processPendingEncryptionsInSession:session withError:nil];
+            if (success)
+            {
+                success(session);
+            }
 
-        } failure:^(NSError *error) {
-            [self processPendingEncryptionsInSession:nil withError:error];
-        }];
+        } failure:failure];
 
         if (operation2)
         {
             [operation mutateTo:operation2];
         }
 
-    } failure:^(NSError *error) {
-        [self processPendingEncryptionsInSession:nil withError:error];
-    }];
+    } failure:failure];
 
     return operation;
 }

--- a/MatrixSDK/Crypto/Algorithms/Olm/MXOlmEncryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Olm/MXOlmEncryption.m
@@ -58,7 +58,7 @@
                                 success:(void (^)(NSDictionary *encryptedContent))success
                                 failure:(void (^)(NSError *error))failure
 {
-    return [self ensureSession:users success:^{
+    return [self ensureSessionForUsers:users success:^(NSObject *sessionInfo) {
 
         NSMutableArray *participantDevices = [NSMutableArray array];
 
@@ -94,11 +94,9 @@
     } failure:failure];
 }
 
-
-#pragma mark - Private methods
-- (MXHTTPOperation*)ensureSession:(NSArray<NSString*>*)users
-                          success:(void (^)())success
-                          failure:(void (^)(NSError *))failure
+- (MXHTTPOperation*)ensureSessionForUsers:(NSArray<NSString*>*)users
+                                  success:(void (^)(NSObject *sessionInfo))success
+                                  failure:(void (^)(NSError *error))failure
 {
     // TODO: Avoid to do this request for every message. Instead, manage a queue of messages waiting for encryption
     // XXX: This class is not used so fix it later
@@ -106,7 +104,7 @@
     operation = [crypto.deviceList downloadKeys:users forceDownload:NO success:^(MXUsersDevicesMap<MXDeviceInfo *> *usersDevicesInfoMap) {
 
         MXHTTPOperation *operation2 = [crypto ensureOlmSessionsForUsers:users success:^(MXUsersDevicesMap<MXOlmSessionResult *> *results) {
-            success();
+            success(nil);
         } failure:failure];
 
         [operation mutateTo:operation2];

--- a/MatrixSDK/Crypto/MXCrypto.h
+++ b/MatrixSDK/Crypto/MXCrypto.h
@@ -120,7 +120,7 @@
 /**
  Ensure that the outbound session is ready to encrypt events.
  
- Thus, the next [MXCrypto encryptEvent] should be sent without HTTP requests.
+ Thus, the next [MXCrypto encryptEvent] should be encrypted without any HTTP requests.
  
  Note: There is no guarantee about this because a new device can still appear before
  the call of [MXCrypto encryptEvent]. Use this method with caution.

--- a/MatrixSDK/Crypto/MXCrypto.h
+++ b/MatrixSDK/Crypto/MXCrypto.h
@@ -93,7 +93,7 @@
  @param eventContent the content of the event.
  @param eventType the type of the event.
  @param room the room the event will be sent.
- *
+
  @param success A block object called when the operation succeeds.
  @param failure A block object called when the operation fails.
 
@@ -116,6 +116,24 @@
  @return YES if the decryption was successful.
  */
 - (BOOL)decryptEvent:(MXEvent*)event inTimeline:(NSString*)timeline;
+
+/**
+ Ensure that the outbound session is ready to encrypt events.
+ 
+ Thus, the next [MXCrypto encryptEvent] should be sent without HTTP requests.
+ 
+ Note: There is no guarantee about this because a new device can still appear before
+ the call of [MXCrypto encryptEvent]. Use this method with caution.
+ 
+ @param roomId the id of the room.
+ @param success A block object called when the operation succeeds.
+ @param failure A block object called when the operation fails.
+
+ @return a MXHTTPOperation instance. May be nil if all required materials is already in place.
+ */
+- (MXHTTPOperation*)ensureEncryptionInRoom:(NSString*)roomId
+                                   success:(void (^)())success
+                                   failure:(void (^)(NSError *error))failure;
 
 /**
  Handle list of changed users provided in the /sync response.

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -499,7 +499,6 @@ NSTimeInterval kMXCryptoUploadOneTimeKeysPeriod = 60.0; // one minute
                     }
                 }];
 
-
                 if (operation2)
                 {
                     [operation mutateTo:operation2];

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -443,6 +443,95 @@ NSTimeInterval kMXCryptoUploadOneTimeKeysPeriod = 60.0; // one minute
 #endif
 }
 
+- (MXHTTPOperation*)ensureEncryptionInRoom:(NSString*)roomId
+                                   success:(void (^)())success
+                                   failure:(void (^)(NSError *error))failure
+{
+
+    // Create an empty operation that will be mutated later
+    MXHTTPOperation *operation = [[MXHTTPOperation alloc] init];
+
+#ifdef MX_CRYPTO
+    MXRoom *room = [mxSession roomWithRoomId:roomId];
+    if (room.state.isEncrypted)
+    {
+        // Get user ids in this room
+        NSMutableArray *userIds = [NSMutableArray array];
+        for (MXRoomMember *member in room.state.joinedMembers)
+        {
+            [userIds addObject:member.userId];
+        }
+
+        dispatch_async(_cryptoQueue, ^{
+
+            NSString *algorithm;
+            id<MXEncrypting> alg = roomEncryptors[room.roomId];
+
+            if (!alg)
+            {
+                // The algorithm has not been initialised yet. So, do it now from room state information
+                algorithm = room.state.encryptionAlgorithm;
+                if (algorithm)
+                {
+                    [self setEncryptionInRoom:room.roomId withAlgorithm:algorithm];
+                    alg = roomEncryptors[room.roomId];
+                }
+            }
+
+            if (alg)
+            {
+                // Check we have everything to encrypt events
+                MXHTTPOperation *operation2 = [alg ensureSessionForUsers:userIds success:^(NSObject *sessionInfo) {
+
+                    if (success)
+                    {
+                        dispatch_async(dispatch_get_main_queue(), ^{
+                            success();
+                        });
+                    }
+
+                } failure:^(NSError *error) {
+                    if (failure)
+                    {
+                        dispatch_async(dispatch_get_main_queue(), ^{
+                            failure(error);
+                        });
+                    }
+                }];
+
+
+                if (operation2)
+                {
+                    [operation mutateTo:operation2];
+                }
+            }
+            else if (failure)
+            {
+                NSError *error = [NSError errorWithDomain:MXDecryptingErrorDomain
+                                                     code:MXDecryptingErrorUnableToEncryptCode
+                                                 userInfo:@{
+                                                            NSLocalizedDescriptionKey: MXDecryptingErrorUnableToEncrypt,
+                                                            NSLocalizedFailureReasonErrorKey: [NSString stringWithFormat:MXDecryptingErrorUnableToEncryptReason, algorithm]
+                                                            }];
+
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    failure(error);
+                });
+            }
+        });
+    }
+    else
+#endif
+    {
+        if (success)
+        {
+            success();
+        }
+    }
+
+    return operation;
+}
+
 // This method is equivalent to the Crypto.prototype._onSyncCompleted in matrix-js-sdk
 - (void)handleDeviceListsChanged:(NSArray<NSString *>*)userIds oldSyncToken:(NSString *)oldSyncToken nextSyncToken:(NSString *)nextSyncToken
 {


### PR DESCRIPTION
Check encryption before making the call stack answering.

This ensures that ICE candidates events are correctly encrypted and sent. This is useful atm in the case of unknown devices because it requires end user interactions.

This will help to solve vector-im/riot-ios#1058