### PR TITLE
CallKit support

### DIFF
--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -215,6 +215,8 @@
 		32FE41371D0AB7070060835E /* MXEnumConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 32FE41351D0AB7070060835E /* MXEnumConstants.m */; };
 		71DE22E01BC7C51200284153 /* MXReceiptData.m in Sources */ = {isa = PBXBuildFile; fileRef = 71DE22DC1BC7C51200284153 /* MXReceiptData.m */; };
 		71DE22E11BC7C51200284153 /* MXReceiptData.h in Headers */ = {isa = PBXBuildFile; fileRef = 71DE22DD1BC7C51200284153 /* MXReceiptData.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9274AFE81EE580240009BEB6 /* MXCallKitAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = 9274AFE61EE580240009BEB6 /* MXCallKitAdapter.h */; };
+		9274AFE91EE580240009BEB6 /* MXCallKitAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9274AFE71EE580240009BEB6 /* MXCallKitAdapter.m */; };
 		A23A8594855481FEFA0E9A22 /* libPods-MatrixSDK.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E1674C6FF8BBF074E7F76059 /* libPods-MatrixSDK.a */; };
 		C60165381E3AA57900B92CFA /* MXSDKOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = F0C34CB91C18C80000C36F09 /* MXSDKOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C61A4AF41E5DD88400442158 /* Dummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C61A4AF31E5DD88400442158 /* Dummy.swift */; };
@@ -491,6 +493,8 @@
 		3ABDD5D65684E6B7F52FB94E /* libPods-MatrixSDKTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-MatrixSDKTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		71DE22DC1BC7C51200284153 /* MXReceiptData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXReceiptData.m; sourceTree = "<group>"; };
 		71DE22DD1BC7C51200284153 /* MXReceiptData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXReceiptData.h; sourceTree = "<group>"; };
+		9274AFE61EE580240009BEB6 /* MXCallKitAdapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXCallKitAdapter.h; sourceTree = "<group>"; };
+		9274AFE71EE580240009BEB6 /* MXCallKitAdapter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXCallKitAdapter.m; sourceTree = "<group>"; };
 		B1F1AE550CF4C15B653DDE6E /* Pods-MatrixSDKTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MatrixSDKTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MatrixSDKTests/Pods-MatrixSDKTests.debug.xcconfig"; sourceTree = "<group>"; };
 		C61A4AF31E5DD88400442158 /* Dummy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Dummy.swift; sourceTree = "<group>"; };
 		C61A4CC31E5F38CB00442158 /* SwiftMatrixSDK.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SwiftMatrixSDK.h; sourceTree = "<group>"; };
@@ -739,6 +743,7 @@
 		3245A74B1AF7B2930001D8A7 /* VoIP */ = {
 			isa = PBXGroup;
 			children = (
+				9274AFE51EE580240009BEB6 /* CallKit */,
 				3240951D1AFA432F00D81C97 /* CallStack */,
 				3245A74C1AF7B2930001D8A7 /* MXCall.h */,
 				3245A74D1AF7B2930001D8A7 /* MXCall.m */,
@@ -1039,6 +1044,15 @@
 			path = Checker;
 			sourceTree = "<group>";
 		};
+		9274AFE51EE580240009BEB6 /* CallKit */ = {
+			isa = PBXGroup;
+			children = (
+				9274AFE61EE580240009BEB6 /* MXCallKitAdapter.h */,
+				9274AFE71EE580240009BEB6 /* MXCallKitAdapter.m */,
+			);
+			path = CallKit;
+			sourceTree = "<group>";
+		};
 		9F1F634E8B36B1ED6D163B04 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -1209,6 +1223,7 @@
 				327137271A24D50A00DB6757 /* MXMyUser.h in Headers */,
 				3220093819EFA4C9008DE41D /* MXEventListener.h in Headers */,
 				71DE22E11BC7C51200284153 /* MXReceiptData.h in Headers */,
+				9274AFE81EE580240009BEB6 /* MXCallKitAdapter.h in Headers */,
 				32DC15D01A8CF7AE006F9AD3 /* MXNotificationCenter.h in Headers */,
 				329FB17F1A0B665800A5E88E /* MXUser.h in Headers */,
 				320DFDE219DD99B60068622A /* MXError.h in Headers */,
@@ -1451,6 +1466,7 @@
 				329B2AC21D3FB01D002D546F /* MXJingleCallStackCall.m in Sources */,
 				322691331E5EF77D00966A6E /* MXDeviceListOperation.m in Sources */,
 				3283F7791EAF30F700C1688C /* MXBugReportRestClient.m in Sources */,
+				9274AFE91EE580240009BEB6 /* MXCallKitAdapter.m in Sources */,
 				3284A5AF1DB7CFA800A09972 /* MXFileCryptoStoreMetaData.m in Sources */,
 				F0AC734F1DA4F53B0011DAEE /* MXRoomEventFilter.m in Sources */,
 				323E0C5C1A306D7A00A31D73 /* MXEvent.m in Sources */,

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -215,6 +215,8 @@
 		32FE41371D0AB7070060835E /* MXEnumConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 32FE41351D0AB7070060835E /* MXEnumConstants.m */; };
 		71DE22E01BC7C51200284153 /* MXReceiptData.m in Sources */ = {isa = PBXBuildFile; fileRef = 71DE22DC1BC7C51200284153 /* MXReceiptData.m */; };
 		71DE22E11BC7C51200284153 /* MXReceiptData.h in Headers */ = {isa = PBXBuildFile; fileRef = 71DE22DD1BC7C51200284153 /* MXReceiptData.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		926F40191EEF0F6E0062630D /* MXJingleCallAudioSessionConfigurator.h in Headers */ = {isa = PBXBuildFile; fileRef = 926F40171EEF0F6E0062630D /* MXJingleCallAudioSessionConfigurator.h */; };
+		926F401A1EEF0F6E0062630D /* MXJingleCallAudioSessionConfigurator.m in Sources */ = {isa = PBXBuildFile; fileRef = 926F40181EEF0F6E0062630D /* MXJingleCallAudioSessionConfigurator.m */; };
 		9274AFE81EE580240009BEB6 /* MXCallKitAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = 9274AFE61EE580240009BEB6 /* MXCallKitAdapter.h */; };
 		9274AFE91EE580240009BEB6 /* MXCallKitAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9274AFE71EE580240009BEB6 /* MXCallKitAdapter.m */; };
 		A23A8594855481FEFA0E9A22 /* libPods-MatrixSDK.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E1674C6FF8BBF074E7F76059 /* libPods-MatrixSDK.a */; };
@@ -493,6 +495,8 @@
 		3ABDD5D65684E6B7F52FB94E /* libPods-MatrixSDKTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-MatrixSDKTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		71DE22DC1BC7C51200284153 /* MXReceiptData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXReceiptData.m; sourceTree = "<group>"; };
 		71DE22DD1BC7C51200284153 /* MXReceiptData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXReceiptData.h; sourceTree = "<group>"; };
+		926F40171EEF0F6E0062630D /* MXJingleCallAudioSessionConfigurator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXJingleCallAudioSessionConfigurator.h; sourceTree = "<group>"; };
+		926F40181EEF0F6E0062630D /* MXJingleCallAudioSessionConfigurator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXJingleCallAudioSessionConfigurator.m; sourceTree = "<group>"; };
 		9274AFE61EE580240009BEB6 /* MXCallKitAdapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXCallKitAdapter.h; sourceTree = "<group>"; };
 		9274AFE71EE580240009BEB6 /* MXCallKitAdapter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXCallKitAdapter.m; sourceTree = "<group>"; };
 		B1F1AE550CF4C15B653DDE6E /* Pods-MatrixSDKTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MatrixSDKTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MatrixSDKTests/Pods-MatrixSDKTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -832,6 +836,8 @@
 		329B2ABA1D3FB01D002D546F /* Jingle */ = {
 			isa = PBXGroup;
 			children = (
+				926F40171EEF0F6E0062630D /* MXJingleCallAudioSessionConfigurator.h */,
+				926F40181EEF0F6E0062630D /* MXJingleCallAudioSessionConfigurator.m */,
 				329B2ABB1D3FB01D002D546F /* MXJingleCallStack.h */,
 				329B2ABC1D3FB01D002D546F /* MXJingleCallStack.m */,
 				329B2ABD1D3FB01D002D546F /* MXJingleCallStackCall.h */,
@@ -1132,6 +1138,7 @@
 				322A51B61D9AB15900C8536D /* MXCrypto.h in Headers */,
 				32114A8F1A262ECB00FF2EC4 /* MXNoStore.h in Headers */,
 				3259CD531DF860C300186944 /* MXRealmCryptoStore.h in Headers */,
+				926F40191EEF0F6E0062630D /* MXJingleCallAudioSessionConfigurator.h in Headers */,
 				32D776811A27877300FC4AA2 /* MXMemoryRoomStore.h in Headers */,
 				32322A4B1E575F65005DD155 /* MXAllowedCertificates.h in Headers */,
 				32A1515B1DB525DA00400192 /* NSObject+sortedKeys.h in Headers */,
@@ -1483,6 +1490,7 @@
 				32322A4C1E575F65005DD155 /* MXAllowedCertificates.m in Sources */,
 				F03EF5051DF01596009DF592 /* MXLRUCache.m in Sources */,
 				71DE22E01BC7C51200284153 /* MXReceiptData.m in Sources */,
+				926F401A1EEF0F6E0062630D /* MXJingleCallAudioSessionConfigurator.m in Sources */,
 				327E37B71A974F75007F026F /* MXLogger.m in Sources */,
 				324BE4691E3FADB1008D99D4 /* MXMegolmExportEncryption.m in Sources */,
 				320DFDE719DD99B60068622A /* MXHTTPClient.m in Sources */,

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -215,6 +215,9 @@
 		32FE41371D0AB7070060835E /* MXEnumConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 32FE41351D0AB7070060835E /* MXEnumConstants.m */; };
 		71DE22E01BC7C51200284153 /* MXReceiptData.m in Sources */ = {isa = PBXBuildFile; fileRef = 71DE22DC1BC7C51200284153 /* MXReceiptData.m */; };
 		71DE22E11BC7C51200284153 /* MXReceiptData.h in Headers */ = {isa = PBXBuildFile; fileRef = 71DE22DD1BC7C51200284153 /* MXReceiptData.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		92634B7F1EF2A37A00DB9F60 /* MXCallAudioSessionConfigurator.h in Headers */ = {isa = PBXBuildFile; fileRef = 92634B7E1EF2A37A00DB9F60 /* MXCallAudioSessionConfigurator.h */; };
+		92634B821EF2E3C400DB9F60 /* MXCallKitConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 92634B801EF2E3C400DB9F60 /* MXCallKitConfiguration.h */; };
+		92634B831EF2E3C400DB9F60 /* MXCallKitConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 92634B811EF2E3C400DB9F60 /* MXCallKitConfiguration.m */; };
 		926F40191EEF0F6E0062630D /* MXJingleCallAudioSessionConfigurator.h in Headers */ = {isa = PBXBuildFile; fileRef = 926F40171EEF0F6E0062630D /* MXJingleCallAudioSessionConfigurator.h */; };
 		926F401A1EEF0F6E0062630D /* MXJingleCallAudioSessionConfigurator.m in Sources */ = {isa = PBXBuildFile; fileRef = 926F40181EEF0F6E0062630D /* MXJingleCallAudioSessionConfigurator.m */; };
 		9274AFE81EE580240009BEB6 /* MXCallKitAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = 9274AFE61EE580240009BEB6 /* MXCallKitAdapter.h */; };
@@ -495,6 +498,9 @@
 		3ABDD5D65684E6B7F52FB94E /* libPods-MatrixSDKTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-MatrixSDKTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		71DE22DC1BC7C51200284153 /* MXReceiptData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXReceiptData.m; sourceTree = "<group>"; };
 		71DE22DD1BC7C51200284153 /* MXReceiptData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXReceiptData.h; sourceTree = "<group>"; };
+		92634B7E1EF2A37A00DB9F60 /* MXCallAudioSessionConfigurator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXCallAudioSessionConfigurator.h; sourceTree = "<group>"; };
+		92634B801EF2E3C400DB9F60 /* MXCallKitConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXCallKitConfiguration.h; sourceTree = "<group>"; };
+		92634B811EF2E3C400DB9F60 /* MXCallKitConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXCallKitConfiguration.m; sourceTree = "<group>"; };
 		926F40171EEF0F6E0062630D /* MXJingleCallAudioSessionConfigurator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXJingleCallAudioSessionConfigurator.h; sourceTree = "<group>"; };
 		926F40181EEF0F6E0062630D /* MXJingleCallAudioSessionConfigurator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXJingleCallAudioSessionConfigurator.m; sourceTree = "<group>"; };
 		9274AFE61EE580240009BEB6 /* MXCallKitAdapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXCallKitAdapter.h; sourceTree = "<group>"; };
@@ -737,6 +743,7 @@
 		3240951D1AFA432F00D81C97 /* CallStack */ = {
 			isa = PBXGroup;
 			children = (
+				92634B7E1EF2A37A00DB9F60 /* MXCallAudioSessionConfigurator.h */,
 				32BED28E1B00A23F00E668FE /* MXCallStack.h */,
 				3240951E1AFA432F00D81C97 /* MXCallStackCall.h */,
 				329B2ABA1D3FB01D002D546F /* Jingle */,
@@ -1055,6 +1062,8 @@
 			children = (
 				9274AFE61EE580240009BEB6 /* MXCallKitAdapter.h */,
 				9274AFE71EE580240009BEB6 /* MXCallKitAdapter.m */,
+				92634B801EF2E3C400DB9F60 /* MXCallKitConfiguration.h */,
+				92634B811EF2E3C400DB9F60 /* MXCallKitConfiguration.m */,
 			);
 			path = CallKit;
 			sourceTree = "<group>";
@@ -1154,11 +1163,13 @@
 				32A1514A1DAF7C0C00400192 /* MXUsersDevicesMap.h in Headers */,
 				323E0C5B1A306D7A00A31D73 /* MXEvent.h in Headers */,
 				327F8DB21C6112BA00581CA3 /* MXRoomThirdPartyInvite.h in Headers */,
+				92634B821EF2E3C400DB9F60 /* MXCallKitConfiguration.h in Headers */,
 				322360521A8E610500A3CA81 /* MXPushRuleDisplayNameCondtionChecker.h in Headers */,
 				F03EF5001DF014D9009DF592 /* MXMediaManager.h in Headers */,
 				3245A7521AF7B2930001D8A7 /* MXCallManager.h in Headers */,
 				C6FE1EF01E65C4F7008587E4 /* MXAnalyticsDelegate.h in Headers */,
 				3264E2A21BDF8D1500F89A86 /* MXCoreDataRoomState.h in Headers */,
+				92634B7F1EF2A37A00DB9F60 /* MXCallAudioSessionConfigurator.h in Headers */,
 				3291D4D41A68FFEB00C3BA41 /* MXFileRoomStore.h in Headers */,
 				320BBF431D6C81550079890E /* MXEventsEnumeratorOnArray.h in Headers */,
 				32C6F93319DD814400EA4E9C /* MatrixSDK.h in Headers */,
@@ -1452,6 +1463,7 @@
 				326056861C76FDF2009D44AD /* MXEventTimeline.m in Sources */,
 				32A1513A1DAD292400400192 /* MXMegolmEncryption.m in Sources */,
 				323B2B011BCE9B6700B11F34 /* MXCoreDataEvent.m in Sources */,
+				92634B831EF2E3C400DB9F60 /* MXCallKitConfiguration.m in Sources */,
 				3265CB391A14C43E00E24B2F /* MXRoomState.m in Sources */,
 				323B2AD01BCD3EF000B11F34 /* MXCoreDataStore.m in Sources */,
 				3281E8B819E42DFE00976E1A /* MXJSONModel.m in Sources */,

--- a/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.h
+++ b/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.h
@@ -1,0 +1,26 @@
+/*
+ Copyright 2017 Vector Creations Ltd
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+
+@import Foundation;
+
+@class MXCall;
+
+@interface MXCallKitAdapter : NSObject
+
+- (void)reportIncomingCall:(MXCall *)call;
+
+@end

--- a/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.h
+++ b/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.h
@@ -14,13 +14,24 @@
  limitations under the License.
  */
 
-
 @import Foundation;
+
+NS_ASSUME_NONNULL_BEGIN
 
 @class MXCall;
 
 @interface MXCallKitAdapter : NSObject
 
+- (void)startCall:(MXCall *)call;
+- (void)endCall:(MXCall *)call;
+
 - (void)reportIncomingCall:(MXCall *)call;
 
+- (void)reportCall:(MXCall *)call startedConnectingAtDate:(nullable NSDate *)date;
+- (void)reportCall:(MXCall *)call connectedAtDate:(nullable NSDate *)date;
+
++ (BOOL)callKitAvailable;
+
 @end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.h
+++ b/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.h
@@ -42,9 +42,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)reportCall:(MXCall *)call connectedAtDate:(nullable NSDate *)date;
 
 /**
- Tells if CallKit is supported by the OS
+ Tell about support of CallKit by the OS
  
- @returns true iff iOS version >= 10.0
+ @return true if iOS version >= 10.0 otherwise false
  */
 + (BOOL)callKitAvailable;
 

--- a/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.h
+++ b/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.h
@@ -19,8 +19,14 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class MXCall;
+@protocol MXCallAudioSessionConfigurator;
 
 @interface MXCallKitAdapter : NSObject
+
+/**
+ The AVAudioSession configurator.
+ */
+@property (nonatomic, nullable, strong) id<MXCallAudioSessionConfigurator> audioSessionConfigurator;
 
 - (void)startCall:(MXCall *)call;
 - (void)endCall:(MXCall *)call;

--- a/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.h
+++ b/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.h
@@ -19,6 +19,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class MXCall;
+@class MXCallKitConfiguration;
 @protocol MXCallAudioSessionConfigurator;
 
 @interface MXCallKitAdapter : NSObject
@@ -28,6 +29,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, nullable, strong) id<MXCallAudioSessionConfigurator> audioSessionConfigurator;
 
+- (instancetype)initWithConfiguration:(MXCallKitConfiguration *)configuration NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 - (void)startCall:(MXCall *)call;
 - (void)endCall:(MXCall *)call;
 
@@ -36,6 +42,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)reportCall:(MXCall *)call startedConnectingAtDate:(nullable NSDate *)date;
 - (void)reportCall:(MXCall *)call connectedAtDate:(nullable NSDate *)date;
 
+/**
+ Tells if CallKit is supported by the OS
+ 
+ @returns true iff iOS version >= 10.0
+ */
 + (BOOL)callKitAvailable;
 
 @end

--- a/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.h
+++ b/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.h
@@ -33,9 +33,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithConfiguration:(MXCallKitConfiguration *)configuration NS_DESIGNATED_INITIALIZER;
 
-- (instancetype)init NS_UNAVAILABLE;
-+ (instancetype)new NS_UNAVAILABLE;
-
 - (void)startCall:(MXCall *)call;
 - (void)endCall:(MXCall *)call;
 

--- a/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.h
+++ b/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.h
@@ -14,6 +14,8 @@
  limitations under the License.
  */
 
+#if TARGET_OS_IPHONE
+
 @import Foundation;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -52,3 +54,5 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+
+#endif

--- a/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.m
+++ b/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.m
@@ -44,6 +44,12 @@
     return self;
 }
 
+- (void)dealloc
+{
+    // CXProvider instance must be invalidated otherwise it will be leaked
+    [_provider invalidate];
+}
+
 + (CXProviderConfiguration *)configuration
 {
     NSString *appDisplayName = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleDisplayName"];

--- a/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.m
+++ b/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.m
@@ -1,0 +1,181 @@
+/*
+ Copyright 2017 Vector Creations Ltd
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXCallKitAdapter.h"
+
+@import CallKit;
+@import UIKit;
+
+#import "MXCall.h"
+#import "MXUser.h"
+#import "MatrixSDK/MXSession.h"
+
+@interface MXCallKitAdapter () <CXProviderDelegate>
+
+@property (nonatomic) CXProvider *provider;
+@property (nonatomic) CXCallController *callController;
+
+@end
+
+@implementation MXCallKitAdapter
+
+- (instancetype)init
+{
+    if (!(self = [super init])) return nil;
+    
+    self.provider = [[CXProvider alloc] initWithConfiguration:[MXCallKitAdapter configuration]];
+    [self.provider setDelegate:self queue:nil];
+    
+    self.callController = [[CXCallController alloc] initWithQueue:dispatch_get_main_queue()];
+    
+    return self;
+}
+
++ (CXProviderConfiguration *)configuration
+{
+    NSString *appDisplayName = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleDisplayName"];
+    
+    CXProviderConfiguration *configuration = [[CXProviderConfiguration alloc] initWithLocalizedName:appDisplayName];
+    configuration.maximumCallGroups = 1;
+    configuration.maximumCallsPerCallGroup = 1;
+    configuration.supportsVideo = false;
+    configuration.supportedHandleTypes = [NSSet setWithObject:@(CXHandleTypeGeneric)];
+    configuration.iconTemplateImageData = UIImagePNGRepresentation([UIImage imageNamed:@"RiotCallKitLogo"]);
+    
+    return configuration;
+}
+
+// Pass user id or smth like this to determine user id
+
+// Outgoing calll
+- (void)startCallWithUUID:(NSUUID *)uuid
+{
+    CXHandle *handle = [[CXHandle alloc] initWithType:CXHandleTypeGeneric value:@"User name"];
+    CXStartCallAction *action = [[CXStartCallAction alloc] initWithCallUUID:uuid handle:handle];
+    action.contactIdentifier = @"User display name";
+    
+    CXTransaction *transaction = [[CXTransaction alloc] initWithAction:action];
+    
+    [self.callController requestTransaction:transaction completion:^(NSError * _Nullable error) {
+        if (error != nil) return;
+        
+        CXCallUpdate *update = [[CXCallUpdate alloc] init];
+        update.remoteHandle = handle;
+        update.localizedCallerName = @"User display name";
+        update.supportsHolding = YES;
+        update.hasVideo = NO;
+        update.supportsGrouping = NO;
+        update.supportsUngrouping = NO;
+        update.supportsDTMF = NO;
+        
+        [self.provider reportNewIncomingCallWithUUID:uuid update:update completion:^(NSError * _Nullable error) {
+            if (error != nil) return;
+            
+            // add call to our list
+        }];
+    }];
+}
+
+- (void)reportIncomingCall:(MXCall *)call {
+    // Create CXHandle instance describing a caller
+    CXHandle *handle = [[CXHandle alloc] initWithType:CXHandleTypeGeneric value:call.callerId];
+    
+    MXSession *mxSession = call.room.mxSession;
+    MXUser *caller = [mxSession userWithUserId:call.callerId];
+    
+    CXCallUpdate *update = [[CXCallUpdate alloc] init];
+    update.remoteHandle = handle;
+    update.localizedCallerName = [caller displayname];
+    update.hasVideo = NO;
+    update.supportsHolding = NO;
+    update.supportsGrouping = NO;
+    update.supportsUngrouping = NO;
+    update.supportsDTMF = NO;
+    
+    NSUUID *callUUID = [NSUUID UUID];//[[NSUUID alloc] initWithUUIDString:call.callId];
+    
+    // Inform system about incoming call
+    [self.provider reportNewIncomingCallWithUUID:callUUID update:update completion:^(NSError * _Nullable error) {
+        /*
+         Only add incoming call to the app's list of calls if the call was allowed (i.e. there was no error)
+         since calls may be "denied" for various legitimate reasons. See CXErrorCodeIncomingCallError.
+         */
+        if (error)
+        {
+            if ([error.domain isEqualToString:CXErrorDomainIncomingCall] && error.code == CXErrorCodeIncomingCallErrorFilteredByDoNotDisturb)
+                // show alert or do smth to inform user
+//                completion(NO, YES);
+                NSLog(@"Do not disturb!");
+            else
+//                completion(YES, NO);
+            
+            return;
+        }
+        
+        // Success
+//        completion(NO, NO);
+    }];
+    
+}
+
+- (void)reportCall:(MXCall *)mxCall startedConnectingAtDate:(NSDate *)date
+{
+    NSUUID *callUUID = [[NSUUID alloc] initWithUUIDString:mxCall.callId];
+    [_provider reportOutgoingCallWithUUID:callUUID startedConnectingAtDate:date];
+}
+
+- (void)reportCall:(MXCall *)mxCall connectedAtDate:(NSDate *)date
+{
+    NSUUID *callUUID = [[NSUUID alloc] initWithUUIDString:mxCall.callId];
+    [_provider reportOutgoingCallWithUUID:callUUID connectedAtDate:date];
+}
+
+- (BOOL)callKitAvailable
+{
+    // TODO: Check iOS version and return apppropriate result based on the system version
+    
+    return YES;
+}
+
+#pragma mark - CXProviderDelegate
+
+- (void)provider:(CXProvider *)__unused provider performStartCallAction:(CXStartCallAction *)action
+{
+    [action fulfill];
+}
+
+#pragma mark - CXProviderDelegate
+
+- (void)providerDidReset:(CXProvider *)provider
+{
+    NSLog(@"Provider did reset");
+}
+
+- (void)provider:(CXProvider *)provider performAnswerCallAction:(CXAnswerCallAction *)action
+{
+    // Call on success
+    [action fulfill];
+    
+    // Call on fail
+    [action fail];
+}
+
+- (void)provider:(CXProvider *)provider performEndCallAction:(CXEndCallAction *)action
+{
+    
+}
+
+@end

--- a/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.m
+++ b/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.m
@@ -21,7 +21,7 @@
 @import UIKit;
 
 #import "MXCall.h"
-#import "MXJingleCallAudioSessionConfigurator.h"
+#import "MXCallAudioSessionConfigurator.h"
 #import "MXUser.h"
 #import "MXSession.h"
 
@@ -177,12 +177,10 @@
         
         self.calls[callUUID] = call;
         
-#ifdef MX_CALL_STACK_JINGLE
         // Workaround from https://forums.developer.apple.com/message/169511 suggests configuring audio in the
         // completion block of the `reportNewIncomingCallWithUUID:update:completion:` method instead of in
         // `provider:performAnswerCallAction:` per the WWDC examples.
-        [MXJingleCallAudioSessionConfigurator configureAudioSessionForVideoCall:call.isVideoCall];
-#endif
+        [self.audioSessionConfigurator configureAudioSessionForVideoCall:call.isVideoCall];
     }];
     
 }
@@ -211,16 +209,12 @@
 
 - (void)provider:(CXProvider *)provider didActivateAudioSession:(AVAudioSession *)audioSession
 {
-#ifdef MX_CALL_STACK_JINGLE
-    [MXJingleCallAudioSessionConfigurator audioSessionDidActivate:audioSession];
-#endif
+    [self.audioSessionConfigurator audioSessionDidActivate:audioSession];
 }
 
 - (void)provider:(CXProvider *)provider didDeactivateAudioSession:(AVAudioSession *)audioSession
 {
-#ifdef MX_CALL_STACK_JINGLE
-    [MXJingleCallAudioSessionConfigurator audioSessionDidDeactivate:audioSession];
-#endif
+    [self.audioSessionConfigurator audioSessionDidDeactivate:audioSession];
 }
 
 - (void)provider:(CXProvider *)provider performStartCallAction:(CXStartCallAction *)action
@@ -232,9 +226,7 @@
         return;
     }
     
-#ifdef MX_CALL_STACK_JINGLE
-    [MXJingleCallAudioSessionConfigurator configureAudioSessionForVideoCall:call.isVideoCall];
-#endif
+    [self.audioSessionConfigurator configureAudioSessionForVideoCall:call.isVideoCall];
     
     [action fulfill];
 }

--- a/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.m
+++ b/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.m
@@ -22,6 +22,7 @@
 
 #import "MXCall.h"
 #import "MXCallAudioSessionConfigurator.h"
+#import "MXCallKitConfiguration.h"
 #import "MXUser.h"
 #import "MXSession.h"
 
@@ -36,11 +37,23 @@
 
 @implementation MXCallKitAdapter
 
-- (instancetype)init
+- (instancetype)initWithConfiguration:(MXCallKitConfiguration *)configuration
 {
     if (self = [super init])
     {
-        _provider = [[CXProvider alloc] initWithConfiguration:[MXCallKitAdapter configuration]];
+        CXProviderConfiguration *providerConfiguration = [[CXProviderConfiguration alloc] initWithLocalizedName:configuration.name];
+        providerConfiguration.ringtoneSound = configuration.ringtoneName;
+        providerConfiguration.maximumCallGroups = 1;
+        providerConfiguration.maximumCallsPerCallGroup = 1;
+        providerConfiguration.supportedHandleTypes = [NSSet setWithObject:@(CXHandleTypeGeneric)];
+        providerConfiguration.supportsVideo = configuration.supportsVideo;
+        
+        if (configuration.iconName)
+        {
+            providerConfiguration.iconTemplateImageData = UIImagePNGRepresentation([UIImage imageNamed:configuration.iconName]);
+        }
+        
+        _provider = [[CXProvider alloc] initWithConfiguration:providerConfiguration];
         [_provider setDelegate:self queue:nil];
         
         _callController = [[CXCallController alloc] initWithQueue:dispatch_get_main_queue()];
@@ -55,20 +68,6 @@
 {
     // CXProvider instance must be invalidated otherwise it will be leaked
     [_provider invalidate];
-}
-
-+ (CXProviderConfiguration *)configuration
-{
-    NSString *appDisplayName = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleDisplayName"];
-    
-    CXProviderConfiguration *configuration = [[CXProviderConfiguration alloc] initWithLocalizedName:appDisplayName];
-    configuration.maximumCallGroups = 1;
-    configuration.maximumCallsPerCallGroup = 1;
-    configuration.supportsVideo = YES;
-    configuration.supportedHandleTypes = [NSSet setWithObject:@(CXHandleTypeGeneric)];
-//    configuration.iconTemplateImageData = UIImagePNGRepresentation([UIImage imageNamed:@"RiotCallKitLogo"]);
-    
-    return configuration;
 }
 
 #pragma mark - Public

--- a/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.m
+++ b/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.m
@@ -14,6 +14,8 @@
  limitations under the License.
  */
 
+#if TARGET_OS_IPHONE
+
 #import "MXCallKitAdapter.h"
 
 @import AVFoundation;
@@ -271,3 +273,5 @@
 }
 
 @end
+
+#endif

--- a/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.m
+++ b/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.m
@@ -39,6 +39,11 @@
 
 @implementation MXCallKitAdapter
 
+- (instancetype)init
+{
+    return [self initWithConfiguration:[[MXCallKitConfiguration alloc] init]];
+}
+
 - (instancetype)initWithConfiguration:(MXCallKitConfiguration *)configuration
 {
     if (self = [super init])

--- a/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.m
+++ b/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.m
@@ -255,7 +255,7 @@
     }
     
     [call hangup];
-    self.calls[action.UUID] = nil;
+    [self.calls removeObjectForKey:action.UUID];
     
     [action fulfill];
 }

--- a/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.m
+++ b/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.m
@@ -212,14 +212,14 @@
 - (void)provider:(CXProvider *)provider didActivateAudioSession:(AVAudioSession *)audioSession
 {
 #ifdef MX_CALL_STACK_JINGLE
-    [MXJingleCallAudioSessionConfigurator audioSessionDidActivated:audioSession];
+    [MXJingleCallAudioSessionConfigurator audioSessionDidActivate:audioSession];
 #endif
 }
 
 - (void)provider:(CXProvider *)provider didDeactivateAudioSession:(AVAudioSession *)audioSession
 {
 #ifdef MX_CALL_STACK_JINGLE
-    [MXJingleCallAudioSessionConfigurator audioSessionDidDeactivated:audioSession];
+    [MXJingleCallAudioSessionConfigurator audioSessionDidDeactivate:audioSession];
 #endif
 }
 

--- a/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.m
+++ b/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.m
@@ -100,9 +100,6 @@
     
     CXTransaction *transaction = [[CXTransaction alloc] initWithAction:action];
     [self.callController requestTransaction:transaction completion:^(NSError * _Nullable error) {
-        if (error)
-            return;
-
         CXCallUpdate *update = [[CXCallUpdate alloc] init];
         update.remoteHandle = handle;
         update.localizedCallerName = caller.displayname;

--- a/MatrixSDK/VoIP/CallKit/MXCallKitConfiguration.h
+++ b/MatrixSDK/VoIP/CallKit/MXCallKitConfiguration.h
@@ -1,10 +1,18 @@
-//
-//  MXCallKitConfiguration.h
-//  MatrixSDK
-//
-//  Created by Denis on 15.06.17.
-//  Copyright © 2017 matrix.org. All rights reserved.
-//
+/*
+ Copyright 2017 Vector Creations Ltd
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
 
 @import Foundation;
 

--- a/MatrixSDK/VoIP/CallKit/MXCallKitConfiguration.h
+++ b/MatrixSDK/VoIP/CallKit/MXCallKitConfiguration.h
@@ -1,0 +1,54 @@
+//
+//  MXCallKitConfiguration.h
+//  MatrixSDK
+//
+//  Created by Denis on 15.06.17.
+//  Copyright © 2017 matrix.org. All rights reserved.
+//
+
+@import Foundation;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ The `MXCallKitConfiguration` describes the desired appereance and behaviour for CallKit.
+ */
+@interface MXCallKitConfiguration : NSObject
+
+/**
+ The string associated with the application and which will be displayed in the native in-call UI
+ to help user identify the source of the call
+ 
+ Defaults to bundle display name.
+ */
+@property (nonatomic, copy) NSString *name;
+
+/**
+ The name of the ringtone sound located in app bundle and that will be played on incoming call. 
+ */
+@property (nonatomic, nullable, copy) NSString *ringtoneName;
+
+/**
+ The name of the icon associated with the application. It will be displayed in the native in-call UI.
+ 
+ The icon image should be a square with side length of 40 points. 
+ The alpha channel of the image is used to create a white image mask.
+ */
+@property (nonatomic, nullable, copy) NSString *iconName;
+
+/**
+ Tells whether video calls is supported.
+ 
+ Defaults to YES.
+ */
+@property (nonatomic) BOOL supportsVideo;
+
+
+- (instancetype)initWithName:(NSString *)name
+                ringtoneName:(nullable NSString *)ringtoneName
+                    iconName:(nullable NSString *)iconName
+               supportsVideo:(BOOL)supportsVideo NS_DESIGNATED_INITIALIZER;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixSDK/VoIP/CallKit/MXCallKitConfiguration.m
+++ b/MatrixSDK/VoIP/CallKit/MXCallKitConfiguration.m
@@ -1,10 +1,18 @@
-//
-//  MXCallKitConfiguration.m
-//  MatrixSDK
-//
-//  Created by Denis on 15.06.17.
-//  Copyright © 2017 matrix.org. All rights reserved.
-//
+/*
+ Copyright 2017 Vector Creations Ltd
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
 
 #import "MXCallKitConfiguration.h"
 

--- a/MatrixSDK/VoIP/CallKit/MXCallKitConfiguration.m
+++ b/MatrixSDK/VoIP/CallKit/MXCallKitConfiguration.m
@@ -1,0 +1,38 @@
+//
+//  MXCallKitConfiguration.m
+//  MatrixSDK
+//
+//  Created by Denis on 15.06.17.
+//  Copyright © 2017 matrix.org. All rights reserved.
+//
+
+#import "MXCallKitConfiguration.h"
+
+@implementation MXCallKitConfiguration
+
+- (instancetype)init
+{
+    NSString *appDisplayName = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleDisplayName"];
+    return [self initWithName:appDisplayName
+                 ringtoneName:nil
+                     iconName:nil
+                supportsVideo:YES];
+}
+
+- (instancetype)initWithName:(NSString *)name
+                ringtoneName:(nullable NSString *)ringtoneName
+                    iconName:(nullable NSString *)iconName
+               supportsVideo:(BOOL)supportsVideo
+{
+    if (self = [super init])
+    {
+        _name = [name copy];
+        _ringtoneName = [ringtoneName copy];
+        _iconName = [iconName copy];
+        _supportsVideo = supportsVideo;
+    }
+    
+    return self;
+}
+
+@end

--- a/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallAudioSessionConfigurator.h
+++ b/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallAudioSessionConfigurator.h
@@ -1,0 +1,53 @@
+/*
+ Copyright 2017 Vector Creations Ltd
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "MXSDKOptions.h"
+
+#ifdef MX_CALL_STACK_JINGLE
+
+@class AVAudioSession;
+
+/**
+ This class helps to provide better integration level with CallKit for WebRTC
+ */
+@interface MXJingleCallAudioSessionConfigurator : NSObject
+
+/**
+ Applies appropriate settings to AVAudioSession
+ 
+ @param isVideoCall: true if need configuration for video call, false if for voice call
+ */
++ (void)configureAudioSessionForVideoCall:(BOOL)isVideoCall;
+
+/**
+ Performs necessary for WebRTC actions after audio session was activated
+ 
+ @param audioSession: Instance of activated audio session
+ */
++ (void)audioSessionDidActivated:(AVAudioSession *)audioSession;
+
+/**
+ Performs necessary for WebRTC actions after audio session was deactivated
+ 
+ @param audioSession: Instance of deactivated audio session
+ */
++ (void)audioSessionDidDeactivated:(AVAudioSession *)audioSession;
+
+@end
+
+#endif // MX_CALL_STACK_JINGLE

--- a/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallAudioSessionConfigurator.h
+++ b/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallAudioSessionConfigurator.h
@@ -39,14 +39,14 @@
  
  @param audioSession: Instance of activated audio session
  */
-+ (void)audioSessionDidActivated:(AVAudioSession *)audioSession;
++ (void)audioSessionDidActivate:(AVAudioSession *)audioSession;
 
 /**
  Performs necessary for WebRTC actions after audio session was deactivated
  
  @param audioSession: Instance of deactivated audio session
  */
-+ (void)audioSessionDidDeactivated:(AVAudioSession *)audioSession;
++ (void)audioSessionDidDeactivate:(AVAudioSession *)audioSession;
 
 @end
 

--- a/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallAudioSessionConfigurator.h
+++ b/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallAudioSessionConfigurator.h
@@ -18,7 +18,7 @@
 
 #import "MXSDKOptions.h"
 
-#ifdef MX_CALL_STACK_JINGLE
+#if defined MX_CALL_STACK_JINGLE && TARGET_OS_IPHONE
 
 #import "MXCallAudioSessionConfigurator.h"
 
@@ -29,4 +29,4 @@
 
 @end
 
-#endif // MX_CALL_STACK_JINGLE
+#endif // MX_CALL_STACK_JINGLE && TARGET_OS_IPHONE

--- a/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallAudioSessionConfigurator.h
+++ b/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallAudioSessionConfigurator.h
@@ -20,33 +20,12 @@
 
 #ifdef MX_CALL_STACK_JINGLE
 
-@class AVAudioSession;
+#import "MXCallAudioSessionConfigurator.h"
 
 /**
- This class helps to provide better integration level with CallKit for WebRTC
+ The `MXJingleCallAudioSessionConfigurator` is the implementation of the `MXCallAudioSessionConfigurator` protocol for using with WebRTC.
  */
-@interface MXJingleCallAudioSessionConfigurator : NSObject
-
-/**
- Applies appropriate settings to AVAudioSession
- 
- @param isVideoCall: true if need configuration for video call, false if for voice call
- */
-+ (void)configureAudioSessionForVideoCall:(BOOL)isVideoCall;
-
-/**
- Performs necessary for WebRTC actions after audio session was activated
- 
- @param audioSession: Instance of activated audio session
- */
-+ (void)audioSessionDidActivate:(AVAudioSession *)audioSession;
-
-/**
- Performs necessary for WebRTC actions after audio session was deactivated
- 
- @param audioSession: Instance of deactivated audio session
- */
-+ (void)audioSessionDidDeactivate:(AVAudioSession *)audioSession;
+@interface MXJingleCallAudioSessionConfigurator : NSObject <MXCallAudioSessionConfigurator>
 
 @end
 

--- a/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallAudioSessionConfigurator.m
+++ b/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallAudioSessionConfigurator.m
@@ -20,8 +20,9 @@
 
 @import AVFoundation;
 
-#import <objc/runtime.h>
 #import <objc/message.h>
+#import <objc/runtime.h>
+#import <sys/utsname.h>
 
 // Preferred hardware sample rate (unit is in Hertz). The client sample rate
 // will be set to this value as well to avoid resampling the the audio unit's
@@ -92,9 +93,16 @@ static const int kRTCAudioSessionPreferredNumberOfChannels = 1;
     // to ensure that the I/O unit does not have to do sample rate conversion.
     // Set the preferred audio I/O buffer duration, in seconds.
     NSUInteger processorCount = [NSProcessInfo processInfo].processorCount;
+    
+    struct utsname systemInfo;
+    uname(&systemInfo);
+    NSString *machineName = [NSString stringWithCString:systemInfo.machine
+                                               encoding:NSUTF8StringEncoding];
+    BOOL isIphone4S = [machineName isEqualToString:@"iPhone4,1"];
+    
     // Use best sample rate and buffer duration if the CPU has more than one
     // core.
-    if (processorCount > 1)
+    if (processorCount > 1 && !isIphone4S)
     {
         sampleRate = kRTCAudioSessionHighPerformanceSampleRate;
         ioBufferDuration = kRTCAudioSessionHighPerformanceIOBufferDuration;

--- a/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallAudioSessionConfigurator.m
+++ b/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallAudioSessionConfigurator.m
@@ -73,7 +73,7 @@ static const int kRTCAudioSessionPreferredNumberOfChannels = 1;
     // AVAudioSessionModeVideoChat is optimized for video calls on modern devices. Instead of using the speaker from the bottom
     // of the phone as it is for AVAudioSessionModeVoiceChat, it uses the speaker located near with buil-in receiver.
     // This really increases audio quality
-    AVAudioSessionMode mode = isVideoCall ? AVAudioSessionModeVideoChat : AVAudioSessionModeVoiceChat;
+    NSString *mode = isVideoCall ? AVAudioSessionModeVideoChat : AVAudioSessionModeVoiceChat;
     [audioSession setMode:mode error:nil];
     
     // Sometimes category options don't stick after setting mode.

--- a/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallAudioSessionConfigurator.m
+++ b/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallAudioSessionConfigurator.m
@@ -70,8 +70,11 @@ static const int kRTCAudioSessionPreferredNumberOfChannels = 1;
                   withOptions:AVAudioSessionCategoryOptionAllowBluetooth
                         error:nil];
     
-    // TODO: Consider video call
-    [audioSession setMode:AVAudioSessionModeVoiceChat error:nil];
+    // AVAudioSessionModeVideoChat is optimized for video calls on modern devices. Instead of using the speaker from the bottom
+    // of the phone as it is for AVAudioSessionModeVoiceChat, it uses the speaker located near with buil-in receiver.
+    // This really increases audio quality
+    AVAudioSessionMode mode = isVideoCall ? AVAudioSessionModeVideoChat : AVAudioSessionModeVoiceChat;
+    [audioSession setMode:mode error:nil];
     
     // Sometimes category options don't stick after setting mode.
     if (audioSession.categoryOptions != AVAudioSessionCategoryOptionAllowBluetooth)

--- a/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallAudioSessionConfigurator.m
+++ b/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallAudioSessionConfigurator.m
@@ -1,0 +1,170 @@
+/*
+ Copyright 2017 Vector Creations Ltd
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXJingleCallAudioSessionConfigurator.h"
+
+#ifdef MX_CALL_STACK_JINGLE
+
+@import AVFoundation;
+
+#import <objc/runtime.h>
+#import <objc/message.h>
+
+// Preferred hardware sample rate (unit is in Hertz). The client sample rate
+// will be set to this value as well to avoid resampling the the audio unit's
+// format converter. Note that, some devices, e.g. BT headsets, only supports
+// 8000Hz as native sample rate.
+static const double kRTCAudioSessionHighPerformanceSampleRate = 48000.0;
+
+// A lower sample rate will be used for devices with only one core
+// (e.g. iPhone 4). The goal is to reduce the CPU load of the application.
+static const double kRTCAudioSessionLowComplexitySampleRate = 16000.0;
+
+// Use a hardware I/O buffer size (unit is in seconds) that matches the 10ms
+// size used by WebRTC. The exact actual size will differ between devices.
+// Example: using 48kHz on iPhone 6 results in a native buffer size of
+// ~10.6667ms or 512 audio frames per buffer. The FineAudioBuffer instance will
+// take care of any buffering required to convert between native buffers and
+// buffers used by WebRTC. It is beneficial for the performance if the native
+// size is as close to 10ms as possible since it results in "clean" callback
+// sequence without bursts of callbacks back to back.
+static const double kRTCAudioSessionHighPerformanceIOBufferDuration = 0.01;
+
+// Use a larger buffer size on devices with only one core (e.g. iPhone 4).
+// It will result in a lower CPU consumption at the cost of a larger latency.
+// The size of 60ms is based on instrumentation that shows a significant
+// reduction in CPU load compared with 10ms on low-end devices.
+// TODO(henrika): monitor this size and determine if it should be modified.
+static const double kRTCAudioSessionLowComplexityIOBufferDuration = 0.06;
+
+// Try to use mono to save resources. Also avoids channel format conversion
+// in the I/O audio unit. Initial tests have shown that it is possible to use
+// mono natively for built-in microphones and for BT headsets but not for
+// wired headsets. Wired headsets only support stereo as native channel format
+// but it is a low cost operation to do a format conversion to mono in the
+// audio unit. Hence, we will not hit a RTC_CHECK in
+// VerifyAudioParametersForActiveAudioSession() for a mismatch between the
+// preferred number of channels and the actual number of channels.
+static const int kRTCAudioSessionPreferredNumberOfChannels = 1;
+
+@implementation MXJingleCallAudioSessionConfigurator
+
++ (void)configureAudioSessionForVideoCall:(BOOL)isVideoCall
+{
+    AVAudioSession *audioSession = [AVAudioSession sharedInstance];
+    
+    [audioSession setCategory:AVAudioSessionCategoryPlayAndRecord
+                  withOptions:AVAudioSessionCategoryOptionAllowBluetooth
+                        error:nil];
+    
+    // TODO: Consider video call
+    [audioSession setMode:AVAudioSessionModeVoiceChat error:nil];
+    
+    // Sometimes category options don't stick after setting mode.
+    if (audioSession.categoryOptions != AVAudioSessionCategoryOptionAllowBluetooth)
+    {
+        [audioSession setCategory:AVAudioSessionCategoryPlayAndRecord
+                      withOptions:AVAudioSessionCategoryOptionAllowBluetooth
+                            error:nil];
+    }
+    
+    double sampleRate;
+    double ioBufferDuration;
+    
+    // Set the session's sample rate or the hardware sample rate.
+    // It is essential that we use the same sample rate as stream format
+    // to ensure that the I/O unit does not have to do sample rate conversion.
+    // Set the preferred audio I/O buffer duration, in seconds.
+    NSUInteger processorCount = [NSProcessInfo processInfo].processorCount;
+    // Use best sample rate and buffer duration if the CPU has more than one
+    // core.
+    if (processorCount > 1)
+    {
+        sampleRate = kRTCAudioSessionHighPerformanceSampleRate;
+        ioBufferDuration = kRTCAudioSessionHighPerformanceIOBufferDuration;
+    }
+    else
+    {
+        sampleRate = kRTCAudioSessionLowComplexitySampleRate;
+        ioBufferDuration = kRTCAudioSessionLowComplexityIOBufferDuration;
+    }
+    
+    [audioSession setPreferredSampleRate:sampleRate error:nil];
+    [audioSession setPreferredIOBufferDuration:ioBufferDuration error:nil];
+}
+
++ (void)audioSessionDidActivated:(AVAudioSession *)audioSession
+{
+    // Finish audio session configuration. These properties can be set only after activation
+    [audioSession setPreferredInputNumberOfChannels:kRTCAudioSessionPreferredNumberOfChannels error:nil];
+    [audioSession setPreferredOutputNumberOfChannels:kRTCAudioSessionPreferredNumberOfChannels error:nil];
+    
+    // Guys from Google have their own mind on priority of task devoted to make RTCAudioSession public to use.
+    // https://bugs.chromium.org/p/webrtc/issues/detail?id=7351
+    //
+    // They had already implemented neccesary methods to make it possible for WebRTC to work with CallKit. They will be available in v.60.
+    // https://bugs.chromium.org/p/webrtc/issues/detail?id=7446
+    //
+    // We use a bit of Obj-C runtime power and call neccesary methods on our own.
+    // It's safe since all necessary checks are performed.
+    // In the future when RTCAudioSession will become public we will switch to use methods directly.
+    //
+    // The reason of this runtime magic is that OS activates audio session earlier than it does WebRTC, it's worth mention that
+    // activation of audio session is expensive operation and it's better to avoid doing job twice
+    
+    Class cls = objc_getClass("RTCAudioSession");
+    Class metaCls = objc_getMetaClass("RTCAudioSession");
+    
+    SEL selSharedInstance = NSSelectorFromString(@"sharedInstance");
+    SEL selIncrementActivationCount = NSSelectorFromString(@"incrementActivationCount");
+    SEL selSetIsActive = NSSelectorFromString(@"setIsActive:");
+    
+    if (cls &&
+        metaCls &&
+        class_respondsToSelector(metaCls, selSharedInstance) &&
+        class_respondsToSelector(cls, selIncrementActivationCount) &&
+        class_respondsToSelector(cls, selSetIsActive))
+    {
+        id rtcAudioSession = ((id (*)(id, SEL))objc_msgSend)(cls, selSharedInstance);
+        ((void (*)(id, SEL))objc_msgSend)(rtcAudioSession, selIncrementActivationCount);
+        ((void (*)(id, SEL, BOOL))objc_msgSend)(rtcAudioSession, selSetIsActive, YES);
+    }
+}
+
++ (void)audioSessionDidDeactivated:(AVAudioSession *)audioSession
+{
+    Class cls = objc_getClass("RTCAudioSession");
+    Class metaCls = objc_getMetaClass("RTCAudioSession");
+    
+    SEL selSharedInstance = NSSelectorFromString(@"sharedInstance");
+    SEL selIncrementActivationCount = NSSelectorFromString(@"decrementActivationCount");
+    SEL selSetIsActive = NSSelectorFromString(@"setIsActive:");
+    
+    if (cls &&
+        metaCls &&
+        class_respondsToSelector(metaCls, selSharedInstance) &&
+        class_respondsToSelector(cls, selIncrementActivationCount) &&
+        class_respondsToSelector(cls, selSetIsActive))
+    {
+        id rtcAudioSession = ((id (*)(id, SEL))objc_msgSend)(cls, selSharedInstance);
+        ((void (*)(id, SEL, BOOL))objc_msgSend)(rtcAudioSession, selSetIsActive, NO);
+        ((void (*)(id, SEL))objc_msgSend)(rtcAudioSession, selIncrementActivationCount);
+    }
+}
+
+@end
+
+#endif // MX_CALL_STACK_JINGLE

--- a/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallAudioSessionConfigurator.m
+++ b/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallAudioSessionConfigurator.m
@@ -63,7 +63,7 @@ static const int kRTCAudioSessionPreferredNumberOfChannels = 1;
 
 @implementation MXJingleCallAudioSessionConfigurator
 
-+ (void)configureAudioSessionForVideoCall:(BOOL)isVideoCall
+- (void)configureAudioSessionForVideoCall:(BOOL)isVideoCall
 {
     AVAudioSession *audioSession = [AVAudioSession sharedInstance];
     
@@ -117,7 +117,7 @@ static const int kRTCAudioSessionPreferredNumberOfChannels = 1;
     [audioSession setPreferredIOBufferDuration:ioBufferDuration error:nil];
 }
 
-+ (void)audioSessionDidActivate:(AVAudioSession *)audioSession
+- (void)audioSessionDidActivate:(AVAudioSession *)audioSession
 {
     // Finish audio session configuration. These properties can be set only after activation
     [audioSession setPreferredInputNumberOfChannels:kRTCAudioSessionPreferredNumberOfChannels error:nil];
@@ -155,7 +155,7 @@ static const int kRTCAudioSessionPreferredNumberOfChannels = 1;
     }
 }
 
-+ (void)audioSessionDidDeactivate:(AVAudioSession *)audioSession
+- (void)audioSessionDidDeactivate:(AVAudioSession *)audioSession
 {
     Class cls = objc_getClass("RTCAudioSession");
     Class metaCls = objc_getMetaClass("RTCAudioSession");

--- a/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallAudioSessionConfigurator.m
+++ b/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallAudioSessionConfigurator.m
@@ -161,7 +161,7 @@ static const int kRTCAudioSessionPreferredNumberOfChannels = 1;
     Class metaCls = objc_getMetaClass("RTCAudioSession");
     
     SEL selSharedInstance = NSSelectorFromString(@"sharedInstance");
-    SEL selIncrementActivationCount = NSSelectorFromString(@"decrementActivationCount");
+    SEL selDecrementActivationCount = NSSelectorFromString(@"decrementActivationCount");
     SEL selSetIsActive = NSSelectorFromString(@"setIsActive:");
     
     if (cls &&
@@ -172,7 +172,7 @@ static const int kRTCAudioSessionPreferredNumberOfChannels = 1;
     {
         id rtcAudioSession = ((id (*)(id, SEL))objc_msgSend)(cls, selSharedInstance);
         ((void (*)(id, SEL, BOOL))objc_msgSend)(rtcAudioSession, selSetIsActive, NO);
-        ((void (*)(id, SEL))objc_msgSend)(rtcAudioSession, selIncrementActivationCount);
+        ((void (*)(id, SEL))objc_msgSend)(rtcAudioSession, selDecrementActivationCount);
     }
 }
 

--- a/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallAudioSessionConfigurator.m
+++ b/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallAudioSessionConfigurator.m
@@ -16,7 +16,7 @@
 
 #import "MXJingleCallAudioSessionConfigurator.h"
 
-#ifdef MX_CALL_STACK_JINGLE
+#if defined MX_CALL_STACK_JINGLE && TARGET_OS_IPHONE
 
 @import AVFoundation;
 
@@ -178,4 +178,4 @@ static const int kRTCAudioSessionPreferredNumberOfChannels = 1;
 
 @end
 
-#endif // MX_CALL_STACK_JINGLE
+#endif // MX_CALL_STACK_JINGLE && TARGET_OS_IPHONE

--- a/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallAudioSessionConfigurator.m
+++ b/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallAudioSessionConfigurator.m
@@ -171,7 +171,7 @@ static const int kRTCAudioSessionPreferredNumberOfChannels = 1;
     if (cls &&
         metaCls &&
         class_respondsToSelector(metaCls, selSharedInstance) &&
-        class_respondsToSelector(cls, selIncrementActivationCount) &&
+        class_respondsToSelector(cls, selDecrementActivationCount) &&
         class_respondsToSelector(cls, selSetIsActive))
     {
         id rtcAudioSession = ((id (*)(id, SEL))objc_msgSend)(cls, selSharedInstance);

--- a/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallAudioSessionConfigurator.m
+++ b/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallAudioSessionConfigurator.m
@@ -12,6 +12,10 @@
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License.
+ 
+ Some parts of the code were taken from WebRTC iOS SDK because there is no public API
+ to configure AVAudioSession for calls. We need these functionality because of CallKit support.
+ See: https://chromium.googlesource.com/external/webrtc/+/master/webrtc/sdk/objc/Framework/Classes/Audio/RTCAudioSessionConfiguration.m
  */
 
 #import "MXJingleCallAudioSessionConfigurator.h"

--- a/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallAudioSessionConfigurator.m
+++ b/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallAudioSessionConfigurator.m
@@ -117,7 +117,7 @@ static const int kRTCAudioSessionPreferredNumberOfChannels = 1;
     [audioSession setPreferredIOBufferDuration:ioBufferDuration error:nil];
 }
 
-+ (void)audioSessionDidActivated:(AVAudioSession *)audioSession
++ (void)audioSessionDidActivate:(AVAudioSession *)audioSession
 {
     // Finish audio session configuration. These properties can be set only after activation
     [audioSession setPreferredInputNumberOfChannels:kRTCAudioSessionPreferredNumberOfChannels error:nil];
@@ -155,7 +155,7 @@ static const int kRTCAudioSessionPreferredNumberOfChannels = 1;
     }
 }
 
-+ (void)audioSessionDidDeactivated:(AVAudioSession *)audioSession
++ (void)audioSessionDidDeactivate:(AVAudioSession *)audioSession
 {
     Class cls = objc_getClass("RTCAudioSession");
     Class metaCls = objc_getMetaClass("RTCAudioSession");

--- a/MatrixSDK/VoIP/CallStack/MXCallAudioSessionConfigurator.h
+++ b/MatrixSDK/VoIP/CallStack/MXCallAudioSessionConfigurator.h
@@ -1,0 +1,48 @@
+/*
+ Copyright 2017 Vector Creations Ltd
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+@class AVAudioSession;
+
+/**
+ The `MXCallAudioSessionConfigurator` is an abstract interface to managing AVAudioSession.
+ It is used to provide a good level of integration with CallKit on iOS.
+ */
+@protocol MXCallAudioSessionConfigurator <NSObject>
+
+/**
+ Applies appropriate settings to AVAudioSession
+ 
+ @param isVideoCall: true if need configuration for video call, false if for voice call
+ */
+- (void)configureAudioSessionForVideoCall:(BOOL)isVideoCall;
+
+/**
+ Performs necessary for call stack actions after audio session was activated
+ 
+ @param audioSession: Instance of activated audio session
+ */
+- (void)audioSessionDidActivate:(AVAudioSession *)audioSession;
+
+/**
+ Performs necessary for call stack actions after audio session was deactivated
+ 
+ @param audioSession: Instance of deactivated audio session
+ */
+- (void)audioSessionDidDeactivate:(AVAudioSession *)audioSession;
+
+@end

--- a/MatrixSDK/VoIP/MXCallManager.h
+++ b/MatrixSDK/VoIP/MXCallManager.h
@@ -116,7 +116,8 @@ extern NSString *const kMXCallManagerConferenceFinished;
 @property (nonatomic) id<MXCallStack> callStack;
 
 /**
- 
+ The CallKit adapter.
+ Provide it if you want to add CallKit support.
  */
 #if TARGET_OS_IPHONE
 @property (nonatomic, nullable) MXCallKitAdapter *callKitAdapter;

--- a/MatrixSDK/VoIP/MXCallManager.h
+++ b/MatrixSDK/VoIP/MXCallManager.h
@@ -19,6 +19,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class MXCall;
+@class MXCallKitAdapter;
 @class MXRoom;
 @class MXRoomMember;
 @class MXSession;
@@ -113,6 +114,13 @@ extern NSString *const kMXCallManagerConferenceFinished;
  The call stack layer.
  */
 @property (nonatomic) id<MXCallStack> callStack;
+
+/**
+ 
+ */
+#if TARGET_OS_IPHONE
+@property (nonatomic, nullable) MXCallKitAdapter *callKitAdapter;
+#endif
 
 /**
  The time in milliseconds that an incoming or outgoing call invite is valid for.

--- a/MatrixSDK/VoIP/MXCallManager.m
+++ b/MatrixSDK/VoIP/MXCallManager.m
@@ -17,6 +17,7 @@
 #import "MXCallManager.h"
 
 #import "MXCall.h"
+#import "MXCallKitAdapter.h"
 #import "MXCallStack.h"
 #import "MXJSONModels.h"
 #import "MXRoom.h"
@@ -389,27 +390,29 @@ static NSString *const kMXCallManagerFallbackSTUNServer = @"stun:stun.l.google.c
 
 - (void)handleCallStateDidChangeNotification:(NSNotification *)notification
 {
+#if TARGET_OS_IPHONE
     MXCall *call = notification.object;
     
     switch (call.state) {
         case MXCallStateCreateOffer:
-            [_callKitAdapter startCall:call];
+            [self.callKitAdapter startCall:call];
             break;
         case MXCallStateRinging:
-            [_callKitAdapter reportIncomingCall:call];
+            [self.callKitAdapter reportIncomingCall:call];
             break;
         case MXCallStateConnecting:
-            [_callKitAdapter reportCall:call startedConnectingAtDate:nil];
+            [self.callKitAdapter reportCall:call startedConnectingAtDate:nil];
             break;
         case MXCallStateConnected:
-            [_callKitAdapter reportCall:call connectedAtDate:nil];
+            [self.callKitAdapter reportCall:call connectedAtDate:nil];
             break;
         case MXCallStateEnded:
-            [_callKitAdapter endCall:call];
+            [self.callKitAdapter endCall:call];
             break;
         default:
             break;
     }
+#endif
 }
 
 #pragma mark - Conference call


### PR DESCRIPTION
`MXCallKitAdapter` is an entity through which we interact with CallKit API

The most interesting part is `MXJingleCallAudioSessionConfigurator`. There is no public API in WebRTC iOS SDK to configure `AVAudioSession`, it is only internal. CallKit has its own rules for where and when we need to configure and activate AVAudioSession. We need to configure AVAudioSession when `provider:performStartCallAction:` is called and in completion block of `reportNewIncomingCallWithUUID:update:completion`. So i decide to extract configuration values from WebRTC iOS SDK and put them into class called `MXJingleCallAudioSessionConfigurator`. So with it help we can configure `AVAudioSession` like it does WebRTC internally. Here is the WebRTC [sources](https://chromium.googlesource.com/external/webrtc/+/master/webrtc/sdk/objc/Framework/Classes/Audio/RTCAudioSessionConfiguration.m).

Another important thing is `AVAudioSession` activation and deactivation. CallKit says us when it activated or deactivated `AVAudioSession` and we need to inform WebRTC somehow. But we also don't have any public API for that. They create new methods for better integration with CallKit and the will be available in v60. The funny fact is that they are located in internal class:)
Because of all these funny things i decided to use Obj-C runtime to have the same behaviour as methods they're going to release in v60. You can check additional comments in the code.

The next important thing i want to talk about is `CXProvider` configuration. For the moment i use a static method for it, but it must be fixed because we must provide chance for our SDK users to configure CallKit as they want. I see several options. In both situations i want to add a parameter for init. In the first case we can pass  `CXProviderConfiguration` instance, in the second we can create class like `MXCallKitConfiguration` which will mirror `CXProviderConfiguration` interface and also will have a static method `defaultConfiguration`. We also can use `init` as a convenience initializer, it will call `initWithConfiguration:` and pass a default configuration to it. Need your help with this.

Signed-off-by: Denis Morozov dmorozkn@gmail.com