### PR TITLE
MXRoomSummary: MXRoomSummaryUpdating: add roomState parameter …

### DIFF
--- a/MatrixSDK/Data/MXRoomSummary.h
+++ b/MatrixSDK/Data/MXRoomSummary.h
@@ -271,11 +271,12 @@ FOUNDATION_EXPORT NSString *const kMXRoomSummaryDidChangeNotification;
  @param session the session the room belongs to.
  @param summary the room summary.
  @param event the candidate event for the room last message event.
- @param state the room state when the event occured.
+ @param eventState the room state when the event occured.
+ @param roomState the current state of the room.
  @return YES if the delegate accepted the event as last message.
          Returning NO can lead to a new call of this method with another candidate event.
  */
-- (BOOL)session:(MXSession*)session updateRoomSummary:(MXRoomSummary*)summary withLastEvent:(MXEvent*)event state:(MXRoomState*)state;
+- (BOOL)session:(MXSession*)session updateRoomSummary:(MXRoomSummary*)summary withLastEvent:(MXEvent*)event eventState:(MXRoomState*)eventState roomState:(MXRoomState*)roomState;
 
 /**
  Called to update the room summary on a received state event.

--- a/MatrixSDK/Data/MXRoomSummary.m
+++ b/MatrixSDK/Data/MXRoomSummary.m
@@ -249,7 +249,7 @@ NSString *const kMXRoomSummaryDidChangeNotification = @"kMXRoomSummaryDidChangeN
         lastEventIdChecked = event.eventId;
 
         // Propose the event as last message
-        lastMessageUpdated = [_mxSession.roomSummaryUpdateDelegate session:_mxSession updateRoomSummary:self withLastEvent:event state:state];
+        lastMessageUpdated = [_mxSession.roomSummaryUpdateDelegate session:_mxSession updateRoomSummary:self withLastEvent:event eventState:state roomState:self.room.state];
         if (lastMessageUpdated)
         {
             // The event is accepted. We have our last message
@@ -366,7 +366,7 @@ NSString *const kMXRoomSummaryDidChangeNotification = @"kMXRoomSummaryDidChangeN
             [state handleStateEvent:event];
         }
 
-        lastMessageUpdated = [_mxSession.roomSummaryUpdateDelegate session:_mxSession updateRoomSummary:self withLastEvent:event state:state];
+        lastMessageUpdated = [_mxSession.roomSummaryUpdateDelegate session:_mxSession updateRoomSummary:self withLastEvent:event eventState:state roomState:self.room.state];
         if (lastMessageUpdated)
         {
             break;
@@ -393,8 +393,10 @@ NSString *const kMXRoomSummaryDidChangeNotification = @"kMXRoomSummaryDidChangeN
 {
     BOOL updated = [_mxSession.roomSummaryUpdateDelegate session:_mxSession updateRoomSummary:self withStateEvents:invitedRoomSync.inviteState.events];
 
+    MXRoom *room = self.room;
+
     // Fake the last message with the invitation event contained in invitedRoomSync.inviteState
-    updated |= [_mxSession.roomSummaryUpdateDelegate session:_mxSession updateRoomSummary:self withLastEvent:invitedRoomSync.inviteState.events.lastObject state:self.room.state];
+    updated |= [_mxSession.roomSummaryUpdateDelegate session:_mxSession updateRoomSummary:self withLastEvent:invitedRoomSync.inviteState.events.lastObject eventState:nil roomState:room.state];
 
     if (updated)
     {
@@ -410,7 +412,7 @@ NSString *const kMXRoomSummaryDidChangeNotification = @"kMXRoomSummaryDidChangeN
 
     if (room)
     {
-        BOOL updated = [_mxSession.roomSummaryUpdateDelegate session:_mxSession updateRoomSummary:self withLastEvent:event state:room.state];
+        BOOL updated = [_mxSession.roomSummaryUpdateDelegate session:_mxSession updateRoomSummary:self withLastEvent:event eventState:nil roomState:room.state];
 
         if (updated)
         {

--- a/MatrixSDK/Data/MXRoomSummaryUpdater.m
+++ b/MatrixSDK/Data/MXRoomSummaryUpdater.m
@@ -42,7 +42,7 @@
 
 #pragma mark - MXRoomSummaryUpdating
 
-- (BOOL)session:(MXSession *)session updateRoomSummary:(MXRoomSummary *)summary withLastEvent:(MXEvent *)event state:(MXRoomState *)state
+- (BOOL)session:(MXSession *)session updateRoomSummary:(MXRoomSummary *)summary withLastEvent:(MXEvent *)event eventState:(MXRoomState *)eventState roomState:(MXRoomState *)roomState
 {
     // Do not show redaction events
     if (event.eventType == MXEventTypeRoomRedaction)

--- a/MatrixSDKTests/MXRoomSummaryTests.m
+++ b/MatrixSDKTests/MXRoomSummaryTests.m
@@ -65,7 +65,7 @@ NSString *uisiString = @"The sender's device has not sent us the keys for this m
      [super tearDown];
 }
 
-- (BOOL)session:(MXSession *)session updateRoomSummary:(MXRoomSummary *)summary withLastEvent:(MXEvent *)event state:(MXRoomState *)state
+- (BOOL)session:(MXSession *)session updateRoomSummary:(MXRoomSummary *)summary withLastEvent:(MXEvent *)event eventState:(MXRoomState *)eventState roomState:(MXRoomState *)roomState
 {
     BOOL updated = NO;
 
@@ -81,7 +81,7 @@ NSString *uisiString = @"The sender's device has not sent us the keys for this m
 
         // Do a classic update
         MXRoomSummaryUpdater *updater = [MXRoomSummaryUpdater roomSummaryUpdaterForSession:session];
-        updated = [updater session:session updateRoomSummary:summary withLastEvent:event state:state];
+        updated = [updater session:session updateRoomSummary:summary withLastEvent:event eventState:eventState roomState:roomState];
 
         summary.lastMessageString = testDelegateLastMessageString;
 
@@ -111,18 +111,18 @@ NSString *uisiString = @"The sender's device has not sent us the keys for this m
     }
     else if ([self.description containsString:@"testStatePassedToMXRoomSummaryUpdating"])
     {
-        XCTAssertNotEqualObjects(state.displayname, @"A room", @"The passed state must be the state of room when the event occured, not the current room state");
+        XCTAssertNotEqualObjects(eventState.displayname, @"A room", @"The passed state must be the state of room when the event occured, not the current room state");
 
         // Do a classic update
         MXRoomSummaryUpdater *updater = [MXRoomSummaryUpdater roomSummaryUpdaterForSession:session];
-        updated = [updater session:session updateRoomSummary:summary withLastEvent:event state:state];
+        updated = [updater session:session updateRoomSummary:summary withLastEvent:event eventState:eventState roomState:roomState];
     }
     else if ([self.description containsString:@"testDoNotStoreDecryptedData"]
              || [self.description containsString:@"testEncryptedLastMessageEvent"])
     {
         // Do a classic update
         MXRoomSummaryUpdater *updater = [MXRoomSummaryUpdater roomSummaryUpdaterForSession:session];
-        updated = [updater session:session updateRoomSummary:summary withLastEvent:event state:state];
+        updated = [updater session:session updateRoomSummary:summary withLastEvent:event eventState:eventState roomState:roomState];
 
         summary.lastMessageString = event.content[@"body"];
     }
@@ -130,7 +130,7 @@ NSString *uisiString = @"The sender's device has not sent us the keys for this m
     {
         // Do a classic update
         MXRoomSummaryUpdater *updater = [MXRoomSummaryUpdater roomSummaryUpdaterForSession:session];
-        updated = [updater session:session updateRoomSummary:summary withLastEvent:event state:state];
+        updated = [updater session:session updateRoomSummary:summary withLastEvent:event eventState:eventState roomState:roomState];
 
         if (event.eventType == MXEventTypeRoomEncrypted)
         {


### PR DESCRIPTION
…to expose the current state of the room

This helps to fix https://github.com/vector-im/riot-ios/issues/1129 (1. last events can contains and old display name)