### PR TITLE
MXMediaLoader: handles client certificate case

### DIFF
--- a/MatrixSDK/Utils/Media/MXMediaLoader.m
+++ b/MatrixSDK/Utils/Media/MXMediaLoader.m
@@ -306,6 +306,14 @@ NSString *const kMXMediaUploadIdPrefix = @"upload-";
             }
         }
     }
+    else if ([protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodClientCertificate])
+    {
+        [challenge.sender performDefaultHandlingForAuthenticationChallenge:challenge];
+    }
+    else
+    {
+        [challenge.sender cancelAuthenticationChallenge:challenge];
+    }
 }
 
 #pragma mark - Upload


### PR DESCRIPTION
Hi,

This PR handles client certificate case performing the default handling. It also cancels the challenge if the case is not managed. Indeed, according to https://developer.apple.com/documentation/foundation/nsurlconnectiondelegate/1414078-connection?language=objc : 
> In this method, you must invoke one of the challenge-responder methods.


It was not managed before.

It is related to issue #446. It is also quoted in https://github.com/vector-im/riot-ios/issues/1634

Next step would be to support the import of certificate to answer properly to client certificate challenge (https://developer.apple.com/library/content/qa/qa1745/_index.html / https://chika-kasymov.github.io/authentication_with_client_private_certificate_using_afnetworking).

Thanks