### PR TITLE
Allow App to use custom certificate

### DIFF
--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -1600,6 +1600,12 @@ typedef enum : NSUInteger
                     success:(void (^)(NSDictionary *thirdPartySigned))success
                     failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
+/**
+ Set the certificates used to evaluate server trust according to the SSL pinning mode.
+ @param Pinned certificates
+ */
+-(void)setPinnedCertificates:(NSSet <NSData *> *)pinnedCertificates;
+
 #pragma mark - VoIP API
 /**
  Get the TURN server configuration advised by the homeserver.

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -4353,6 +4353,9 @@ MXAuthAction;
                                          }];
 }
 
+-(void)setPinnedCertificates:(NSSet <NSData *> *)pinnedCertificates {
+    httpClient.pinnedCertificates = pinnedCertificates;
+}
 
 #pragma mark - VoIP API
 - (MXHTTPOperation *)turnServer:(void (^)(MXTurnServerResponse *))success

--- a/MatrixSDK/Utils/MXHTTPClient.h
+++ b/MatrixSDK/Utils/MXHTTPClient.h
@@ -150,4 +150,9 @@ typedef BOOL (^MXHTTPClientOnUnrecognizedCertificate)(NSData *certificate);
  */
 + (NSUInteger)timeForRetry:(MXHTTPOperation*)httpOperation;
 
+/**
+ The certificates used to evaluate server trust according to the SSL pinning mode.
+ */
+@property (nonatomic, strong, nullable) NSSet <NSData *> *pinnedCertificates;
+
 @end


### PR DESCRIPTION
AFSecurityPolicy try to retrieve certificate in the AFNetworking Bundle
However, with Cocoapods 1.0 the pod bundle is not equal to the app
Bundle. So certificates are not retrieved