### PR TITLE
API break: MXCrypto: Remove deviceWithDeviceId and devicesForUser methods

### DIFF
--- a/MatrixSDK/Crypto/MXCrypto.h
+++ b/MatrixSDK/Crypto/MXCrypto.h
@@ -194,23 +194,6 @@ FOUNDATION_EXPORT NSString *const kMXCryptoRoomKeyRequestCancellationNotificatio
 - (MXDeviceInfo *)eventDeviceInfo:(MXEvent*)event;
 
 /**
- Get the stored device keys for a user's device.
-
- @param deviceId the id of the user's device.
- @param userId the user id.
- @param complete a block called with the device keys. nil if not found.
- */
-- (void)deviceWithDeviceId:(NSString*)deviceId ofUser:(NSString*)userId complete:(void (^)(MXDeviceInfo *device))complete;
-
-/**
- Get the stored device keys for a user.
-
- @param userId the user to list keys for.
- @param complete a block called with the list of devices.
- */
-- (void)devicesForUser:(NSString*)userId complete:(void (^)(NSArray<MXDeviceInfo*> *devices))complete;
-
-/**
  Update the blocked/verified state of the given device
 
  @param verificationStatus the new verification status.
@@ -235,9 +218,14 @@ FOUNDATION_EXPORT NSString *const kMXCryptoRoomKeyRequestCancellationNotificatio
                complete:(void (^)(void))complete;
 
 /**
- Download the device keys for a list of users and stores them into the crypto store.
+ Get the device keys for a list of users.
+
+ Keys will be downloaded from the matrix homeserver and stored into the crypto store
+ if the information in the store is not up-to-date.
+ 
 
  @param userIds The users to fetch.
+ @param forceDownload to force the download.
 
  @param success A block object called when the operation succeeds.
  @param failure A block object called when the operation fails.
@@ -245,8 +233,9 @@ FOUNDATION_EXPORT NSString *const kMXCryptoRoomKeyRequestCancellationNotificatio
  @return a MXHTTPOperation instance. May be nil if the data is already in the store.
  */
 - (MXHTTPOperation*)downloadKeys:(NSArray<NSString*>*)userIds
-                        success:(void (^)(MXUsersDevicesMap<MXDeviceInfo*> *usersDevicesInfoMap))success
-                        failure:(void (^)(NSError *error))failure;
+                   forceDownload:(BOOL)forceDownload
+                         success:(void (^)(MXUsersDevicesMap<MXDeviceInfo*> *usersDevicesInfoMap))success
+                         failure:(void (^)(NSError *error))failure;
 
 /**
  Reset replay attack data for the given timeline.

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -675,40 +675,6 @@ NSTimeInterval kMXCryptoUploadOneTimeKeysPeriod = 60.0; // one minute
     return device;
 }
 
-- (void)deviceWithDeviceId:(NSString *)deviceId ofUser:(NSString *)userId complete:(void (^)(MXDeviceInfo *))complete
-{
-#ifdef MX_CRYPTO
-    dispatch_async(_cryptoQueue, ^{
-
-        MXDeviceInfo *device = [self.deviceList storedDevice:userId deviceId:deviceId];
-
-        dispatch_async(dispatch_get_main_queue(), ^{
-            complete(device);
-        });
-
-    });
-#else
-    complete(nil);
-#endif
-}
-
-- (void)devicesForUser:(NSString*)userId complete:(void (^)(NSArray<MXDeviceInfo*> *devices))complete
-{
-#ifdef MX_CRYPTO
-    dispatch_async(_cryptoQueue, ^{
-
-        NSArray<MXDeviceInfo*> *devices = [self.deviceList storedDevicesForUser:userId];
-
-        dispatch_async(dispatch_get_main_queue(), ^{
-            complete(devices);
-        });
-
-    });
-#else
-    complete(nil);
-#endif
-}
-
 - (void)setDeviceVerification:(MXDeviceVerification)verificationStatus forDevice:(NSString*)deviceId ofUser:(NSString*)userId
                       success:(void (^)(void))success
                       failure:(void (^)(NSError *error))failure
@@ -801,6 +767,7 @@ NSTimeInterval kMXCryptoUploadOneTimeKeysPeriod = 60.0; // one minute
 }
 
 - (MXHTTPOperation*)downloadKeys:(NSArray<NSString*>*)userIds
+                   forceDownload:(BOOL)forceDownload
                          success:(void (^)(MXUsersDevicesMap<MXDeviceInfo*> *usersDevicesInfoMap))success
                          failure:(void (^)(NSError *error))failure
 {
@@ -811,7 +778,7 @@ NSTimeInterval kMXCryptoUploadOneTimeKeysPeriod = 60.0; // one minute
 
     dispatch_async(_cryptoQueue, ^{
 
-        MXHTTPOperation *operation2 = [self.deviceList downloadKeys:userIds forceDownload:YES success:^(MXUsersDevicesMap<MXDeviceInfo *> *usersDevicesInfoMap) {
+        MXHTTPOperation *operation2 = [self.deviceList downloadKeys:userIds forceDownload:forceDownload success:^(MXUsersDevicesMap<MXDeviceInfo *> *usersDevicesInfoMap) {
             if (success)
             {
                 dispatch_async(dispatch_get_main_queue(), ^{


### PR DESCRIPTION
because they return local values that may be out of sync.

The downloadKeys method is preferred for better accuracy.
Using downloadKeys will fix https://github.com/vector-im/riot-ios/issues/1782.