### PR TITLE
MXTools - Groups: add `isMatrixGroupIdentifier` method.

### DIFF
--- a/MatrixSDK/Utils/MXTools.h
+++ b/MatrixSDK/Utils/MXTools.h
@@ -70,6 +70,7 @@ FOUNDATION_EXPORT NSString *const kMXToolsRegexStringForMatrixUserIdentifier;
 FOUNDATION_EXPORT NSString *const kMXToolsRegexStringForMatrixRoomAlias;
 FOUNDATION_EXPORT NSString *const kMXToolsRegexStringForMatrixRoomIdentifier;
 FOUNDATION_EXPORT NSString *const kMXToolsRegexStringForMatrixEventIdentifier;
+FOUNDATION_EXPORT NSString *const kMXToolsRegexStringForMatrixGroupIdentifier;
 
 /**
  Check whether a string is formatted as an email address.
@@ -105,6 +106,13 @@ FOUNDATION_EXPORT NSString *const kMXToolsRegexStringForMatrixEventIdentifier;
  @return YES if the provided string is formatted as a matrix event identifier.
  */
 + (BOOL)isMatrixEventIdentifier:(NSString *)inputString;
+
+/**
+ Check whether a string is formatted as a matrix group identifier.
+ 
+ @return YES if the provided string is formatted as a matrix group identifier.
+ */
++ (BOOL)isMatrixGroupIdentifier:(NSString *)inputString;
 
 
 #pragma mark - Permalink

--- a/MatrixSDK/Utils/MXTools.m
+++ b/MatrixSDK/Utils/MXTools.m
@@ -27,6 +27,7 @@ NSString *const kMXToolsRegexStringForMatrixUserIdentifier  = @"@[A-Z0-9._=-]+:[
 NSString *const kMXToolsRegexStringForMatrixRoomAlias       = @"#[A-Z0-9._%#+-]+:[A-Z0-9.-]+\\.[A-Z]{2,}";
 NSString *const kMXToolsRegexStringForMatrixRoomIdentifier  = @"![A-Z0-9]+:[A-Z0-9.-]+\\.[A-Z]{2,}";
 NSString *const kMXToolsRegexStringForMatrixEventIdentifier = @"\\$[A-Z0-9]+:[A-Z0-9.-]+\\.[A-Z]{2,}";
+NSString *const kMXToolsRegexStringForMatrixGroupIdentifier = @"\\+[A-Z0-9=_\\-./]+:[A-Z0-9.-]+\\.[A-Z]{2,}";
 
 
 #pragma mark - MXTools static private members
@@ -39,6 +40,7 @@ static NSRegularExpression *isMatrixUserIdentifierRegex;
 static NSRegularExpression *isMatrixRoomAliasRegex;
 static NSRegularExpression *isMatrixRoomIdentifierRegex;
 static NSRegularExpression *isMatrixEventIdentifierRegex;
+static NSRegularExpression *isMatrixGroupIdentifierRegex;
 
 static NSUInteger transactionIdCount;
 
@@ -103,6 +105,8 @@ static NSUInteger transactionIdCount;
                                                                                 options:NSRegularExpressionCaseInsensitive error:nil];
         isMatrixEventIdentifierRegex = [NSRegularExpression regularExpressionWithPattern:[NSString stringWithFormat:@"^%@$", kMXToolsRegexStringForMatrixEventIdentifier]
                                                                                  options:NSRegularExpressionCaseInsensitive error:nil];
+        isMatrixGroupIdentifierRegex = [NSRegularExpression regularExpressionWithPattern:[NSString stringWithFormat:@"^%@$", kMXToolsRegexStringForMatrixGroupIdentifier]
+                                                                                options:NSRegularExpressionCaseInsensitive error:nil];
 
         transactionIdCount = 0;
     });
@@ -288,6 +292,15 @@ static NSUInteger transactionIdCount;
     if (inputString)
     {
         return (nil != [isMatrixEventIdentifierRegex firstMatchInString:inputString options:0 range:NSMakeRange(0, inputString.length)]);
+    }
+    return NO;
+}
+
++ (BOOL)isMatrixGroupIdentifier:(NSString *)inputString
+{
+    if (inputString)
+    {
+        return (nil != [isMatrixGroupIdentifierRegex firstMatchInString:inputString options:0 range:NSMakeRange(0, inputString.length)]);
     }
     return NO;
 }


### PR DESCRIPTION
Check whether a string is formatted as a matrix group identifier.