### PR TITLE
MXFileStore: Improve NSCoding implementation of MXEvent by storing en…

### DIFF
--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
@@ -27,7 +27,7 @@
 
 #import "MXSDKOptions.h"
 
-NSUInteger const kMXFileVersion = 40;
+NSUInteger const kMXFileVersion = 41;
 
 NSString *const kMXFileStoreFolder = @"MXFileStore";
 NSString *const kMXFileStoreMedaDataFile = @"MXFileStore";

--- a/MatrixSDK/JSONModels/MXEvent.h
+++ b/MatrixSDK/JSONModels/MXEvent.h
@@ -28,7 +28,7 @@
  */
 typedef enum : NSUInteger
 {
-    MXEventTypeRoomName,
+    MXEventTypeRoomName = 0,
     MXEventTypeRoomTopic,
     MXEventTypeRoomAvatar,
     MXEventTypeRoomMember,

--- a/MatrixSDK/JSONModels/MXEvent.m
+++ b/MatrixSDK/JSONModels/MXEvent.m
@@ -223,6 +223,12 @@ NSString *const kMXEventIdentifierKey = @"kMXEventIdentifierKey";
     _wireEventType = [MXTools eventType:_wireType];
 }
 
+- (void)setWireEventType:(MXEventType)wireEventType
+{
+    _wireEventType = wireEventType;
+    _wireType = [MXTools eventTypeString:_wireEventType];
+}
+
 - (void)setAge:(NSUInteger)age
 {
     // If the age has not been stored yet in local time stamp, do it now
@@ -599,7 +605,6 @@ NSString *const kMXEventIdentifierKey = @"kMXEventIdentifierKey";
     if (self)
     {
         _eventId = [aDecoder decodeObjectForKey:@"eventId"];
-        self.wireType = [aDecoder decodeObjectForKey:@"type"];
         _roomId = [aDecoder decodeObjectForKey:@"roomId"];
         _sender = [aDecoder decodeObjectForKey:@"userId"];
         _sentState = (MXEventSentState)[aDecoder decodeIntegerForKey:@"sentState"];
@@ -613,6 +618,18 @@ NSString *const kMXEventIdentifierKey = @"kMXEventIdentifierKey";
         _redactedBecause = [aDecoder decodeObjectForKey:@"redactedBecause"];
         _inviteRoomState = [aDecoder decodeObjectForKey:@"inviteRoomState"];
         _sentError = [aDecoder decodeObjectForKey:@"sentError"];
+
+        _wireEventType = (MXEventType)[aDecoder decodeIntegerForKey:@"eventType"];
+        if (_wireEventType == MXEventTypeCustom)
+        {
+            self.wireType = [aDecoder decodeObjectForKey:@"type"];
+        }
+        else
+        {
+            // Retrieve the type string from the enum
+            self.wireEventType = _wireEventType;
+        }
+
     }
     return self;
 }
@@ -623,7 +640,6 @@ NSString *const kMXEventIdentifierKey = @"kMXEventIdentifierKey";
     [aCoder encodeObject:_roomId forKey:@"roomId"];
     [aCoder encodeObject:_sender forKey:@"userId"];
     [aCoder encodeInteger:(NSInteger)_sentState forKey:@"sentState"];
-    [aCoder encodeObject:_wireType forKey:@"type"];
     [aCoder encodeObject:_wireContent forKey:@"content"];
     [aCoder encodeObject:_prevContent forKey:@"prevContent"];
     [aCoder encodeObject:_stateKey forKey:@"stateKey"];
@@ -634,6 +650,13 @@ NSString *const kMXEventIdentifierKey = @"kMXEventIdentifierKey";
     [aCoder encodeObject:_redactedBecause forKey:@"redactedBecause"];
     [aCoder encodeObject:_inviteRoomState forKey:@"inviteRoomState"];
     [aCoder encodeObject:_sentError forKey:@"sentError"];
+
+    [aCoder encodeInteger:(NSInteger)_wireEventType forKey:@"eventType"];
+    if (_wireEventType == MXEventTypeCustom)
+    {
+        // Store the type string only if it does not have an enum
+        [aCoder encodeObject:_wireType forKey:@"type"];
+    }
 }
 
 @end

--- a/MatrixSDK/Utils/MXTools.m
+++ b/MatrixSDK/Utils/MXTools.m
@@ -32,9 +32,9 @@ NSString *const kMXToolsRegexStringForMatrixEventIdentifier = @"\\$[A-Z0-9]+:[A-
 
 
 #pragma mark - MXTools static private members
-// Mapping from MXEventTypeString to MXEventType
-static NSDictionary<MXEventTypeString, NSNumber*> *eventTypesMap;
-static NSArray<MXEventTypeString> *revertEventTypesMap;
+// Mapping from MXEventTypeString to MXEventType and vice versa
+static NSDictionary<MXEventTypeString, NSNumber*> *eventTypeMapStringToEnum;
+static NSArray<MXEventTypeString> *eventTypeMapEnumToString;
 
 static NSRegularExpression *isEmailAddressRegex;
 static NSRegularExpression *isMatrixUserIdentifierRegex;
@@ -50,38 +50,44 @@ static NSRegularExpression *isMatrixEventIdentifierRegex;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
 
-        eventTypesMap = @{
-                          kMXEventTypeStringRoomName: @(MXEventTypeRoomName),
-                          kMXEventTypeStringRoomTopic: @(MXEventTypeRoomTopic),
-                          kMXEventTypeStringRoomAvatar: @(MXEventTypeRoomAvatar),
-                          kMXEventTypeStringRoomMember: @(MXEventTypeRoomMember),
-                          kMXEventTypeStringRoomCreate: @(MXEventTypeRoomCreate),
-                          kMXEventTypeStringRoomJoinRules: @(MXEventTypeRoomJoinRules),
-                          kMXEventTypeStringRoomPowerLevels: @(MXEventTypeRoomPowerLevels),
-                          kMXEventTypeStringRoomAliases: @(MXEventTypeRoomAliases),
-                          kMXEventTypeStringRoomCanonicalAlias: @(MXEventTypeRoomCanonicalAlias),
-                          kMXEventTypeStringRoomEncrypted: @(MXEventTypeRoomEncrypted),
-                          kMXEventTypeStringRoomEncryption: @(MXEventTypeRoomEncryption),
-                          kMXEventTypeStringRoomHistoryVisibility: @(MXEventTypeRoomHistoryVisibility),
-                          kMXEventTypeStringRoomGuestAccess: @(MXEventTypeRoomGuestAccess),
-                          kMXEventTypeStringRoomKey: @(MXEventTypeRoomKey),
-                          kMXEventTypeStringRoomMessage: @(MXEventTypeRoomMessage),
-                          kMXEventTypeStringRoomMessageFeedback: @(MXEventTypeRoomMessageFeedback),
-                          kMXEventTypeStringRoomRedaction: @(MXEventTypeRoomRedaction),
-                          kMXEventTypeStringRoomThirdPartyInvite: @(MXEventTypeRoomThirdPartyInvite),
-                          kMXEventTypeStringRoomTag: @(MXEventTypeRoomTag),
-                          kMXEventTypeStringPresence: @(MXEventTypePresence),
-                          kMXEventTypeStringTypingNotification: @(MXEventTypeTypingNotification),
-                          kMXEventTypeStringNewDevice: @(MXEventTypeNewDevice),
-                          kMXEventTypeStringCallInvite: @(MXEventTypeCallInvite),
-                          kMXEventTypeStringCallCandidates: @(MXEventTypeCallCandidates),
-                          kMXEventTypeStringCallAnswer: @(MXEventTypeCallAnswer),
-                          kMXEventTypeStringCallHangup: @(MXEventTypeCallHangup),
-                          kMXEventTypeStringReceipt: @(MXEventTypeReceipt),
-                          kMXEventTypeStringReadMarker: @(MXEventTypeReadMarker)
-                          };
+        eventTypeMapEnumToString = @[
+                                kMXEventTypeStringRoomName,
+                                kMXEventTypeStringRoomTopic,
+                                kMXEventTypeStringRoomAvatar,
+                                kMXEventTypeStringRoomMember,
+                                kMXEventTypeStringRoomCreate,
+                                kMXEventTypeStringRoomJoinRules,
+                                kMXEventTypeStringRoomPowerLevels,
+                                kMXEventTypeStringRoomAliases,
+                                kMXEventTypeStringRoomCanonicalAlias,
+                                kMXEventTypeStringRoomEncrypted,
+                                kMXEventTypeStringRoomEncryption,
+                                kMXEventTypeStringRoomHistoryVisibility,
+                                kMXEventTypeStringRoomGuestAccess,
+                                kMXEventTypeStringRoomKey,
+                                kMXEventTypeStringRoomMessage,
+                                kMXEventTypeStringRoomMessageFeedback,
+                                kMXEventTypeStringRoomRedaction,
+                                kMXEventTypeStringRoomThirdPartyInvite,
+                                kMXEventTypeStringRoomTag,
+                                kMXEventTypeStringPresence,
+                                kMXEventTypeStringTypingNotification,
+                                kMXEventTypeStringNewDevice,
+                                kMXEventTypeStringCallInvite,
+                                kMXEventTypeStringCallCandidates,
+                                kMXEventTypeStringCallAnswer,
+                                kMXEventTypeStringCallHangup,
+                                kMXEventTypeStringReceipt,
+                                kMXEventTypeStringReadMarker
+                                ];
 
-        revertEventTypesMap = eventTypesMap.allKeys;
+        NSMutableDictionary *map = [NSMutableDictionary dictionaryWithCapacity:eventTypeMapEnumToString.count];
+        for (NSUInteger i = 0; i <eventTypeMapEnumToString.count; i++)
+        {
+            MXEventTypeString type = eventTypeMapEnumToString[i];
+            map[type] = @(i);
+        }
+        eventTypeMapStringToEnum = map;
 
         isEmailAddressRegex =  [NSRegularExpression regularExpressionWithPattern:[NSString stringWithFormat:@"^%@$", kMXToolsRegexStringForEmailAddress]
                                                                          options:NSRegularExpressionCaseInsensitive error:nil];
@@ -98,9 +104,9 @@ static NSRegularExpression *isMatrixEventIdentifierRegex;
 
 + (MXEventTypeString)eventTypeString:(MXEventType)eventType
 {
-    if (eventType < revertEventTypesMap.count)
+    if (eventType < eventTypeMapEnumToString.count)
     {
-        return revertEventTypesMap[eventType];
+        return eventTypeMapEnumToString[eventType];
     }
     return nil;
 }
@@ -109,7 +115,7 @@ static NSRegularExpression *isMatrixEventIdentifierRegex;
 {
     MXEventType eventType = MXEventTypeCustom;
 
-    NSNumber *number = [eventTypesMap objectForKey:eventTypeString];
+    NSNumber *number = [eventTypeMapStringToEnum objectForKey:eventTypeString];
     if (number)
     {
         eventType = [number unsignedIntegerValue];

--- a/MatrixSDK/Utils/MXTools.m
+++ b/MatrixSDK/Utils/MXTools.m
@@ -33,7 +33,8 @@ NSString *const kMXToolsRegexStringForMatrixEventIdentifier = @"\\$[A-Z0-9]+:[A-
 
 #pragma mark - MXTools static private members
 // Mapping from MXEventTypeString to MXEventType
-static NSDictionary*eventTypesMap;
+static NSDictionary<MXEventTypeString, NSNumber*> *eventTypesMap;
+static NSArray<MXEventTypeString> *revertEventTypesMap;
 
 static NSRegularExpression *isEmailAddressRegex;
 static NSRegularExpression *isMatrixUserIdentifierRegex;
@@ -80,6 +81,8 @@ static NSRegularExpression *isMatrixEventIdentifierRegex;
                           kMXEventTypeStringReadMarker: @(MXEventTypeReadMarker)
                           };
 
+        revertEventTypesMap = eventTypesMap.allKeys;
+
         isEmailAddressRegex =  [NSRegularExpression regularExpressionWithPattern:[NSString stringWithFormat:@"^%@$", kMXToolsRegexStringForEmailAddress]
                                                                          options:NSRegularExpressionCaseInsensitive error:nil];
         isMatrixUserIdentifierRegex = [NSRegularExpression regularExpressionWithPattern:[NSString stringWithFormat:@"^%@$", kMXToolsRegexStringForMatrixUserIdentifier]
@@ -95,8 +98,11 @@ static NSRegularExpression *isMatrixEventIdentifierRegex;
 
 + (MXEventTypeString)eventTypeString:(MXEventType)eventType
 {
-    NSArray *matches = [eventTypesMap allKeysForObject:@(eventType)];
-    return [matches lastObject];
+    if (eventType < revertEventTypesMap.count)
+    {
+        return revertEventTypesMap[eventType];
+    }
+    return nil;
 }
 
 + (MXEventType)eventType:(MXEventTypeString)eventTypeString


### PR DESCRIPTION
…um values instead of NSStrings when possible, ie for not custom event type.

Loading MatrixHQ room state events takes 840ms instead of 900ms.

We also save some RAM when loading events from the store: all known event types strings point to the same strings consts.