### PR TITLE
MXPushRule: Ignore the events without identifier in `room_member_coun…

### DIFF
--- a/MatrixSDK/NotificationCenter/Checker/MXPushRuleRoomMemberCountConditionChecker.m
+++ b/MatrixSDK/NotificationCenter/Checker/MXPushRuleRoomMemberCountConditionChecker.m
@@ -49,10 +49,10 @@
 
 - (BOOL)isCondition:(MXPushRuleCondition*)condition satisfiedBy:(MXEvent*)event withJsonDict:(NSDictionary*)contentAsJsonDict
 {
-    if ((event.eventType == MXEventTypeTypingNotification) || (event.eventType == MXEventTypeReceipt))
+    if (!event.eventId)
     {
-        // Do not take into account typing notifications in room_member_count conditions
-        // as it may fire a lot of times
+        // Do not take into account the events without identifier (typing notifications, read receipts...)
+        // in room_member_count conditions, as they may be triggered a lot of times.
         return NO;
     }
 

--- a/MatrixSDK/NotificationCenter/Checker/MXPushRuleSenderNotificationPermissionConditionChecker.m
+++ b/MatrixSDK/NotificationCenter/Checker/MXPushRuleSenderNotificationPermissionConditionChecker.m
@@ -38,10 +38,10 @@
 
 - (BOOL)isCondition:(MXPushRuleCondition*)condition satisfiedBy:(MXEvent*)event withJsonDict:(NSDictionary*)contentAsJsonDict
 {
-    if ((event.eventType == MXEventTypeTypingNotification) || (event.eventType == MXEventTypeReceipt))
+    if (!event.eventId)
     {
-        // Do not take into account typing notifications in sender_notification_permission conditions
-        // as it may fire a lot of times
+        // Do not take into account the events without identifier (typing notifications, read receipts...)
+        // in sender_notification_permission conditions, as they may be triggered a lot of times.
         return NO;
     }
 


### PR DESCRIPTION
…t` and `sender_notification_permission` conditions.

 (they correspond to the typing notifications, the read receipts...)