### PR TITLE
MXRestClient/MXRoom: 3rd party invite methods (inviteUserByEmail, inv…

### DIFF
--- a/MatrixSDK/Data/MXRoom.h
+++ b/MatrixSDK/Data/MXRoom.h
@@ -623,7 +623,7 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidFlushDataNotification;
  @return a MXHTTPOperation instance.
  */
 - (MXHTTPOperation*)inviteUserByEmail:(NSString*)email
-                              success:(void (^)(NSDictionary *JSONResponse))success
+                              success:(void (^)(void))success
                               failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -1315,7 +1315,7 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
 }
 
 - (MXHTTPOperation*)inviteUserByEmail:(NSString*)email
-                              success:(void (^)(NSDictionary *JSONResponse))success
+                              success:(void (^)(void))success
                               failure:(void (^)(NSError *error))failure
 {
     return [mxSession.matrixRestClient inviteUserByEmail:email toRoom:self.roomId success:success failure:failure];

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -956,7 +956,7 @@ typedef enum : NSUInteger
  */
 - (MXHTTPOperation*)inviteUserByEmail:(NSString*)email
                                toRoom:(NSString*)roomId
-                              success:(void (^)(NSDictionary *JSONResponse))success
+                              success:(void (^)(void))success
                               failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -973,7 +973,7 @@ typedef enum : NSUInteger
 - (MXHTTPOperation*)inviteByThreePid:(NSString*)medium
                              address:(NSString*)address
                               toRoom:(NSString*)roomId
-                             success:(void (^)(NSDictionary *JSONResponse))success
+                             success:(void (^)(void))success
                              failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -2410,7 +2410,7 @@ MXAuthAction;
 
 - (MXHTTPOperation*)inviteUserByEmail:(NSString*)email
                                toRoom:(NSString*)roomId
-                              success:(void (^)(NSDictionary *JSONResponse))success
+                              success:(void (^)(void))success
                               failure:(void (^)(NSError *error))failure
 {
     return [self inviteByThreePid:kMX3PIDMediumEmail
@@ -2422,7 +2422,7 @@ MXAuthAction;
 - (MXHTTPOperation*)inviteByThreePid:(NSString*)medium
                              address:(NSString*)address
                               toRoom:(NSString*)roomId
-                             success:(void (^)(NSDictionary *JSONResponse))success
+                             success:(void (^)(void))success
                              failure:(void (^)(NSError *error))failure
 {
     // The identity server must be defined
@@ -2473,7 +2473,7 @@ MXAuthAction;
                                              {
                                                  dispatch_async(completionQueue, ^{
                                                      
-                                                     success(JSONResponse);
+                                                     success();
                                                      
                                                  });
                                              }


### PR DESCRIPTION
…iteByThreePid) should not return a JSON response dict but void like the other invite method