### PR TITLE
MXRoom - `setIsDirect:`: Update synchronously direct user id in case …

### DIFF
--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -1982,6 +1982,9 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
                 [mxSession.directRooms removeObjectForKey:_directUserId];
             }
             
+            // Update
+            _directUserId = nil;
+            
             // Note: mxSession will post the 'kMXSessionDirectRoomsDidChangeNotification' notification on account data update.
             return [mxSession uploadDirectRooms:success failure:failure];
         }
@@ -2063,6 +2066,9 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
                 [mxSession.directRooms removeObjectForKey:_directUserId];
             }
         }
+        
+        // Update
+        _directUserId = newDirectUserId;
         
         // Note: mxSession will post the 'kMXSessionDirectRoomsDidChangeNotification' notification on account data update.
         return [mxSession uploadDirectRooms:success failure:failure];


### PR DESCRIPTION
…of change.

Do not wait for the server response