### PR TITLE
MXRealmCryptoStore: Fix implementation of sessionsWithDevice.

### DIFF
--- a/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
+++ b/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
@@ -552,7 +552,7 @@ RLM_ARRAY_TYPE(MXRealmOlmInboundGroupSession)
             sessionsWithDevice = [NSMutableDictionary dictionary];
         }
 
-        sessionsWithDevice[realmOlmSession.deviceKey] = [NSKeyedUnarchiver unarchiveObjectWithData:realmOlmSession.olmSessionData];
+        sessionsWithDevice[realmOlmSession.sessionId] = [NSKeyedUnarchiver unarchiveObjectWithData:realmOlmSession.olmSessionData];
     }
 
     return sessionsWithDevice;


### PR DESCRIPTION
The keys in the returned dict were wrong. Note that it did not affect the crypto module behavior as long as these keys were consistent.

It only fixes debug logs.