### PR TITLE
SwiftMatrixSDK: Enum cleanup

### DIFF
--- a/MatrixSDK/Contrib/Swift/JSONModels/MXEvent.swift
+++ b/MatrixSDK/Contrib/Swift/JSONModels/MXEvent.swift
@@ -96,6 +96,11 @@ public enum MXEventType {
         case .custom(let string): return string
         }
     }
+
+    public init(identifier: String) {
+        let events: [MXEventType] = [.roomName, .roomTopic, .roomAvatar, .roomMember, .roomCreate, .roomJoinRules, .roomPowerLevels, .roomAliases, .roomCanonicalAlias, .roomEncrypted, .roomEncryption, .roomGuestAccess, .roomHistoryVisibility, .roomKey, .roomForwardedKey, .roomKeyRequest, .roomMessage, .roomMessageFeedback, .roomRedaction, .roomThirdPartyInvite, .roomTag, .presence, .typing, .callInvite, .callCandidates, .callAnswer, .callHangup, .receipt]
+        self = events.first(where: { $0.identifier == identifier }) ?? .custom(identifier)
+    }
 }
 
 
@@ -117,6 +122,11 @@ public enum MXMessageType {
         case .file: return kMXMessageTypeFile
         case .custom(let value): return value
         }
+    }
+
+    public init(identifier: String) {
+        let messages: [MXMessageType] = [.text, .emote, .notice, .image, .audio, .video, .location, .file]
+        self = messages.first(where: { $0.identifier == identifier }) ?? .custom(identifier)
     }
 }
 

--- a/MatrixSDK/Contrib/Swift/JSONModels/MXEvent.swift
+++ b/MatrixSDK/Contrib/Swift/JSONModels/MXEvent.swift
@@ -105,7 +105,7 @@ public enum MXMessageType {
     case text, emote, notice, image, audio, video, location, file
     case custom(String)
     
-    var identifier: String {
+    public var identifier: String {
         switch self {
         case .text: return kMXMessageTypeText
         case .emote: return kMXMessageTypeEmote
@@ -125,7 +125,7 @@ public enum MXMessageType {
 public enum MXMembership {
     case unknown, invite, join, leave, ban
     
-    var identifier: __MXMembership {
+    public var identifier: __MXMembership {
         switch self {
         case .unknown: return __MXMembershipUnknown
         case .invite: return __MXMembershipInvite
@@ -135,7 +135,7 @@ public enum MXMembership {
         }
     }
     
-    init(identifier: __MXMembership) {
+    public init(identifier: __MXMembership) {
         let possibilities: [MXMembership] = [.unknown, .invite, .join, .leave, .ban]
         self = possibilities.first(where: { $0.identifier == identifier }) ?? .unknown
     }

--- a/MatrixSDK/Contrib/Swift/JSONModels/MXJSONModels.swift
+++ b/MatrixSDK/Contrib/Swift/JSONModels/MXJSONModels.swift
@@ -40,6 +40,11 @@ public enum MXLoginFlowType {
         case .other(let value): return value
         }
     }
+
+    public init(identifier: String) {
+        let flowTypess: [MXLoginFlowType] = [.password, .recaptcha, .OAuth2, .emailIdentity, .token, .dummy, .emailCode]
+        self = flowTypess.first(where: { $0.identifier == identifier }) ?? .other(identifier)
+    }
 }
 
 
@@ -78,6 +83,12 @@ public enum MXPushRuleKind {
         case .underride: return __MXPushRuleKindUnderride
         }
     }
+
+    public init?(identifier: __MXPushRuleKind?) {
+        let pushRules: [MXPushRuleKind] = [.override, .content, .room, .sender, .underride]
+        guard let pushRule = pushRules.first(where: { $0.identifier == identifier }) else { return nil }
+        self = pushRule
+    }
 }
 
 
@@ -94,5 +105,10 @@ public enum MXPushRuleScope {
         case .global: return "global"
         case .device(let profileTag): return "device/\(profileTag)"
         }
+    }
+
+    public init(identifier: String) {
+        let scopes: [MXPushRuleScope] = [.global]
+        self = scopes.first(where: { $0.identifier == identifier }) ?? .device(profileTag: identifier)
     }
 }


### PR DESCRIPTION
There were a couple of enums in the Swift SDK that either had the wrong access control on their "identifier" properties and/or were missing an init(identifier: T) function.

I attempted to match the existing style in the other enums as best possible.

Signed-off-by: John Flanagan <john.flanagan@spok.com>