### PR TITLE
BF: Avoid flair to make requests in loop

### DIFF
--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -3136,7 +3136,7 @@ typedef void (^MXOnResumeDone)(void);
             [self.matrixRestClient getPublicisedGroupsForUsers:@[userId] success:^(NSDictionary<NSString *,NSArray<NSString *> *> *updatedPublicisedGroupsByUserId) {
                 
                 // Check whether the publicised groups have been actually modified.
-                if ((publicisedGroupsByUserId[userId] || updatedPublicisedGroupsByUserId[userId]) && ![publicisedGroupsByUserId[userId] isEqualToArray:updatedPublicisedGroupsByUserId[userId]])
+                if (updatedPublicisedGroupsByUserId[userId] && ![publicisedGroupsByUserId[userId] isEqualToArray:updatedPublicisedGroupsByUserId[userId]])
                 {
                     // refresh the internal dict
                     publicisedGroupsByUserId[userId] = updatedPublicisedGroupsByUserId[userId];


### PR DESCRIPTION
in case the HS returns an empty response for `/publicised_groups`

Fixes https://github.com/vector-im/riot-ios/issues/1869: RoomVC: messages with link blink forever