### PR TITLE
MXCallManager: delay the call invite handling during sync and backgro…

### DIFF
--- a/MatrixSDK/VoIP/MXCall.m
+++ b/MatrixSDK/VoIP/MXCall.m
@@ -171,7 +171,11 @@ NSString *const kMXCallStateDidChange = @"kMXCallStateDidChange";
                 [callStackCall startCapturingMediaWithVideo:self.isVideoCall success:^{
                     [callStackCall handleOffer:callInviteEventContent.offer.sdp
                                        success:^{
-                                           [self setState:MXCallStateRinging reason:event];
+                                           // Check whether the call has not been ended.
+                                           if (_state != MXCallStateEnded)
+                                           {
+                                               [self setState:MXCallStateRinging reason:event];
+                                           }
                                        }
                                        failure:^(NSError * _Nonnull error) {
                                            NSLog(@"[MXCall] handleOffer: ERROR: Couldn't handle offer. Error: %@", error);

--- a/MatrixSDK/VoIP/MXCallManager.m
+++ b/MatrixSDK/VoIP/MXCallManager.m
@@ -365,7 +365,7 @@ static NSString *const kMXCallManagerFallbackSTUNServer = @"stun:stun.l.google.c
     {
         // If the app is resuming, wait for the complete end of the session resume in order
         // to check if the invite is still valid
-        if (_mxSession.state != MXSessionStateRunning)
+        if (_mxSession.state == MXSessionStateSyncInProgress || _mxSession.state == MXSessionStateBackgroundSyncInProgress)
         {
             // The dispatch  on the main thread should be enough.
             // It means that the sync response that contained the invite (and possibly its end


### PR DESCRIPTION
…und sync.

Do not consider the call invite only when the session is `running`. A call invite should be handled whereas the session is paused (or pause requested).