### PR TITLE
MXRoom: Canceled message can be sent

### DIFF
--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -1421,7 +1421,11 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
     // Launch the operation if there is none pending or executing.
     if (orderedOperations.count == 1)
     {
-        roomOperation.block();
+        // Dispatch so that we can return the new`roomOperation` to the caller
+        // before calling its block
+        dispatch_async(dispatch_get_main_queue(), ^{
+            roomOperation.block();
+        });
     }
 
     return roomOperation;

--- a/MatrixSDK/Utils/MXHTTPOperation.m
+++ b/MatrixSDK/Utils/MXHTTPOperation.m
@@ -77,7 +77,13 @@
     _numberOfTries = operation.numberOfTries;
     _maxNumberOfTries = operation.maxRetriesTime;
     _maxRetriesTime = operation.maxRetriesTime;
-    _canceled = operation.canceled;
+
+    // If the current operation was canceled, cancel the new one to avoid
+    // that the chained operations ends up with a successful operation
+    if (_canceled)
+    {
+        [operation cancel];
+    }
 }
 
 @end


### PR DESCRIPTION
 if there is only one in the message sending queue

https://github.com/vector-im/riot-ios/issues/1797

Regression made by #378.
Revealed by the `testFailedOutgoingMessageEcho` test.