### PR TITLE
Fix issue #393

### DIFF
--- a/MatrixSDK/Contrib/Swift/MXResponse.swift
+++ b/MatrixSDK/Contrib/Swift/MXResponse.swift
@@ -166,6 +166,11 @@ internal func currySuccess<T, U>(transform: @escaping (_ input: T) -> U? = { ret
     return { completion(.fromOptional(value: transform($0))) }
 }
 
+/// Special case of currySuccess for Objective-C functions whose competion handlers that take no arguments
+internal func currySuccess(_ completion: @escaping (_ response: MXResponse<Void>) -> Void) -> () -> Void {
+    return { completion(MXResponse.success(Void())) }
+}
+
 /// Return a closure that accepts any error, converts it to a MXResponse value, and then executes the provded completion block
 internal func curryFailure<T>(_ completion: @escaping (MXResponse<T>) -> Void) -> (Error?) -> Void {
     return { completion(.fromOptional(error: $0)) }

--- a/MatrixSDK/Contrib/Swift/MXResponse.swift
+++ b/MatrixSDK/Contrib/Swift/MXResponse.swift
@@ -166,7 +166,7 @@ internal func currySuccess<T, U>(transform: @escaping (_ input: T) -> U? = { ret
     return { completion(.fromOptional(value: transform($0))) }
 }
 
-/// Special case of currySuccess for Objective-C functions whose competion handlers that take no arguments
+/// Special case of currySuccess for Objective-C functions whose competion handlers take no arguments
 internal func currySuccess(_ completion: @escaping (_ response: MXResponse<Void>) -> Void) -> () -> Void {
     return { completion(MXResponse.success(Void())) }
 }


### PR DESCRIPTION
This is required because of this change in Swift 4:
https://github.com/apple/swift-evolution/blob/master/proposals/0029-remove-implicit-tuple-splat.md