### PR TITLE
Bug Fix - Read marker: hit "Jump to first unread marker" leads to mes…

### DIFF
--- a/MatrixSDK/Data/MXRoom.h
+++ b/MatrixSDK/Data/MXRoom.h
@@ -847,9 +847,13 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidFlushDataNotification;
  This will indicate to the homeserver that the user has read this event.
  Set YES the boolean updateReadMarker to let know the homeserver the user has read up to this event.
  
+ @warning Because the event related to the current read marker may not be in the local storage, no check
+ is performed before updating the read marker. The caller should check whether the provided event
+ is posterior to the current read marker position.
+ 
  @discussion If the type of the provided event is not defined in MXSession.acknowledgableEventTypes,
  this method acknowlegdes the first prior event of type defined in MXSession.acknowledgableEventTypes.
- The updated read marker (if any) will refer to the provided event.
+ The read marker (if its update is requested) will refer to the provided event.
  
  @param event the event to acknowlegde.
  @param updateReadMarker tell whether the read marker should be moved to this event.

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -1746,14 +1746,9 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
         }
         
         
-        if (![_accountData.readMarkerEventId isEqualToString:updatedReadMarkerEvent.eventId])
+        if (updatedReadMarkerEvent && ![_accountData.readMarkerEventId isEqualToString:updatedReadMarkerEvent.eventId])
         {
-            MXEvent *currentReadMarkerEvent = [mxSession.store eventWithEventId:_accountData.readMarkerEventId inRoom:self.roomId];
-            
-            if (!currentReadMarkerEvent || (currentReadMarkerEvent.originServerTs <= updatedReadMarkerEvent.originServerTs))
-            {
-                readMarkerEventId = updatedReadMarkerEvent.eventId;
-            }
+            readMarkerEventId = updatedReadMarkerEvent.eventId;
         }
     }
     
@@ -1767,7 +1762,8 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
                                             eventId:updatedReadReceiptEvent.eventId
                                             success:nil
                                             failure:nil];
-    }}
+    }
+}
 
 - (void)markAllAsRead
 {


### PR DESCRIPTION
…sage above the last unread.

MXRoom `- (void)acknowledgeEvent:(MXEvent*)event andUpdateReadMarker:(BOOL)updateReadMarker;`
Because the event related to the current read marker may not be in the local storage, no check
 is performed before updating the read marker. The caller should check whether the provided event
 is posterior to the current read marker position.

https://github.com/vector-im/riot-ios/issues/1293