### PR TITLE
Improvements in VoIP-related classes

### DIFF
--- a/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallStack.h
+++ b/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallStack.h
@@ -20,8 +20,6 @@
 
 #ifdef MX_CALL_STACK_JINGLE
 
-#import <WebRTC/WebRTC.h>
-
 #import "MXCallStack.h"
 
 /**

--- a/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallStack.m
+++ b/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallStack.m
@@ -19,6 +19,7 @@
 #ifdef MX_CALL_STACK_JINGLE
 
 #import "MXJingleCallStackCall.h"
+#import <WebRTC/RTCPeerConnectionFactory.h>
 
 @interface MXJingleCallStack ()
 {

--- a/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallStackCall.h
+++ b/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallStackCall.h
@@ -16,13 +16,14 @@
 
 #import <Foundation/Foundation.h>
 
-#import "MXJingleCallStack.h"
+#import "MXSDKOptions.h"
 
 #ifdef MX_CALL_STACK_JINGLE
 
 #import "MXCallStackCall.h"
+#import <WebRTC/RTCPeerConnection.h>
 
-#import <WebRTC/WebRTC.h>
+NS_ASSUME_NONNULL_BEGIN
 
 @class RTCPeerConnectionFactory;
 
@@ -32,10 +33,15 @@
 
  @see https://developers.google.com/talk/libjingle/developer_guide
  */
-@interface MXJingleCallStackCall : NSObject <MXCallStackCall, RTCPeerConnectionDelegate>
+@interface MXJingleCallStackCall : NSObject <MXCallStackCall>
 
-- (instancetype)initWithFactory:(RTCPeerConnectionFactory*)factory;
+- (instancetype)initWithFactory:(RTCPeerConnectionFactory *)factory NS_DESIGNATED_INITIALIZER;
+
++ (instancetype)new NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
 
 @end
+
+NS_ASSUME_NONNULL_END
 
 #endif  // MX_CALL_STACK_JINGLE

--- a/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallStackCall.m
+++ b/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallStackCall.m
@@ -18,13 +18,13 @@
 
 #ifdef MX_CALL_STACK_JINGLE
 
+#import <AVFoundation/AVFoundation.h>
 #import <UIKit/UIKit.h>
-#import <AVFoundation/AVCaptureDevice.h>
-#import <AVFoundation/AVMediaFormat.h>
 
 #import "MXJingleVideoView.h"
+#import <WebRTC/WebRTC.h>
 
-@interface MXJingleCallStackCall ()
+@interface MXJingleCallStackCall () <RTCPeerConnectionDelegate>
 {
     /**
      The libjingle all purpose factory.
@@ -81,7 +81,7 @@
     isVideoCall = video;
 
     // Video requires views to render to before calling startGetCaptureSourcesForAudio
-    if (NO == video || (selfVideoView && remoteVideoView))
+    if (!video || (selfVideoView && remoteVideoView))
     {
         [self createLocalMediaStream];
     }
@@ -100,7 +100,7 @@
     self.remoteVideoView = nil;
 }
 
-- (void)addTURNServerUris:(NSArray *)uris withUsername:(NSString *)username password:(NSString *)password
+- (void)addTURNServerUris:(NSArray<NSString *> *)uris withUsername:(nullable NSString *)username password:(nullable NSString *)password
 {
     RTCIceServer *ICEServer = [[RTCIceServer alloc] initWithURLStrings:uris
                                                               username:username
@@ -134,9 +134,11 @@
     }
 }
 
-- (void)handleRemoteCandidate:(NSDictionary *)candidate
+- (void)handleRemoteCandidate:(NSDictionary<NSString *, NSObject *> *)candidate
 {
-    RTCIceCandidate *iceCandidate = [[RTCIceCandidate alloc] initWithSdp:candidate[@"candidate"] sdpMLineIndex:[(NSNumber*)candidate[@"sdpMLineIndex"] intValue] sdpMid:candidate[@"sdpMid"]];
+    RTCIceCandidate *iceCandidate = [[RTCIceCandidate alloc] initWithSdp:(NSString *)candidate[@"candidate"]
+                                                           sdpMLineIndex:[(NSNumber *)candidate[@"sdpMLineIndex"] intValue]
+                                                                  sdpMid:(NSString *)candidate[@"sdpMid"]];
     [peerConnection addIceCandidate:iceCandidate];
 }
 
@@ -250,23 +252,6 @@
     }];
 }
 
-
-#pragma mark - Properties
-- (void)setSelfVideoView:(UIView *)selfVideoView2
-{
-    selfVideoView = selfVideoView2;
-
-    [self checkStartGetCaptureSourcesForVideo];
-}
-
-- (void)setRemoteVideoView:(UIView *)remoteVideoView2
-{
-    remoteVideoView = remoteVideoView2;
- 
-    [self checkStartGetCaptureSourcesForVideo];
-}
-
-
 #pragma mark - RTCPeerConnectionDelegate delegate
 
 // Triggered when the SignalingState changed.
@@ -371,6 +356,21 @@ didRemoveIceCandidates:(NSArray<RTCIceCandidate *> *)candidates;
 
 
 #pragma mark - Properties
+
+- (void)setSelfVideoView:(UIView *)selfVideoView2
+{
+    selfVideoView = selfVideoView2;
+    
+    [self checkStartGetCaptureSourcesForVideo];
+}
+
+- (void)setRemoteVideoView:(UIView *)remoteVideoView2
+{
+    remoteVideoView = remoteVideoView2;
+    
+    [self checkStartGetCaptureSourcesForVideo];
+}
+
 - (UIDeviceOrientation)selfOrientation
 {
     // @TODO: Hmm
@@ -436,7 +436,7 @@ didRemoveIceCandidates:(NSArray<RTCIceCandidate *> *)candidates;
 
 
 #pragma mark - Private methods
-- (RTCMediaConstraints*)mediaConstraints
+- (RTCMediaConstraints *)mediaConstraints
 {
     return [[RTCMediaConstraints alloc] initWithMandatoryConstraints:@{
                                                                        @"OfferToReceiveAudio": @"true",
@@ -447,7 +447,7 @@ didRemoveIceCandidates:(NSArray<RTCIceCandidate *> *)candidates;
 
 - (void)createLocalMediaStream
 {
-    RTCMediaStream* localStream = [peerConnectionFactory mediaStreamWithStreamId:@"ARDAMS"];
+    RTCMediaStream *localStream = [peerConnectionFactory mediaStreamWithStreamId:@"ARDAMS"];
 
     // Set up audio
     localAudioTrack = [peerConnectionFactory audioTrackWithTrackId:@"ARDAMSa0"];

--- a/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallStackCall.m
+++ b/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallStackCall.m
@@ -357,14 +357,14 @@ didRemoveIceCandidates:(NSArray<RTCIceCandidate *> *)candidates;
 
 #pragma mark - Properties
 
-- (void)setSelfVideoView:(UIView *)selfVideoView2
+- (void)setSelfVideoView:(nullable UIView *)selfVideoView2
 {
     selfVideoView = selfVideoView2;
     
     [self checkStartGetCaptureSourcesForVideo];
 }
 
-- (void)setRemoteVideoView:(UIView *)remoteVideoView2
+- (void)setRemoteVideoView:(nullable UIView *)remoteVideoView2
 {
     remoteVideoView = remoteVideoView2;
     

--- a/MatrixSDK/VoIP/CallStack/Jingle/MXJingleVideoView.h
+++ b/MatrixSDK/VoIP/CallStack/Jingle/MXJingleVideoView.h
@@ -15,11 +15,13 @@
  */
 #import <Foundation/Foundation.h>
 
-#import "MXJingleCallStack.h"
+#import "MXSDKOptions.h"
 
 #ifdef MX_CALL_STACK_JINGLE
 
-#import <WebRTC/WebRTC.h>
+#import <WebRTC/RTCEAGLVideoView.h>
+
+NS_ASSUME_NONNULL_BEGIN
 
 /**
  `MXJingleVideoView` is responsible for rendering RTCEAGLVideoView into
@@ -29,8 +31,13 @@
  */
 @interface MXJingleVideoView : RTCEAGLVideoView <RTCEAGLVideoViewDelegate>
 
-- (instancetype)initWithContainerView:(UIView*)containerView;
+- (instancetype)initWithContainerView:(UIView *)containerView NS_DESIGNATED_INITIALIZER;
+
++ (instancetype)new NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
 
 @end
+
+NS_ASSUME_NONNULL_END
 
 #endif  //MX_CALL_STACK_JINGLE

--- a/MatrixSDK/VoIP/CallStack/MXCallStack.h
+++ b/MatrixSDK/VoIP/CallStack/MXCallStack.h
@@ -16,7 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import "MXCallStackCall.h"
+@protocol MXCallStackCall;
 
 /**
  The `MXCallStack` is an abstract interface to integrate a VoIP call stack.
@@ -36,6 +36,6 @@
  
  @return an object that implements the `MXCallStackCall` protocol.
  */
-- (id<MXCallStackCall>)createCall;
+- (nullable id<MXCallStackCall>)createCall;
 
 @end

--- a/MatrixSDK/VoIP/CallStack/MXCallStackCall.h
+++ b/MatrixSDK/VoIP/CallStack/MXCallStackCall.h
@@ -24,6 +24,8 @@
 
 #import <AVFoundation/AVCaptureDevice.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @protocol MXCallStackCallDelegate;
 
 /**
@@ -60,14 +62,14 @@
  @param username the username of the Matrix user on these TURN servers.
  @param password the associated password.
  */
-- (void)addTURNServerUris:(NSArray*)uris withUsername:(NSString*)username password:(NSString*)password;
+- (void)addTURNServerUris:(NSArray<NSString *> *)uris withUsername:(nullable NSString *)username password:(nullable NSString *)password;
 
 /**
  Make the call stack process an incoming candidate.
  
  @param candidate the candidate description.
  */
-- (void)handleRemoteCandidate:(NSDictionary*)candidate;
+- (void)handleRemoteCandidate:(NSDictionary<NSString *, NSObject *> *)candidate;
 
 
 #pragma mark - Incoming call
@@ -78,7 +80,7 @@
 
  @param sdpOffer the description of the peer media.
  */
-- (void)handleOffer:(NSString*)sdpOffer;
+- (void)handleOffer:(NSString *)sdpOffer;
 
 /**
  Generate an answer to send to the peer.
@@ -93,7 +95,7 @@
  @param failure A block object called when the operation fails.
  */
 - (void)createAnswer:(void (^)(NSString *sdpAnswer))success
-            failure:(void (^)(NSError *error))failure;
+             failure:(void (^)(NSError *error))failure;
 
 
 #pragma mark - Outgoing call
@@ -118,7 +120,7 @@
  @param success A block object called when the operation succeeds. 
  @param failure A block object called when the operation fails.
  */
-- (void)handleAnswer:(NSString*)sdp
+- (void)handleAnswer:(NSString *)sdp
              success:(void (^)())success
              failure:(void (^)(NSError *error))failure;
 
@@ -127,15 +129,15 @@
 /**
  The delegate.
  */
-@property (nonatomic) id<MXCallStackCallDelegate> delegate;
+@property (nonatomic, nullable, weak) id<MXCallStackCallDelegate> delegate;
 
 /**
  The UIView that receives frames from the user's camera.
  */
 #if TARGET_OS_IPHONE
-@property (nonatomic) UIView *selfVideoView;
+@property (nonatomic, nullable) UIView *selfVideoView;
 #elif TARGET_OS_OSX
-@property (nonatomic) NSView *selfVideoView;
+@property (nonatomic, nullable) NSView *selfVideoView;
 #endif
 
 
@@ -143,9 +145,9 @@
  The UIView that receives frames from the remote camera.
  */
 #if TARGET_OS_IPHONE
-@property (nonatomic) UIView *remoteVideoView;
+@property (nonatomic, nullable) UIView *remoteVideoView;
 #elif TARGET_OS_OSX
-@property (nonatomic) NSView *remoteVideoView;
+@property (nonatomic, nullable) NSView *remoteVideoView;
 #endif
 
 /**
@@ -195,7 +197,7 @@
  @param sdpMLineIndex the index of m-line in the SDP.
  @param candidate the candidate SDP.
  */
-- (void)callStackCall:(id<MXCallStackCall>)callStackCall onICECandidateWithSdpMid:(NSString*)sdpMid sdpMLineIndex:(NSInteger)sdpMLineIndex candidate:(NSString*)candidate;
+- (void)callStackCall:(id<MXCallStackCall>)callStackCall onICECandidateWithSdpMid:(NSString *)sdpMid sdpMLineIndex:(NSInteger)sdpMLineIndex candidate:(NSString *)candidate;
 
 /**
  Tells the delegate an error occured.
@@ -203,6 +205,8 @@
  @param callStackCall the corresponding instance.
  @param error the error.
  */
-- (void)callStackCall:(id<MXCallStackCall>)callStackCall onError:(NSError*)error;
+- (void)callStackCall:(id<MXCallStackCall>)callStackCall onError:(nullable NSError *)error;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixSDK/VoIP/MXCall.h
+++ b/MatrixSDK/VoIP/MXCall.h
@@ -22,27 +22,26 @@
 #import <Cocoa/Cocoa.h>
 #endif
 
-#import "MXEvent.h"
 #import "MXCallStackCall.h"
 
-@class MXCallManager;
-@class MXRoom;
+NS_ASSUME_NONNULL_BEGIN
 
+@class MXCallManager;
+@class MXEvent;
+@class MXRoom;
 
 /**
  Call states.
  */
-typedef enum : NSUInteger
+typedef NS_ENUM(NSUInteger, MXCallState)
 {
     MXCallStateFledgling,
     MXCallStateWaitLocalMedia,
 
-    // MXCallStateWaitLocalMedia
     MXCallStateCreateOffer,
     MXCallStateInviteSent,
 
     MXCallStateRinging,
-    // MXCallStateWaitLocalMedia
     MXCallStateCreateAnswer,
     MXCallStateConnecting,
 
@@ -51,7 +50,7 @@ typedef enum : NSUInteger
 
     MXCallStateInviteExpired,
     MXCallStateAnsweredElseWhere
-} MXCallState;
+};
 
 /**
  Posted when a `MXCall` object has changed its state.
@@ -66,6 +65,8 @@ extern NSString *const kMXCallStateDidChange;
  */
 @interface MXCall : NSObject <MXCallStackCallDelegate>
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /**
  Create a `MXCall` instance in order to place a call.
 
@@ -73,7 +74,7 @@ extern NSString *const kMXCallStateDidChange;
  @param callManager the manager of all MXCall objects.
  @return the newly created MXCall instance.
  */
-- (instancetype)initWithRoomId:(NSString*)roomId andCallManager:(MXCallManager*)callManager;
+- (instancetype)initWithRoomId:(NSString *)roomId andCallManager:(MXCallManager *)callManager;
 
 /**
  Create a `MXCall` instance in order to place a call using a conference server.
@@ -83,14 +84,14 @@ extern NSString *const kMXCallStateDidChange;
  @param callManager the manager of all MXCall objects.
  @return the newly created MXCall instance.
  */
-- (instancetype)initWithRoomId:(NSString*)roomId callSignalingRoomId:(NSString*)callSignalingRoomId andCallManager:(MXCallManager*)callManager;
+- (instancetype)initWithRoomId:(NSString *)roomId callSignalingRoomId:(NSString *)callSignalingRoomId andCallManager:(MXCallManager *)callManager NS_DESIGNATED_INITIALIZER;
 
 /**
  Handle call event.
 
  @param event the call event coming from the event stream.
  */
-- (void)handleCallEvent:(MXEvent*)event;
+- (void)handleCallEvent:(MXEvent *)event;
 
 
 #pragma mark - Controls
@@ -209,7 +210,7 @@ extern NSString *const kMXCallStateDidChange;
 /**
  The delegate.
  */
-@property (nonatomic) id<MXCallDelegate> delegate;
+@property (nonatomic, weak) id<MXCallDelegate> delegate;
 
 @end
 
@@ -228,7 +229,7 @@ extern NSString *const kMXCallStateDidChange;
               The `event` paramater is this event.
               If it is our user, `event` is nil.
  */
-- (void)call:(MXCall *)call stateDidChange:(MXCallState)state reason:(MXEvent*)event;
+- (void)call:(MXCall *)call stateDidChange:(MXCallState)state reason:(nullable MXEvent *)event;
 
 @optional
 
@@ -239,6 +240,8 @@ extern NSString *const kMXCallStateDidChange;
  @param call the instance that changes.
  @param error the error.
  */
-- (void)call:(MXCall *)call didEncounterError:(NSError*)error;
+- (void)call:(MXCall *)call didEncounterError:(NSError *)error;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixSDK/VoIP/MXCall.h
+++ b/MatrixSDK/VoIP/MXCall.h
@@ -158,18 +158,18 @@ extern NSString *const kMXCallStateDidChange;
  The UIView that receives frames from the user's camera.
  */
 #if TARGET_OS_IPHONE
-@property (nonatomic) UIView *selfVideoView;
+@property (nonatomic, nullable) UIView *selfVideoView;
 #elif TARGET_OS_OSX
-@property (nonatomic) NSView *selfVideoView;
+@property (nonatomic, nullable) NSView *selfVideoView;
 #endif
 
 /**
  The UIView that receives frames from the remote camera.
  */
 #if TARGET_OS_IPHONE
-@property (nonatomic) UIView *remoteVideoView;
+@property (nonatomic, nullable) UIView *remoteVideoView;
 #elif TARGET_OS_OSX
-@property (nonatomic) NSView *remoteVideoView;
+@property (nonatomic, nullable) NSView *remoteVideoView;
 #endif
 
 /**

--- a/MatrixSDK/VoIP/MXCall.m
+++ b/MatrixSDK/VoIP/MXCall.m
@@ -59,7 +59,7 @@ NSString *const kMXCallStateDidChange = @"kMXCallStateDidChange";
     /**
      A queue of gathered local ICE candidates waiting to be sent to the other peer.
      */
-    NSMutableArray<NSDictionary*> *localICECandidates;
+    NSMutableArray<NSDictionary *> *localICECandidates;
 
     /**
      Timer for sending local ICE candidates.
@@ -427,9 +427,9 @@ NSString *const kMXCallStateDidChange = @"kMXCallStateDidChange";
 }
 
 #if TARGET_OS_IPHONE
-- (void)setSelfVideoView:(UIView *)selfVideoView
+- (void)setSelfVideoView:(nullable UIView *)selfVideoView
 #elif TARGET_OS_OSX
-- (void)setSelfVideoView:(NSView *)selfVideoView
+- (void)setSelfVideoView:(nullable NSView *)selfVideoView
 #endif
 {
     if (selfVideoView != _selfVideoView)
@@ -440,9 +440,9 @@ NSString *const kMXCallStateDidChange = @"kMXCallStateDidChange";
 }
 
 #if TARGET_OS_IPHONE
-- (void)setRemoteVideoView:(UIView *)remoteVideoView
+- (void)setRemoteVideoView:(nullable UIView *)remoteVideoView
 #elif TARGET_OS_OSX
-- (void)setRemoteVideoView:(NSView *)remoteVideoView
+- (void)setRemoteVideoView:(nullable NSView *)remoteVideoView
 #endif
 {
     if (remoteVideoView != _remoteVideoView)

--- a/MatrixSDK/VoIP/MXCall.m
+++ b/MatrixSDK/VoIP/MXCall.m
@@ -17,8 +17,9 @@
 
 #import "MXCall.h"
 
+#import "MXCallStack.h"
+#import "MXEvent.h"
 #import "MXSession.h"
-#import "MXCallStackCall.h"
 
 #pragma mark - Constants definitions
 NSString *const kMXCallStateDidChange = @"kMXCallStateDidChange";
@@ -76,7 +77,7 @@ NSString *const kMXCallStateDidChange = @"kMXCallStateDidChange";
     return [self initWithRoomId:roomId callSignalingRoomId:roomId andCallManager:theCallManager];
 }
 
-- (instancetype)initWithRoomId:(NSString*)roomId callSignalingRoomId:(NSString*)callSignalingRoomId andCallManager:(MXCallManager*)theCallManager;
+- (instancetype)initWithRoomId:(NSString *)roomId callSignalingRoomId:(NSString *)callSignalingRoomId andCallManager:(MXCallManager *)theCallManager;
 {
     self = [super init];
     if (self)
@@ -105,6 +106,7 @@ NSString *const kMXCallStateDidChange = @"kMXCallStateDidChange";
         if (nil == callStackCall)
         {
             NSLog(@"[MXCall] Error: Cannot create call. [MXCallStack createCall] returned nil.");
+            [callManager.mxSession releasePreventPause];
             return nil;
         }
 
@@ -114,8 +116,8 @@ NSString *const kMXCallStateDidChange = @"kMXCallStateDidChange";
         if (callManager.turnServers)
         {
             [callStackCall addTURNServerUris:callManager.turnServers.uris
-                                        withUsername:callManager.turnServers.username
-                                            password:callManager.turnServers.password];
+                                withUsername:callManager.turnServers.username
+                                    password:callManager.turnServers.password];
         }
         else
         {
@@ -134,7 +136,7 @@ NSString *const kMXCallStateDidChange = @"kMXCallStateDidChange";
         {
             callInviteEventContent = [MXCallInviteEventContent modelFromJSON:event.content];
 
-            if (NO == [event.sender isEqualToString:_callSignalingRoom.mxSession.myUser.userId])
+            if (![event.sender isEqualToString:_callSignalingRoom.mxSession.myUser.userId])
             {
                 // Incoming call
 
@@ -163,11 +165,11 @@ NSString *const kMXCallStateDidChange = @"kMXCallStateDidChange";
 
             // Start expiration timer
             inviteExpirationTimer = [[NSTimer alloc] initWithFireDate:[NSDate dateWithTimeIntervalSinceNow:callInviteEventContent.lifetime / 1000]
-                                                              interval:0
-                                                                target:self
-                                                              selector:@selector(expireCallInvite)
-                                                              userInfo:nil
-                                                               repeats:NO];
+                                                             interval:0
+                                                               target:self
+                                                             selector:@selector(expireCallInvite)
+                                                             userInfo:nil
+                                                              repeats:NO];
             [[NSRunLoop mainRunLoop] addTimer:inviteExpirationTimer forMode:NSDefaultRunLoopMode];
 
             break;
@@ -176,7 +178,7 @@ NSString *const kMXCallStateDidChange = @"kMXCallStateDidChange";
         case MXEventTypeCallAnswer:
         {
             // Listen to answer event only for call we are making, not receiving
-            if (NO == _isIncoming)
+            if (!_isIncoming)
             {
                 // MXCall receives this event only when it placed a call
                 MXCallAnswerEventContent *content = [MXCallAnswerEventContent modelFromJSON:event.content];
@@ -385,7 +387,7 @@ NSString *const kMXCallStateDidChange = @"kMXCallStateDidChange";
 
 
 #pragma marl - Properties
-- (void)setState:(MXCallState)state reason:(MXEvent*)event
+- (void)setState:(MXCallState)state reason:(MXEvent *)event
 {
     // Manage call duration
     if (MXCallStateConnected == state)
@@ -575,7 +577,7 @@ NSString *const kMXCallStateDidChange = @"kMXCallStateDidChange";
 
 
 #pragma mark - Private methods
-- (void)terminateWithReason:(MXEvent*)event
+- (void)terminateWithReason:(MXEvent *)event
 {
     if (inviteExpirationTimer)
     {
@@ -593,7 +595,7 @@ NSString *const kMXCallStateDidChange = @"kMXCallStateDidChange";
     [self setState:MXCallStateEnded reason:event];
 }
 
-- (void)didEncounterError:(NSError*)error
+- (void)didEncounterError:(NSError *)error
 {
     if ([_delegate respondsToSelector:@selector(call:didEncounterError:)])
     {
@@ -637,4 +639,3 @@ NSString *const kMXCallStateDidChange = @"kMXCallStateDidChange";
 }
 
 @end
-

--- a/MatrixSDK/VoIP/MXCallManager.h
+++ b/MatrixSDK/VoIP/MXCallManager.h
@@ -16,12 +16,15 @@
 
 #import <Foundation/Foundation.h>
 
-#import "MXCall.h"
-#import "MXCallStack.h"
-#import "MXJSONModels.h"
+NS_ASSUME_NONNULL_BEGIN
 
-@class MXSession;
+@class MXCall;
+@class MXRoom;
 @class MXRoomMember;
+@class MXSession;
+@class MXTurnServerResponse;
+
+@protocol MXCallStack;
 
 /**
  Posted when a new `MXCall` instance has been created. It happens on an incoming
@@ -55,7 +58,10 @@ extern NSString *const kMXCallManagerConferenceFinished;
  @param mxSession the mxSession to the home server.
  @return the newly created MXCallManager instance.
  */
-- (instancetype)initWithMatrixSession:(MXSession*)mxSession andCallStack:(id<MXCallStack>)callstack;
+- (instancetype)initWithMatrixSession:(MXSession *)mxSession andCallStack:(id<MXCallStack>)callstack NS_DESIGNATED_INITIALIZER;
+
++ (instancetype)new NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
 
 /**
  Stop the call manager.
@@ -69,7 +75,7 @@ extern NSString *const kMXCallManagerConferenceFinished;
  @param callId the id of the call to retrieve.
  @result the `MXCall` object. Nil if not found.
  */
-- (MXCall*)callWithCallId:(NSString*)callId;
+- (nullable MXCall *)callWithCallId:(NSString *)callId;
 
 /**
  Retrieve the `MXCall` instance that is in progress in a given room.
@@ -77,7 +83,7 @@ extern NSString *const kMXCallManagerConferenceFinished;
  @param roomId the id of the room to look up.
  @result the `MXCall` object. Nil if there is no call in progress in the room.
  */
-- (MXCall*)callInRoom:(NSString*)roomId;
+- (nullable MXCall *)callInRoom:(NSString *)roomId;
 
 /**
  Place a voice or a video call into a room.
@@ -87,16 +93,16 @@ extern NSString *const kMXCallManagerConferenceFinished;
  @param success A block object called when the operation succeeds. It provides the created MXCall instance.
  @param failure A block object called when the operation fails.
  */
-- (void)placeCallInRoom:(NSString*)roomId withVideo:(BOOL)video
+- (void)placeCallInRoom:(NSString *)roomId withVideo:(BOOL)video
                 success:(void (^)(MXCall *call))success
-                failure:(void (^)(NSError *error))failure;
+                failure:(void (^)(NSError * _Nullable error))failure;
 
 /**
  Make the call manager forget a call.
  
  @param call the `MXCall` instance reference to forget.
  */
-- (void)removeCall:(MXCall*)call;
+- (void)removeCall:(MXCall *)call;
 
 /**
  The related matrix session.
@@ -118,7 +124,7 @@ extern NSString *const kMXCallManagerConferenceFinished;
  The list of TURN/STUN servers advertised by the user's homeserver.
  Can be nil. In this case, use `fallbackSTUNServer`.
  */
-@property (nonatomic, readonly) MXTurnServerResponse *turnServers;
+@property (nonatomic, nullable, readonly) MXTurnServerResponse *turnServers;
 
 /**
  STUN server used if the homeserver does not provide TURN/STUN servers.
@@ -134,7 +140,7 @@ extern NSString *const kMXCallManagerConferenceFinished;
  @param conferenceUserMember the member object of the conference user.
  @param roomId the room where there is conference call.
  */
-- (void)handleConferenceUserUpdate:(MXRoomMember*)conferenceUserMember inRoom:(NSString *)roomId;
+- (void)handleConferenceUserUpdate:(MXRoomMember *)conferenceUserMember inRoom:(NSString *)roomId;
 
 /**
  Return the id of the conference user dedicated for the passed room.
@@ -142,7 +148,7 @@ extern NSString *const kMXCallManagerConferenceFinished;
  @param roomId the room id.
  @return the conference user id.
  */
-+ (NSString*)conferenceUserIdForRoom:(NSString*)roomId;
++ (NSString *)conferenceUserIdForRoom:(NSString *)roomId;
 
 /**
  Check if the passed user id corresponds to the a conference user.
@@ -150,7 +156,7 @@ extern NSString *const kMXCallManagerConferenceFinished;
  @param userId the user id to check.
  @return YES if the id is reserved to a conference user.
  */
-+ (BOOL)isConferenceUser:(NSString*)userId;
++ (BOOL)isConferenceUser:(NSString *)userId;
 
 /**
  Check if the user can place a conference call in a given room.
@@ -161,6 +167,8 @@ extern NSString *const kMXCallManagerConferenceFinished;
  @param room the room to check.
  @return YES if the user can.
  */
-+ (BOOL)canPlaceConferenceCallInRoom:(MXRoom*)room;
++ (BOOL)canPlaceConferenceCallInRoom:(MXRoom *)room;
 
 @end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
In this PR i provide several improvements:
* Add nullability annotations. This makes code more self-documented and also provides a better interoperability with Swift
* Mark some initializers as designated
* Use forward declaration
* Adopt generics for Foundation collection types
* Use `NS_ENUM` macro instead of C `enum` for MXCallState. We can specify underlying type for our enumeration, it is translated into Swift's enums, compiler informs about uncovered values in `switch` statement and assigning to type different from the underlying one.
* Fix issue in `MXCallManager` with `refreshTURNServer` method
* Fix issue in `MXCall` connected with `retainPreventPause` of `MXSession`
* Fix issue in `MXCall` connected with retain cycle between `MXCall` instance and it's property `callStackCall`. I decided to change `MXCallStackCall`'s `delegate` property memory semantics from `strong` to `weak`. It's safer and easier to maintain rather than `strong` reference. This retain cycle is reproduced in the current develop build of Riot.
* Some cosmetic fixes to make code consistent

I've tested all changes on Riot app

Signed-off-by: Denis Morozov dmorozkn@gmail.com