### PR TITLE
Bug Fix: Avatars (and probably other media) do not display with accou…

### DIFF
--- a/MatrixSDK/Utils/MXAllowedCertificates.h
+++ b/MatrixSDK/Utils/MXAllowedCertificates.h
@@ -25,7 +25,7 @@
 /**
  The `MXAllowedCertificates` singleton.
  */
-+ (id)sharedInstance;
++ (instancetype)sharedInstance;
 
 /**
  Add a certificate in the allowed list.
@@ -46,5 +46,10 @@
  Forget all allowed certificates.
  */
 - (void)reset;
+
+/**
+ The current list of allowed certificates.
+ */
+@property (readonly) NSSet<NSData*> *certificates;
 
 @end

--- a/MatrixSDK/Utils/MXAllowedCertificates.m
+++ b/MatrixSDK/Utils/MXAllowedCertificates.m
@@ -24,6 +24,7 @@
 @end
 
 @implementation MXAllowedCertificates
+@synthesize certificates;
 
 + (MXAllowedCertificates *)sharedInstance
 {


### PR DESCRIPTION
…nt on a self-signed server.

The MXMediaLoader adds now all the allowed certificates to the chain of trust at the time of preparing the SSL negotiation.

https://github.com/vector-im/riot-ios/issues/816