### PR TITLE
Bug Fix - Room settings: the displayed room access settings is wrong

### DIFF
--- a/MatrixSDK/Data/MXRoomState.m
+++ b/MatrixSDK/Data/MXRoomState.m
@@ -847,8 +847,13 @@
 
     stateCopy->_isLive = _isLive;
 
-    // Copy the list of state events pointers. A deep copy is not necessary as MXEvent objects are immutable
-    stateCopy->stateEvents = [[NSMutableDictionary allocWithZone:zone] initWithDictionary:stateEvents];
+    // Copy the state events. A deep copy of each events array is necessary.
+    stateCopy->stateEvents = [[NSMutableDictionary allocWithZone:zone] initWithCapacity:stateEvents.count];
+    for (NSString *key in stateEvents)
+    {
+        // Copy the list of state events pointers. A deep copy is not necessary as MXEvent objects are immutable
+        stateCopy->stateEvents[key] = [[NSMutableArray allocWithZone:zone] initWithArray:stateEvents[key]];
+    }
 
     // Same thing here. MXRoomMembers are also immutable. A new instance of it is created each time
     // the sdk receives room member event, even if it is an update of an existing member like a

--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
@@ -23,7 +23,7 @@
 #import "MXFileStoreMetaData.h"
 #import "MXSDKOptions.h"
 
-static NSUInteger const kMXFileVersion = 43;
+static NSUInteger const kMXFileVersion = 44;
 
 static NSString *const kMXFileStoreFolder = @"MXFileStore";
 static NSString *const kMXFileStoreMedaDataFile = @"MXFileStore";


### PR DESCRIPTION
MXRoomState copy: a deep copy of each state events array is necessary.
Force file store refresh.

https://github.com/vector-im/riot-ios/issues/1494