### PR TITLE
MatrixSDK/JingleCallStack: Upgrade the minimal iOS version to 9.0

### DIFF
--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -40,7 +40,7 @@ Pod::Spec.new do |s|
   end
 
   s.subspec 'JingleCallStack' do |ss|
-    ss.ios.deployment_target = "8.0"
+    ss.ios.deployment_target = "9.0"
     
     ss.source_files  = "MatrixSDKExtensions/VoIP/Jingle/**/*.{h,m}"
     


### PR DESCRIPTION
because the WebRTC framework requires it.

https://github.com/vector-im/riot-ios/issues/1821