### PR TITLE
GZIP 1.2.1

### DIFF
--- a/SwiftMatrixSDK.podspec
+++ b/SwiftMatrixSDK.podspec
@@ -30,6 +30,6 @@ Pod::Spec.new do |s|
   s.requires_arc  = true
 
   s.dependency 'AFNetworking', '~> 3.1.0'
-  s.dependency 'GZIP', '~> 1.1.1'
+  s.dependency 'GZIP', '~> 1.2.1'
 
 end


### PR DESCRIPTION
Bumped `SwiftMatrixSDK.podspec` dependency to `GZIP 1.2.1`. 

Signed-off-by: Nick Rakochy <nick.rakochy@gmail.com>