### PR TITLE
Bug Fix: Avatars do not display with account on a self-signed server

### DIFF
--- a/MatrixSDK/Utils/Media/MXMediaLoader.m
+++ b/MatrixSDK/Utils/Media/MXMediaLoader.m
@@ -250,6 +250,8 @@ NSString *const kMXMediaUploadIdPrefix = @"upload-";
         if (pinnedCertificates.count > 0)
         {
             SecTrustSetAnchorCertificates(protectionSpace.serverTrust, (__bridge CFArrayRef)pinnedCertificates);
+            // Reenable trusting anchor certificates in addition to those passed in via the SecTrustSetAnchorCertificates API.
+            SecTrustSetAnchorCertificatesOnly(protectionSpace.serverTrust, false);
         }
         
         SecTrustRef trust = [protectionSpace serverTrust];


### PR DESCRIPTION
Avatars do not display with matrix.org account after trusting a self-signed certificate.
Fix: reenable trusting anchor certificates in addition to those passed in via the SecTrustSetAnchorCertificates API.

https://github.com/vector-im/riot-ios/issues/816