### PR TITLE
Make Access Token Updatable and simplify new login request development

### DIFF
--- a/MatrixSDK/Crypto/MXCrypto.h
+++ b/MatrixSDK/Crypto/MXCrypto.h
@@ -317,6 +317,13 @@
  */
 - (void)setBlacklistUnverifiedDevicesInRoom:(NSString *)roomId blacklist:(BOOL)blacklist;
 
+/**
+ Update acces token if needed
+ 
+ @param New access token to use
+ */
+- (void) setAccessToken:(NSString *) newAccessToken;
+
 @end
 
 

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -1059,6 +1059,10 @@ NSTimeInterval kMXCryptoUploadOneTimeKeysPeriod = 60.0; // one minute
 #endif
 }
 
+- (void) setAccessToken:(NSString *) newAccessToken
+{
+    [_matrixRestClient.httpClient setAccessToken:newAccessToken];
+}
 
 #pragma mark - Private API
 

--- a/MatrixSDK/Data/MXRoomState.m
+++ b/MatrixSDK/Data/MXRoomState.m
@@ -471,6 +471,18 @@
     {
         case MXEventTypeRoomMember:
         {
+            // Filter events in timeline events older than events in room state
+            // to be robust if some events miss in timeline events
+            // However, not sure there is not an impact on back pagination management
+            MXRoomMember* memberCurrentState = members[event.stateKey];
+            if (nil != memberCurrentState)
+            {
+                if(memberCurrentState.originalEvent.originServerTs > event.originServerTs){
+                    NSLog(@"[MxRoomState] The room member event is obsolet -> ignore it: event %@, state key %@ and sender %@", event, event.stateKey, event.sender);
+                    break;
+                }
+            }
+
             MXRoomMember *roomMember = [[MXRoomMember alloc] initWithMXEvent:event andEventContent:[self contentOfEvent:event]];
             if (roomMember)
             {
@@ -490,9 +502,11 @@
                 }
             }
             else
-            {
+            {   
                 // The user is no more part of the room. Remove him.
                 // This case happens during back pagination: we remove here users when they are not in the room yet.
+                NSLog(@"[MxRoomState] The user is no more part of the room : event %@, state key %@ and sender %@", event, event.stateKey, event.sender);
+
                 [members removeObjectForKey:event.stateKey];
             }
 

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -103,6 +103,30 @@ typedef enum : NSUInteger
     - the specified Matrix identity server
  */
 @interface MXRestClient : NSObject
+    {
+        /**
+         HTTP client to the home server.
+         */
+        MXHTTPClient *httpClient;
+        
+        /**
+         HTTP client to the identity server.
+         */
+        MXHTTPClient *identityHttpClient;
+        
+        /**
+         The queue to process server response.
+         This queue is used to create models from JSON dictionary without blocking the main thread.
+         */
+        dispatch_queue_t processingQueue;
+        
+        /**
+         The queue on which asynchronous response blocks are called.
+         Default is dispatch_get_main_queue().
+         */
+        dispatch_queue_t completionQueue;
+    }
+
 
 /**
  The homeserver.
@@ -112,7 +136,7 @@ typedef enum : NSUInteger
 /**
  The user credentials on this home server.
  */
-@property (nonatomic, readonly) MXCredentials *credentials;
+@property (nonatomic) MXCredentials *credentials;
 
 /**
  The homeserver suffix (for example ":matrix.org"). Available only when credentials have been set.
@@ -149,6 +173,21 @@ typedef enum : NSUInteger
  */
 @property (nonatomic, strong) dispatch_queue_t completionQueue;
 
+/**
+ HTTP client to the home server.
+ */
+@property (nonatomic) MXHTTPClient *httpClient;
+
+/**
+ HTTP client to the identity server.
+ */
+@property (nonatomic) MXHTTPClient *identityHttpClient;
+
+/**
+ The queue to process server response.
+ This queue is used to create models from JSON dictionary without blocking the main thread.
+ */
+@property (nonatomic) dispatch_queue_t processingQueue;
 
 /**
  Create an instance based on homeserver url.

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -77,29 +77,10 @@ MXAuthAction;
 
 
 #pragma mark - MXRestClient
-@interface MXRestClient ()
-{
-    /**
-     HTTP client to the home server.
-     */
-    MXHTTPClient *httpClient;
-    
-    /**
-     HTTP client to the identity server.
-     */
-    MXHTTPClient *identityHttpClient;
-    
-    /**
-     The queue to process server response.
-     This queue is used to create models from JSON dictionary without blocking the main thread.
-     */
-    dispatch_queue_t processingQueue;
-}
-@end
+
 
 @implementation MXRestClient
-@synthesize homeserver, homeserverSuffix, credentials, apiPathPrefix, contentPathPrefix, completionQueue;
-
+@synthesize homeserver, homeserverSuffix, credentials, apiPathPrefix, contentPathPrefix, completionQueue, httpClient, identityHttpClient, processingQueue;
 -(id)initWithHomeServer:(NSString *)inHomeserver andOnUnrecognizedCertificateBlock:(MXHTTPClientOnUnrecognizedCertificate)onUnrecognizedCertBlock
 {
     self = [super init];

--- a/MatrixSDK/MXSession.h
+++ b/MatrixSDK/MXSession.h
@@ -574,6 +574,12 @@ typedef void (^MXOnBackgroundSyncFail)(NSError *error);
                       success:(void (^)())success
                       failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
+/**
+ Update acces token if needed
+ 
+ @param New access token to use
+ */
+- (void) setAccessToken:(NSString *) newAccessToken;
 
 #pragma mark - The user's rooms
 /**

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -1580,6 +1580,12 @@ typedef void (^MXOnResumeDone)();
     } failure:failure];
 }
 
+- (void) setAccessToken:(NSString *) newAccessToken
+{
+  // We also need to update access token specific to crypto
+  [matrixRestClient.httpClient setAccessToken:newAccessToken];
+  [_crypto setAccessToken:newAccessToken];
+}
 
 #pragma mark - The user's rooms
 - (MXRoom *)roomWithRoomId:(NSString *)roomId

--- a/MatrixSDK/Utils/MXHTTPClient.h
+++ b/MatrixSDK/Utils/MXHTTPClient.h
@@ -155,4 +155,9 @@ typedef BOOL (^MXHTTPClientOnUnrecognizedCertificate)(NSData *certificate);
  */
 @property (nonatomic, strong) NSSet <NSData *> *pinnedCertificates;
 
+/**
+ Need a setter yo update access token on the fly 
+ */
+- (void) setAccessToken:(NSString *) newAccessToken;
+
 @end

--- a/MatrixSDK/Utils/MXHTTPClient.m
+++ b/MatrixSDK/Utils/MXHTTPClient.m
@@ -698,4 +698,8 @@ NSString * const MXHTTPClientErrorResponseDataKey = @"com.matrixsdk.httpclient.e
     }
 }
 
+- (void) setAccessToken:(NSString *) newAccessToken
+{
+    accessToken = newAccessToken;
+}
 @end


### PR DESCRIPTION
With this code it is possible to perform a new login each time access_token expires and to use new token returned by server
Some private methods/attributes become public to simplify creation of custom loggin request.

Signed-off-by: Jean-Philippe Rouault: jean-philippe.rouault@nagra.com