### PR TITLE
MXTools: Fix the regex part for the HS domain part in all isMatrixXxxxIdentifier methods

### DIFF
--- a/MatrixSDK/Utils/MXTools.m
+++ b/MatrixSDK/Utils/MXTools.m
@@ -23,11 +23,15 @@
 
 #pragma mark - Constant definition
 NSString *const kMXToolsRegexStringForEmailAddress          = @"[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,}";
-NSString *const kMXToolsRegexStringForMatrixUserIdentifier  = @"@[\\x21-\\x39\\x3B-\\x7F]+:[A-Z0-9.-]+\\.[A-Z]{2,}";
-NSString *const kMXToolsRegexStringForMatrixRoomAlias       = @"#[A-Z0-9._%#+-]+:[A-Z0-9.-]+\\.[A-Z]{2,}";
-NSString *const kMXToolsRegexStringForMatrixRoomIdentifier  = @"![A-Z0-9]+:[A-Z0-9.-]+\\.[A-Z]{2,}";
-NSString *const kMXToolsRegexStringForMatrixEventIdentifier = @"\\$[A-Z0-9]+:[A-Z0-9.-]+\\.[A-Z]{2,}";
-NSString *const kMXToolsRegexStringForMatrixGroupIdentifier = @"\\+[A-Z0-9=_\\-./]+:[A-Z0-9.-]+\\.[A-Z]{2,}";
+
+// The HS domain part in Matrix identifiers
+#define MATRIX_HOMESERVER_DOMAIN_REGEX                        @"[A-Z0-9.-]+(\\.[A-Z]{2,})?+(\\:[0-9]{2,})?"
+
+NSString *const kMXToolsRegexStringForMatrixUserIdentifier  = @"@[\\x21-\\x39\\x3B-\\x7F]+:" MATRIX_HOMESERVER_DOMAIN_REGEX;
+NSString *const kMXToolsRegexStringForMatrixRoomAlias       = @"#[A-Z0-9._%#+-]+:" MATRIX_HOMESERVER_DOMAIN_REGEX;
+NSString *const kMXToolsRegexStringForMatrixRoomIdentifier  = @"![A-Z0-9]+:" MATRIX_HOMESERVER_DOMAIN_REGEX;
+NSString *const kMXToolsRegexStringForMatrixEventIdentifier = @"\\$[A-Z0-9]+:" MATRIX_HOMESERVER_DOMAIN_REGEX;
+NSString *const kMXToolsRegexStringForMatrixGroupIdentifier = @"\\+[A-Z0-9=_\\-./]+:" MATRIX_HOMESERVER_DOMAIN_REGEX;
 
 
 #pragma mark - MXTools static private members

--- a/MatrixSDKTests/MXToolsTests.m
+++ b/MatrixSDKTests/MXToolsTests.m
@@ -42,4 +42,30 @@
     XCTAssertNotNil(secret);
 }
 
+- (void)testMatrixIdentifiers
+{
+    // Tests on homeserver domain (https://matrix.org/docs/spec/legacy/#users)
+    XCTAssertTrue([MXTools isMatrixUserIdentifier:@"@bob:matrix.org"]);
+    XCTAssertTrue([MXTools isMatrixUserIdentifier:@"@bob:chat1234.matrix.org"]);
+    XCTAssertTrue([MXTools isMatrixUserIdentifier:@"@bob:matrix.org:8480"]);
+    XCTAssertTrue([MXTools isMatrixUserIdentifier:@"@bob:localhost"]);
+    XCTAssertTrue([MXTools isMatrixUserIdentifier:@"@bob:localhost:8480"]);
+    XCTAssertTrue([MXTools isMatrixUserIdentifier:@"@bob:127.0.0.1"]);
+    XCTAssertTrue([MXTools isMatrixUserIdentifier:@"@bob:127.0.0.1:8480"]);
+    XCTAssertFalse([MXTools isMatrixUserIdentifier:@"@bob:matrix+25.org"]);
+    XCTAssertFalse([MXTools isMatrixUserIdentifier:@"@bob:matrix[].org"]);
+
+    XCTAssertTrue([MXTools isMatrixUserIdentifier:@"@Bob:matrix.org"]);
+    XCTAssertTrue([MXTools isMatrixUserIdentifier:@"@bob1234:matrix.org"]);
+    XCTAssertTrue([MXTools isMatrixUserIdentifier:@"@+33012:matrix.org"]);
+
+    XCTAssertTrue([MXTools isMatrixEventIdentifier:@"$123456EventId:matrix.org"]);
+
+    XCTAssertTrue([MXTools isMatrixRoomIdentifier:@"!an1234Room:matrix.org"]);
+
+    XCTAssertTrue([MXTools isMatrixRoomAlias:@"#matrix:matrix.org"]);
+
+    XCTAssertTrue([MXTools isMatrixGroupIdentifier:@"+matrix:matrix.org"]);
+}
+
 @end


### PR DESCRIPTION
This will fix SDK tests that fail since #453 because user ids have a port ("@bob:localhost:8480").