### PR TITLE
Fixed an issue that would prevent attachments from being downloaded v…

### DIFF
--- a/MatrixSDK/Utils/Media/MXMediaLoader.m
+++ b/MatrixSDK/Utils/Media/MXMediaLoader.m
@@ -234,9 +234,11 @@ NSString *const kMXMediaUploadIdPrefix = @"upload-";
     if ([protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust])
     {
         NSSet <NSData *> *certificates = [AFSecurityPolicy certificatesInBundle:[NSBundle mainBundle]];
-        if (certificates && certificates.count > 0) {
+        if (certificates && certificates.count > 0)
+        {
             NSMutableArray *pinnedCertificates = [NSMutableArray array];
-            for (NSData *certificateData in certificates) {
+            for (NSData *certificateData in certificates)
+            {
                 [pinnedCertificates addObject:(__bridge_transfer id)SecCertificateCreateWithData(NULL, (__bridge CFDataRef)certificateData)];
             }
             SecTrustSetAnchorCertificates(protectionSpace.serverTrust, (__bridge CFArrayRef)pinnedCertificates);

--- a/MatrixSDK/Utils/Media/MXMediaLoader.m
+++ b/MatrixSDK/Utils/Media/MXMediaLoader.m
@@ -20,6 +20,7 @@
 #import "MXHTTPOperation.h"
 
 #import "MXAllowedCertificates.h"
+#import <AFNetworking/AFSecurityPolicy.h>
 
 NSString *const kMXMediaDownloadProgressNotification = @"kMXMediaDownloadProgressNotification";
 NSString *const kMXMediaDownloadDidFinishNotification = @"kMXMediaDownloadDidFinishNotification";
@@ -232,6 +233,14 @@ NSString *const kMXMediaUploadIdPrefix = @"upload-";
     NSURLProtectionSpace *protectionSpace = [challenge protectionSpace];
     if ([protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust])
     {
+        NSSet <NSData *> *certificates = [AFSecurityPolicy certificatesInBundle:[NSBundle mainBundle]];
+        if (certificates && certificates.count > 0) {
+            NSMutableArray *pinnedCertificates = [NSMutableArray array];
+            for (NSData *certificateData in certificates) {
+                [pinnedCertificates addObject:(__bridge_transfer id)SecCertificateCreateWithData(NULL, (__bridge CFDataRef)certificateData)];
+            }
+            SecTrustSetAnchorCertificates(protectionSpace.serverTrust, (__bridge CFArrayRef)pinnedCertificates);
+        }
         SecTrustRef trust = [protectionSpace serverTrust];
 
         // Re-evaluate the trust policy


### PR DESCRIPTION
…ia SSL connections when using a custom CA ceritficate that was included in the bundle.

Explanation:
All of the network operations use AFNetworking except for the download of files, which uses NSURLRequest. AFNetworking automatically checks which certificates are in the bundle and uses them to validate SSL connections. On the contrary, the MXMediaLoader class was relying only on those certificates that were manually accepted by the user. This could create a situation where all network connections worked, except for downloading media/attachments.
The MXMediaLoader now is capable of asking AFNetworking for those pinned certificates, and adds the CA to the chain of trust at the time of preparing the SSL negotiation.