### PR TITLE
Fix many more warnings regarding strict prototypes.

### DIFF
--- a/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmEncryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmEncryption.m
@@ -344,7 +344,7 @@
 
 - (MXHTTPOperation*)shareKey:(MXOutboundSessionInfo*)session
                  withDevices:(NSDictionary<NSString* /* userId */, NSArray<MXDeviceInfo*>*>*)devicesByUser
-                        success:(void (^)())success
+                        success:(void (^)(void))success
                         failure:(void (^)(NSError *))failure
 
 {

--- a/MatrixSDK/Crypto/Data/Store/MXCryptoStore.h
+++ b/MatrixSDK/Crypto/Data/Store/MXCryptoStore.h
@@ -73,7 +73,7 @@
  @param onComplete the callback called once the data has been loaded.
  @param failure the callback called in case of error.
  */
-- (void)open:(void (^)())onComplete failure:(void (^)(NSError *error))failure;
+- (void)open:(void (^)(void))onComplete failure:(void (^)(NSError *error))failure;
 
 /**
  Store the device id.

--- a/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
+++ b/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
@@ -319,7 +319,7 @@ RLM_ARRAY_TYPE(MXRealmOlmInboundGroupSession)
     return [MXRealmOlmAccount objectsInRealm:self.realm where:@"userId = %@", userId].firstObject;
 }
 
-- (void)open:(void (^)())onComplete failure:(void (^)(NSError *error))failure
+- (void)open:(void (^)(void))onComplete failure:(void (^)(NSError *error))failure
 {
     onComplete();
 }

--- a/MatrixSDK/Crypto/MXCrypto.h
+++ b/MatrixSDK/Crypto/MXCrypto.h
@@ -100,7 +100,7 @@ FOUNDATION_EXPORT NSString *const kMXCryptoRoomKeyRequestCancellationNotificatio
  @param onComplete A block object called when the operation succeeds.
  @param failure A block object called when the operation fails.
  */
-- (void)start:(void (^)())onComplete
+- (void)start:(void (^)(void))onComplete
       failure:(void (^)(NSError *error))failure;
 
 /**
@@ -153,7 +153,7 @@ FOUNDATION_EXPORT NSString *const kMXCryptoRoomKeyRequestCancellationNotificatio
  @return a MXHTTPOperation instance. May be nil if all required materials is already in place.
  */
 - (MXHTTPOperation*)ensureEncryptionInRoom:(NSString*)roomId
-                                   success:(void (^)())success
+                                   success:(void (^)(void))success
                                    failure:(void (^)(NSError *error))failure;
 
 /**
@@ -213,7 +213,7 @@ FOUNDATION_EXPORT NSString *const kMXCryptoRoomKeyRequestCancellationNotificatio
  @param failure A block object called when the operation fails.
  */
 - (void)setDeviceVerification:(MXDeviceVerification)verificationStatus forDevice:(NSString*)deviceId ofUser:(NSString*)userId
-                      success:(void (^)())success
+                      success:(void (^)(void))success
                       failure:(void (^)(NSError *error))failure;
 
 /**
@@ -224,7 +224,7 @@ FOUNDATION_EXPORT NSString *const kMXCryptoRoomKeyRequestCancellationNotificatio
  @param complete A block object called when the operation completes.
  */
 - (void)setDevicesKnown:(MXUsersDevicesMap<MXDeviceInfo*>*)devices
-               complete:(void (^)())complete;
+               complete:(void (^)(void))complete;
 
 /**
  Download the device keys for a list of users and stores them into the crypto store.
@@ -296,7 +296,7 @@ FOUNDATION_EXPORT NSString *const kMXCryptoRoomKeyRequestCancellationNotificatio
  @param failure A block object called when the operation fails.
  */
 - (void)importRoomKeys:(NSArray<NSDictionary*>*)keys
-               success:(void (^)())success
+               success:(void (^)(void))success
                failure:(void (^)(NSError *error))failure;
 
 /**
@@ -308,7 +308,7 @@ FOUNDATION_EXPORT NSString *const kMXCryptoRoomKeyRequestCancellationNotificatio
  @param failure A block object called when the operation fails.
  */
 - (void)importRoomKeys:(NSData *)keyFile withPassword:(NSString*)password
-               success:(void (^)())success
+               success:(void (^)(void))success
                failure:(void (^)(NSError *error))failure;
 
 

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -193,7 +193,7 @@ NSTimeInterval kMXCryptoUploadOneTimeKeysPeriod = 60.0; // one minute
 #endif
 }
 
-- (void)start:(void (^)())success
+- (void)start:(void (^)(void))success
       failure:(void (^)(NSError *error))failure
 {
 
@@ -467,7 +467,7 @@ NSTimeInterval kMXCryptoUploadOneTimeKeysPeriod = 60.0; // one minute
 }
 
 - (MXHTTPOperation*)ensureEncryptionInRoom:(NSString*)roomId
-                                   success:(void (^)())success
+                                   success:(void (^)(void))success
                                    failure:(void (^)(NSError *error))failure
 {
 
@@ -710,7 +710,7 @@ NSTimeInterval kMXCryptoUploadOneTimeKeysPeriod = 60.0; // one minute
 }
 
 - (void)setDeviceVerification:(MXDeviceVerification)verificationStatus forDevice:(NSString*)deviceId ofUser:(NSString*)userId
-                      success:(void (^)())success
+                      success:(void (^)(void))success
                       failure:(void (^)(NSError *error))failure
 {
 #ifdef MX_CRYPTO
@@ -766,7 +766,7 @@ NSTimeInterval kMXCryptoUploadOneTimeKeysPeriod = 60.0; // one minute
 #endif
 }
 
-- (void)setDevicesKnown:(MXUsersDevicesMap<MXDeviceInfo *> *)devices complete:(void (^)())complete
+- (void)setDevicesKnown:(MXUsersDevicesMap<MXDeviceInfo *> *)devices complete:(void (^)(void))complete
 {
 #ifdef MX_CRYPTO
     dispatch_async(_cryptoQueue, ^{
@@ -990,7 +990,7 @@ NSTimeInterval kMXCryptoUploadOneTimeKeysPeriod = 60.0; // one minute
 #endif
 }
 
-- (void)importRoomKeys:(NSArray<NSDictionary *> *)keys success:(void (^)())success failure:(void (^)(NSError *))failure
+- (void)importRoomKeys:(NSArray<NSDictionary *> *)keys success:(void (^)(void))success failure:(void (^)(NSError *))failure
 {
 #ifdef MX_CRYPTO
     dispatch_async(_decryptionQueue, ^{
@@ -1031,7 +1031,7 @@ NSTimeInterval kMXCryptoUploadOneTimeKeysPeriod = 60.0; // one minute
 #endif
 }
 
-- (void)importRoomKeys:(NSData *)keyFile withPassword:(NSString *)password success:(void (^)())success failure:(void (^)(NSError *))failure
+- (void)importRoomKeys:(NSData *)keyFile withPassword:(NSString *)password success:(void (^)(void))success failure:(void (^)(NSError *))failure
 {
 #ifdef MX_CRYPTO
     dispatch_async(_decryptionQueue, ^{
@@ -1733,7 +1733,7 @@ NSTimeInterval kMXCryptoUploadOneTimeKeysPeriod = 60.0; // one minute
  @param failure A block object called when the operation fails.
  */
 - (void)invalidateDeviceListsSince:(NSString*)oldSyncToken to:(NSString*)lastKnownSyncToken
-                           success:(void (^)())success
+                           success:(void (^)(void))success
                            failure:(void (^)(NSError *error))failure
 {
     [_matrixRestClient keyChangesFrom:oldSyncToken to:lastKnownSyncToken success:^(MXDeviceListResponse *deviceLists) {
@@ -1869,7 +1869,7 @@ NSTimeInterval kMXCryptoUploadOneTimeKeysPeriod = 60.0; // one minute
  @param failure A block object called when the operation fails.
  */
 - (MXHTTPOperation*)makeAnnoucement:(NSMutableDictionary<NSString*, NSMutableArray*> *)roomsByUser
-                            success:(void (^)())success
+                            success:(void (^)(void))success
                             failure:(void (^)(NSError *error))failure
 {
     // This method is called when the initialSync was done or the session was resumed
@@ -2118,7 +2118,7 @@ NSTimeInterval kMXCryptoUploadOneTimeKeysPeriod = 60.0; // one minute
 /**
  Check if it's time to upload one-time keys, and do so if so.
  */
-- (void)maybeUploadOneTimeKeys:(void (^)())success failure:(void (^)(NSError *))failure
+- (void)maybeUploadOneTimeKeys:(void (^)(void))success failure:(void (^)(NSError *))failure
 {
     if (uploadOneTimeKeysOperation)
     {

--- a/MatrixSDK/Data/MXEventTimeline.h
+++ b/MatrixSDK/Data/MXEventTimeline.h
@@ -153,7 +153,7 @@ typedef void (^MXOnRoomEvent)(MXEvent *event, MXTimelineDirection direction, MXR
  @return a MXHTTPOperation instance.
  */
 - (MXHTTPOperation*)resetPaginationAroundInitialEventWithLimit:(NSUInteger)limit
-                                                       success:(void(^)())success
+                                                       success:(void(^)(void))success
                                                        failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -176,7 +176,7 @@ typedef void (^MXOnRoomEvent)(MXEvent *event, MXTimelineDirection direction, MXR
 - (MXHTTPOperation*)paginate:(NSUInteger)numItems
                    direction:(MXTimelineDirection)direction
                onlyFromStore:(BOOL)onlyFromStore
-                    complete:(void (^)())complete
+                    complete:(void (^)(void))complete
                      failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**

--- a/MatrixSDK/Data/MXEventTimeline.m
+++ b/MatrixSDK/Data/MXEventTimeline.m
@@ -173,7 +173,7 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
     storeMessagesEnumerator = [store messagesEnumeratorForRoom:_state.roomId];
 }
 
-- (MXHTTPOperation *)resetPaginationAroundInitialEventWithLimit:(NSUInteger)limit success:(void (^)())success failure:(void (^)(NSError *))failure
+- (MXHTTPOperation *)resetPaginationAroundInitialEventWithLimit:(NSUInteger)limit success:(void (^)(void))success failure:(void (^)(NSError *))failure
 {
     NSParameterAssert(success);
     NSAssert(_initialEventId, @"[MXEventTimeline] resetPaginationAroundInitialEventWithLimit cannot be called on live timeline");
@@ -221,7 +221,7 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
 }
 
 
-- (MXHTTPOperation *)paginate:(NSUInteger)numItems direction:(MXTimelineDirection)direction onlyFromStore:(BOOL)onlyFromStore complete:(void (^)())complete failure:(void (^)(NSError *))failure
+- (MXHTTPOperation *)paginate:(NSUInteger)numItems direction:(MXTimelineDirection)direction onlyFromStore:(BOOL)onlyFromStore complete:(void (^)(void))complete failure:(void (^)(NSError *))failure
 {
     MXHTTPOperation *operation;
 

--- a/MatrixSDK/Data/MXMyUser.h
+++ b/MatrixSDK/Data/MXMyUser.h
@@ -46,7 +46,7 @@
  @param failure A block object called when the operation fails.
  */
 - (void)setDisplayName:(NSString*)displayname
-               success:(void (^)())success
+               success:(void (^)(void))success
                failure:(void (^)(NSError *error))failure;
 
 
@@ -59,7 +59,7 @@
  @param failure A block object called when the operation fails.
  */
 - (void)setAvatarUrl:(NSString*)avatarUrl
-             success:(void (^)())success
+             success:(void (^)(void))success
              failure:(void (^)(NSError *error))failure;
 
 /**
@@ -72,7 +72,7 @@
  @param failure A block object called when the operation fails.
  */
 - (void)setPresence:(MXPresence)presence andStatusMessage:(NSString*)statusMessage
-            success:(void (^)())success
+            success:(void (^)(void))success
             failure:(void (^)(NSError *error))failure;
 
 @end

--- a/MatrixSDK/Data/MXMyUser.m
+++ b/MatrixSDK/Data/MXMyUser.m
@@ -34,7 +34,7 @@
     return self;
 }
 
-- (void)setDisplayName:(NSString *)displayname success:(void (^)())success failure:(void (^)(NSError *))failure
+- (void)setDisplayName:(NSString *)displayname success:(void (^)(void))success failure:(void (^)(NSError *))failure
 {
     [_mxSession.matrixRestClient setDisplayName:displayname success:^{
 
@@ -60,7 +60,7 @@
     }];
 }
 
-- (void)setAvatarUrl:(NSString *)avatarUrl success:(void (^)())success failure:(void (^)(NSError *))failure
+- (void)setAvatarUrl:(NSString *)avatarUrl success:(void (^)(void))success failure:(void (^)(NSError *))failure
 {
     [_mxSession.matrixRestClient setAvatarUrl:avatarUrl success:^{
 
@@ -86,7 +86,7 @@
     }];
 }
 
-- (void)setPresence:(MXPresence)presence andStatusMessage:(NSString *)statusMessage success:(void (^)())success failure:(void (^)(NSError *))failure
+- (void)setPresence:(MXPresence)presence andStatusMessage:(NSString *)statusMessage success:(void (^)(void))success failure:(void (^)(NSError *))failure
 {
     [_mxSession.matrixRestClient setPresence:presence andStatusMessage:statusMessage success:^{
 

--- a/MatrixSDK/Data/MXPeekingRoom.h
+++ b/MatrixSDK/Data/MXPeekingRoom.h
@@ -42,7 +42,7 @@
                          is up-to-date with the homeserver.
  @param failure A block object called when the operation fails.
  */
-- (void)start:(void (^)())onServerSyncDone
+- (void)start:(void (^)(void))onServerSyncDone
       failure:(void (^)(NSError *error))failure;
 
 /**

--- a/MatrixSDK/Data/MXPeekingRoom.m
+++ b/MatrixSDK/Data/MXPeekingRoom.m
@@ -41,7 +41,7 @@
     return [self initWithRoomId:roomId matrixSession:mxSession andStore:memoryStore];
 }
 
-- (void)start:(void (^)())onServerSyncDone failure:(void (^)(NSError *error))failure
+- (void)start:(void (^)(void))onServerSyncDone failure:(void (^)(NSError *error))failure
 {
     // Make an /initialSync request to get data
     // Use a 0 messages limit for now because:

--- a/MatrixSDK/Data/MXRoom.h
+++ b/MatrixSDK/Data/MXRoom.h
@@ -136,7 +136,7 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidFlushDataNotification;
  */
 - (MXHTTPOperation*)setIsDirect:(BOOL)isDirect
                      withUserId:(NSString*)userId
-                        success:(void (^)())success
+                        success:(void (^)(void))success
                         failure:(void (^)(NSError *error))failure;
 
 /**
@@ -442,7 +442,7 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidFlushDataNotification;
  @return a MXHTTPOperation instance.
  */
 - (MXHTTPOperation*)setTopic:(NSString*)topic
-                     success:(void (^)())success
+                     success:(void (^)(void))success
                      failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -455,7 +455,7 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidFlushDataNotification;
  @return a MXHTTPOperation instance.
  */
 - (MXHTTPOperation*)setAvatar:(NSString*)avatar
-                      success:(void (^)())success
+                      success:(void (^)(void))success
                       failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -468,7 +468,7 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidFlushDataNotification;
  @return a MXHTTPOperation instance.
  */
 - (MXHTTPOperation*)setName:(NSString*)name
-                    success:(void (^)())success
+                    success:(void (^)(void))success
                     failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -481,7 +481,7 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidFlushDataNotification;
  @return a MXHTTPOperation instance.
  */
 - (MXHTTPOperation*)setHistoryVisibility:(MXRoomHistoryVisibility)historyVisibility
-                                 success:(void (^)())success
+                                 success:(void (^)(void))success
                                  failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -494,7 +494,7 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidFlushDataNotification;
  @return a MXHTTPOperation instance.
  */
 - (MXHTTPOperation*)setJoinRule:(MXRoomJoinRule)joinRule
-                        success:(void (^)())success
+                        success:(void (^)(void))success
                         failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -507,7 +507,7 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidFlushDataNotification;
  @return a MXHTTPOperation instance.
  */
 - (MXHTTPOperation*)setGuestAccess:(MXRoomGuestAccess)guestAccess
-                           success:(void (^)())success
+                           success:(void (^)(void))success
                            failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -520,7 +520,7 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidFlushDataNotification;
  @return a MXHTTPOperation instance.
  */
 - (MXHTTPOperation*)setDirectoryVisibility:(MXRoomDirectoryVisibility)directoryVisibility
-                                   success:(void (^)())success
+                                   success:(void (^)(void))success
                                    failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -533,7 +533,7 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidFlushDataNotification;
  @return a MXHTTPOperation instance.
  */
 - (MXHTTPOperation*)addAlias:(NSString *)roomAlias
-                     success:(void (^)())success
+                     success:(void (^)(void))success
                      failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -546,7 +546,7 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidFlushDataNotification;
  @return a MXHTTPOperation instance.
  */
 - (MXHTTPOperation*)removeAlias:(NSString *)roomAlias
-                        success:(void (^)())success
+                        success:(void (^)(void))success
                         failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -559,7 +559,7 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidFlushDataNotification;
  @return a MXHTTPOperation instance.
  */
 - (MXHTTPOperation*)setCanonicalAlias:(NSString *)canonicalAlias
-                              success:(void (^)())success
+                              success:(void (^)(void))success
                               failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -586,7 +586,7 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidFlushDataNotification;
 
  @return a MXHTTPOperation instance.
  */
-- (MXHTTPOperation*)join:(void (^)())success
+- (MXHTTPOperation*)join:(void (^)(void))success
                  failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -597,7 +597,7 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidFlushDataNotification;
 
  @return a MXHTTPOperation instance.
  */
-- (MXHTTPOperation*)leave:(void (^)())success
+- (MXHTTPOperation*)leave:(void (^)(void))success
                   failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -610,7 +610,7 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidFlushDataNotification;
  @return a MXHTTPOperation instance.
  */
 - (MXHTTPOperation*)inviteUser:(NSString*)userId
-                       success:(void (^)())success
+                       success:(void (^)(void))success
                        failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -623,7 +623,7 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidFlushDataNotification;
  @return a MXHTTPOperation instance.
  */
 - (MXHTTPOperation*)inviteUserByEmail:(NSString*)email
-                              success:(void (^)())success
+                              success:(void (^)(NSDictionary *JSONResponse))success
                               failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -637,7 +637,7 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidFlushDataNotification;
  */
 - (MXHTTPOperation*)kickUser:(NSString*)userId
                       reason:(NSString*)reason
-                     success:(void (^)())success
+                     success:(void (^)(void))success
                      failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -651,7 +651,7 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidFlushDataNotification;
  */
 - (MXHTTPOperation*)banUser:(NSString*)userId
                      reason:(NSString*)reason
-                    success:(void (^)())success
+                    success:(void (^)(void))success
                     failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -664,7 +664,7 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidFlushDataNotification;
  @return a MXHTTPOperation instance.
  */
 - (MXHTTPOperation*)unbanUser:(NSString*)userId
-                      success:(void (^)())success
+                      success:(void (^)(void))success
                       failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -679,7 +679,7 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidFlushDataNotification;
  @return a MXHTTPOperation instance.
  */
 - (MXHTTPOperation*)setPowerLevelOfUserWithUserID:(NSString*)userId powerLevel:(NSInteger)powerLevel
-                                          success:(void (^)())success
+                                          success:(void (^)(void))success
                                           failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -696,7 +696,7 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidFlushDataNotification;
  */
 - (MXHTTPOperation*)sendTypingNotification:(BOOL)typing
                                    timeout:(NSUInteger)timeout
-                                   success:(void (^)())success
+                                   success:(void (^)(void))success
                                    failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -712,7 +712,7 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidFlushDataNotification;
  */
 - (MXHTTPOperation*)redactEvent:(NSString*)eventId
                          reason:(NSString*)reason
-                        success:(void (^)())success
+                        success:(void (^)(void))success
                         failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -731,7 +731,7 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidFlushDataNotification;
 - (MXHTTPOperation*)reportEvent:(NSString*)eventId
                           score:(NSInteger)score
                          reason:(NSString*)reason
-                        success:(void (^)())success
+                        success:(void (^)(void))success
                         failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 
@@ -808,7 +808,7 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidFlushDataNotification;
  */
 - (MXHTTPOperation*)addTag:(NSString*)tag
                  withOrder:(NSString*)order
-                   success:(void (^)())success
+                   success:(void (^)(void))success
                    failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 /**
  Remove a tag from a room.
@@ -821,7 +821,7 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidFlushDataNotification;
  @return a MXHTTPOperation instance.
  */
 - (MXHTTPOperation*)removeTag:(NSString*)tag
-                      success:(void (^)())success
+                      success:(void (^)(void))success
                       failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -839,7 +839,7 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidFlushDataNotification;
 - (MXHTTPOperation*)replaceTag:(NSString*)oldTag
                          byTag:(NSString*)newTag
                      withOrder:(NSString*)newTagOrder
-                       success:(void (^)())success
+                       success:(void (^)(void))success
                        failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 
@@ -929,7 +929,7 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidFlushDataNotification;
  @return a MXHTTPOperation instance.
 */
 - (MXHTTPOperation*)enableEncryptionWithAlgorithm:(NSString*)algorithm
-                                          success:(void (^)())success
+                                          success:(void (^)(void))success
                                           failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -1217,14 +1217,14 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
 }
 
 - (MXHTTPOperation*)setTopic:(NSString*)topic
-                     success:(void (^)())success
+                     success:(void (^)(void))success
                      failure:(void (^)(NSError *error))failure
 {
     return [mxSession.matrixRestClient setRoomTopic:self.roomId topic:topic success:success failure:failure];
 }
 
 - (MXHTTPOperation*)setAvatar:(NSString*)avatar
-                     success:(void (^)())success
+                     success:(void (^)(void))success
                      failure:(void (^)(NSError *error))failure
 {
     return [mxSession.matrixRestClient setRoomAvatar:self.roomId avatar:avatar success:success failure:failure];
@@ -1232,56 +1232,56 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
 
 
 - (MXHTTPOperation*)setName:(NSString*)name
-                    success:(void (^)())success
+                    success:(void (^)(void))success
                     failure:(void (^)(NSError *error))failure
 {
     return [mxSession.matrixRestClient setRoomName:self.roomId name:name success:success failure:failure];
 }
 
 - (MXHTTPOperation *)setHistoryVisibility:(MXRoomHistoryVisibility)historyVisibility
-                                  success:(void (^)())success
+                                  success:(void (^)(void))success
                                   failure:(void (^)(NSError *))failure
 {
     return [mxSession.matrixRestClient setRoomHistoryVisibility:self.roomId historyVisibility:historyVisibility success:success failure:failure];
 }
 
 - (MXHTTPOperation*)setJoinRule:(MXRoomJoinRule)joinRule
-                        success:(void (^)())success
+                        success:(void (^)(void))success
                         failure:(void (^)(NSError *error))failure
 {
     return [mxSession.matrixRestClient setRoomJoinRule:self.roomId joinRule:joinRule success:success failure:failure];
 }
 
 - (MXHTTPOperation*)setGuestAccess:(MXRoomGuestAccess)guestAccess
-                           success:(void (^)())success
+                           success:(void (^)(void))success
                            failure:(void (^)(NSError *error))failure
 {
     return [mxSession.matrixRestClient setRoomGuestAccess:self.roomId guestAccess:guestAccess success:success failure:failure];
 }
 
 - (MXHTTPOperation*)setDirectoryVisibility:(MXRoomDirectoryVisibility)directoryVisibility
-                                   success:(void (^)())success
+                                   success:(void (^)(void))success
                                    failure:(void (^)(NSError *error))failure
 {
     return [mxSession.matrixRestClient setRoomDirectoryVisibility:self.roomId directoryVisibility:directoryVisibility success:success failure:failure];
 }
 
 - (MXHTTPOperation*)addAlias:(NSString *)roomAlias
-                     success:(void (^)())success
+                     success:(void (^)(void))success
                      failure:(void (^)(NSError *error))failure
 {
     return [mxSession.matrixRestClient addRoomAlias:self.roomId alias:roomAlias success:success failure:failure];
 }
 
 - (MXHTTPOperation*)removeAlias:(NSString *)roomAlias
-                     success:(void (^)())success
+                     success:(void (^)(void))success
                      failure:(void (^)(NSError *error))failure
 {
     return [mxSession.matrixRestClient removeRoomAlias:roomAlias success:success failure:failure];
 }
 
 - (MXHTTPOperation*)setCanonicalAlias:(NSString *)canonicalAlias
-                              success:(void (^)())success
+                              success:(void (^)(void))success
                               failure:(void (^)(NSError *error))failure
 {
     return [mxSession.matrixRestClient setRoomCanonicalAlias:self.roomId canonicalAlias:canonicalAlias success:success failure:failure];
@@ -1293,7 +1293,7 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
     return [mxSession.matrixRestClient directoryVisibilityOfRoom:self.roomId success:success failure:failure];
 }
 
-- (MXHTTPOperation*)join:(void (^)())success
+- (MXHTTPOperation*)join:(void (^)(void))success
                  failure:(void (^)(NSError *error))failure
 {
     return [mxSession joinRoom:self.roomId success:^(MXRoom *room) {
@@ -1301,21 +1301,21 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
     } failure:failure];
 }
 
-- (MXHTTPOperation*)leave:(void (^)())success
+- (MXHTTPOperation*)leave:(void (^)(void))success
                   failure:(void (^)(NSError *error))failure
 {
     return [mxSession leaveRoom:self.roomId success:success failure:failure];
 }
 
 - (MXHTTPOperation*)inviteUser:(NSString*)userId
-                       success:(void (^)())success
+                       success:(void (^)(void))success
                        failure:(void (^)(NSError *error))failure
 {
     return [mxSession.matrixRestClient inviteUser:userId toRoom:self.roomId success:success failure:failure];
 }
 
 - (MXHTTPOperation*)inviteUserByEmail:(NSString*)email
-                              success:(void (^)())success
+                              success:(void (^)(NSDictionary *JSONResponse))success
                               failure:(void (^)(NSError *error))failure
 {
     return [mxSession.matrixRestClient inviteUserByEmail:email toRoom:self.roomId success:success failure:failure];
@@ -1323,7 +1323,7 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
 
 - (MXHTTPOperation*)kickUser:(NSString*)userId
                       reason:(NSString*)reason
-                     success:(void (^)())success
+                     success:(void (^)(void))success
                      failure:(void (^)(NSError *error))failure
 {
     return [mxSession.matrixRestClient kickUser:userId fromRoom:self.roomId reason:reason success:success failure:failure];
@@ -1331,21 +1331,21 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
 
 - (MXHTTPOperation*)banUser:(NSString*)userId
                      reason:(NSString*)reason
-                    success:(void (^)())success
+                    success:(void (^)(void))success
                     failure:(void (^)(NSError *error))failure
 {
     return [mxSession.matrixRestClient banUser:userId inRoom:self.roomId reason:reason success:success failure:failure];
 }
 
 - (MXHTTPOperation*)unbanUser:(NSString*)userId
-                      success:(void (^)())success
+                      success:(void (^)(void))success
                       failure:(void (^)(NSError *error))failure
 {
     return [mxSession.matrixRestClient unbanUser:userId inRoom:self.roomId success:success failure:failure];
 }
 
 - (MXHTTPOperation*)setPowerLevelOfUserWithUserID:(NSString *)userId powerLevel:(NSInteger)powerLevel
-                                          success:(void (^)())success
+                                          success:(void (^)(void))success
                                           failure:(void (^)(NSError *))failure
 {
     // To set this new value, we have to take the current powerLevels content,
@@ -1365,7 +1365,7 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
 
 - (MXHTTPOperation*)sendTypingNotification:(BOOL)typing
                                    timeout:(NSUInteger)timeout
-                                   success:(void (^)())success
+                                   success:(void (^)(void))success
                                    failure:(void (^)(NSError *error))failure
 {
     return [mxSession.matrixRestClient sendTypingNotificationInRoom:self.roomId typing:typing timeout:timeout success:success failure:failure];
@@ -1373,7 +1373,7 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
 
 - (MXHTTPOperation*)redactEvent:(NSString*)eventId
                          reason:(NSString*)reason
-                        success:(void (^)())success
+                        success:(void (^)(void))success
                         failure:(void (^)(NSError *error))failure
 {
     return [mxSession.matrixRestClient redactEvent:eventId inRoom:self.roomId reason:reason success:success failure:failure];
@@ -1382,7 +1382,7 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
 - (MXHTTPOperation *)reportEvent:(NSString *)eventId
                            score:(NSInteger)score
                           reason:(NSString *)reason
-                         success:(void (^)())success
+                         success:(void (^)(void))success
                          failure:(void (^)(NSError *))failure
 {
     return [mxSession.matrixRestClient reportEvent:eventId inRoom:self.roomId score:score reason:reason success:success failure:failure];
@@ -1397,7 +1397,7 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
  @param block the code block to schedule.
  @return a `MXRoomOperation` object.
  */
-- (MXRoomOperation *)preserveOperationOrder:(MXEvent*)localEvent block:(void (^)())block
+- (MXRoomOperation *)preserveOperationOrder:(MXEvent*)localEvent block:(void (^)(void))block
 {
     // Queue the operation requests
     MXRoomOperation *roomOperation = [[MXRoomOperation alloc] init];
@@ -1766,7 +1766,7 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
 #pragma mark - Room tags operations
 - (MXHTTPOperation*)addTag:(NSString*)tag
                  withOrder:(NSString*)order
-                   success:(void (^)())success
+                   success:(void (^)(void))success
                    failure:(void (^)(NSError *error))failure
 {
     // _accountData.tags will be updated by the live streams
@@ -1774,7 +1774,7 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
 }
 
 - (MXHTTPOperation*)removeTag:(NSString*)tag
-                      success:(void (^)())success
+                      success:(void (^)(void))success
                       failure:(void (^)(NSError *error))failure
 {
     // _accountData.tags will be updated by the live streams
@@ -1784,7 +1784,7 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
 - (MXHTTPOperation*)replaceTag:(NSString*)oldTag
                          byTag:(NSString*)newTag
                      withOrder:(NSString*)newTagOrder
-                       success:(void (^)())success
+                       success:(void (^)(void))success
                        failure:(void (^)(NSError *error))failure
 {
     MXHTTPOperation *operation;
@@ -2175,7 +2175,7 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
 
 - (MXHTTPOperation*)setIsDirect:(BOOL)isDirect
                      withUserId:(NSString*)userId
-                        success:(void (^)())success
+                        success:(void (^)(void))success
                         failure:(void (^)(NSError *error))failure
 {
     if (isDirect == NO)
@@ -2355,7 +2355,7 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
 #pragma mark - Crypto
 
 - (MXHTTPOperation *)enableEncryptionWithAlgorithm:(NSString *)algorithm
-                                           success:(void (^)())success failure:(void (^)(NSError *))failure
+                                           success:(void (^)(void))success failure:(void (^)(NSError *))failure
 {
     MXHTTPOperation *operation;
 

--- a/MatrixSDK/Data/MXRoomSummary.h
+++ b/MatrixSDK/Data/MXRoomSummary.h
@@ -194,7 +194,7 @@ FOUNDATION_EXPORT NSString *const kMXRoomSummaryDidChangeNotification;
 
  @return a MXHTTPOperation instance.
  */
-- (MXHTTPOperation*)resetLastMessage:(void (^)())complete failure:(void (^)(NSError *))failure commit:(BOOL)commit;
+- (MXHTTPOperation*)resetLastMessage:(void (^)(void))complete failure:(void (^)(NSError *))failure commit:(BOOL)commit;
 
 
 #pragma mark - Data related to business logic

--- a/MatrixSDK/Data/MXRoomSummary.m
+++ b/MatrixSDK/Data/MXRoomSummary.m
@@ -153,7 +153,7 @@ NSString *const kMXRoomSummaryDidChangeNotification = @"kMXRoomSummaryDidChangeN
     _isLastMessageEncrypted = event.isEncrypted;
 }
 
-- (MXHTTPOperation *)resetLastMessage:(void (^)())complete failure:(void (^)(NSError *))failure commit:(BOOL)commit
+- (MXHTTPOperation *)resetLastMessage:(void (^)(void))complete failure:(void (^)(NSError *))failure commit:(BOOL)commit
 {
     lastMessageEvent = nil;
     _lastMessageEventId = nil;
@@ -179,7 +179,7 @@ NSString *const kMXRoomSummaryDidChangeNotification = @"kMXRoomSummaryDidChangeN
  global [MXStore commit] will happen. This optimises IO.
  @return a MXHTTPOperation
  */
-- (MXHTTPOperation *)fetchLastMessage:(void (^)())complete failure:(void (^)(NSError *))failure lastEventIdChecked:(NSString*)lastEventIdChecked operation:(MXHTTPOperation *)operation commit:(BOOL)commit
+- (MXHTTPOperation *)fetchLastMessage:(void (^)(void))complete failure:(void (^)(NSError *))failure lastEventIdChecked:(NSString*)lastEventIdChecked operation:(MXHTTPOperation *)operation commit:(BOOL)commit
 {
     MXRoom *room = self.room;
     if (!room)

--- a/MatrixSDK/Data/MXUser.h
+++ b/MatrixSDK/Data/MXUser.h
@@ -106,7 +106,7 @@
  @param success a block when the operation succeeds.
  @param failure a block when the operation fails.
  */
-- (void)updateFromHomeserverOfMatrixSession:(MXSession*)mxSession success:(void (^)())success failure:(void (^)(NSError *error))failure;
+- (void)updateFromHomeserverOfMatrixSession:(MXSession*)mxSession success:(void (^)(void))success failure:(void (^)(NSError *error))failure;
 
 
 #pragma mark - Events listeners

--- a/MatrixSDK/Data/MXUser.m
+++ b/MatrixSDK/Data/MXUser.m
@@ -121,7 +121,7 @@
     [self notifyListeners:presenceEvent];
 }
 
-- (void)updateFromHomeserverOfMatrixSession:(MXSession *)mxSession success:(void (^)())success failure:(void (^)(NSError *))failure
+- (void)updateFromHomeserverOfMatrixSession:(MXSession *)mxSession success:(void (^)(void))success failure:(void (^)(NSError *))failure
 {
     [mxSession.matrixRestClient displayNameForUser:_userId success:^(NSString *displayname) {
 

--- a/MatrixSDK/Data/Store/MXCoreDataStore/MXCoreDataStore.m
+++ b/MatrixSDK/Data/Store/MXCoreDataStore/MXCoreDataStore.m
@@ -88,7 +88,7 @@ NSString *const kMXCoreDataStoreFolder = @"MXCoreDataStore";
     return self;
 }
 
-- (void)openWithCredentials:(MXCredentials*)credentials onComplete:(void (^)())onComplete failure:(void (^)(NSError *))failure
+- (void)openWithCredentials:(MXCredentials*)credentials onComplete:(void (^)(void))onComplete failure:(void (^)(NSError *))failure
 {
     NSError *error;
 

--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
@@ -131,7 +131,7 @@ static NSString *const kMXFileStoreRoomReadReceiptsFile = @"readReceipts";
     return self;
 }
 
-- (void)openWithCredentials:(MXCredentials*)someCredentials onComplete:(void (^)())onComplete failure:(void (^)(NSError *))failure
+- (void)openWithCredentials:(MXCredentials*)someCredentials onComplete:(void (^)(void))onComplete failure:(void (^)(NSError *))failure
 {
     credentials = someCredentials;
     

--- a/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryStore.m
+++ b/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryStore.m
@@ -42,7 +42,7 @@
     return self;
 }
 
-- (void)openWithCredentials:(MXCredentials *)someCredentials onComplete:(void (^)())onComplete failure:(void (^)(NSError *))failure
+- (void)openWithCredentials:(MXCredentials *)someCredentials onComplete:(void (^)(void))onComplete failure:(void (^)(NSError *))failure
 {
     credentials = someCredentials;
     // Nothing to do

--- a/MatrixSDK/Data/Store/MXNoStore/MXNoStore.m
+++ b/MatrixSDK/Data/Store/MXNoStore/MXNoStore.m
@@ -66,7 +66,7 @@
     return self;
 }
 
-- (void)openWithCredentials:(MXCredentials *)credentials onComplete:(void (^)())onComplete failure:(void (^)(NSError *))failure
+- (void)openWithCredentials:(MXCredentials *)credentials onComplete:(void (^)(void))onComplete failure:(void (^)(NSError *))failure
 {
     // Nothing to do
     onComplete();

--- a/MatrixSDK/Data/Store/MXStore.h
+++ b/MatrixSDK/Data/Store/MXStore.h
@@ -43,7 +43,7 @@
  @param onComplete the callback called once the data has been loaded
  @param failure the callback called in case of error.
  */
-- (void)openWithCredentials:(MXCredentials*)credentials onComplete:(void (^)())onComplete failure:(void (^)(NSError *error))failure;
+- (void)openWithCredentials:(MXCredentials*)credentials onComplete:(void (^)(void))onComplete failure:(void (^)(NSError *error))failure;
 
 /**
  Store a room event received from the home server.

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -342,7 +342,7 @@ typedef enum : NSUInteger
  @return a MXHTTPOperation instance.
  */
 - (MXHTTPOperation*)resetPasswordWithParameters:(NSDictionary*)parameters
-                                        success:(void (^)())success
+                                        success:(void (^)(void))success
                                         failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -356,7 +356,7 @@ typedef enum : NSUInteger
  @return a MXHTTPOperation instance.
  */
 - (MXHTTPOperation*)changePassword:(NSString*)oldPassword with:(NSString*)newPassword
-                           success:(void (^)())success
+                           success:(void (^)(void))success
                            failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -367,7 +367,7 @@ typedef enum : NSUInteger
  
  @return a MXHTTPOperation instance.
  */
-- (MXHTTPOperation*)logout:(void (^)())success
+- (MXHTTPOperation*)logout:(void (^)(void))success
                    failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 #pragma mark - Account data
@@ -384,7 +384,7 @@ typedef enum : NSUInteger
  */
 - (MXHTTPOperation*)setAccountData:(NSDictionary*)data
                            forType:(NSString*)type
-                           success:(void (^)())success
+                           success:(void (^)(void))success
                            failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -492,7 +492,7 @@ typedef enum : NSUInteger
                                     lang:(NSString *)lang
                                     data:(NSDictionary *)data
                                   append:(BOOL)append
-                                 success:(void (^)())success
+                                 success:(void (^)(void))success
                                  failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -520,7 +520,7 @@ typedef enum : NSUInteger
                               scope:(NSString*)scope
                                kind:(MXPushRuleKind)kind
                              enable:(BOOL)enable
-                            success:(void (^)())success
+                            success:(void (^)(void))success
                             failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -535,7 +535,7 @@ typedef enum : NSUInteger
 - (MXHTTPOperation *)removePushRule:(NSString*)ruleId
                               scope:(NSString*)scope
                                kind:(MXPushRuleKind)kind
-                            success:(void (^)())success
+                            success:(void (^)(void))success
                             failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -556,7 +556,7 @@ typedef enum : NSUInteger
                          actions:(NSArray*)actions
                          pattern:(NSString*)pattern
                       conditions:(NSArray<NSDictionary *> *)conditions
-                         success:(void (^)())success
+                         success:(void (^)(void))success
                          failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 
@@ -646,7 +646,7 @@ typedef enum : NSUInteger
  */
 - (MXHTTPOperation*)setRoomTopic:(NSString*)roomId
                            topic:(NSString*)topic
-                         success:(void (^)())success
+                         success:(void (^)(void))success
                          failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -675,7 +675,7 @@ typedef enum : NSUInteger
  */
 - (MXHTTPOperation*)setRoomAvatar:(NSString*)roomId
                            avatar:(NSString*)avatar
-                          success:(void (^)())success
+                          success:(void (^)(void))success
                           failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -703,7 +703,7 @@ typedef enum : NSUInteger
  */
 - (MXHTTPOperation*)setRoomName:(NSString*)roomId
                            name:(NSString*)name
-                        success:(void (^)())success
+                        success:(void (^)(void))success
                         failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -731,7 +731,7 @@ typedef enum : NSUInteger
  */
 - (MXHTTPOperation*)setRoomHistoryVisibility:(NSString*)roomId
                            historyVisibility:(MXRoomHistoryVisibility)historyVisibility
-                                     success:(void (^)())success
+                                     success:(void (^)(void))success
                                      failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -759,7 +759,7 @@ typedef enum : NSUInteger
  */
 - (MXHTTPOperation*)setRoomJoinRule:(NSString*)roomId
                            joinRule:(MXRoomJoinRule)joinRule
-                            success:(void (^)())success
+                            success:(void (^)(void))success
                             failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -787,7 +787,7 @@ typedef enum : NSUInteger
  */
 - (MXHTTPOperation*)setRoomGuestAccess:(NSString*)roomId
                            guestAccess:(MXRoomGuestAccess)guestAccess
-                               success:(void (^)())success
+                               success:(void (^)(void))success
                                failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -815,7 +815,7 @@ typedef enum : NSUInteger
  */
 - (MXHTTPOperation*)setRoomDirectoryVisibility:(NSString*)roomId
                            directoryVisibility:(MXRoomDirectoryVisibility)directoryVisibility
-                                       success:(void (^)())success
+                                       success:(void (^)(void))success
                                        failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -843,7 +843,7 @@ typedef enum : NSUInteger
  */
 - (MXHTTPOperation*)addRoomAlias:(NSString*)roomId
                            alias:(NSString*)roomAlias
-                         success:(void (^)())success
+                         success:(void (^)(void))success
                          failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -856,7 +856,7 @@ typedef enum : NSUInteger
  @return a MXHTTPOperation instance.
  */
 - (MXHTTPOperation*)removeRoomAlias:(NSString*)roomAlias
-                            success:(void (^)())success
+                            success:(void (^)(void))success
                             failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -871,7 +871,7 @@ typedef enum : NSUInteger
  */
 - (MXHTTPOperation*)setRoomCanonicalAlias:(NSString*)roomId
                            canonicalAlias:(NSString *)canonicalAlias
-                           success:(void (^)())success
+                           success:(void (^)(void))success
                            failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -926,7 +926,7 @@ typedef enum : NSUInteger
  @return a MXHTTPOperation instance.
  */
 - (MXHTTPOperation*)leaveRoom:(NSString*)roomId
-                      success:(void (^)())success
+                      success:(void (^)(void))success
                       failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -941,7 +941,7 @@ typedef enum : NSUInteger
  */
 - (MXHTTPOperation*)inviteUser:(NSString*)userId
                         toRoom:(NSString*)roomId
-                       success:(void (^)())success
+                       success:(void (^)(void))success
                        failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -956,7 +956,7 @@ typedef enum : NSUInteger
  */
 - (MXHTTPOperation*)inviteUserByEmail:(NSString*)email
                                toRoom:(NSString*)roomId
-                              success:(void (^)())success
+                              success:(void (^)(NSDictionary *JSONResponse))success
                               failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -973,7 +973,7 @@ typedef enum : NSUInteger
 - (MXHTTPOperation*)inviteByThreePid:(NSString*)medium
                              address:(NSString*)address
                               toRoom:(NSString*)roomId
-                             success:(void (^)())success
+                             success:(void (^)(NSDictionary *JSONResponse))success
                              failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -989,7 +989,7 @@ typedef enum : NSUInteger
 - (MXHTTPOperation*)kickUser:(NSString*)userId
                     fromRoom:(NSString*)roomId
                       reason:(NSString*)reason
-                     success:(void (^)())success
+                     success:(void (^)(void))success
                      failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -1005,7 +1005,7 @@ typedef enum : NSUInteger
 - (MXHTTPOperation*)banUser:(NSString*)userId
                      inRoom:(NSString*)roomId
                      reason:(NSString*)reason
-                    success:(void (^)())success
+                    success:(void (^)(void))success
                     failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -1020,7 +1020,7 @@ typedef enum : NSUInteger
  */
 - (MXHTTPOperation*)unbanUser:(NSString*)userId
                        inRoom:(NSString*)roomId
-                      success:(void (^)())success
+                      success:(void (^)(void))success
                       failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -1156,7 +1156,7 @@ typedef enum : NSUInteger
 - (MXHTTPOperation*)sendTypingNotificationInRoom:(NSString*)roomId
                                           typing:(BOOL)typing
                                          timeout:(NSUInteger)timeout
-                                         success:(void (^)())success
+                                         success:(void (^)(void))success
                                          failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -1174,7 +1174,7 @@ typedef enum : NSUInteger
 - (MXHTTPOperation*)redactEvent:(NSString*)eventId
                          inRoom:(NSString*)roomId
                          reason:(NSString*)reason
-                        success:(void (^)())success
+                        success:(void (^)(void))success
                         failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -1195,7 +1195,7 @@ typedef enum : NSUInteger
                          inRoom:(NSString*)roomId
                           score:(NSInteger)score
                          reason:(NSString*)reason
-                        success:(void (^)())success
+                        success:(void (^)(void))success
                         failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -1270,7 +1270,7 @@ typedef enum : NSUInteger
 - (MXHTTPOperation*)addTag:(NSString*)tag
                  withOrder:(NSString*)order
                     toRoom:(NSString*)roomId
-                   success:(void (^)())success
+                   success:(void (^)(void))success
                    failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 /**
  Remove a tag from a room.
@@ -1285,7 +1285,7 @@ typedef enum : NSUInteger
  */
 - (MXHTTPOperation*)removeTag:(NSString*)tag
                      fromRoom:(NSString*)roomId
-                      success:(void (^)())success
+                      success:(void (^)(void))success
                       failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 
@@ -1301,7 +1301,7 @@ typedef enum : NSUInteger
  @return a MXHTTPOperation instance.
  */
 - (MXHTTPOperation*)setDisplayName:(NSString*)displayname
-                           success:(void (^)())success
+                           success:(void (^)(void))success
                            failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -1329,7 +1329,7 @@ typedef enum : NSUInteger
  @return a MXHTTPOperation instance.
  */
 - (MXHTTPOperation*)setAvatarUrl:(NSString*)avatarUrl
-                         success:(void (^)())success
+                         success:(void (^)(void))success
                          failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -1361,7 +1361,7 @@ typedef enum : NSUInteger
 - (MXHTTPOperation*)add3PID:(NSString*)sid
                clientSecret:(NSString*)clientSecret
                        bind:(BOOL)bind
-                    success:(void (^)())success
+                    success:(void (^)(void))success
                     failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -1376,7 +1376,7 @@ typedef enum : NSUInteger
  */
 - (MXHTTPOperation*)remove3PID:(NSString*)address
                         medium:(NSString*)medium
-                       success:(void (^)())success
+                       success:(void (^)(void))success
                        failure:(void (^)(NSError *error))failure;
 
 /**
@@ -1404,7 +1404,7 @@ typedef enum : NSUInteger
  @return a MXHTTPOperation instance.
  */
 - (MXHTTPOperation*)setPresence:(MXPresence)presence andStatusMessage:(NSString*)statusMessage
-                        success:(void (^)())success
+                        success:(void (^)(void))success
                         failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -1674,7 +1674,7 @@ typedef enum : NSUInteger
                                         medium:(NSString *)medium
                                   clientSecret:(NSString *)clientSecret
                                            sid:(NSString *)sid
-                                       success:(void (^)())success
+                                       success:(void (^)(void))success
                                        failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -1725,7 +1725,7 @@ typedef enum : NSUInteger
  */
 - (MXHTTPOperation*)sendReadReceipt:(NSString*)roomId
                             eventId:(NSString*)eventId
-                            success:(void (^)())success
+                            success:(void (^)(void))success
                             failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 #pragma mark - read marker
@@ -1743,7 +1743,7 @@ typedef enum : NSUInteger
 - (MXHTTPOperation*)sendReadMarker:(NSString*)roomId
                  readMarkerEventId:(NSString*)readMarkerEventId
                 readReceiptEventId:(NSString*)readReceiptEventId
-                           success:(void (^)())success
+                           success:(void (^)(void))success
                            failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 #pragma mark - Search
@@ -1886,7 +1886,7 @@ typedef enum : NSUInteger
  */
 - (MXHTTPOperation*)sendToDevice:(NSString*)eventType contentMap:(MXUsersDevicesMap<NSDictionary*>*)contentMap
                            txnId:(NSString*)txnId
-                         success:(void (^)())success
+                         success:(void (^)(void))success
                          failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 #pragma mark - Device Management
@@ -1926,7 +1926,7 @@ typedef enum : NSUInteger
  */
 - (MXHTTPOperation*)setDeviceName:(NSString *)deviceName
                       forDeviceId:(NSString *)deviceId
-                          success:(void (^)())success
+                          success:(void (^)(void))success
                           failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -1956,7 +1956,7 @@ typedef enum : NSUInteger
  */
 - (MXHTTPOperation*)deleteDeviceByDeviceId:(NSString *)deviceId
                                 authParams:(NSDictionary*)authParameters
-                                   success:(void (^)())success
+                                   success:(void (^)(void))success
                                    failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 @end

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -668,7 +668,7 @@ MXAuthAction;
 #pragma mark - password update operation
 
 - (MXHTTPOperation*)resetPasswordWithParameters:(NSDictionary*)parameters
-                           success:(void (^)())success
+                           success:(void (^)(void))success
                            failure:(void (^)(NSError *error))failure
 {
     // sanity check
@@ -730,7 +730,7 @@ MXAuthAction;
 }
 
 - (MXHTTPOperation*)changePassword:(NSString*)oldPassword with:(NSString*)newPassword
-                           success:(void (^)())success
+                           success:(void (^)(void))success
                            failure:(void (^)(NSError *error))failure
 {
     // sanity check
@@ -897,7 +897,7 @@ MXAuthAction;
                                  }];
 }
 
-- (MXHTTPOperation*)logout:(void (^)())success
+- (MXHTTPOperation*)logout:(void (^)(void))success
                    failure:(void (^)(NSError *error))failure
 {
     return [httpClient requestWithMethod:@"POST"
@@ -941,7 +941,7 @@ MXAuthAction;
 #pragma mark - Account data
 - (MXHTTPOperation*)setAccountData:(NSDictionary*)data
                            forType:(NSString*)type
-                           success:(void (^)())success
+                           success:(void (^)(void))success
                            failure:(void (^)(NSError *error))failure
 {
     NSString *path = [NSString stringWithFormat:@"%@/user/%@/account_data/%@", apiPathPrefix, credentials.userId, type];
@@ -1199,7 +1199,7 @@ MXAuthAction;
                                     lang:(NSString *)lang
                                     data:(NSDictionary *)data
                                   append:(BOOL)append
-                                 success:(void (^)())success
+                                 success:(void (^)(void))success
                                  failure:(void (^)(NSError *))failure
 {
     // sanity check
@@ -1320,7 +1320,7 @@ MXAuthAction;
                               scope:(NSString*)scope
                                kind:(MXPushRuleKind)kind
                              enable:(BOOL)enable
-                            success:(void (^)())success
+                            success:(void (^)(void))success
                             failure:(void (^)(NSError *error))failure
 {
     NSString *kindString;
@@ -1389,7 +1389,7 @@ MXAuthAction;
 - (MXHTTPOperation *)removePushRule:(NSString*)ruleId
                               scope:(NSString*)scope
                                kind:(MXPushRuleKind)kind
-                            success:(void (^)())success
+                            success:(void (^)(void))success
                             failure:(void (^)(NSError *error))failure
 {
     NSString *kindString;
@@ -1453,7 +1453,7 @@ MXAuthAction;
                          actions:(NSArray*)actions
                          pattern:(NSString*)pattern
                       conditions:(NSArray<NSDictionary *> *)conditions
-                         success:(void (^)())success
+                         success:(void (^)(void))success
                          failure:(void (^)(NSError *error))failure
 {
     NSString *kindString;
@@ -1699,7 +1699,7 @@ MXAuthAction;
 - (MXHTTPOperation*)doMembershipRequest:(NSString*)roomId
                              membership:(NSString*)membership
                              parameters:(NSDictionary*)parameters
-                                success:(void (^)())success
+                                success:(void (^)(void))success
                                 failure:(void (^)(NSError *error))failure
 {
     NSString *path = [NSString stringWithFormat:@"%@/rooms/%@/%@", apiPathPrefix, roomId, membership];
@@ -1762,7 +1762,7 @@ MXAuthAction;
 - (MXHTTPOperation*)updateStateEvent:(MXEventTypeString)eventType
                         withValue:(NSDictionary*)value
                            inRoom:(NSString*)roomId
-                          success:(void (^)())success
+                          success:(void (^)(void))success
                           failure:(void (^)(NSError *error))failure
 {
     NSString *path = [NSString stringWithFormat:@"%@/rooms/%@/state/%@", apiPathPrefix, roomId, eventType];
@@ -1861,7 +1861,7 @@ MXAuthAction;
 
 - (MXHTTPOperation*)setRoomTopic:(NSString*)roomId
                            topic:(NSString*)topic
-                         success:(void (^)())success
+                         success:(void (^)(void))success
                          failure:(void (^)(NSError *error))failure
 {
     return [self updateStateEvent:kMXEventTypeStringRoomTopic
@@ -1901,7 +1901,7 @@ MXAuthAction;
 
 - (MXHTTPOperation *)setRoomAvatar:(NSString *)roomId
                             avatar:(NSString *)avatar
-                           success:(void (^)())success
+                           success:(void (^)(void))success
                            failure:(void (^)(NSError *))failure
 {
     return [self updateStateEvent:kMXEventTypeStringRoomAvatar
@@ -1941,7 +1941,7 @@ MXAuthAction;
 
 - (MXHTTPOperation*)setRoomName:(NSString*)roomId
                            name:(NSString*)name
-                        success:(void (^)())success
+                        success:(void (^)(void))success
                         failure:(void (^)(NSError *error))failure
 {
     return [self updateStateEvent:kMXEventTypeStringRoomName
@@ -1981,7 +1981,7 @@ MXAuthAction;
 
 - (MXHTTPOperation *)setRoomHistoryVisibility:(NSString *)roomId
                             historyVisibility:(MXRoomHistoryVisibility)historyVisibility
-                                      success:(void (^)())success
+                                      success:(void (^)(void))success
                                       failure:(void (^)(NSError *))failure
 {
     return [self updateStateEvent:kMXEventTypeStringRoomHistoryVisibility
@@ -2021,7 +2021,7 @@ MXAuthAction;
 
 - (MXHTTPOperation*)setRoomJoinRule:(NSString*)roomId
                            joinRule:(MXRoomJoinRule)joinRule
-                            success:(void (^)())success
+                            success:(void (^)(void))success
                             failure:(void (^)(NSError *error))failure
 {
     return [self updateStateEvent:kMXEventTypeStringRoomJoinRules
@@ -2061,7 +2061,7 @@ MXAuthAction;
 
 - (MXHTTPOperation*)setRoomGuestAccess:(NSString*)roomId
                            guestAccess:(MXRoomGuestAccess)guestAccess
-                               success:(void (^)())success
+                               success:(void (^)(void))success
                                failure:(void (^)(NSError *error))failure
 {
     return [self updateStateEvent:kMXEventTypeStringRoomGuestAccess
@@ -2101,7 +2101,7 @@ MXAuthAction;
 
 - (MXHTTPOperation*)setRoomDirectoryVisibility:(NSString*)roomId
                            directoryVisibility:(MXRoomDirectoryVisibility)directoryVisibility
-                                       success:(void (^)())success
+                                       success:(void (^)(void))success
                                        failure:(void (^)(NSError *error))failure
 {
     
@@ -2192,7 +2192,7 @@ MXAuthAction;
 
 - (MXHTTPOperation*)addRoomAlias:(NSString*)roomId
                            alias:(NSString*)roomAlias
-                         success:(void (^)())success
+                         success:(void (^)(void))success
                          failure:(void (^)(NSError *error))failure
 {
     // Note: characters in a room alias need to be escaped in the URL
@@ -2237,7 +2237,7 @@ MXAuthAction;
 }
 
 - (MXHTTPOperation*)removeRoomAlias:(NSString*)roomAlias
-                            success:(void (^)())success
+                            success:(void (^)(void))success
                             failure:(void (^)(NSError *error))failure
 {
     // Note: characters in a room alias need to be escaped in the URL
@@ -2281,7 +2281,7 @@ MXAuthAction;
 
 - (MXHTTPOperation*)setRoomCanonicalAlias:(NSString*)roomId
                            canonicalAlias:(NSString *)canonicalAlias
-                                  success:(void (^)())success
+                                  success:(void (^)(void))success
                                   failure:(void (^)(NSError *error))failure
 {
     return [self updateStateEvent:kMXEventTypeStringRoomCanonicalAlias
@@ -2386,7 +2386,7 @@ MXAuthAction;
 }
 
 - (MXHTTPOperation*)leaveRoom:(NSString*)roomId
-                      success:(void (^)())success
+                      success:(void (^)(void))success
                       failure:(void (^)(NSError *error))failure
 {
     return [self doMembershipRequest:roomId
@@ -2397,7 +2397,7 @@ MXAuthAction;
 
 - (MXHTTPOperation*)inviteUser:(NSString*)userId
                         toRoom:(NSString*)roomId
-                       success:(void (^)())success
+                       success:(void (^)(void))success
                        failure:(void (^)(NSError *error))failure
 {
     return [self doMembershipRequest:roomId
@@ -2410,7 +2410,7 @@ MXAuthAction;
 
 - (MXHTTPOperation*)inviteUserByEmail:(NSString*)email
                                toRoom:(NSString*)roomId
-                              success:(void (^)())success
+                              success:(void (^)(NSDictionary *JSONResponse))success
                               failure:(void (^)(NSError *error))failure
 {
     return [self inviteByThreePid:kMX3PIDMediumEmail
@@ -2422,7 +2422,7 @@ MXAuthAction;
 - (MXHTTPOperation*)inviteByThreePid:(NSString*)medium
                              address:(NSString*)address
                               toRoom:(NSString*)roomId
-                             success:(void (^)())success
+                             success:(void (^)(NSDictionary *JSONResponse))success
                              failure:(void (^)(NSError *error))failure
 {
     // The identity server must be defined
@@ -2501,7 +2501,7 @@ MXAuthAction;
 - (MXHTTPOperation*)kickUser:(NSString*)userId
                     fromRoom:(NSString*)roomId
                       reason:(NSString*)reason
-                     success:(void (^)())success
+                     success:(void (^)(void))success
                      failure:(void (^)(NSError *error))failure
 {
     NSString *path = [NSString stringWithFormat:@"%@/rooms/%@/state/m.room.member/%@", apiPathPrefix,
@@ -2557,7 +2557,7 @@ MXAuthAction;
 - (MXHTTPOperation*)banUser:(NSString*)userId
                      inRoom:(NSString*)roomId
                      reason:(NSString*)reason
-                    success:(void (^)())success
+                    success:(void (^)(void))success
                     failure:(void (^)(NSError *error))failure
 {
     NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
@@ -2576,7 +2576,7 @@ MXAuthAction;
 
 - (MXHTTPOperation*)unbanUser:(NSString*)userId
                        inRoom:(NSString*)roomId
-                      success:(void (^)())success
+                      success:(void (^)(void))success
                       failure:(void (^)(NSError *error))failure
 {
     NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
@@ -2895,7 +2895,7 @@ MXAuthAction;
 - (MXHTTPOperation*)sendTypingNotificationInRoom:(NSString*)roomId
                                           typing:(BOOL)typing
                                          timeout:(NSUInteger)timeout
-                                         success:(void (^)())success
+                                         success:(void (^)(void))success
                                          failure:(void (^)(NSError *error))failure
 {
     NSString *path = [NSString stringWithFormat:@"%@/rooms/%@/typing/%@", apiPathPrefix,
@@ -2954,7 +2954,7 @@ MXAuthAction;
 - (MXHTTPOperation*)redactEvent:(NSString*)eventId
                          inRoom:(NSString*)roomId
                          reason:(NSString*)reason
-                        success:(void (^)())success
+                        success:(void (^)(void))success
                         failure:(void (^)(NSError *error))failure
 {
     NSString *path = [NSString stringWithFormat:@"%@/rooms/%@/redact/%@", apiPathPrefix, roomId, eventId];
@@ -3008,7 +3008,7 @@ MXAuthAction;
                          inRoom:(NSString *)roomId
                           score:(NSInteger)score
                          reason:(NSString *)reason
-                        success:(void (^)())success
+                        success:(void (^)(void))success
                         failure:(void (^)(NSError *))failure
 {
     NSString *path = [NSString stringWithFormat:@"%@/rooms/%@/report/%@", apiPathPrefix, roomId, eventId];
@@ -3215,7 +3215,7 @@ MXAuthAction;
 - (MXHTTPOperation*)addTag:(NSString*)tag
                  withOrder:(NSString*)order
                     toRoom:(NSString*)roomId
-                   success:(void (^)())success
+                   success:(void (^)(void))success
                    failure:(void (^)(NSError *error))failure
 {
    NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
@@ -3265,7 +3265,7 @@ MXAuthAction;
 
 - (MXHTTPOperation*)removeTag:(NSString*)tag
                      fromRoom:(NSString*)roomId
-                      success:(void (^)())success
+                      success:(void (^)(void))success
                       failure:(void (^)(NSError *error))failure
 {
     NSString *path = [NSString stringWithFormat:@"%@/user/%@/rooms/%@/tags/%@", apiPathPrefix, credentials.userId, roomId, tag];
@@ -3307,7 +3307,7 @@ MXAuthAction;
 
 #pragma mark - Profile operations
 - (MXHTTPOperation*)setDisplayName:(NSString*)displayname
-                           success:(void (^)())success
+                           success:(void (^)(void))success
                            failure:(void (^)(NSError *error))failure
 {
     NSString *path = [NSString stringWithFormat:@"%@/profile/%@/displayname", apiPathPrefix, credentials.userId];
@@ -3404,7 +3404,7 @@ MXAuthAction;
 }
 
 - (MXHTTPOperation*)setAvatarUrl:(NSString*)avatarUrl
-                         success:(void (^)())success
+                         success:(void (^)(void))success
                          failure:(void (^)(NSError *error))failure
 {
     NSString *path = [NSString stringWithFormat:@"%@/profile/%@/avatar_url", apiPathPrefix, credentials.userId];
@@ -3501,7 +3501,7 @@ MXAuthAction;
 - (MXHTTPOperation*)add3PID:(NSString*)sid
                clientSecret:(NSString*)clientSecret
                        bind:(BOOL)bind
-                    success:(void (^)())success
+                    success:(void (^)(void))success
                     failure:(void (^)(NSError *error))failure
 {
     NSURL *identityServerURL = [NSURL URLWithString:_identityServer];
@@ -3552,7 +3552,7 @@ MXAuthAction;
 
 - (MXHTTPOperation*)remove3PID:(NSString*)address
                         medium:(NSString*)medium
-                       success:(void (^)())success
+                       success:(void (^)(void))success
                        failure:(void (^)(NSError *error))failure
 {
     NSString *path = [NSString stringWithFormat:@"%@/account/3pid/delete", kMXAPIPrefixPathUnstable];
@@ -3645,7 +3645,7 @@ MXAuthAction;
 
 #pragma mark - Presence operations
 - (MXHTTPOperation*)setPresence:(MXPresence)presence andStatusMessage:(NSString*)statusMessage
-                        success:(void (^)())success
+                        success:(void (^)(void))success
                         failure:(void (^)(NSError *error))failure
 {
     NSString *path = [NSString stringWithFormat:@"%@/presence/%@/status", apiPathPrefix, credentials.userId];
@@ -3786,7 +3786,7 @@ MXAuthAction;
 }
 
 - (MXHTTPOperation*)presenceListAddUsers:(NSArray*)users
-                                 success:(void (^)())success
+                                 success:(void (^)(void))success
                                  failure:(void (^)(NSError *error))failure
 {
     NSString *path = [NSString stringWithFormat:@"%@/presence/list/%@", apiPathPrefix, credentials.userId];
@@ -3916,7 +3916,7 @@ MXAuthAction;
 #pragma mark - read receipt
 - (MXHTTPOperation*)sendReadReceipt:(NSString*)roomId
                             eventId:(NSString*)eventId
-                            success:(void (^)())success
+                            success:(void (^)(void))success
                             failure:(void (^)(NSError *error))failure
 {
     return [httpClient requestWithMethod:@"POST"
@@ -3960,7 +3960,7 @@ MXAuthAction;
 - (MXHTTPOperation*)sendReadMarker:(NSString*)roomId
                  readMarkerEventId:(NSString*)readMarkerEventId
                 readReceiptEventId:(NSString*)readReceiptEventId
-                           success:(void (^)())success
+                           success:(void (^)(void))success
                            failure:(void (^)(NSError *error))failure
 {
     NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
@@ -4560,7 +4560,7 @@ MXAuthAction;
                                         medium:(NSString *)medium
                                   clientSecret:(NSString *)clientSecret
                                            sid:(NSString *)sid
-                                       success:(void (^)())success
+                                       success:(void (^)(void))success
                                        failure:(void (^)(NSError *))failure
 {
     // Sanity check
@@ -5082,7 +5082,7 @@ MXAuthAction;
 #pragma mark - Direct-to-device messaging
 - (MXHTTPOperation*)sendToDevice:(NSString*)eventType contentMap:(MXUsersDevicesMap<NSDictionary*>*)contentMap
                            txnId:(NSString*)txnId
-                         success:(void (^)())success
+                         success:(void (^)(void))success
                          failure:(void (^)(NSError *error))failure
 {
     if (!txnId)
@@ -5229,7 +5229,7 @@ MXAuthAction;
 
 - (MXHTTPOperation*)setDeviceName:(NSString *)deviceName
                       forDeviceId:(NSString *)deviceId
-                          success:(void (^)())success
+                          success:(void (^)(void))success
                           failure:(void (^)(NSError *error))failure
 {
     NSDictionary *parameters;
@@ -5343,7 +5343,7 @@ MXAuthAction;
 
 - (MXHTTPOperation*)deleteDeviceByDeviceId:(NSString *)deviceId
                                 authParams:(NSDictionary*)authParameters
-                                   success:(void (^)())success
+                                   success:(void (^)(void))success
                                    failure:(void (^)(NSError *error))failure
 {
     NSData *payloadData = nil;

--- a/MatrixSDK/MXSession.h
+++ b/MatrixSDK/MXSession.h
@@ -312,7 +312,7 @@ FOUNDATION_EXPORT NSString *const kMXSessionNoRoomTag;
  @param failure A block object called when the operation fails. In case of failure during the
  initial sync the session state is MXSessionStateInitialSyncFailed.
  */
-- (void)start:(void (^)())onServerSyncDone
+- (void)start:(void (^)(void))onServerSyncDone
       failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -326,7 +326,7 @@ FOUNDATION_EXPORT NSString *const kMXSessionNoRoomTag;
  @param failure A block object called when the operation fails.
  */
 - (void)startWithMessagesLimit:(NSUInteger)messagesLimit
-              onServerSyncDone:(void (^)())onServerSyncDone
+              onServerSyncDone:(void (^)(void))onServerSyncDone
                        failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -349,7 +349,7 @@ FOUNDATION_EXPORT NSString *const kMXSessionNoRoomTag;
                    CAUTION The session state is updated (to MXSessionStateRunning) after
                    calling this block. It SHOULD not be modified by this block.
  */
-- (void)resume:(void (^)())resumeDone;
+- (void)resume:(void (^)(void))resumeDone;
 
 typedef void (^MXOnBackgroundSyncDone)();
 typedef void (^MXOnBackgroundSyncFail)(NSError *error);
@@ -387,7 +387,7 @@ typedef void (^MXOnBackgroundSyncFail)(NSError *error);
  
  @return a MXHTTPOperation instance.
  */
-- (MXHTTPOperation*)logout:(void (^)())success
+- (MXHTTPOperation*)logout:(void (^)(void))success
                    failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 
@@ -435,7 +435,7 @@ typedef void (^MXOnBackgroundSyncFail)(NSError *error);
  the home server.
  @param failure A block object called when the operation fails.
  */
-- (void)setStore:(id<MXStore>)store success:(void (^)())onStoreDataReady
+- (void)setStore:(id<MXStore>)store success:(void (^)(void))onStoreDataReady
          failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -468,7 +468,7 @@ typedef void (^MXOnBackgroundSyncFail)(NSError *error);
  @param success A block object called when the operation succeeds.
  @param failure A block object called when the operation fails.
  */
-- (void)enableCrypto:(BOOL)enableCrypto success:(void (^)())success failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
+- (void)enableCrypto:(BOOL)enableCrypto success:(void (^)(void))success failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 
 #pragma mark - Rooms operations
@@ -582,7 +582,7 @@ typedef void (^MXOnBackgroundSyncFail)(NSError *error);
  @return a MXHTTPOperation instance.
  */
 - (MXHTTPOperation*)leaveRoom:(NSString*)roomId
-                      success:(void (^)())success
+                      success:(void (^)(void))success
                       failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 
@@ -637,7 +637,7 @@ typedef void (^MXOnBackgroundSyncFail)(NSError *error);
  
  @return a MXHTTPOperation instance.
  */
-- (MXHTTPOperation*)uploadDirectRooms:(void (^)())success
+- (MXHTTPOperation*)uploadDirectRooms:(void (^)(void))success
                               failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 
@@ -777,7 +777,7 @@ typedef void (^MXOnBackgroundSyncFail)(NSError *error);
  @return a MXHTTPOperation instance.
  */
 - (MXHTTPOperation*)ignoreUsers:(NSArray<NSString*>*)userIds
-                        success:(void (^)())success
+                        success:(void (^)(void))success
                         failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -790,7 +790,7 @@ typedef void (^MXOnBackgroundSyncFail)(NSError *error);
  @return a MXHTTPOperation instance.
  */
 - (MXHTTPOperation*)unIgnoreUsers:(NSArray<NSString*>*)userIds
-                        success:(void (^)())success
+                        success:(void (^)(void))success
                         failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -232,7 +232,7 @@ typedef void (^MXOnResumeDone)();
     }
 }
 
--(void)setStore:(id<MXStore>)store success:(void (^)())onStoreDataReady failure:(void (^)(NSError *))failure
+-(void)setStore:(id<MXStore>)store success:(void (^)(void))onStoreDataReady failure:(void (^)(NSError *))failure
 {
     NSAssert(MXSessionStateInitialised == _state, @"Store can be set only just after initialisation");
     NSParameterAssert(store);
@@ -351,14 +351,14 @@ typedef void (^MXOnResumeDone)();
     }];
 }
 
-- (void)start:(void (^)())onServerSyncDone
+- (void)start:(void (^)(void))onServerSyncDone
       failure:(void (^)(NSError *error))failure
 {
     [self startWithMessagesLimit:-1 onServerSyncDone:onServerSyncDone failure:failure];
 }
 
 - (void)startWithMessagesLimit:(NSUInteger)messagesLimit
-              onServerSyncDone:(void (^)())onServerSyncDone
+              onServerSyncDone:(void (^)(void))onServerSyncDone
                        failure:(void (^)(NSError *error))failure
 {
     if (nil == _store)
@@ -507,7 +507,7 @@ typedef void (^MXOnResumeDone)();
     }
 }
 
-- (void)resume:(void (^)())resumeDone
+- (void)resume:(void (^)(void))resumeDone
 {
     NSLog(@"[MXSession] resume the event stream from state %tu", _state);
 
@@ -662,7 +662,7 @@ typedef void (^MXOnResumeDone)();
     [self setState:MXSessionStateClosed];
 }
 
-- (MXHTTPOperation*)logout:(void (^)())success
+- (MXHTTPOperation*)logout:(void (^)(void))success
                    failure:(void (^)(NSError *error))failure
 {
     // Create an empty operation that will be mutated later
@@ -740,7 +740,7 @@ typedef void (^MXOnResumeDone)();
 #pragma mark - Server sync
 
 - (void)serverSyncWithServerTimeout:(NSUInteger)serverTimeout
-                            success:(void (^)())success
+                            success:(void (^)(void))success
                             failure:(void (^)(NSError *error))failure
                       clientTimeout:(NSUInteger)clientTimeout
                         setPresence:(NSString*)setPresence
@@ -1321,7 +1321,7 @@ typedef void (^MXOnResumeDone)();
     _callManager = [[MXCallManager alloc] initWithMatrixSession:self andCallStack:callStack];
 }
 
-- (void)enableCrypto:(BOOL)enableCrypto success:(void (^)())success failure:(void (^)(NSError *))failure
+- (void)enableCrypto:(BOOL)enableCrypto success:(void (^)(void))success failure:(void (^)(NSError *))failure
 {
     NSLog(@"[MXSesion] enableCrypto: %@", @(enableCrypto));
 
@@ -1603,7 +1603,7 @@ typedef void (^MXOnResumeDone)();
 }
 
 - (MXHTTPOperation*)leaveRoom:(NSString*)roomId
-                      success:(void (^)())success
+                      success:(void (^)(void))success
                       failure:(void (^)(NSError *error))failure
 {
     return [matrixRestClient leaveRoom:roomId success:^{
@@ -1696,7 +1696,7 @@ typedef void (^MXOnResumeDone)();
     return nil;
 }
 
-- (MXHTTPOperation*)uploadDirectRooms:(void (^)())success
+- (MXHTTPOperation*)uploadDirectRooms:(void (^)(void))success
                               failure:(void (^)(NSError *error))failure
 {
     __weak typeof(self) weakSelf = self;
@@ -1979,7 +1979,7 @@ typedef void (^MXOnResumeDone)();
 }
 
 - (MXHTTPOperation*)ignoreUsers:(NSArray<NSString*>*)userIds
-                       success:(void (^)())success
+                       success:(void (^)(void))success
                        failure:(void (^)(NSError *error))failure
 {
     // Create the new account data subset for m.ignored_user_list
@@ -2023,7 +2023,7 @@ typedef void (^MXOnResumeDone)();
     } failure:failure];
 }
 
-- (MXHTTPOperation *)unIgnoreUsers:(NSArray<NSString *> *)userIds success:(void (^)())success failure:(void (^)(NSError *))failure
+- (MXHTTPOperation *)unIgnoreUsers:(NSArray<NSString *> *)userIds success:(void (^)(void))success failure:(void (^)(NSError *))failure
 {
     // Create the new account data subset for m.ignored_user_list
     // by substracting userIds
@@ -2362,7 +2362,7 @@ typedef void (^MXOnResumeDone)();
  @param success a block called in any case when the operation completes.
  @param failure a block object called when the operation fails.
  */
-- (void)startCrypto:(void (^)())success
+- (void)startCrypto:(void (^)(void))success
             failure:(void (^)(NSError *error))failure
 {
     NSLog(@"[MXSession] Start crypto");

--- a/MatrixSDK/NotificationCenter/MXNotificationCenter.h
+++ b/MatrixSDK/NotificationCenter/MXNotificationCenter.h
@@ -122,7 +122,7 @@ extern NSString *const kMXNotificationCenterAllOtherRoomMessagesRuleID;
 
  @return a MXHTTPOperation instance.
  */
-- (MXHTTPOperation *)refreshRules:(void (^)())success
+- (MXHTTPOperation *)refreshRules:(void (^)(void))success
              failure:(void (^)(NSError *error))failure;
 
 

--- a/MatrixSDK/NotificationCenter/MXNotificationCenter.m
+++ b/MatrixSDK/NotificationCenter/MXNotificationCenter.m
@@ -103,7 +103,7 @@ NSString *const kMXNotificationCenterAllOtherRoomMessagesRuleID = @".m.rule.mess
     return self;
 }
 
-- (MXHTTPOperation *)refreshRules:(void (^)())success failure:(void (^)(NSError *))failure
+- (MXHTTPOperation *)refreshRules:(void (^)(void))success failure:(void (^)(NSError *))failure
 {
     return [mxSession.matrixRestClient pushRules:^(MXPushRulesResponse *pushRules) {
 

--- a/MatrixSDK/Utils/MXBackgroundModeHandler.h
+++ b/MatrixSDK/Utils/MXBackgroundModeHandler.h
@@ -26,7 +26,7 @@
 @protocol MXBackgroundModeHandler <NSObject>
 - (NSUInteger)invalidIdentifier;
 - (NSUInteger)startBackgroundTask;
-- (NSUInteger)startBackgroundTaskWithName:(NSString *)name completion:(void(^)())completion;
+- (NSUInteger)startBackgroundTaskWithName:(NSString *)name completion:(void(^)(void))completion;
 - (void)endBackgrounTaskWithIdentifier:(NSUInteger)identifier;
 @end
 

--- a/MatrixSDK/Utils/MXBugReportRestClient.m
+++ b/MatrixSDK/Utils/MXBugReportRestClient.m
@@ -292,7 +292,7 @@
 
 
 #pragma mark - Private methods
-- (void)zipFiles:(BOOL)logs crashLog:(BOOL)crashLog progress:(void (^)(MXBugReportState, NSProgress *))progress complete:(void (^)())complete
+- (void)zipFiles:(BOOL)logs crashLog:(BOOL)crashLog progress:(void (^)(MXBugReportState, NSProgress *))progress complete:(void (^)(void))complete
 {
     // Put all files to send in the same array
     NSMutableArray *logFiles = [NSMutableArray array];

--- a/MatrixSDK/Utils/MXTools.h
+++ b/MatrixSDK/Utils/MXTools.h
@@ -179,7 +179,7 @@ FOUNDATION_EXPORT NSString *const kMXToolsRegexStringForMatrixEventIdentifier;
  */
 + (void)convertVideoToMP4:(NSURL*)videoLocalURL
                   success:(void(^)(NSURL *videoLocalURL, NSString *mimetype, CGSize size, double durationInMs))success
-                  failure:(void(^)())failure;
+                  failure:(void(^)(void))failure;
 
 #pragma mark - JSON Serialisation
 

--- a/MatrixSDK/Utils/MXTools.m
+++ b/MatrixSDK/Utils/MXTools.m
@@ -506,7 +506,7 @@ static NSMutableDictionary *fileExtensionByContentType = nil;
 
 + (void)convertVideoToMP4:(NSURL*)videoLocalURL
                   success:(void(^)(NSURL *videoLocalURL, NSString *mimetype, CGSize size, double durationInMs))success
-                  failure:(void(^)())failure
+                  failure:(void(^)(void))failure
 {
     NSParameterAssert(success);
     NSParameterAssert(failure);

--- a/MatrixSDK/Utils/MXUIKitBackgroundModeHandler.m
+++ b/MatrixSDK/Utils/MXUIKitBackgroundModeHandler.m
@@ -34,7 +34,7 @@
     return [self startBackgroundTaskWithName:nil completion:nil];
 }
 
-- (NSUInteger)startBackgroundTaskWithName:(NSString *)name completion:(void(^)())completion
+- (NSUInteger)startBackgroundTaskWithName:(NSString *)name completion:(void(^)(void))completion
 {
     NSUInteger token = UIBackgroundTaskInvalid;
     

--- a/MatrixSDK/Utils/Media/MXMediaManager.h
+++ b/MatrixSDK/Utils/Media/MXMediaManager.h
@@ -140,7 +140,7 @@ extern NSString *const kMXMediaManagerDefaultCacheFolder;
  */
 + (MXMediaLoader*)downloadMediaFromURL:(NSString *)mediaURL
                       andSaveAtFilePath:(NSString *)filePath
-                                success:(void (^)())success
+                                success:(void (^)(void))success
                                 failure:(void (^)(NSError *error))failure;
 
 /**

--- a/MatrixSDK/Utils/Media/MXMediaManager.m
+++ b/MatrixSDK/Utils/Media/MXMediaManager.m
@@ -338,7 +338,7 @@ static MXLRUCache* imagesCacheLruCache = nil;
 
 + (MXMediaLoader*)downloadMediaFromURL:(NSString *)mediaURL
                       andSaveAtFilePath:(NSString *)filePath
-                                success:(void (^)())success
+                                success:(void (^)(void))success
                                 failure:(void (^)(NSError *error))failure
 {
     // Check provided file path

--- a/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallStackCall.m
+++ b/MatrixSDK/VoIP/CallStack/Jingle/MXJingleCallStackCall.m
@@ -80,7 +80,7 @@
     return self;
 }
 
-- (void)startCapturingMediaWithVideo:(BOOL)video success:(void (^)())success failure:(void (^)(NSError *))failure
+- (void)startCapturingMediaWithVideo:(BOOL)video success:(void (^)(void))success failure:(void (^)(NSError *))failure
 {
     onStartCapturingMediaWithVideoSuccess = success;
     isVideoCall = video;
@@ -156,7 +156,7 @@
 
 
 #pragma mark - Incoming call
-- (void)handleOffer:(NSString *)sdpOffer success:(void (^)())success failure:(void (^)(NSError *error))failure
+- (void)handleOffer:(NSString *)sdpOffer success:(void (^)(void))success failure:(void (^)(NSError *error))failure
 {
     RTCSessionDescription *sessionDescription = [[RTCSessionDescription alloc] initWithType:RTCSdpTypeOffer sdp:sdpOffer];
     [peerConnection setRemoteDescription:sessionDescription completionHandler:^(NSError * _Nullable error) {
@@ -254,7 +254,7 @@
     }];
 }
 
-- (void)handleAnswer:(NSString *)sdp success:(void (^)())success failure:(void (^)(NSError *))failure
+- (void)handleAnswer:(NSString *)sdp success:(void (^)(void))success failure:(void (^)(NSError *))failure
 {
     RTCSessionDescription *sessionDescription = [[RTCSessionDescription alloc] initWithType:RTCSdpTypeAnswer sdp:sdp];
     [peerConnection setRemoteDescription:sessionDescription completionHandler:^(NSError * _Nullable error) {

--- a/MatrixSDK/VoIP/CallStack/MXCallStackCall.h
+++ b/MatrixSDK/VoIP/CallStack/MXCallStackCall.h
@@ -43,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param failure A block object called when the operation fails.
  */
 - (void)startCapturingMediaWithVideo:(BOOL)video
-                             success:(void (^)())success
+                             success:(void (^)(void))success
                              failure:(void (^)(NSError *error))failure;
 
 /**
@@ -83,7 +83,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param failure A block object called when the operation fails.
  */
 - (void)handleOffer:(NSString *)sdpOffer
-            success:(void (^)())success
+            success:(void (^)(void))success
             failure:(void (^)(NSError *error))failure;
 
 /**
@@ -125,7 +125,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param failure A block object called when the operation fails.
  */
 - (void)handleAnswer:(NSString *)sdp
-             success:(void (^)())success
+             success:(void (^)(void))success
              failure:(void (^)(NSError *error))failure;
 
 

--- a/MatrixSDK/VoIP/MXCallManager.m
+++ b/MatrixSDK/VoIP/MXCallManager.m
@@ -558,7 +558,7 @@ NSString *const kMXCallManagerConferenceUserDomain  = @"matrix.org";
  @param failure A block object called when the operation fails.
  */
 - (void)inviteConferenceUserToRoom:(MXRoom *)room
-                           success:(void (^)())success
+                           success:(void (^)(void))success
                            failure:(void (^)(NSError *error))failure
 {
     NSString *conferenceUserId = [MXCallManager conferenceUserIdForRoom:room.roomId];

--- a/MatrixSDKTests/MXRestClientNoAuthAPITests.m
+++ b/MatrixSDKTests/MXRestClientNoAuthAPITests.m
@@ -54,7 +54,7 @@
 }
 
 // Make sure MXTESTS_USER exists on the HS
-- (void)createTestAccount:(void (^)())onReady
+- (void)createTestAccount:(void (^)(void))onReady
 {
     // Register the user
     [mxRestClient registerWithLoginType:kMXLoginFlowTypeDummy username:MXTESTS_USER password:MXTESTS_PWD success:^(MXCredentials *credentials) {

--- a/MatrixSDKTests/MXRoomStateDynamicTests.m
+++ b/MatrixSDKTests/MXRoomStateDynamicTests.m
@@ -60,7 +60,7 @@
  5 - Bob changes the room topic to "Topic #2"
  6 - Bob: "Bonjour"
  */
--(void)createScenario1:(MXRestClient*)bobRestClient inRoom:(NSString*)roomId expectation:(XCTestExpectation*)expectation onComplete:(void(^)())onComplete
+-(void)createScenario1:(MXRestClient*)bobRestClient inRoom:(NSString*)roomId expectation:(XCTestExpectation*)expectation onComplete:(void(^)(void))onComplete
 {
     __block MXRestClient *bobRestClient2 = bobRestClient;
     

--- a/MatrixSDKTests/MXRoomStateTests.m
+++ b/MatrixSDKTests/MXRoomStateTests.m
@@ -746,7 +746,7 @@
  5 - Bob invites Alice
  6 - Bob: "I wait for Alice"
  */
-- (void)createInviteByUserScenario:(MXRestClient*)bobRestClient inRoom:(NSString*)roomId inviteAlice:(BOOL)inviteAlice expectation:(XCTestExpectation*)expectation onComplete:(void(^)())onComplete
+- (void)createInviteByUserScenario:(MXRestClient*)bobRestClient inRoom:(NSString*)roomId inviteAlice:(BOOL)inviteAlice expectation:(XCTestExpectation*)expectation onComplete:(void(^)(void))onComplete
 {
     [bobRestClient sendTextMessageToRoom:roomId text:@"Hello world" success:^(NSString *eventId) {
 

--- a/MatrixSDKTests/MatrixSDKTestsData.h
+++ b/MatrixSDKTests/MatrixSDKTestsData.h
@@ -45,7 +45,7 @@ FOUNDATION_EXPORT NSString * const kMXTestsAliceAvatarURL;
 
 // Get credentials asynchronously
 // The user will be created if needed
-- (void)getBobCredentials:(void (^)())success;
+- (void)getBobCredentials:(void (^)(void))success;
 
 // Prepare a test with a MXRestClient for mxBob so that we can make test on it
 - (void)doMXRestClientTestWithBob:(XCTestCase*)testCase
@@ -114,8 +114,8 @@ FOUNDATION_EXPORT NSString * const kMXTestsAliceAvatarURL;
 
 
 #pragma mark - HTTPS mxBob
-- (void)getHttpsBobCredentials:(void (^)())success;
-- (void)getHttpsBobCredentials:(void (^)())success onUnrecognizedCertificateBlock:(MXHTTPClientOnUnrecognizedCertificate)onUnrecognizedCertBlock;
+- (void)getHttpsBobCredentials:(void (^)(void))success;
+- (void)getHttpsBobCredentials:(void (^)(void))success onUnrecognizedCertificateBlock:(MXHTTPClientOnUnrecognizedCertificate)onUnrecognizedCertBlock;
 
 - (void)doHttpsMXRestClientTestWithBob:(XCTestCase*)testCase
                            readyToTest:(void (^)(MXRestClient *bobRestClient, XCTestExpectation *expectation))readyToTest;
@@ -130,7 +130,7 @@ FOUNDATION_EXPORT NSString * const kMXTestsAliceAvatarURL;
 // Close the current session by erasing the crypto to store  and log the user in with a new device
 - (void)relogUserSessionWithNewDevice:(MXSession*)session withPassword:(NSString*)password onComplete:(void (^)(MXSession *newSession))onComplete;
 
-- (void)for:(MXRestClient *)mxRestClient2 andRoom:(NSString*)roomId sendMessages:(NSUInteger)messagesCount success:(void (^)())success;
+- (void)for:(MXRestClient *)mxRestClient2 andRoom:(NSString*)roomId sendMessages:(NSUInteger)messagesCount success:(void (^)(void))success;
 
 // Close the session
 // Before closing, it checks if the session must be cleaning.

--- a/MatrixSDKTests/MatrixSDKTestsData.m
+++ b/MatrixSDKTests/MatrixSDKTestsData.m
@@ -60,7 +60,7 @@ NSMutableArray *roomsToClean;
     return self;
 }
 
-- (void)getBobCredentials:(void (^)())success
+- (void)getBobCredentials:(void (^)(void))success
 {
     if (self.bobCredentials)
     {
@@ -300,7 +300,7 @@ NSMutableArray *roomsToClean;
 }
 
 
-- (void)for:(MXRestClient *)mxRestClient2 andRoom:(NSString*)roomId sendMessages:(NSUInteger)messagesCount success:(void (^)())success
+- (void)for:(MXRestClient *)mxRestClient2 andRoom:(NSString*)roomId sendMessages:(NSUInteger)messagesCount success:(void (^)(void))success
 {
     NSLog(@"sendMessages :%tu to %@", messagesCount, roomId);
     if (0 == messagesCount)
@@ -322,7 +322,7 @@ NSMutableArray *roomsToClean;
     }
 }
 
-- (void)for:(MXRestClient *)mxRestClient2 createRooms:(NSUInteger)roomsCount withMessages:(NSUInteger)messagesCount success:(void (^)())success
+- (void)for:(MXRestClient *)mxRestClient2 createRooms:(NSUInteger)roomsCount withMessages:(NSUInteger)messagesCount success:(void (^)(void))success
 {
     if (0 == roomsCount)
     {
@@ -452,7 +452,7 @@ NSMutableArray *roomsToClean;
 
 
 #pragma mark - mxAlice
-- (void)getAliceCredentials:(void (^)())success
+- (void)getAliceCredentials:(void (^)(void))success
 {
     if (self.aliceCredentials)
     {
@@ -625,14 +625,14 @@ NSMutableArray *roomsToClean;
 
 
 #pragma mark - HTTPS mxBob
-- (void)getHttpsBobCredentials:(void (^)())success
+- (void)getHttpsBobCredentials:(void (^)(void))success
 {
     [self getHttpsBobCredentials:success onUnrecognizedCertificateBlock:^BOOL(NSData *certificate) {
         return YES;
     }];
 }
 
-- (void)getHttpsBobCredentials:(void (^)())success onUnrecognizedCertificateBlock:(MXHTTPClientOnUnrecognizedCertificate)onUnrecognizedCertBlock
+- (void)getHttpsBobCredentials:(void (^)(void))success onUnrecognizedCertificateBlock:(MXHTTPClientOnUnrecognizedCertificate)onUnrecognizedCertBlock
 {
     if (self.bobCredentials)
     {
@@ -815,7 +815,7 @@ NSMutableArray *roomsToClean;
     [mxSession close];
 }
 
-- (void)leaveAllRoomsAsync:(NSMutableArray*)rooms onComplete:(void (^)())onComplete
+- (void)leaveAllRoomsAsync:(NSMutableArray*)rooms onComplete:(void (^)(void))onComplete
 {
     if (rooms.count)
     {

--- a/MatrixSDKTests/Mocks/MXMockCallStackCall.m
+++ b/MatrixSDKTests/Mocks/MXMockCallStackCall.m
@@ -34,7 +34,7 @@
     return self;
 }
 
-- (void)startCapturingMediaWithVideo:(BOOL)video success:(void (^)())success failure:(void (^)(NSError *))failure
+- (void)startCapturingMediaWithVideo:(BOOL)video success:(void (^)(void))success failure:(void (^)(NSError *))failure
 {
     dispatch_async(dispatch_get_main_queue(), ^{
         success();
@@ -76,7 +76,7 @@
     });
 }
 
-- (void)handleAnswer:(NSString *)sdp success:(void (^)())success failure:(void (^)(NSError *))failure
+- (void)handleAnswer:(NSString *)sdp success:(void (^)(void))success failure:(void (^)(NSError *))failure
 {
     dispatch_async(dispatch_get_main_queue(), ^{
         success();


### PR DESCRIPTION
E.g. basically replacing `void (^)()` by `void (^)(void)`