### PR TITLE
MXMemoryStore: improve getEventReceipts implementation.

### DIFF
--- a/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryStore.m
+++ b/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryStore.m
@@ -154,15 +154,13 @@
 {
     NSMutableArray* receipts = [[NSMutableArray alloc] init];
     
-    NSMutableDictionary* receiptsByUserId = [receiptsByRoomId objectForKey:roomId];
+    NSMutableDictionary* receiptsByUserId = receiptsByRoomId[roomId];
     
     if (receiptsByUserId)
     {
-        NSArray* userIds = [[receiptsByUserId allKeys] copy];
-        
-        for(NSString* userId in userIds)
+        for (NSString* userId in receiptsByUserId)
         {
-            MXReceiptData* receipt = [receiptsByUserId objectForKey:userId];
+            MXReceiptData* receipt = receiptsByUserId[userId];
             
             if (receipt && [receipt.eventId isEqualToString:eventId])
             {


### PR DESCRIPTION
Remove useless code. This has an impact on perf when scrolling room history

![](https://matrix.org/_matrix/media/v1/download/matrix.org/YMbpNsyQGMJMosODCokglIkW)