### PR TITLE
API break: Replace [MXRoomState stateEventWithType:] by [MXRoomState stateEventsWithType:]

### DIFF
--- a/MatrixSDK/Contrib/Swift/Data/MXRoomState.swift
+++ b/MatrixSDK/Contrib/Swift/Data/MXRoomState.swift
@@ -1,5 +1,6 @@
 /*
  Copyright 2017 Avery Pierce
+ Copyright 2017 Vector Creations Ltd
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -43,12 +44,12 @@ extension MXRoomState {
     }
     
     /**
-     Return the state event with the given type.
+     Return the state events with the given type.
      
      - parameter type: The type of the event
-     - returns: The state of the event
+     - returns: The state events
      */
-    public func stateEvent(with type: MXEventType) -> MXEvent? {
-        return __stateEvent(withType: type.identifier)
+    public func stateEvents(with type: MXEventType) -> [MXEvent]? {
+        return __stateEvents(withType: type.identifier)
     }
 }

--- a/MatrixSDK/Data/MXRoomState.h
+++ b/MatrixSDK/Data/MXRoomState.h
@@ -190,12 +190,12 @@ A copy of the list of third party invites (actually MXRoomThirdPartyInvite insta
 - (void)handleStateEvent:(MXEvent*)event;
 
 /**
- Return the state event with the given type.
+ Return the state events with the given type.
  
  @param eventType the type of event.
- @return the state event. Can be nil.
+ @return the state events. Can be nil.
  */
-- (MXEvent*)stateEventWithType:(MXEventTypeString)eventType NS_REFINED_FOR_SWIFT;
+- (NSArray<MXEvent*> *)stateEventsWithType:(MXEventTypeString)eventType NS_REFINED_FOR_SWIFT;
 
 /**
  Return the member with the given user id.

--- a/MatrixSDK/Data/MXRoomState.m
+++ b/MatrixSDK/Data/MXRoomState.m
@@ -165,7 +165,7 @@
 
 - (NSArray<MXEvent *> *)stateEvents
 {
-    NSMutableArray<MXEvent *> *state;
+    NSMutableArray<MXEvent *> *state = [NSMutableArray array];
     for (NSArray<MXEvent*> *events in stateEvents.allValues)
     {
         [state addObjectsFromArray:events];

--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
@@ -23,7 +23,7 @@
 #import "MXFileStoreMetaData.h"
 #import "MXSDKOptions.h"
 
-static NSUInteger const kMXFileVersion = 41;
+static NSUInteger const kMXFileVersion = 42;
 
 static NSString *const kMXFileStoreFolder = @"MXFileStore";
 static NSString *const kMXFileStoreMedaDataFile = @"MXFileStore";


### PR DESCRIPTION
We can have several state events of the same type, like memberships. Note that memberships worked because they were stored in a separate dict.

The impact on performance and storage size should be limited because, compared to membership events, other state events are a small number.