### PR TITLE
SwiftMatrixSDK: Add swift refinements to MXRoomState

### DIFF
--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -223,6 +223,7 @@
 		C61A4CC41E5F38CB00442158 /* SwiftMatrixSDK.h in Headers */ = {isa = PBXBuildFile; fileRef = C61A4CC31E5F38CB00442158 /* SwiftMatrixSDK.h */; };
 		C63E78B01F26588000AC692F /* MXRoomPowerLevels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C63E78AF1F26588000AC692F /* MXRoomPowerLevels.swift */; };
 		C6481AF21F1678A9000DB8A0 /* MXSessionEventListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6481AF11F1678A9000DB8A0 /* MXSessionEventListener.swift */; };
+		C6B40F521F2A35BE00C42C72 /* MXRoomState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6B40F511F2A35BE00C42C72 /* MXRoomState.swift */; };
 		C6D5D60A1E4FA74000706C0F /* MXEnumConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6D5D6091E4FA74000706C0F /* MXEnumConstants.swift */; };
 		C6D5D60E1E4FBD2900706C0F /* MXSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6D5D60D1E4FBD2900706C0F /* MXSession.swift */; };
 		C6F9357C1E5B39CA00FC34BF /* MXRestClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6F9357B1E5B39CA00FC34BF /* MXRestClient.swift */; };
@@ -502,6 +503,7 @@
 		C61A4CC31E5F38CB00442158 /* SwiftMatrixSDK.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SwiftMatrixSDK.h; sourceTree = "<group>"; };
 		C63E78AF1F26588000AC692F /* MXRoomPowerLevels.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXRoomPowerLevels.swift; sourceTree = "<group>"; };
 		C6481AF11F1678A9000DB8A0 /* MXSessionEventListener.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXSessionEventListener.swift; sourceTree = "<group>"; };
+		C6B40F511F2A35BE00C42C72 /* MXRoomState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXRoomState.swift; sourceTree = "<group>"; };
 		C6CC43261E5CB0FD00DB9C34 /* MatrixSDKTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MatrixSDKTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		C6D5D6091E4FA74000706C0F /* MXEnumConstants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXEnumConstants.swift; sourceTree = "<group>"; };
 		C6D5D60D1E4FBD2900706C0F /* MXSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXSession.swift; sourceTree = "<group>"; };
@@ -1083,6 +1085,7 @@
 			isa = PBXGroup;
 			children = (
 				C602B58B1F2268F700B67D87 /* MXRoom.swift */,
+				C6B40F511F2A35BE00C42C72 /* MXRoomState.swift */,
 				C6F935831E5B3BE600FC34BF /* MX3PID.swift */,
 				C6F935841E5B3BE600FC34BF /* MXEventTimeline.swift */,
 				C6481AF11F1678A9000DB8A0 /* MXSessionEventListener.swift */,
@@ -1445,6 +1448,7 @@
 				323B2AD01BCD3EF000B11F34 /* MXCoreDataStore.m in Sources */,
 				3281E8B819E42DFE00976E1A /* MXJSONModel.m in Sources */,
 				32A1514B1DAF7C0C00400192 /* MXUsersDevicesMap.m in Sources */,
+				C6B40F521F2A35BE00C42C72 /* MXRoomState.swift in Sources */,
 				3264E2A31BDF8D1500F89A86 /* MXCoreDataRoomState.m in Sources */,
 				32D776821A27877300FC4AA2 /* MXMemoryRoomStore.m in Sources */,
 				C602B58C1F2268F700B67D87 /* MXRoom.swift in Sources */,

--- a/MatrixSDK/Contrib/Swift/Data/MXRoomState.swift
+++ b/MatrixSDK/Contrib/Swift/Data/MXRoomState.swift
@@ -1,0 +1,46 @@
+/*
+ Copyright 2017 Avery Pierce
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import Foundation
+
+extension MXRoomState {
+    
+    /// The history visibility of the room
+    var historyVisibility: MXRoomHistoryVisibility! {
+        return MXRoomHistoryVisibility(identifier: self.__historyVisibility)
+    }
+    
+    /// The join rule of the room
+    var joinRule: MXRoomJoinRule! {
+        return MXRoomJoinRule(identifier: self.__joinRule)
+    }
+    
+    /// The guest access of the room
+    var guestAccess: MXRoomGuestAccess! {
+        return MXRoomGuestAccess(identifier: self.__guestAccess)
+    }
+    
+    
+    /**
+     Return the state event with the given type.
+     
+     - parameter type: The type of the event
+     - returns: The state of the event
+     */
+    func stateEvent(with type: MXEventType) -> MXEvent? {
+        return __stateEvent(withType: type.identifier)
+    }
+}

--- a/MatrixSDK/Contrib/Swift/Data/MXRoomState.swift
+++ b/MatrixSDK/Contrib/Swift/Data/MXRoomState.swift
@@ -34,6 +34,14 @@ extension MXRoomState {
     }
     
     
+    /// The membership state of the logged in user for this room
+    ///
+    /// If the membership is `invite`, the room state contains few information.
+    /// Join the room with [MXRoom join] to get full information about the room.
+    public var membership: MXMembership {
+        return MXMembership(identifier: self.__membership)
+    }
+    
     /**
      Return the state event with the given type.
      

--- a/MatrixSDK/Contrib/Swift/Data/MXRoomState.swift
+++ b/MatrixSDK/Contrib/Swift/Data/MXRoomState.swift
@@ -19,17 +19,17 @@ import Foundation
 extension MXRoomState {
     
     /// The history visibility of the room
-    var historyVisibility: MXRoomHistoryVisibility! {
+    public var historyVisibility: MXRoomHistoryVisibility! {
         return MXRoomHistoryVisibility(identifier: self.__historyVisibility)
     }
     
     /// The join rule of the room
-    var joinRule: MXRoomJoinRule! {
+    public var joinRule: MXRoomJoinRule! {
         return MXRoomJoinRule(identifier: self.__joinRule)
     }
     
     /// The guest access of the room
-    var guestAccess: MXRoomGuestAccess! {
+    public var guestAccess: MXRoomGuestAccess! {
         return MXRoomGuestAccess(identifier: self.__guestAccess)
     }
     
@@ -40,7 +40,7 @@ extension MXRoomState {
      - parameter type: The type of the event
      - returns: The state of the event
      */
-    func stateEvent(with type: MXEventType) -> MXEvent? {
+    public func stateEvent(with type: MXEventType) -> MXEvent? {
         return __stateEvent(withType: type.identifier)
     }
 }

--- a/MatrixSDK/Contrib/Swift/JSONModels/MXEvent.swift
+++ b/MatrixSDK/Contrib/Swift/JSONModels/MXEvent.swift
@@ -117,3 +117,25 @@ public enum MXMessageType {
         }
     }
 }
+
+
+/// Membership definitions
+public enum MXMembership {
+    case unknown, invite, join, leave, ban
+    
+    var rawValue: UInt {
+        switch self {
+        case .unknown: return __MXMembershipUnknown.rawValue
+        case .invite: return __MXMembershipInvite.rawValue
+        case .join: return __MXMembershipJoin.rawValue
+        case .leave: return __MXMembershipLeave.rawValue
+        case .ban: return __MXMembershipBan.rawValue
+        }
+    }
+    
+    init?(rawValue: UInt) {
+        let possibilities: [MXMembership] = [.unknown, .invite, .join, .leave, .ban]
+        guard let value = possibilities.first(where: { $0.rawValue == rawValue }) else { return nil }
+        self = value
+    }
+}

--- a/MatrixSDK/Contrib/Swift/JSONModels/MXEvent.swift
+++ b/MatrixSDK/Contrib/Swift/JSONModels/MXEvent.swift
@@ -123,19 +123,18 @@ public enum MXMessageType {
 public enum MXMembership {
     case unknown, invite, join, leave, ban
     
-    var rawValue: UInt {
+    var identifier: __MXMembership {
         switch self {
-        case .unknown: return __MXMembershipUnknown.rawValue
-        case .invite: return __MXMembershipInvite.rawValue
-        case .join: return __MXMembershipJoin.rawValue
-        case .leave: return __MXMembershipLeave.rawValue
-        case .ban: return __MXMembershipBan.rawValue
+        case .unknown: return __MXMembershipUnknown
+        case .invite: return __MXMembershipInvite
+        case .join: return __MXMembershipJoin
+        case .leave: return __MXMembershipLeave
+        case .ban: return __MXMembershipBan
         }
     }
     
-    init?(rawValue: UInt) {
+    init(identifier: __MXMembership) {
         let possibilities: [MXMembership] = [.unknown, .invite, .join, .leave, .ban]
-        guard let value = possibilities.first(where: { $0.rawValue == rawValue }) else { return nil }
-        self = value
+        self = possibilities.first(where: { $0.identifier == identifier }) ?? .unknown
     }
 }

--- a/MatrixSDK/Data/MXRoomState.h
+++ b/MatrixSDK/Data/MXRoomState.h
@@ -129,7 +129,7 @@ A copy of the list of third party invites (actually MXRoomThirdPartyInvite insta
  If the membership is `invite`, the room state contains few information.
  Join the room with [MXRoom join] to get full information about the room.
  */
-@property (nonatomic, readonly) MXMembership membership;
+@property (nonatomic, readonly) MXMembership membership NS_REFINED_FOR_SWIFT;
 
 /**
  Indicate whether encryption is enabled for this room.

--- a/MatrixSDK/Data/MXRoomState.h
+++ b/MatrixSDK/Data/MXRoomState.h
@@ -100,12 +100,12 @@ A copy of the list of third party invites (actually MXRoomThirdPartyInvite insta
 /**
  The history visibility of the room.
  */
-@property (nonatomic, readonly) MXRoomHistoryVisibility historyVisibility;
+@property (nonatomic, readonly) MXRoomHistoryVisibility historyVisibility NS_REFINED_FOR_SWIFT;
 
 /**
  The join rule of the room.
  */
-@property (nonatomic, readonly) MXRoomJoinRule joinRule;
+@property (nonatomic, readonly) MXRoomJoinRule joinRule NS_REFINED_FOR_SWIFT;
 
 /**
  Shortcut to check if the self.joinRule is public.
@@ -115,7 +115,7 @@ A copy of the list of third party invites (actually MXRoomThirdPartyInvite insta
 /**
  The guest access of the room.
  */
-@property (nonatomic, readonly) MXRoomGuestAccess guestAccess;
+@property (nonatomic, readonly) MXRoomGuestAccess guestAccess NS_REFINED_FOR_SWIFT;
 
 /**
  The display name of the room.
@@ -195,7 +195,7 @@ A copy of the list of third party invites (actually MXRoomThirdPartyInvite insta
  @param eventType the type of event.
  @return the state event. Can be nil.
  */
-- (MXEvent*)stateEventWithType:(MXEventTypeString)eventType;
+- (MXEvent*)stateEventWithType:(MXEventTypeString)eventType NS_REFINED_FOR_SWIFT;
 
 /**
  Return the member with the given user id.

--- a/MatrixSDK/JSONModels/MXEvent.h
+++ b/MatrixSDK/JSONModels/MXEvent.h
@@ -124,7 +124,7 @@ typedef enum : NSUInteger
     MXMembershipJoin,
     MXMembershipLeave,
     MXMembershipBan
-} MXMembership;
+} MXMembership NS_REFINED_FOR_SWIFT;
 
 /**
  The internal event state used to handle the different steps of the event sending.


### PR DESCRIPTION
Brings swift-refined types (`MXRoomHistoryVisibility`, `MXRoomJoinRule`, `MXRoomGuestAccess`, and `MXEventType`) to `MXRoomState`

Signed-off-by: Avery Pierce <aapierce0@gmail.com>