### PR TITLE
MXRoomState: Improve algorithm to manage room members displaynames disambiguation

### DIFF
--- a/MatrixSDK/Data/MXRoomState.m
+++ b/MatrixSDK/Data/MXRoomState.m
@@ -656,8 +656,7 @@
     {
         return nil;
     }
-    
-    // First, lookup in the cache
+
     NSString *displayName;
 
     // Get the user display name from the member list of the room


### PR DESCRIPTION
This improves the code in 2 ways:
 - speed: the loop in the memberName method took 4ms per member in a room like MatrixHQ. As there is a lot of membership changes in this room, there was very often a reset on the cache, which made it a bit useless.
 - more robust against race condition: MatrixKit calls the memberName method on one of its processing queue. The new implementation of memberName does only read operations on ivars which is less risky than the write to `membersNamesCache` it did before. It should fix https://github.com/matrix-org/riot-ios-rageshakes/issues/132 (App crashed I don't know why, suspect memory issues / Crash in [MXRoomState copyWithZone:])