### PR TITLE
MXFileStore: commits can stay pending after [MXFileStore close]

### DIFF
--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
@@ -612,9 +612,6 @@ static NSString *const kMXFileStoreRoomReadReceiptsFile = @"readReceipts";
     // Once done, we are sure pending operations blocks are complete
     dispatch_sync(dispatchQueue, ^(void){
     });
-
-
-    NSLog(@"### %@", @(pendingCommits));
 }
 
 

--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
@@ -577,15 +577,17 @@ static NSString *const kMXFileStoreRoomReadReceiptsFile = @"readReceipts";
         // Do it on the same GCD queue
         dispatch_async(dispatchQueue, ^(void){
             [[NSFileManager defaultManager] removeItemAtPath:storeBackupPath error:nil];
-            
-            if (handler)
-            {
-                // Release the background task if there is no more pending commits
-                dispatch_async(dispatch_get_main_queue(), ^(void){
 
-                    NSLog(@"[MXFileStore commit] lasted %.0fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+            // Release the background task if there is no more pending commits
+            dispatch_async(dispatch_get_main_queue(), ^(void){
 
-                    if (--pendingCommits == 0)
+                NSLog(@"[MXFileStore commit] lasted %.0fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+
+                pendingCommits--;
+
+                if (handler)
+                {
+                    if (pendingCommits == 0)
                     {
                         NSLog(@"[MXFileStore commit] Background task #%tu is complete - lasted %.0fms",
                               backgroundTaskIdentifier, [[NSDate date] timeIntervalSinceDate:backgroundTaskStartDate] * 1000);
@@ -598,8 +600,8 @@ static NSString *const kMXFileStoreRoomReadReceiptsFile = @"readReceipts";
                         NSLog(@"[MXFileStore commit] Background task #%tu is kept - running since %.0fms",
                               backgroundTaskIdentifier, [[NSDate date] timeIntervalSinceDate:backgroundTaskStartDate] * 1000);
                     }
-                });
-            }
+                }
+            });
         });
     }
 }
@@ -610,6 +612,9 @@ static NSString *const kMXFileStoreRoomReadReceiptsFile = @"readReceipts";
     // Once done, we are sure pending operations blocks are complete
     dispatch_sync(dispatchQueue, ^(void){
     });
+
+
+    NSLog(@"### %@", @(pendingCommits));
 }
 
 


### PR DESCRIPTION
in case there is no `backgroundModeHandler` which happens in tests and on MacOS.

https://github.com/vector-im/riot-ios/issues/1797

Regression made by #436.
Revealed by the `testDoNotStoreDecryptedData` test.