### PR TITLE
Fix problem with regex in MXPushRuleEventMatchConditionChecker

### DIFF
--- a/MatrixSDK/NotificationCenter/Checker/MXPushRuleEventMatchConditionChecker.m
+++ b/MatrixSDK/NotificationCenter/Checker/MXPushRuleEventMatchConditionChecker.m
@@ -77,6 +77,10 @@
     NSString *res = [glob stringByReplacingOccurrencesOfString:@"*" withString:@".*"];
     res = [res stringByReplacingOccurrencesOfString:@"?" withString:@"."];
 
+    // To correctly handle roomIDs and userIDs which start with ! and @ characters
+    if ([res hasPrefix:@"@"] || [res hasPrefix:@"!"])
+        res = [res substringFromIndex:1];
+    
     // In all cases, enable world delimiters
     res = [NSString stringWithFormat:@"\\b%@\\b", res];
 


### PR DESCRIPTION
Now `event_match` conditions don't work if userID or roomID is used as a `pattern` because regex uses word boundary `\b`, so everything that won't be started with a word character will fail match.

Signed-off-by: Denis Morozov dmorozkn@gmail.com