### PR TITLE
Crypto: Make [MXCrypto decryptEvent] return decryption results instea…

### DIFF
--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -210,6 +210,8 @@
 		32E226A61D06AC9F00E6CA54 /* MXPeekingRoom.h in Headers */ = {isa = PBXBuildFile; fileRef = 32E226A41D06AC9F00E6CA54 /* MXPeekingRoom.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		32E226A71D06AC9F00E6CA54 /* MXPeekingRoom.m in Sources */ = {isa = PBXBuildFile; fileRef = 32E226A51D06AC9F00E6CA54 /* MXPeekingRoom.m */; };
 		32E226A91D081CE200E6CA54 /* MXPeekingRoomTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 32E226A81D081CE200E6CA54 /* MXPeekingRoomTests.m */; };
+		32F634AB1FC5E3480054EF49 /* MXEventDecryptionResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 32F634A91FC5E3470054EF49 /* MXEventDecryptionResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		32F634AC1FC5E3480054EF49 /* MXEventDecryptionResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 32F634AA1FC5E3470054EF49 /* MXEventDecryptionResult.m */; };
 		32F945F51FAB83D900622468 /* MXIncomingRoomKeyRequestCancellation.m in Sources */ = {isa = PBXBuildFile; fileRef = 32F945F11FAB83D800622468 /* MXIncomingRoomKeyRequestCancellation.m */; };
 		32F945F61FAB83D900622468 /* MXIncomingRoomKeyRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 32F945F21FAB83D900622468 /* MXIncomingRoomKeyRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		32F945F71FAB83D900622468 /* MXIncomingRoomKeyRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 32F945F31FAB83D900622468 /* MXIncomingRoomKeyRequest.m */; };
@@ -507,6 +509,8 @@
 		32E226A51D06AC9F00E6CA54 /* MXPeekingRoom.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXPeekingRoom.m; sourceTree = "<group>"; };
 		32E226A81D081CE200E6CA54 /* MXPeekingRoomTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXPeekingRoomTests.m; sourceTree = "<group>"; };
 		32F1FE9AF82A426C2EAED587 /* Pods-MatrixSDK.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MatrixSDK.release.xcconfig"; path = "Pods/Target Support Files/Pods-MatrixSDK/Pods-MatrixSDK.release.xcconfig"; sourceTree = "<group>"; };
+		32F634A91FC5E3470054EF49 /* MXEventDecryptionResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXEventDecryptionResult.h; sourceTree = "<group>"; };
+		32F634AA1FC5E3470054EF49 /* MXEventDecryptionResult.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXEventDecryptionResult.m; sourceTree = "<group>"; };
 		32F945F11FAB83D800622468 /* MXIncomingRoomKeyRequestCancellation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXIncomingRoomKeyRequestCancellation.m; sourceTree = "<group>"; };
 		32F945F21FAB83D900622468 /* MXIncomingRoomKeyRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXIncomingRoomKeyRequest.h; sourceTree = "<group>"; };
 		32F945F31FAB83D900622468 /* MXIncomingRoomKeyRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXIncomingRoomKeyRequest.m; sourceTree = "<group>"; };
@@ -733,6 +737,8 @@
 				3271877A1DA7CAA60071C818 /* MXEncrypting.h */,
 				32F9FA7B1DBA0CF0009D98A6 /* MXDecryptionResult.h */,
 				32F9FA7C1DBA0CF0009D98A6 /* MXDecryptionResult.m */,
+				32F634A91FC5E3470054EF49 /* MXEventDecryptionResult.h */,
+				32F634AA1FC5E3470054EF49 /* MXEventDecryptionResult.m */,
 			);
 			path = Algorithms;
 			sourceTree = "<group>";
@@ -1267,6 +1273,7 @@
 				32CAB10B1A925B41008C5BB9 /* MXHTTPOperation.h in Headers */,
 				32F945F81FAB83D900622468 /* MXIncomingRoomKeyRequestCancellation.h in Headers */,
 				3240969D1F9F751600DBA607 /* MXPushRuleSenderNotificationPermissionConditionChecker.h in Headers */,
+				32F634AB1FC5E3480054EF49 /* MXEventDecryptionResult.h in Headers */,
 				322A51C71D9BBD3C00C8536D /* MXOlmDevice.h in Headers */,
 				320DFDE419DD99B60068622A /* MXRestClient.h in Headers */,
 				3265CB381A14C43E00E24B2F /* MXRoomState.h in Headers */,
@@ -1542,6 +1549,7 @@
 				329B2AC01D3FB01D002D546F /* MXJingleCallStack.m in Sources */,
 				C6D5D60E1E4FBD2900706C0F /* MXSession.swift in Sources */,
 				320DFDE319DD99B60068622A /* MXError.m in Sources */,
+				32F634AC1FC5E3480054EF49 /* MXEventDecryptionResult.m in Sources */,
 				327137281A24D50A00DB6757 /* MXMyUser.m in Sources */,
 				C6F935881E5B3BE600FC34BF /* MX3PID.swift in Sources */,
 				C6F9358A1E5B3BE600FC34BF /* MXEvent.swift in Sources */,

--- a/MatrixSDK/Crypto/Algorithms/MXDecrypting.h
+++ b/MatrixSDK/Crypto/Algorithms/MXDecrypting.h
@@ -19,6 +19,7 @@
 #import "MXHTTPOperation.h"
 #import "MXEvent.h"
 #import "MXDecryptionResult.h"
+#import "MXEventDecryptionResult.h"
 #import "MXIncomingRoomKeyRequest.h"
 
 @class MXCrypto, MXMegolmSessionData;
@@ -42,10 +43,11 @@
  @param event the raw event.
  @param timeline the id of the timeline where the event is decrypted. It is used
                  to prevent replay attack.
+ @param error the result error if there is a problem decrypting the event.
 
- @return YES if the decryption was successful.
+ @return The decryption result. Nil if it failed.
  */
-- (BOOL)decryptEvent:(MXEvent*)event inTimeline:(NSString*)timeline;
+- (MXEventDecryptionResult *)decryptEvent:(MXEvent*)event inTimeline:(NSString*)timeline error:(NSError** )error;
 
 /**
  * Handle a key event.

--- a/MatrixSDK/Crypto/Algorithms/MXEventDecryptionResult.h
+++ b/MatrixSDK/Crypto/Algorithms/MXEventDecryptionResult.h
@@ -1,5 +1,5 @@
 /*
- Copyright 2017 OpenMarket Ltd
+ Copyright 2017 Vector Creations Ltd
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/MatrixSDK/Crypto/Algorithms/MXEventDecryptionResult.h
+++ b/MatrixSDK/Crypto/Algorithms/MXEventDecryptionResult.h
@@ -1,0 +1,47 @@
+/*
+ Copyright 2017 OpenMarket Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+/**
+ The result of a (successful) call to decryptEvent.
+ */
+@interface MXEventDecryptionResult : NSObject
+
+/**
+ The plaintext payload for the event (typically containing "type" and "content" fields).
+ */
+@property (nonatomic) NSDictionary *clearEvent;
+
+/**
+ Key owned by the sender of this event.
+ See MXEvent.senderKey.
+ */
+@property (nonatomic) NSString *senderCurve25519Key;
+
+/**
+ Ed25519 key claimed by the sender of this event.
+ See MXEvent.claimedEd25519Key.
+ */
+@property (nonatomic) NSString *claimedEd25519Key;
+
+/**
+ List of curve25519 keys involved in telling us about the senderCurve25519Key and
+ claimedEd25519Key. See MXEvent.forwardingCurve25519KeyChain.
+ */
+@property NSArray<NSString *> *forwardingCurve25519KeyChain;
+
+@end

--- a/MatrixSDK/Crypto/Algorithms/MXEventDecryptionResult.m
+++ b/MatrixSDK/Crypto/Algorithms/MXEventDecryptionResult.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2017 OpenMarket Ltd
+ Copyright 2017 Vector Creations Ltd
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/MatrixSDK/Crypto/Algorithms/MXEventDecryptionResult.m
+++ b/MatrixSDK/Crypto/Algorithms/MXEventDecryptionResult.m
@@ -1,0 +1,21 @@
+/*
+ Copyright 2017 OpenMarket Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXEventDecryptionResult.h"
+
+@implementation MXEventDecryptionResult
+
+@end

--- a/MatrixSDK/Crypto/MXCrypto.h
+++ b/MatrixSDK/Crypto/MXCrypto.h
@@ -20,6 +20,7 @@
 
 #import "MXDeviceInfo.h"
 #import "MXCryptoConstants.h"
+#import "MXEventDecryptionResult.h"
 
 #import "MXRestClient.h"
 
@@ -132,9 +133,11 @@ FOUNDATION_EXPORT NSString *const kMXCryptoRoomKeyRequestCancellationNotificatio
  @param timeline the id of the timeline where the event is decrypted. It is used
                  to prevent replay attack.
  
- @return YES if the decryption was successful.
+ @param error the result error if there is a problem decrypting the event.
+
+ @return The decryption result. Nil if it failed.
  */
-- (BOOL)decryptEvent:(MXEvent*)event inTimeline:(NSString*)timeline;
+- (MXEventDecryptionResult *)decryptEvent:(MXEvent*)event inTimeline:(NSString*)timeline error:(NSError** )error;
 
 /**
  Ensure that the outbound session is ready to encrypt events.

--- a/MatrixSDK/Crypto/MXCrypto_Private.h
+++ b/MatrixSDK/Crypto/MXCrypto_Private.h
@@ -21,6 +21,7 @@
 #ifdef MX_CRYPTO
 
 #import "MXCryptoStore.h"
+#import "MXSession.h"
 #import "MXRestClient.h"
 #import "MXOlmDevice.h"
 #import "MXDeviceList.h"
@@ -46,6 +47,11 @@
   The libolm wrapper.
  */
 @property (nonatomic, readonly) MXOlmDevice *olmDevice;
+
+/**
+ The Matrix session.
+ */
+@property (nonatomic, readonly) MXSession *mxSession;
 
 /**
   The instance used to make requests to the homeserver.

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -406,10 +406,13 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
 
                         event.wireType = encryptedEventType;
                         event.wireContent = encryptedContent;
-                        [event setClearData:clearEvent
-                        senderCurve25519Key:mxSession.crypto.deviceCurve25519Key
-                          claimedEd25519Key:mxSession.crypto.deviceEd25519Key
-               forwardingCurve25519KeyChain:nil];
+
+                        MXEventDecryptionResult *decryptionResult = [[MXEventDecryptionResult alloc] init];
+                        decryptionResult.clearEvent = clearEvent.JSONDictionary;
+                        decryptionResult.senderCurve25519Key = mxSession.crypto.deviceCurve25519Key;
+                        decryptionResult.claimedEd25519Key = mxSession.crypto.deviceEd25519Key;
+
+                        [event setClearData:decryptionResult];
 
                         // Update the local echo state (This will trigger kMXEventDidChangeSentStateNotification notification).
                         event.sentState = MXEventSentStateSending;

--- a/MatrixSDK/JSONModels/MXEvent.h
+++ b/MatrixSDK/JSONModels/MXEvent.h
@@ -16,6 +16,8 @@
 
 #import "MXJSONModel.h"
 
+@class MXEventDecryptionResult;
+
 /**
  Types of Matrix events
  
@@ -427,16 +429,9 @@ extern NSString *const kMXEventIdentifierKey;
  This is used after decrypting an event; it should not be used by applications.
  It fires kMXEventDidDecryptNotification.
 
- @param clearEvent the plaintext payload for the event.
- @param senderCurve25519Key curve25519 key to record for the sender of this event.
-        See `senderKey` property.
- @param claimedEd25519Key claimed ed25519 key to record for the sender if this event.
-        See `claimedEd25519Key` property.
- @param forwardingCurve25519KeyChain list of curve25519 keys involved in telling us
-        about the senderCurve25519Key and claimedEd25519Key.
-        See `property` property.
+ @param decryptionResult the decryption result, including the plaintext and some key info.
  */
-- (void)setClearData:(MXEvent*)clearEvent senderCurve25519Key:(NSString*)senderCurve25519Key claimedEd25519Key:(NSString*)claimedEd25519Key forwardingCurve25519KeyChain:(NSArray<NSString*>*)forwardingCurve25519KeyChain;
+- (void)setClearData:(MXEventDecryptionResult *)decryptionResult;
 
 /**
  For encrypted events, the plaintext payload for the event.

--- a/MatrixSDK/JSONModels/MXEvent.m
+++ b/MatrixSDK/JSONModels/MXEvent.m
@@ -17,6 +17,7 @@
 #import "MXEvent.h"
 
 #import "MXTools.h"
+#import "MXEventDecryptionResult.h"
 
 #pragma mark - Constants definitions
 
@@ -523,14 +524,19 @@ NSString *const kMXEventIdentifierKey = @"kMXEventIdentifierKey";
     return (self.wireEventType == MXEventTypeRoomEncrypted);
 }
 
-- (void)setClearData:(MXEvent*)clearEvent senderCurve25519Key:(NSString*)senderCurve25519Key claimedEd25519Key:(NSString*)claimedEd25519Key forwardingCurve25519KeyChain:(NSArray<NSString*>*)forwardingCurve25519KeyChain
+- (void)setClearData:(MXEventDecryptionResult *)decryptionResult
 {
-    _clearEvent = clearEvent;
+    _clearEvent = nil;
+    if (decryptionResult.clearEvent)
+    {
+        _clearEvent = [MXEvent modelFromJSON:decryptionResult.clearEvent];
+    }
+
     if (_clearEvent)
     {
-        _clearEvent->senderCurve25519Key = senderCurve25519Key;
-        _clearEvent->claimedEd25519Key = claimedEd25519Key;
-        _clearEvent->forwardingCurve25519KeyChain = forwardingCurve25519KeyChain ? forwardingCurve25519KeyChain : @[];
+        _clearEvent->senderCurve25519Key = decryptionResult.senderCurve25519Key;
+        _clearEvent->claimedEd25519Key = decryptionResult.claimedEd25519Key;
+        _clearEvent->forwardingCurve25519KeyChain = decryptionResult.forwardingCurve25519KeyChain ? decryptionResult.forwardingCurve25519KeyChain : @[];
     }
 
     // Notify only for events that are lately decrypted

--- a/MatrixSDKTests/MXCryptoTests.m
+++ b/MatrixSDKTests/MXCryptoTests.m
@@ -1376,11 +1376,12 @@
         [roomFromBobPOV.liveTimeline listenToEventsOfTypes:@[kMXEventTypeStringRoomMessage] onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
 
             // Try to decrypt the event again
-            [event setClearData:nil senderCurve25519Key:nil claimedEd25519Key:nil forwardingCurve25519KeyChain:nil];
+            [event setClearData:nil];
             BOOL b = [bobSession decryptEvent:event inTimeline:roomFromBobPOV.liveTimeline.timelineId];
 
             // It must fail
             XCTAssertFalse(b);
+            XCTAssert(event.decryptionError);
             XCTAssertEqual(event.decryptionError.code, MXDecryptingErrorDuplicateMessageIndexCode);
             XCTAssertNil(event.clearEvent);
 
@@ -1444,7 +1445,7 @@
             // We still must be able to decrypt the event
             // ie, the implementation must have ignored the new room key with the advanced outbound group
             // session key
-            [event setClearData:nil senderCurve25519Key:nil claimedEd25519Key:nil forwardingCurve25519KeyChain:nil];
+            [event setClearData:nil];
             BOOL b = [bobSession decryptEvent:event inTimeline:nil];
 
             XCTAssert(b);
@@ -1495,7 +1496,7 @@
             [bobCryptoStore removeInboundGroupSessionWithId:sessionId andSenderKey:toDeviceEvent.senderKey];
 
             // So that we cannot decrypt it anymore right now
-            [event setClearData:nil senderCurve25519Key:nil claimedEd25519Key:nil forwardingCurve25519KeyChain:nil];
+            [event setClearData:nil];
             BOOL b = [bobSession decryptEvent:event inTimeline:nil];
 
             XCTAssertFalse(b);

--- a/MatrixSDKTests/MXRoomSummaryTests.m
+++ b/MatrixSDKTests/MXRoomSummaryTests.m
@@ -1171,7 +1171,7 @@ NSString *uisiString = @"The sender's device has not sent us the keys for this m
             [bobCryptoStore removeInboundGroupSessionWithId:sessionId andSenderKey:toDeviceEvent.senderKey];
 
             // So that we cannot decrypt it anymore right now
-            [event setClearData:nil senderCurve25519Key:nil claimedEd25519Key:nil forwardingCurve25519KeyChain:nil];
+            [event setClearData:nil];
             BOOL b = [bobSession decryptEvent:event inTimeline:nil];
 
             XCTAssertFalse(b, @"Failed to set up test condition");


### PR DESCRIPTION
…d of having it call event.setClearData

Port of https://github.com/matrix-org/matrix-js-sdk/pull/523

The interface is cleaner. The crypto module does not change MXEvent data anymore (which required threads switching). This is now the role of MXSession.