### PR TITLE
MXSession: Pause could not be delayed if no background mode handler h…

### DIFF
--- a/MatrixSDK/MXSession.h
+++ b/MatrixSDK/MXSession.h
@@ -397,6 +397,9 @@ typedef void (^MXOnBackgroundSyncFail)(NSError *error);
 
  Note that the events stream continues on a UIBackgroundTask which can be terminated
  by the system at anytime.
+ 
+ @warning This request is ignored if no background mode handler has been set in the
+ MXSDKOptions sharedInstance (see `backgroundModeHandler`).
  */
 - (void)retainPreventPause;
 

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -460,7 +460,7 @@ typedef void (^MXOnResumeDone)();
 {
     NSLog(@"[MXSession] pause the event stream in state %tu", _state);
 
-    // Check that noone required the session to keep running even if the app goes in
+    // Check that none required the session to keep running even if the app goes in
     // background
     if (_preventPauseCount)
     {
@@ -673,7 +673,11 @@ typedef void (^MXOnResumeDone)();
 #pragma mark - MXSession pause prevention
 - (void)retainPreventPause
 {
-    self.preventPauseCount++;
+    // Check whether a background mode handler has been set.
+    if ([MXSDKOptions sharedInstance].backgroundModeHandler)
+    {
+        self.preventPauseCount++;
+    }
 }
 
 - (void)releasePreventPause


### PR DESCRIPTION
…as been set in the MXSDKOptions sharedInstance (see `backgroundModeHandler`).