### PR TITLE
MXRestClient: Update publicRooms to support pagination and 3rd party networks

### DIFF
--- a/MatrixSDK/Contrib/Swift/MXRestClient.swift
+++ b/MatrixSDK/Contrib/Swift/MXRestClient.swift
@@ -1,6 +1,7 @@
 /*
  Copyright 2017 Avery Pierce
- 
+ Copyright 2017 Vector Creations Ltd
+
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
@@ -1391,13 +1392,33 @@ public extension MXRestClient {
     /**
      Get the list of public rooms hosted by the home server.
      
-     - parameter completion: A block object called when the operation is complete.
-     - parameter response: Provides an array of the public rooms on this server on `success`
+     Pagination parameters (`limit` and `since`) should be used in order to limit
+     homeserver resources usage.
+
+     - parameters:
+        - server: (optional) the remote server to query for the room list. If nil, get the user homeserver's public room list.
+        - limit:  (optional, use -1 to not defined this value) the maximum number of entries to return.
+        - since: (optional) token to paginate from.
+        - filter: (optional) the string to search for.
+        - thirdPartyInstanceId: (optional) returns rooms published to specific lists on a third party instance (like an IRC bridge).
+        - includeAllNetworks: if YES, returns all rooms that have been published to any list. NO to return rooms on the main, default list.
+
+        - completion: A block object called when the operation is complete.
+        - response: Provides an publicRoomsResponse instance on `success`
      
      - returns: a `MXHTTPOperation` instance.
      */
-    @nonobjc @discardableResult func publicRooms(completion: @escaping (_ response: MXResponse<[MXPublicRoom]>) -> Void) -> MXHTTPOperation {
-        return __publicRooms(currySuccess(completion), failure: curryFailure(completion))
+    @nonobjc @discardableResult func publicRooms(onServer server: String, limit:UInt?, since: String? = nil, filter: String? = nil, thirdPartyInstanceId: String? = nil, includeAllNetworks: Bool? = false, completion: @escaping (_ response: MXResponse<MXPublicRoomsResponse>) -> Void) -> MXHTTPOperation {
+
+        // The `limit` variable should be set to -1 if it's not provided.
+        let _limit: Int
+        if let limit = limit {
+            _limit = Int(limit)
+        } else {
+            _limit = -1;
+        }
+
+        return __publicRooms(onServer: server, limit: UInt(_limit), since: since, filter: filter, thirdPartyInstanceId: thirdPartyInstanceId, includeAllNetworks: includeAllNetworks!, success: currySuccess(completion), failure: curryFailure(completion))
     }
     
     /**

--- a/MatrixSDK/JSONModels/MXJSONModels.h
+++ b/MatrixSDK/JSONModels/MXJSONModels.h
@@ -91,6 +91,29 @@ FOUNDATION_EXPORT NSString *const kMX3PIDMediumMSISDN;
 
 
 /**
+  `MXPublicRoomsResponse` represents the response of a publicRoom request.
+ */
+@interface MXPublicRoomsResponse : MXJSONModel
+
+/**
+ A batch of MXPublicRoom instances.
+ */
+@property (nonatomic) NSArray<MXPublicRoom*> *chunk;
+
+/**
+ Token that can be used to get the next batch of results.
+ */
+@property (nonatomic) NSString *nextBatch;
+
+/**
+ An estimated count of public rooms matching the request.
+ */
+@property (nonatomic) NSUInteger totalRoomCountEstimate;
+
+@end
+
+
+/**
  Login flow types
  */
 typedef NSString* MXLoginFlowType NS_REFINED_FOR_SWIFT;

--- a/MatrixSDK/JSONModels/MXJSONModels.m
+++ b/MatrixSDK/JSONModels/MXJSONModels.m
@@ -72,6 +72,23 @@
 @end
 
 
+@implementation MXPublicRoomsResponse
+
++ (id)modelFromJSON:(NSDictionary *)JSONDictionary
+{
+    MXPublicRoomsResponse *publicRoomsResponse = [[MXPublicRoomsResponse alloc] init];
+    if (publicRoomsResponse)
+    {
+        MXJSONModelSetMXJSONModelArray(publicRoomsResponse.chunk, MXPublicRoom, JSONDictionary[@"chunk"]);
+        MXJSONModelSetString(publicRoomsResponse.nextBatch , JSONDictionary[@"next_batch"]);
+        MXJSONModelSetUInteger(publicRoomsResponse.totalRoomCountEstimate , JSONDictionary[@"total_room_count_estimate"]);
+    }
+
+    return publicRoomsResponse;
+}
+@end
+
+
 NSString *const kMXLoginFlowTypePassword = @"m.login.password";
 NSString *const kMXLoginFlowTypeRecaptcha = @"m.login.recaptcha";
 NSString *const kMXLoginFlowTypeOAuth2 = @"m.login.oauth2";

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -976,7 +976,7 @@ typedef enum : NSUInteger
  @param roomId the id of the room.
  @param from the token to start getting results from.
  @param direction `MXTimelineDirectionForwards` or `MXTimelineDirectionBackwards`
- @param limit (optional, use -1 to not defined this value) the maximum nuber of messages to return.
+ @param limit (optional, use -1 to not defined this value) the maximum number of messages to return.
  @param filter to filter returned events with.
 
  @param success A block object called when the operation succeeds. It provides a `MXPaginationResponse` object.
@@ -1340,15 +1340,35 @@ typedef enum : NSUInteger
 
 #pragma mark - Directory operations
 /**
- Get the list of public rooms hosted by the home server.
+ Get the list of public rooms hosted by a home server.
+ 
+ @discussion
+ Pagination parameters (`limit` and `since`) should be used in order to limit
+ homeserver resources usage.
+ 
+ @param server (optional) the remote server to query for the room list. If nil, get the user
+               homeserver's public room list.
+ @param limit (optional, use -1 to not defined this value) the maximum number of entries to return.
+ @param since (optional) token to paginate from.
+ @param filter (optional) the string to search for.
+ @param thirdPartyInstanceId (optional) returns rooms published to specific lists on 
+                             a third party instance (like an IRC bridge).
+ @param includeAllNetworks if YES, returns all rooms that have been published to any list. 
+                           NO to return rooms on the main, default list.
 
- @param success A block object called when the operation succeeds. rooms is an array of MXPublicRoom objects
+ @param success A block object called when the operation succeeds.
  @param failure A block object called when the operation fails.
 
  @return a MXHTTPOperation instance.
  */
-- (MXHTTPOperation*)publicRooms:(void (^)(NSArray *rooms))success
-                        failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
+- (MXHTTPOperation*)publicRoomsOnServer:(NSString*)server
+                                  limit:(NSUInteger)limit
+                                  since:(NSString*)since
+                                 filter:(NSString*)filter
+                   thirdPartyInstanceId:(NSString*)thirdPartyInstanceId
+                     includeAllNetworks:(BOOL)includeAllNetworks
+                                success:(void (^)(MXPublicRoomsResponse *publicRoomsResponse))success
+                                failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
  Get the room ID corresponding to this room alias

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -3657,7 +3657,9 @@ MXAuthAction;
     }
     if (filter)
     {
-        parameters[@"filter"] = filter;
+        parameters[@"filter"] = @{
+                                  @"generic_search_term": filter
+                                  };
     }
     if (thirdPartyInstanceId)
     {

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -3630,12 +3630,43 @@ MXAuthAction;
 }
 
 #pragma mark - Directory operations
-- (MXHTTPOperation*)publicRooms:(void (^)(NSArray *rooms))success
-                        failure:(void (^)(NSError *error))failure
+- (MXHTTPOperation *)publicRoomsOnServer:(NSString *)server
+                                   limit:(NSUInteger)limit
+                                   since:(NSString *)since
+                                  filter:(NSString *)filter
+                    thirdPartyInstanceId:(NSString *)thirdPartyInstanceId
+                      includeAllNetworks:(BOOL)includeAllNetworks
+                                 success:(void (^)(MXPublicRoomsResponse *))success
+                                 failure:(void (^)(NSError *))failure
 {
-    return [httpClient requestWithMethod:@"GET"
+    NSMutableDictionary *parameters = [NSMutableDictionary dictionaryWithDictionary:@{
+                                                                                      @"include_all_networks": @(includeAllNetworks)
+                                                                                      }];
+
+    if (server)
+    {
+        parameters[@"server"] = server;
+    }
+    if (-1 != limit)
+    {
+        parameters[@"limit"] = @(limit);
+    }
+    if (since)
+    {
+        parameters[@"since"] = since;
+    }
+    if (filter)
+    {
+        parameters[@"filter"] = filter;
+    }
+    if (thirdPartyInstanceId)
+    {
+        parameters[@"thirdPartyInstanceId"] = thirdPartyInstanceId;
+    }
+
+    return [httpClient requestWithMethod:@"POST"
                                     path:[NSString stringWithFormat:@"%@/publicRooms", apiPathPrefix]
-                              parameters:nil
+                              parameters:parameters
                                  success:^(NSDictionary *JSONResponse) {
                                      if (success && processingQueue)
                                      {
@@ -3644,13 +3675,13 @@ MXAuthAction;
                                              // Create public rooms array from JSON on processing queue
                                              dispatch_async(processingQueue, ^{
 
-                                                 NSArray *publicRooms;
-                                                 MXJSONModelSetMXJSONModelArray(publicRooms, MXPublicRoom, JSONResponse[@"chunk"]);
+                                                 MXPublicRoomsResponse *publicRoomsResponse;
+                                                 MXJSONModelSetMXJSONModel(publicRoomsResponse, MXPublicRoomsResponse, JSONResponse);
 
                                                  if (completionQueue)
                                                  {
                                                      dispatch_async(completionQueue, ^{
-                                                         success(publicRooms);
+                                                         success(publicRoomsResponse);
                                                      });
                                                  }
 

--- a/MatrixSDKTests/MXSelfSignedHomeserverTests.m
+++ b/MatrixSDKTests/MXSelfSignedHomeserverTests.m
@@ -253,7 +253,7 @@
     MXRestClient *mxRestClient = [[MXRestClient alloc] initWithHomeServer:kMXTestsHomeServerHttpsURL
                                         andOnUnrecognizedCertificateBlock:nil];
 
-    [mxRestClient publicRooms:^(NSArray *rooms) {
+    [mxRestClient publicRoomsOnServer:nil limit:-1 since:nil filter:nil thirdPartyInstanceId:nil includeAllNetworks:NO success:^(MXPublicRoomsResponse *publicRoomsResponse) {
 
         XCTFail(@"The operation must fail because the self-signed certficate was not trusted");
         [expectation fulfill];


### PR DESCRIPTION
This is an API break because pagination is highly advised to save homeserver resources.