### PR TITLE
MXSession: Fix parallel /sync requests streams.

### DIFF
--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -919,6 +919,7 @@ typedef void (^MXOnResumeDone)();
         if (nextServerTimeout == 0)
         {
             [self serverSyncWithServerTimeout:nextServerTimeout success:success failure:failure clientTimeout:CLIENT_TIMEOUT_MS setPresence:nil];
+            return;
         }
         
         // there is a pending backgroundSync


### PR DESCRIPTION
This should improve network and battery usage.

When resuming, if several /syncs are required to accomplish the catching up, the code was launching several parallel loops of [self serverSyncWithServerTimeout:...] calls, ie several parallel event streams :/