### PR TITLE
SwiftMatrixSDK: Update the access control for the identifier property on some swift enums

### DIFF
--- a/MatrixSDK/Contrib/Swift/Data/MX3PID.swift
+++ b/MatrixSDK/Contrib/Swift/Data/MX3PID.swift
@@ -20,15 +20,13 @@ import Foundation
 /// Represents a third-party identifier
 public struct MX3PID {
     
-
-
     /// Types of third-party identifiers.
-    enum Medium {
+    public enum Medium {
         case email
         case msisdn
         case other(String)
         
-        var identifier: String {
+        public var identifier: String {
             switch self {
             case .email: return kMX3PIDMediumEmail
             case .msisdn: return kMX3PIDMediumMSISDN
@@ -36,7 +34,7 @@ public struct MX3PID {
             }
         }
         
-        init(identifier: String) {
+        public init(identifier: String) {
             let possibleOptions: [Medium] = [.email, .msisdn]
             if let selectedOption = possibleOptions.first(where: { $0.identifier == identifier }) {
                 self = selectedOption
@@ -46,8 +44,8 @@ public struct MX3PID {
         }
     }
     
-    var medium: Medium
-    var address: String
+    public var medium: Medium
+    public var address: String
 }
 
 extension MX3PID : Hashable {

--- a/MatrixSDK/Contrib/Swift/JSONModels/MXEvent.swift
+++ b/MatrixSDK/Contrib/Swift/JSONModels/MXEvent.swift
@@ -58,7 +58,7 @@ public enum MXEventType {
     
     case custom(String)
     
-    var identifier: String {
+    public var identifier: String {
         switch self {
         case .roomName: return kMXEventTypeStringRoomName
         case .roomTopic: return kMXEventTypeStringRoomTopic

--- a/MatrixSDK/Contrib/Swift/JSONModels/MXJSONModels.swift
+++ b/MatrixSDK/Contrib/Swift/JSONModels/MXJSONModels.swift
@@ -28,7 +28,7 @@ public enum MXLoginFlowType {
     case emailCode
     case other(String)
     
-    var identifier: String {
+    public var identifier: String {
         switch self {
         case .password: return kMXLoginFlowTypePassword
         case .recaptcha: return kMXLoginFlowTypeRecaptcha
@@ -49,7 +49,7 @@ public enum MXLoginFlowType {
 public enum MXPusherKind {
     case http, none, custom(String)
     
-    var objectValue: NSObject {
+    public var objectValue: NSObject {
         switch self {
         case .http: return "http" as NSString
         case .none: return NSNull()
@@ -69,7 +69,7 @@ public enum MXPusherKind {
 public enum MXPushRuleKind {
     case override, content, room, sender, underride
     
-    var identifier: __MXPushRuleKind {
+    public var identifier: __MXPushRuleKind {
         switch self  {
         case .override: return __MXPushRuleKindOverride
         case .content: return __MXPushRuleKindContent
@@ -89,7 +89,7 @@ public enum MXPushRuleKind {
 public enum MXPushRuleScope {
     case global, device(profileTag: String)
     
-    var identifier: String {
+    public var identifier: String {
         switch self {
         case .global: return "global"
         case .device(let profileTag): return "device/\(profileTag)"

--- a/MatrixSDK/Contrib/Swift/MXEnumConstants.swift
+++ b/MatrixSDK/Contrib/Swift/MXEnumConstants.swift
@@ -20,7 +20,7 @@ import Foundation
 public enum MXRoomHistoryVisibility {
     case worldReadable, shared, invited, joined
     
-    var identifier: String {
+    public var identifier: String {
         switch self {
         case .worldReadable: return kMXRoomHistoryVisibilityWorldReadable
         case .shared: return kMXRoomHistoryVisibilityShared
@@ -29,7 +29,7 @@ public enum MXRoomHistoryVisibility {
         }
     }
     
-    init?(identifier: String?) {
+    public init?(identifier: String?) {
         let historyVisibilities: [MXRoomHistoryVisibility] = [.worldReadable, .shared, .invited, .joined]
         guard let value = historyVisibilities.first(where: {$0.identifier == identifier}) else { return nil }
         self = value
@@ -54,7 +54,7 @@ public enum MXRoomJoinRule {
     /// Reserved keyword which is not implemented by homeservers.
     case `private`, knock
     
-    var identifier: String {
+    public var identifier: String {
         switch self {
         case .public: return kMXRoomJoinRulePublic
         case .invite: return kMXRoomJoinRuleInvite
@@ -63,7 +63,7 @@ public enum MXRoomJoinRule {
         }
     }
     
-    init?(identifier: String?) {
+    public init?(identifier: String?) {
         let joinRules: [MXRoomJoinRule] = [.public, .invite, .private, .knock]
         guard let value = joinRules.first(where: { $0.identifier == identifier}) else { return nil }
         self = value
@@ -82,14 +82,14 @@ public enum MXRoomGuestAccess {
     case forbidden
     
     /// String identifier
-    var identifier: String {
+    public var identifier: String {
         switch self {
         case .canJoin: return kMXRoomGuestAccessCanJoin
         case .forbidden: return kMXRoomGuestAccessForbidden
         }
     }
     
-    init?(identifier: String?) {
+    public init?(identifier: String?) {
         let accessRules: [MXRoomGuestAccess] = [.canJoin, .forbidden]
         guard let value = accessRules.first(where: { $0.identifier == identifier}) else { return nil }
         self = value
@@ -110,14 +110,14 @@ public enum MXRoomDirectoryVisibility {
     /// The room is listed in the homeserver directory
     case `public`
     
-    var identifier: String {
+    public var identifier: String {
         switch self {
         case .private: return kMXRoomDirectoryVisibilityPrivate
         case .public: return kMXRoomDirectoryVisibilityPublic
         }
     }
     
-    init?(identifier: String?) {
+    public init?(identifier: String?) {
         let visibility: [MXRoomDirectoryVisibility] = [.public, .private]
         guard let value = visibility.first(where: { $0.identifier == identifier}) else { return nil }
         self = value
@@ -141,12 +141,18 @@ public enum MXRoomPreset {
     case publicChat
     
     
-    var identifier: String {
+    public var identifier: String {
         switch self {
         case .privateChat: return kMXRoomPresetPrivateChat
         case .trustedPrivateChat: return kMXRoomPresetTrustedPrivateChat
         case .publicChat: return kMXRoomPresetPublicChat
         }
+    }
+    
+    public init?(identifier: String?) {
+        let presets: [MXRoomPreset] = [.privateChat, .trustedPrivateChat, .publicChat]
+        guard let value = presets.first(where: {$0.identifier == identifier }) else { return nil }
+        self = value
     }
 }
 
@@ -165,14 +171,14 @@ public enum MXTimelineDirection {
     /// These events come from a back pagination.
     case backwards
     
-    var identifier: __MXTimelineDirection {
+    public var identifier: __MXTimelineDirection {
         switch self {
         case .forwards: return __MXTimelineDirectionForwards
         case .backwards: return __MXTimelineDirectionBackwards
         }
     }
     
-    init(identifer _identifier: __MXTimelineDirection) {
+    public init(identifer _identifier: __MXTimelineDirection) {
         self = (_identifier == __MXTimelineDirectionForwards ? .forwards : .backwards)
     }
 }


### PR DESCRIPTION
I encountered a couple cases where I needed to access the raw constants of some enums (such as MXEventType). The `identifier` property on these swift enums returns the raw value (typically a String), but the access level of that property defaults to `internal`, so getting to those constants in my client project was difficult.

This PR declares those identifiers as `public`, so they're easily accessible in a client project.

signed-off-by: Avery Pierce <aapierce0@gmail.com>