### PR TITLE
MXSession unknown token failure callback

### DIFF
--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -1008,6 +1008,12 @@ typedef void (^MXOnResumeDone)();
             {
                 NSLog(@"[MXSession] The access token is no more valid. Go to MXSessionStateUnknownToken state.");
                 [self setState:MXSessionStateUnknownToken];
+                
+                // Inform the caller that an error has occurred
+                if (failure)
+                {
+                    failure(error);
+                }
 
                 // Do nothing more because without a valid access_token, the session is useless
                 return;


### PR DESCRIPTION
I encountered an issue in my client project where the `-[MXSession start:failure:]` method would not call the failure block if the token was invalid.

signed-off-by: Avery Pierce <aapierce0@gmail.com>