### PR TITLE
Fix issue #933

### DIFF
--- a/MatrixSDK/VoIP/MXCall.m
+++ b/MatrixSDK/VoIP/MXCall.m
@@ -164,7 +164,7 @@ NSString *const kMXCallStateDidChange = @"kMXCallStateDidChange";
                 _isVideoCall = callInviteEventContent.isVideoCall;
 
                 // Set up the default audio route
-                callStackCall.audioToSpeaker = NO;
+                callStackCall.audioToSpeaker = _isVideoCall;
                 
                 [self setState:MXCallStateWaitLocalMedia reason:nil];
                 
@@ -271,10 +271,10 @@ NSString *const kMXCallStateDidChange = @"kMXCallStateDidChange";
 
     _isVideoCall = video;
 
-    [self setState:MXCallStateWaitLocalMedia reason:nil];
-
     // Set up the default audio route
-    callStackCall.audioToSpeaker = NO;
+    callStackCall.audioToSpeaker = _isVideoCall;
+    
+    [self setState:MXCallStateWaitLocalMedia reason:nil];
 
     [callStackCall startCapturingMediaWithVideo:video success:^() {
 


### PR DESCRIPTION
Route to speaker every video call by default. See [#933](https://github.com/vector-im/riot-ios/issues/933)

Signed-off-by: Denis Morozov dmorozkn@gmail.com