### PR TITLE
Remove depency to WebRTC and add parameter to use GA

### DIFF
--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -30,5 +30,6 @@ Pod::Spec.new do |s|
 
   s.dependency 'AFNetworking', '~> 3.1.0'
   s.dependency 'GZIP', '~> 1.1.1'
+  s.dependency 'WebRTC', '~> 56.10'
 
 end

--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
@@ -30,11 +30,9 @@
 
 #import "MXEnumConstants.h"
 
-#ifdef MX_GA
 #import "GAI.h"
 #import "GAIFields.h"
 #import "GAIDictionaryBuilder.h"
-#endif
 
 NSUInteger const kMXFileVersion = 39;
 

--- a/MatrixSDK/MXSDKOptions.h
+++ b/MatrixSDK/MXSDKOptions.h
@@ -21,22 +21,6 @@
 #pragma mark - Build time options
 
 #pragma mark Automatic enabling
-/**
- These flags are automatically enabled if the application Xcode workspace contains
- their associated Cocoa pods.
- */
-
-/**
- VoIP with libjingle.
-
- Application can use the libjingle build pod provided at
- https://github.com/Anakros/WebRTC.git :
-
-     pod 'WebRTC'
- */
-#if __has_include(<WebRTC/RTCPeerConnection.h>)
-#define MX_CALL_STACK_JINGLE
-#endif
 
 /**
  Crypto.
@@ -56,7 +40,7 @@
  The Matrix SDK will send some stats to Google Analytics if the application imports
  the GoogleAnalytics library (like pod 'GoogleAnalytics') and if 'enableGoogleAnalytics' is YES.
  */
-#if __has_include(<GoogleAnalytics/GAI.h>)
+#if __has_include(<GoogleAnalytics/GAI.h>) && defined(GA_ENABLED)
 #define MX_GA
 #endif
 

--- a/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallStack.h
+++ b/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallStack.h
@@ -18,8 +18,6 @@
 
 #import "MXSDKOptions.h"
 
-#ifdef MX_CALL_STACK_JINGLE
-
 #import <WebRTC/WebRTC.h>
 
 #import "MXCallStack.h"
@@ -33,5 +31,3 @@
 @interface MXJingleCallStack : NSObject <MXCallStack>
 
 @end
-
-#endif // MX_CALL_STACK_JINGLE

--- a/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallStack.m
+++ b/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallStack.m
@@ -16,8 +16,6 @@
 
 #import "MXJingleCallStack.h"
 
-#ifdef MX_CALL_STACK_JINGLE
-
 #import "MXJingleCallStackCall.h"
 
 @interface MXJingleCallStack ()
@@ -45,5 +43,3 @@
 }
 
 @end
-
-#endif  // MX_CALL_STACK_JINGLE

--- a/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallStackCall.h
+++ b/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallStackCall.h
@@ -18,8 +18,6 @@
 
 #import "MXJingleCallStack.h"
 
-#ifdef MX_CALL_STACK_JINGLE
-
 #import "MXCallStackCall.h"
 
 #import <WebRTC/WebRTC.h>
@@ -37,5 +35,3 @@
 - (instancetype)initWithFactory:(RTCPeerConnectionFactory*)factory;
 
 @end
-
-#endif  // MX_CALL_STACK_JINGLE

--- a/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallStackCall.m
+++ b/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallStackCall.m
@@ -16,8 +16,6 @@
 
 #import "MXJingleCallStackCall.h"
 
-#ifdef MX_CALL_STACK_JINGLE
-
 #import <UIKit/UIKit.h>
 #import <AVFoundation/AVCaptureDevice.h>
 #import <AVFoundation/AVMediaFormat.h>
@@ -523,5 +521,3 @@ didRemoveIceCandidates:(NSArray<RTCIceCandidate *> *)candidates;
 }
 
 @end
-
-#endif  // MX_CALL_STACK_JINGLE

--- a/MatrixSDK/VoIP/CallStack/Jingle/MXJingleVideoView.h
+++ b/MatrixSDK/VoIP/CallStack/Jingle/MXJingleVideoView.h
@@ -17,8 +17,6 @@
 
 #import "MXJingleCallStack.h"
 
-#ifdef MX_CALL_STACK_JINGLE
-
 #import <WebRTC/WebRTC.h>
 
 /**
@@ -32,5 +30,3 @@
 - (instancetype)initWithContainerView:(UIView*)containerView;
 
 @end
-
-#endif  //MX_CALL_STACK_JINGLE

--- a/MatrixSDK/VoIP/CallStack/Jingle/MXJingleVideoView.m
+++ b/MatrixSDK/VoIP/CallStack/Jingle/MXJingleVideoView.m
@@ -16,8 +16,6 @@
 
 #import "MXJingleVideoView.h"
 
-#ifdef MX_CALL_STACK_JINGLE
-
 #import <AVFoundation/AVFoundation.h>
 
 @interface MXJingleVideoView ()
@@ -107,5 +105,3 @@
 }
 
 @end
-
-#endif  // MX_CALL_STACK_JINGLE


### PR DESCRIPTION
I'm ready to discuss about this fix.

The problem is the use of "use_frameworks!" parameter in the Podfile includ in swift project.

Indeed, with cocoa pods 1.x and the use_frameworks parameters, pod are built atomically and cannot refer to library that are not directly linked to the pod.

So you can have build issue like:

Undefined symbols '_GAI' not found in MXFileStore.o