### PR TITLE
MXMediaManager: Expose the media cache version

### DIFF
--- a/MatrixSDK/MXSDKOptions.h
+++ b/MatrixSDK/MXSDKOptions.h
@@ -1,5 +1,6 @@
 /*
  Copyright 2015 OpenMarket Ltd
+ Copyright 2017 Vector Creations Ltd
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -60,10 +61,10 @@
 #endif
 
 
-#pragma mark - Runtime options
+#pragma mark - Launch time options
 
 /**
- SDK options that can be set at runtime.
+ SDK options that can be set at the launch time.
  */
 @interface MXSDKOptions : NSObject
 
@@ -89,5 +90,13 @@
  NO by default.
  */
 @property (nonatomic) BOOL enableGoogleAnalytics;
+
+/**
+ The version of the media cache at the application level.
+ By updating this value the application is able to clear the existing media cache.
+ 
+ The default version value is 0.
+ */
+@property (nonatomic) NSUInteger mediaCacheAppVersion;
 
 @end

--- a/MatrixSDK/MXSDKOptions.m
+++ b/MatrixSDK/MXSDKOptions.m
@@ -1,5 +1,6 @@
 /*
  Copyright 2015 OpenMarket Ltd
+ Copyright 2017 Vector Creations Ltd
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -25,6 +26,22 @@ static MXSDKOptions *sharedOnceInstance = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{ sharedOnceInstance = [[self alloc] init]; });
     return sharedOnceInstance;
+}
+
+#pragma mark - Initializations -
+
+- (id)init
+{
+    self = [super init];
+    if (self)
+    {
+        _disableIdenticonUseForUserAvatar = NO;
+        _enableCryptoWhenStartingMXSession = NO;
+        _enableGoogleAnalytics = NO;
+        _mediaCacheAppVersion = 0;
+    }
+    
+    return self;
 }
 
 @end

--- a/MatrixSDK/Utils/Media/MXMediaManager.h
+++ b/MatrixSDK/Utils/Media/MXMediaManager.h
@@ -1,5 +1,6 @@
 /*
  Copyright 2016 OpenMarket Ltd
+ Copyright 2017 Vector Creations Ltd
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -236,6 +237,13 @@ extern NSString *const kMXMediaManagerDefaultCacheFolder;
  Return cache root path
  */
 + (NSString*)getCachePath;
+
+/**
+ Return the current media cache version.
+ This value depends on the version defined at the application level (see [MXSDKOptions mediaCacheAppVersion]),
+ and the one defined at SDK level.
+ */
++ (NSString*)getCacheVersionString;
 
 /**
  Cache size management (values are in bytes)


### PR DESCRIPTION
This value depends on the version defined at the application level (see [MXSDKOptions mediaCacheAppVersion]), and the one defined at SDK level.