### PR TITLE
SwiftMatrixSDK: Add Swift refinements to MXRoomPowerLevels.

### DIFF
--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -219,6 +219,7 @@
 		C60165381E3AA57900B92CFA /* MXSDKOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = F0C34CB91C18C80000C36F09 /* MXSDKOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C61A4AF41E5DD88400442158 /* Dummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C61A4AF31E5DD88400442158 /* Dummy.swift */; };
 		C61A4CC41E5F38CB00442158 /* SwiftMatrixSDK.h in Headers */ = {isa = PBXBuildFile; fileRef = C61A4CC31E5F38CB00442158 /* SwiftMatrixSDK.h */; };
+		C63E78B01F26588000AC692F /* MXRoomPowerLevels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C63E78AF1F26588000AC692F /* MXRoomPowerLevels.swift */; };
 		C6481AF21F1678A9000DB8A0 /* MXSessionEventListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6481AF11F1678A9000DB8A0 /* MXSessionEventListener.swift */; };
 		C6D5D60A1E4FA74000706C0F /* MXEnumConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6D5D6091E4FA74000706C0F /* MXEnumConstants.swift */; };
 		C6D5D60E1E4FBD2900706C0F /* MXSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6D5D60D1E4FBD2900706C0F /* MXSession.swift */; };
@@ -495,6 +496,7 @@
 		B1F1AE550CF4C15B653DDE6E /* Pods-MatrixSDKTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MatrixSDKTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MatrixSDKTests/Pods-MatrixSDKTests.debug.xcconfig"; sourceTree = "<group>"; };
 		C61A4AF31E5DD88400442158 /* Dummy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Dummy.swift; sourceTree = "<group>"; };
 		C61A4CC31E5F38CB00442158 /* SwiftMatrixSDK.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SwiftMatrixSDK.h; sourceTree = "<group>"; };
+		C63E78AF1F26588000AC692F /* MXRoomPowerLevels.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXRoomPowerLevels.swift; sourceTree = "<group>"; };
 		C6481AF11F1678A9000DB8A0 /* MXSessionEventListener.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXSessionEventListener.swift; sourceTree = "<group>"; };
 		C6CC43261E5CB0FD00DB9C34 /* MatrixSDKTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MatrixSDKTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		C6D5D6091E4FA74000706C0F /* MXEnumConstants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXEnumConstants.swift; sourceTree = "<group>"; };
@@ -1087,6 +1089,7 @@
 			children = (
 				C6F935861E5B3BE600FC34BF /* MXEvent.swift */,
 				C6F935871E5B3BE600FC34BF /* MXJSONModels.swift */,
+				C63E78AF1F26588000AC692F /* MXRoomPowerLevels.swift */,
 			);
 			path = JSONModels;
 			sourceTree = "<group>";
@@ -1453,6 +1456,7 @@
 				329B2AC21D3FB01D002D546F /* MXJingleCallStackCall.m in Sources */,
 				322691331E5EF77D00966A6E /* MXDeviceListOperation.m in Sources */,
 				3283F7791EAF30F700C1688C /* MXBugReportRestClient.m in Sources */,
+				C63E78B01F26588000AC692F /* MXRoomPowerLevels.swift in Sources */,
 				3284A5AF1DB7CFA800A09972 /* MXFileCryptoStoreMetaData.m in Sources */,
 				F0AC734F1DA4F53B0011DAEE /* MXRoomEventFilter.m in Sources */,
 				323E0C5C1A306D7A00A31D73 /* MXEvent.m in Sources */,

--- a/MatrixSDK/Contrib/Swift/JSONModels/MXRoomPowerLevels.swift
+++ b/MatrixSDK/Contrib/Swift/JSONModels/MXRoomPowerLevels.swift
@@ -1,0 +1,35 @@
+//
+//  MXRoomPowerLevels.swift
+//  MatrixSDK
+//
+//  Created by Avery Pierce on 7/24/17.
+//  Copyright © 2017 matrix.org. All rights reserved.
+//
+
+import Foundation
+
+extension MXRoomPowerLevels {
+    
+    /**
+     Helper to get the minimum power level the user must have to send an event of the given type
+     as a message.
+     
+     - parameter eventType: the type of event.
+     - returns: the required minimum power level.
+     */
+    @nonobjc func minimumPowerLevelForSendingMessageEvent(_ eventType: MXEventType) -> Int {
+        return __minimumPowerLevelForSendingEvent(asMessage: eventType.identifier)
+    }
+    
+    /**
+     Helper to get the minimum power level the user must have to send an event of the given type
+     as a state event.
+     
+     - parameter eventType: the type of event.
+     - returns: the required minimum power level.
+     */
+    @nonobjc func minimumPowerLevelForSendingStateEvent(_ eventType: MXEventType) -> Int {
+        return __minimumPowerLevelForSendingEvent(asStateEvent: eventType.identifier)
+    }
+    
+}

--- a/MatrixSDK/Contrib/Swift/JSONModels/MXRoomPowerLevels.swift
+++ b/MatrixSDK/Contrib/Swift/JSONModels/MXRoomPowerLevels.swift
@@ -1,10 +1,18 @@
-//
-//  MXRoomPowerLevels.swift
-//  MatrixSDK
-//
-//  Created by Avery Pierce on 7/24/17.
-//  Copyright © 2017 matrix.org. All rights reserved.
-//
+/*
+ Copyright 2017 Avery Pierce
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
 
 import Foundation
 

--- a/MatrixSDK/JSONModels/MXRoomPowerLevels.h
+++ b/MatrixSDK/JSONModels/MXRoomPowerLevels.h
@@ -96,7 +96,7 @@
  @param eventTypeString the type of event.
  @return the required minimum power level.
  */
-- (NSInteger)minimumPowerLevelForSendingEventAsMessage:(MXEventTypeString)eventTypeString;
+- (NSInteger)minimumPowerLevelForSendingEventAsMessage:(MXEventTypeString)eventTypeString NS_REFINED_FOR_SWIFT;
 
 /**
  Helper to get the minimum power level the user must have to send an event of the given type
@@ -105,6 +105,6 @@
  @param eventTypeString the type of event.
  @return the required minimum power level.
  */
-- (NSInteger)minimumPowerLevelForSendingEventAsStateEvent:(MXEventTypeString)eventTypeString;
+- (NSInteger)minimumPowerLevelForSendingEventAsStateEvent:(MXEventTypeString)eventTypeString NS_REFINED_FOR_SWIFT;
 
 @end


### PR DESCRIPTION
Uses the Swift enum `MXEventType` instead of the raw `MXEventTypeString` when getting the minimum level.