### PR TITLE
Crypto: The crypto is now built by default in matrix-ios-sdk.

### DIFF
--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -36,7 +36,7 @@ Pod::Spec.new do |s|
 
       # Requirements for e2e encryption
       ss.dependency 'OLMKit', '~> 2.2.2'
-      ss.dependency 'Realm', '~> 3.0.1'
+      ss.dependency 'Realm', '~> 3.1.0'
   end
 
   s.subspec 'JingleCallStack' do |ss|

--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -33,6 +33,10 @@ Pod::Spec.new do |s|
       
       ss.dependency 'AFNetworking', '~> 3.1.0'
       ss.dependency 'GZIP', '~> 1.2.1'
+
+      # Requirements for e2e encryption
+      ss.dependency 'OLMKit', '~> 2.2.2'
+      ss.dependency 'Realm', '~> 3.0.1'
   end
 
   s.subspec 'JingleCallStack' do |ss|

--- a/MatrixSDK/MXSDKOptions.h
+++ b/MatrixSDK/MXSDKOptions.h
@@ -21,23 +21,12 @@
 
 #pragma mark - Build time options
 
-#pragma mark Automatic enabling
-/**
- These flags are automatically enabled if the application Xcode workspace contains
- their associated Cocoa pods.
- */
-
 /**
  Crypto.
 
- The crypto module depends on libolm (https://matrix.org/git/olm/ ), which the iOS wrapper
- is OLMKit:
-
-     pod 'OLMKit'
+ Enable it by default.
  */
-#if __has_include(<OLMKit/OLMKit.h>)
 #define MX_CRYPTO
-#endif
 
 
 #pragma mark - Launch time options

--- a/README.rst
+++ b/README.rst
@@ -44,11 +44,6 @@ If you want to enable VoIP using the http://webrtc.org VoIP stack, add the follo
 
     pod 'MatrixSDK/JingleCallStack'
 
-If you want to enable end-to-end encryption, add::
-
-    pod 'OLMKit'
-    pod 'Realm'
-
 
 Overview
 ========

--- a/SwiftMatrixSDK.podspec
+++ b/SwiftMatrixSDK.podspec
@@ -34,6 +34,6 @@ Pod::Spec.new do |s|
   
   # Requirements for e2e encryption
   ss.dependency 'OLMKit', '~> 2.2.2'
-  ss.dependency 'Realm', '~> 3.0.1'
+  ss.dependency 'Realm', '~> 3.1.0'
 
 end

--- a/SwiftMatrixSDK.podspec
+++ b/SwiftMatrixSDK.podspec
@@ -31,5 +31,9 @@ Pod::Spec.new do |s|
 
   s.dependency 'AFNetworking', '~> 3.1.0'
   s.dependency 'GZIP', '~> 1.2.1'
+  
+  # Requirements for e2e encryption
+  ss.dependency 'OLMKit', '~> 2.2.2'
+  ss.dependency 'Realm', '~> 3.0.1'
 
 end


### PR DESCRIPTION
There is no more the `pod 'OLMKit'` technique for the app to enable it because it does not work with frameworks