### PR TITLE
Build scripts: Call `pod install` instead of `pod update` to speed up…

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,14 +3,6 @@
 set -e
 set -x
 
-pod update
+pod install
 
 xcodebuild -workspace MatrixSDK.xcworkspace/ -scheme MatrixSDK -sdk iphonesimulator  -destination 'name=iPhone 5s'
-
-# Force lib lint on last Swift version
-echo "4.1" > .swift-version
-
-# Run CocoaPod lint in order to check pod submission
-# Note: --allow-warnings should be removed once we fix our warnings with CallKit stuff only available from iOS10
-pod lib lint MatrixSDK.podspec --use-libraries --allow-warnings
-pod lib lint SwiftMatrixSDK.podspec --allow-warnings

--- a/lint.sh
+++ b/lint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -e
+set -x
+
+pod update
+
+# Force lib lint on last Swift version
+echo "4.1" > .swift-version
+
+# Run CocoaPod lint in order to check pod submission
+# Note: --allow-warnings should be removed once we fix our warnings with CallKit stuff only available from iOS10
+pod lib lint MatrixSDK.podspec --use-libraries --allow-warnings
+pod lib lint SwiftMatrixSDK.podspec --allow-warnings

--- a/test.sh
+++ b/test.sh
@@ -3,7 +3,7 @@
 set -e
 set -x
 
-pod update
+pod install
 #xcodebuild -workspace MatrixSDK.xcworkspace/ -scheme MatrixSDK -sdk iphonesimulator analyze
 
 git -C synapse pull || git clone https://github.com/matrix-org/synapse


### PR DESCRIPTION
… builds on jenkins.

build.sh took 20 min.

`pod update` just needs to be called periodically, not on every build.
The `pod update` is now done by lint.sh. This script, which is already slow, will be launched during the night everyday.