### PR TITLE
Bug Fix - CallKit - When I reject or answer a call on one device, it …

### DIFF
--- a/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.m
+++ b/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.m
@@ -143,6 +143,9 @@ NSString * const kMXCallKitAdapterAudioSessionDidActive = @"kMXCallKitAdapterAud
             case MXCallEndReasonMissed:
                 reason = CXCallEndedReasonUnanswered;
                 break;
+            case MXCallEndReasonAnsweredElseWhere:
+                reason = CXCallEndedReasonAnsweredElsewhere;
+                break;
             default:
                 break;
         }

--- a/MatrixSDK/VoIP/MXCall.h
+++ b/MatrixSDK/VoIP/MXCall.h
@@ -63,6 +63,7 @@ typedef NS_ENUM(NSInteger, MXCallEndReason)
     MXCallEndReasonRemoteHangup, // The call was ended by the remote side
     MXCallEndReasonBusy, // The call was declined by the remote side before it was being established. Only for outgoing calls
     MXCallEndReasonMissed, // The call wasn't established in a given period of time
+    MXCallEndReasonAnsweredElseWhere // The call was answered on another device
 };
 
 /**

--- a/MatrixSDK/VoIP/MXCall.m
+++ b/MatrixSDK/VoIP/MXCall.m
@@ -691,6 +691,9 @@ NSString *const kMXCallStateDidChange = @"kMXCallStateDidChange";
 {
     // Send the notif that the call has been answered from another device to the app
     [self setState:MXCallStateAnsweredElseWhere reason:nil];
+    
+    // Set appropriate call end reason
+    _endReason = MXCallEndReasonAnsweredElseWhere;
 
     // And set the final state: MXCallStateEnded
     [self setState:MXCallStateEnded reason:nil];


### PR DESCRIPTION
…should stop ringing on all other iOS devices

Handle correctly call answered  on another device

vector-im/riot-ios#1618