### PR TITLE
Prevent override of user selected output port by WebRTC

### DIFF
--- a/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallStackCall.m
+++ b/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallStackCall.m
@@ -561,7 +561,7 @@ didRemoveIceCandidates:(NSArray<RTCIceCandidate *> *)candidates;
         // which user selected when the call was in connecting state.
         // So we need to perform additional checks and override ouput port if needed
         AVAudioSessionRouteDescription *currentRoute = [[AVAudioSession sharedInstance] currentRoute];
-        BOOL isOutputSpeaker = currentRoute.outputs.firstObject.portType == AVAudioSessionPortBuiltInSpeaker;
+        BOOL isOutputSpeaker = [currentRoute.outputs.firstObject.portType isEqualToString:AVAudioSessionPortBuiltInSpeaker];
         if (audioToSpeaker && !isOutputSpeaker)
         {
             [[AVAudioSession sharedInstance] overrideOutputAudioPort:AVAudioSessionPortOverrideSpeaker error:nil];


### PR DESCRIPTION
The problem was described in [#1471](https://github.com/vector-im/riot-ios/issues/1471)

> turning on the loudspeaker before the call gets accepted enables it in the UI, but won't enable it afterwards. In fact, it's one more step to turn it on after the call gets accepted (need to turn it off first and then back on again)

Signed-off-by: Denis Morozov dmorozkn@gmail.com