### PR TITLE
Groups: Display flair for users in room history.

### DIFF
--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -2091,4 +2091,18 @@ typedef enum : NSUInteger
                           success:(void (^)(MXGroupRooms *groupRooms))success
                           failure:(void (^)(NSError *error))failure;
 
+/**
+ Get the publicised groups for a list of users.
+ We got a list of group identifiers for each listed user id.
+ 
+ @param userIds the list of the user identifiers.
+ @param success A block object called when the operation succeeds.
+ @param failure A block object called when the operation fails.
+ 
+ @return a MXHTTPOperation instance.
+ */
+- (MXHTTPOperation*)getPublicisedGroupsForUsers:(NSArray<NSString*>*)userIds
+                                        success:(void (^)(NSDictionary<NSString*, NSArray<NSString*>*> *publicisedGroupsByUserId))success
+                                        failure:(void (^)(NSError *error))failure;
+
 @end

--- a/MatrixSDK/MXSession.h
+++ b/MatrixSDK/MXSession.h
@@ -253,6 +253,14 @@ FOUNDATION_EXPORT NSString *const kMXSessionDidUpdateGroupRoomsNotification;
  */
 FOUNDATION_EXPORT NSString *const kMXSessionDidUpdateGroupUsersNotification;
 
+/**
+ Posted when MXSession has updated the publicised groups of some matrix users.
+ 
+ The passed userInfo dictionary contains:
+ - `kMXSessionNotificationUserIdsArrayKey` the list of the user ids who's the publicised groups are updated.
+ */
+FOUNDATION_EXPORT NSString *const kMXSessionDidUpdatePublicisedGroupsForUsersNotification;
+
 #pragma mark - Notifications keys
 /**
  The key in notification userInfo dictionary representating the roomId.
@@ -284,6 +292,11 @@ FOUNDATION_EXPORT NSString *const kMXSessionNotificationSyncResponseKey;
  The key in notification userInfo dictionary representating the error.
  */
 FOUNDATION_EXPORT NSString *const kMXSessionNotificationErrorKey;
+
+/**
+ The key in notification userInfo dictionary representating a list of user ids.
+ */
+FOUNDATION_EXPORT NSString *const kMXSessionNotificationUserIdsArrayKey;
 
 
 #pragma mark - Other constants
@@ -1099,5 +1112,23 @@ typedef void (^MXOnBackgroundSyncFail)(NSError *error);
  Unregister all listeners.
  */
 - (void)removeAllListeners;
+
+#pragma mark - Publicised groups
+
+/**
+ Force the matrix session to refresh the cached data related to the publicised groups of the users.
+ */
+- (void)markOutdatedPublicisedGroupsByUserData;
+
+/**
+ Get the current publicised groups for a matrix user.
+ If this information is not available or marked as outdated, this method returns the current
+ value and triggers a server request to retrieve the actual publicised groups of this user.
+ Listen to `kMXSessionDidUpdatePublicisedGroupsForUsersNotification` to be notified in case of update.
+ 
+ @param userId the user identifiers.
+ @return the current publicised groups for the provided user.
+ */
+- (NSArray<NSString *> *)publicisedGroupsForUser:(NSString*)userId;
 
 @end

--- a/MatrixSDK/MXSession.h
+++ b/MatrixSDK/MXSession.h
@@ -1126,6 +1126,8 @@ typedef void (^MXOnBackgroundSyncFail)(NSError *error);
  value and triggers a server request to retrieve the actual publicised groups of this user.
  Listen to `kMXSessionDidUpdatePublicisedGroupsForUsersNotification` to be notified in case of update.
  
+ There is no new request if there is already one in progress for the provided userId.
+ 
  @param userId the user identifiers.
  @return the current publicised groups for the provided user.
  */

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -57,7 +57,7 @@ NSString *const kMXSessionDidLeaveGroupNotification = @"kMXSessionDidLeaveGroupN
 NSString *const kMXSessionDidUpdateGroupSummaryNotification = @"kMXSessionDidUpdateGroupSummaryNotification";
 NSString *const kMXSessionDidUpdateGroupRoomsNotification = @"kMXSessionDidUpdateGroupRoomsNotification";
 NSString *const kMXSessionDidUpdateGroupUsersNotification = @"kMXSessionDidUpdateGroupUsersNotification";
-
+NSString *const kMXSessionDidUpdatePublicisedGroupsForUsersNotification = @"kMXSessionDidUpdatePublicisedGroupsForUsersNotification";
 
 NSString *const kMXSessionNotificationRoomIdKey = @"roomId";
 NSString *const kMXSessionNotificationGroupKey = @"group";
@@ -65,6 +65,7 @@ NSString *const kMXSessionNotificationGroupIdKey = @"groupId";
 NSString *const kMXSessionNotificationEventKey = @"event";
 NSString *const kMXSessionNotificationSyncResponseKey = @"syncResponse";
 NSString *const kMXSessionNotificationErrorKey = @"error";
+NSString *const kMXSessionNotificationUserIdsArrayKey = @"userIds";
 
 NSString *const kMXSessionNoRoomTag = @"m.recent";  // Use the same value as matrix-react-sdk
 
@@ -158,6 +159,17 @@ typedef void (^MXOnResumeDone)(void);
      Tell whether the direct rooms list has been updated during last account data parsing.
      */
     BOOL didDirectRoomsChange;
+    
+    /**
+     The current publicised groups list by userId dictionary.
+     The key is the user id; the value, the list of the group ids that the user enabled in his profile.
+     */
+    NSMutableDictionary <NSString*, NSArray<NSString*>*> *publicisedGroupsByUserId;
+    
+    /**
+     The list of users for who a publicised groups list is available but outdated.
+     */
+    NSMutableArray <NSString*> *userIdsWithOutdatedPublicisedGroups;
 }
 
 /**
@@ -186,6 +198,7 @@ typedef void (^MXOnResumeDone)(void);
         accountData = [[MXAccountData alloc] init];
         peekingRooms = [NSMutableArray array];
         _preventPauseCount = 0;
+        publicisedGroupsByUserId = [[NSMutableDictionary alloc] init];
         
         firstSyncDone = NO;
         didDirectRoomsChange = NO;
@@ -661,6 +674,9 @@ typedef void (^MXOnResumeDone)(void);
         [_crypto close:NO];
         _crypto = nil;
     }
+    
+    publicisedGroupsByUserId = nil;
+    userIdsWithOutdatedPublicisedGroups = nil;
 
     // Stop background task
     id<MXBackgroundModeHandler> handler = [MXSDKOptions sharedInstance].backgroundModeHandler;
@@ -3036,6 +3052,70 @@ typedef void (^MXOnResumeDone)(void);
             [listener notify:event direction:direction andCustomObject:nil];
         }
     }
+}
+
+#pragma mark - Publicised groups
+
+- (void)markOutdatedPublicisedGroupsByUserData
+{
+    // Retrieve the current list of users for who a publicised groups list is available.
+    // A server request will be triggered only when the publicised groups will be requested again for these users.
+    userIdsWithOutdatedPublicisedGroups = [NSMutableArray arrayWithArray:[publicisedGroupsByUserId allKeys]];
+}
+
+- (NSArray<NSString *> *)publicisedGroupsForUser:(NSString*)userId
+{
+    NSArray *publicisedGroups;
+    if (userId)
+    {
+        publicisedGroups = publicisedGroupsByUserId[userId];
+        
+        BOOL shouldRefresh = NO;
+        
+        if (!publicisedGroups)
+        {
+            shouldRefresh = YES;
+            
+            // In order to prevent multiple request on the same user id, we put a temporary empty array when no value is available yet.
+            // This temporary array will be replaced by the value received from the server.
+            publicisedGroups = publicisedGroupsByUserId[userId] = @[];
+        }
+        else if (userIdsWithOutdatedPublicisedGroups.count)
+        {
+            NSUInteger index = [userIdsWithOutdatedPublicisedGroups indexOfObject:userId];
+            if (index != NSNotFound)
+            {
+                shouldRefresh = YES;
+                
+                // Remove this user id from the pending list
+                [userIdsWithOutdatedPublicisedGroups removeObjectAtIndex:index];
+            }
+        }
+        
+        if (shouldRefresh)
+        {
+            [self.matrixRestClient getPublicisedGroupsForUsers:@[userId] success:^(NSDictionary<NSString *,NSArray<NSString *> *> *updatedPublicisedGroupsByUserId) {
+                
+                // Check whether the publicised groups have been actually modified.
+                if ((publicisedGroupsByUserId[userId] || updatedPublicisedGroupsByUserId[userId]) && ![publicisedGroupsByUserId[userId] isEqualToArray:updatedPublicisedGroupsByUserId[userId]])
+                {
+                    // refresh the internal dict
+                    publicisedGroupsByUserId[userId] = updatedPublicisedGroupsByUserId[userId];
+                    
+                    // Notify the publicised groups for these users have been updated.
+                    [[NSNotificationCenter defaultCenter] postNotificationName:kMXSessionDidUpdatePublicisedGroupsForUsersNotification
+                                                                        object:self
+                                                                      userInfo:@{
+                                                                                 kMXSessionNotificationUserIdsArrayKey: @[userId]
+                                                                                 }];
+                }
+                
+                
+            } failure:nil];
+        }
+    }
+    
+    return publicisedGroups;
 }
 
 @end

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -3111,7 +3111,16 @@ typedef void (^MXOnResumeDone)(void);
                 }
                 
                 
-            } failure:nil];
+            } failure:^(NSError *error) {
+                
+                // We should trigger a new request for this user if his publicised groups are requested again.
+                if (!userIdsWithOutdatedPublicisedGroups)
+                {
+                    userIdsWithOutdatedPublicisedGroups = [NSMutableArray array];
+                }
+                [userIdsWithOutdatedPublicisedGroups addObject:userId];
+                
+            }];
         }
     }
     


### PR DESCRIPTION
MXRestClient: Add the method to get the publicised groups for a list of users.
MXSession: Cache the publicised groups of the matrix users in order to limit the server requests.

https://github.com/vector-im/riot-meta/issues/118