### PR TITLE
 BF: we should retry messages with same txn id when hitting 'resend'

### DIFF
--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -365,7 +365,7 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
             }
 
             roomOperation = [self preserveOperationOrder:event block:^{
-                MXHTTPOperation *operation = [self _sendEventOfType:eventTypeString content:contentCopy success:onSuccess failure:onFailure];
+                MXHTTPOperation *operation = [self _sendEventOfType:eventTypeString content:contentCopy txnId:event.eventId success:onSuccess failure:onFailure];
                 [roomOperation.operation mutateTo:operation];
             }];
         }
@@ -422,7 +422,7 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
                     }
 
                     // Send the encrypted content
-                    MXHTTPOperation *operation2 = [self _sendEventOfType:encryptedEventType content:encryptedContent success:onSuccess failure:onFailure];
+                    MXHTTPOperation *operation2 = [self _sendEventOfType:encryptedEventType content:encryptedContent txnId:event.eventId success:onSuccess failure:onFailure];
                     if (operation2)
                     {
                         // Mutate MXHTTPOperation so that the user can cancel this new operation
@@ -467,7 +467,7 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
         }
 
         roomOperation = [self preserveOperationOrder:event block:^{
-            MXHTTPOperation *operation = [self _sendEventOfType:eventTypeString content:contentCopy success:onSuccess failure:onFailure];
+            MXHTTPOperation *operation = [self _sendEventOfType:eventTypeString content:contentCopy txnId:event.eventId success:onSuccess failure:onFailure];
             [roomOperation.operation mutateTo:operation];
         }];
     }
@@ -477,10 +477,11 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
 
 - (MXHTTPOperation*)_sendEventOfType:(MXEventTypeString)eventTypeString
                             content:(NSDictionary*)content
+                            txnId:(NSString*)txnId
                             success:(void (^)(NSString *eventId))success
                             failure:(void (^)(NSError *error))failure
 {
-    return [mxSession.matrixRestClient sendEventToRoom:self.roomId eventType:eventTypeString content:content success:success failure:failure];
+    return [mxSession.matrixRestClient sendEventToRoom:self.roomId eventType:eventTypeString content:content txnId:txnId success:success failure:failure];
 }
 
 - (MXHTTPOperation*)sendStateEventOfType:(MXEventTypeString)eventTypeString

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -567,6 +567,7 @@ typedef enum : NSUInteger
  @param roomId the id of the room.
  @param eventTypeString the type of the event. @see MXEventType.
  @param content the content that will be sent to the server as a JSON object.
+ @param txnId the transaction id to use. If nil, one will be generated.
  @param success A block object called when the operation succeeds. It returns
  the event id of the event generated on the home server
  @param failure A block object called when the operation fails.
@@ -576,6 +577,7 @@ typedef enum : NSUInteger
 - (MXHTTPOperation*)sendEventToRoom:(NSString*)roomId
                           eventType:(MXEventTypeString)eventTypeString
                             content:(NSDictionary*)content
+                              txnId:(NSString*)txnId
                             success:(void (^)(NSString *eventId))success
                             failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -1565,14 +1565,21 @@ MXAuthAction;
 }
 
 #pragma mark - Room operations
-- (MXHTTPOperation*)sendEventToRoom:(NSString*)roomId
-                          eventType:(MXEventTypeString)eventTypeString
-                            content:(NSDictionary*)content
-                            success:(void (^)(NSString *eventId))success
-                            failure:(void (^)(NSError *error))failure
+- (MXHTTPOperation *)sendEventToRoom:(NSString *)roomId
+                           eventType:(MXEventTypeString)eventTypeString
+                             content:(NSDictionary *)content
+                               txnId:(NSString *)txnId
+                             success:(void (^)(NSString *))success
+                             failure:(void (^)(NSError *))failure
 {
-    // Prepare the path by adding a random transaction id (This id is used to prevent duplicated event).
-    NSString *path = [NSString stringWithFormat:@"%@/rooms/%@/send/%@/%@", apiPathPrefix, roomId, eventTypeString, [MXTools generateTransactionId]];
+    if (!txnId.length)
+    {
+        // Create a random transaction id to prevent duplicated events
+        txnId = [MXTools generateTransactionId];
+    }
+
+    // Prepare the path
+    NSString *path = [NSString stringWithFormat:@"%@/rooms/%@/send/%@/%@", apiPathPrefix, roomId, eventTypeString, [txnId stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
     
     return [httpClient requestWithMethod:@"PUT"
                                     path:path
@@ -1679,7 +1686,7 @@ MXAuthAction;
     NSMutableDictionary *eventContent = [NSMutableDictionary dictionaryWithDictionary:content];
     eventContent[@"msgtype"] = msgType;
     
-    return [self sendEventToRoom:roomId eventType:kMXEventTypeStringRoomMessage content:eventContent success:success failure:failure];
+    return [self sendEventToRoom:roomId eventType:kMXEventTypeStringRoomMessage content:eventContent txnId:nil success:success failure:failure];
 }
 
 - (MXHTTPOperation*)sendTextMessageToRoom:(NSString*)roomId


### PR DESCRIPTION
https://github.com/vector-im/riot-ios/issues/1731

Use the local event id as the transaction id so that we will reuse the same transaction id if the user hits resend.