### PR TITLE
Tests: Keep refs in tests

### DIFF
--- a/MatrixSDKTests/MXAccountDataTests.m
+++ b/MatrixSDKTests/MXAccountDataTests.m
@@ -44,6 +44,8 @@
 - (void)tearDown
 {
     [super tearDown];
+    
+    matrixSDKTestsData = nil;
 }
 
 - (void)testIgnoreUser

--- a/MatrixSDKTests/MXCryptoTests.m
+++ b/MatrixSDKTests/MXCryptoTests.m
@@ -71,6 +71,9 @@
     [bobSessionToClose close];
     bobSessionToClose = nil;
 
+    matrixSDKTestsData = nil;
+    matrixSDKTestsE2EData = nil;
+
     [super tearDown];
 }
 
@@ -2223,6 +2226,7 @@
 
                 // 5 - Instantiante a MXRestclient, alice1MatrixRestClient
                 MXRestClient *alice1MatrixRestClient = [[MXRestClient alloc] initWithCredentials:alice1Credentials andOnUnrecognizedCertificateBlock:nil];
+                [matrixSDKTestsData retain:alice1MatrixRestClient];
 
                 // 6 - Make alice1MatrixRestClient make a fake room key request for the message sent at step #4
                 NSDictionary *requestMessage = @{

--- a/MatrixSDKTests/MXEventTests.m
+++ b/MatrixSDKTests/MXEventTests.m
@@ -43,7 +43,7 @@
 {
     if (mxSession)
     {
-        [matrixSDKTestsData closeMXSession:mxSession];
+        [mxSession close];
         mxSession = nil;
     }
 

--- a/MatrixSDKTests/MXEventTests.m
+++ b/MatrixSDKTests/MXEventTests.m
@@ -46,6 +46,9 @@
         [matrixSDKTestsData closeMXSession:mxSession];
         mxSession = nil;
     }
+
+    matrixSDKTestsData = nil;
+    
     [super tearDown];
 }
 

--- a/MatrixSDKTests/MXEventTimelineTests.m
+++ b/MatrixSDKTests/MXEventTimelineTests.m
@@ -45,8 +45,10 @@ NSString *theInitialEventMessage = @"The initial timelime event";
     {
         [matrixSDKTestsData closeMXSession:mxSession];
         mxSession = nil;
-        matrixSDKTestsData = nil;
     }
+
+    matrixSDKTestsData = nil;
+
     [super tearDown];
 }
 
@@ -222,10 +224,7 @@ NSString *theInitialEventMessage = @"The initial timelime event";
             // Get some messages in the past
             [eventTimeline paginate:10 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^{
 
-                // @TODO: The result should be 21 but it fails because of https://matrix.org/jira/browse/SYN-641
-                // @TODO: Come back to 21 once Synapse is fixed
-                //XCTAssertEqual(events.count, 21, @"10 + 5 + 1 + 5 = 21");
-                XCTAssertEqual(events.count, 17, @"If the result 21, this means that https://matrix.org/jira/browse/SYN-641 is fixed ");
+                XCTAssertEqual(events.count, 21, @"10 + 5 + 1 + 5 = 21");
 
                 // Check events order
                 uint64_t prev_ts = 0;

--- a/MatrixSDKTests/MXEventTimelineTests.m
+++ b/MatrixSDKTests/MXEventTimelineTests.m
@@ -43,7 +43,7 @@ NSString *theInitialEventMessage = @"The initial timelime event";
 {
     if (mxSession)
     {
-        [matrixSDKTestsData closeMXSession:mxSession];
+        [mxSession close];
         mxSession = nil;
     }
 

--- a/MatrixSDKTests/MXJSONModelTests.m
+++ b/MatrixSDKTests/MXJSONModelTests.m
@@ -75,6 +75,7 @@
 - (void)tearDown
 {
     httpClient = nil;
+    matrixSDKTestsData = nil;
     
     [super tearDown];
 }

--- a/MatrixSDKTests/MXMyUserTests.m
+++ b/MatrixSDKTests/MXMyUserTests.m
@@ -48,6 +48,9 @@
         matrixSDKTestsData = nil;
         mxSession = nil;
     }
+
+    matrixSDKTestsData = nil;
+    
     [super tearDown];
 }
 

--- a/MatrixSDKTests/MXMyUserTests.m
+++ b/MatrixSDKTests/MXMyUserTests.m
@@ -44,8 +44,7 @@
 {
     if (mxSession)
     {
-        [matrixSDKTestsData closeMXSession:mxSession];
-        matrixSDKTestsData = nil;
+        [mxSession close];
         mxSession = nil;
     }
 

--- a/MatrixSDKTests/MXNotificationCenterTests.m
+++ b/MatrixSDKTests/MXNotificationCenterTests.m
@@ -42,10 +42,11 @@
     matrixSDKTestsData = [[MatrixSDKTestsData alloc] init];
 }
 
-- (void)tearDown {
+- (void)tearDown
+{
     if (mxSession)
     {
-        [matrixSDKTestsData closeMXSession:mxSession];
+        [mxSession close];
         mxSession = nil;
     }
 

--- a/MatrixSDKTests/MXNotificationCenterTests.m
+++ b/MatrixSDKTests/MXNotificationCenterTests.m
@@ -48,6 +48,9 @@
         [matrixSDKTestsData closeMXSession:mxSession];
         mxSession = nil;
     }
+
+    matrixSDKTestsData = nil;
+    
     [super tearDown];
 }
 

--- a/MatrixSDKTests/MXPeekingRoomTests.m
+++ b/MatrixSDKTests/MXPeekingRoomTests.m
@@ -49,8 +49,10 @@
     {
         [matrixSDKTestsData closeMXSession:mxSession];
         mxSession = nil;
-        matrixSDKTestsData = nil;
     }
+
+    matrixSDKTestsData = nil;
+
     [super tearDown];
 }
 

--- a/MatrixSDKTests/MXPeekingRoomTests.m
+++ b/MatrixSDKTests/MXPeekingRoomTests.m
@@ -47,7 +47,7 @@
 {
     if (mxSession)
     {
-        [matrixSDKTestsData closeMXSession:mxSession];
+        [mxSession close];
         mxSession = nil;
     }
 

--- a/MatrixSDKTests/MXRestClientNoAuthAPITests.m
+++ b/MatrixSDKTests/MXRestClientNoAuthAPITests.m
@@ -343,7 +343,7 @@
 
         // Search for "mxPublic"
         // Room created by doMXRestClientTestWithBobAndThePublicRoom is mxPublic-something
-        [bobRestClient publicRoomsOnServer:nil limit:10 since:nil filter:@"mxPublic" thirdPartyInstanceId:nil includeAllNetworks:NO success:^(MXPublicRoomsResponse *publicRoomsResponse) {
+        [bobRestClient publicRoomsOnServer:nil limit:100 since:nil filter:@"mxPublic" thirdPartyInstanceId:nil includeAllNetworks:NO success:^(MXPublicRoomsResponse *publicRoomsResponse) {
 
             XCTAssertGreaterThan(publicRoomsResponse.chunk.count, 0);
             XCTAssertGreaterThan(publicRoomsResponse.totalRoomCountEstimate, 0);

--- a/MatrixSDKTests/MXRestClientNoAuthAPITests.m
+++ b/MatrixSDKTests/MXRestClientNoAuthAPITests.m
@@ -47,8 +47,10 @@
                           andOnUnrecognizedCertificateBlock:nil];
 }
 
-- (void)tearDown {
+- (void)tearDown
+{
     mxRestClient = nil;
+    matrixSDKTestsData = nil;
 
     [super tearDown];
 }

--- a/MatrixSDKTests/MXRestClientTests.m
+++ b/MatrixSDKTests/MXRestClientTests.m
@@ -46,8 +46,9 @@
 
 - (void)tearDown
 {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
     [super tearDown];
+
+    matrixSDKTestsData = nil;
 }
 
 - (void)testInit
@@ -118,11 +119,10 @@
 - (void)testRoomTopic
 {
     [matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
-        
-        __block MXRestClient *bobRestClient2 = bobRestClient;
+
         [bobRestClient setRoomTopic:roomId topic:@"Topic setter and getter functions are tested here" success:^{
             
-            [bobRestClient2 topicOfRoom:roomId success:^(NSString *topic) {
+            [bobRestClient topicOfRoom:roomId success:^(NSString *topic) {
                 
                 XCTAssertNotNil(topic);
                 XCTAssertNotEqual(topic.length, 0);
@@ -1131,17 +1131,15 @@
 - (void)testUserAvatarUrl
 {
     [matrixSDKTestsData doMXRestClientTestWithAlice:self readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation) {
-        
-        __block MXRestClient *aliceRestClient2 = aliceRestClient;
-        
+
         // Set the avatar url
         __block NSString *newAvatarUrl = @"http://matrix.org/matrix2.png";
         [aliceRestClient setAvatarUrl:newAvatarUrl success:^{
               
             // Then retrieve it
-            [aliceRestClient2 avatarUrlForUser:nil success:^(NSString *avatarUrl) {
-                
-                XCTAssertTrue([avatarUrl isEqualToString:newAvatarUrl], @"Must retrieved the set string: %@ - %@", avatarUrl, newAvatarUrl);
+            [aliceRestClient avatarUrlForUser:nil success:^(NSString *avatarUrl) {
+
+                XCTAssertEqual(avatarUrl, newAvatarUrl);
                 [expectation fulfill];
                 
             } failure:^(NSError *error) {
@@ -1168,8 +1166,8 @@
                 
                 // Then retrieve it from a Bob restClient
                 [bobRestClient avatarUrlForUser:matrixSDKTestsData.aliceCredentials.userId success:^(NSString *avatarUrl) {
-                    
-                    XCTAssertTrue([avatarUrl isEqualToString:newAvatarUrl], @"Must retrieved the set string: %@ - %@", avatarUrl, newAvatarUrl);
+
+                    XCTAssertEqual(avatarUrl, newAvatarUrl);
                     [expectation fulfill];
                     
                 } failure:^(NSError *error) {

--- a/MatrixSDKTests/MXRoomMemberTests.m
+++ b/MatrixSDKTests/MXRoomMemberTests.m
@@ -38,6 +38,8 @@
 
 - (void)tearDown
 {
+    matrixSDKTestsData = nil;
+    
     [super tearDown];
 }
 

--- a/MatrixSDKTests/MXRoomStateDynamicTests.m
+++ b/MatrixSDKTests/MXRoomStateDynamicTests.m
@@ -42,7 +42,7 @@
 {
     if (mxSession)
     {
-        [matrixSDKTestsData closeMXSession:mxSession];
+        [mxSession close];
         mxSession = nil;
     }
 

--- a/MatrixSDKTests/MXRoomStateDynamicTests.m
+++ b/MatrixSDKTests/MXRoomStateDynamicTests.m
@@ -45,6 +45,9 @@
         [matrixSDKTestsData closeMXSession:mxSession];
         mxSession = nil;
     }
+
+    matrixSDKTestsData = nil;
+    
     [super tearDown];
 }
 

--- a/MatrixSDKTests/MXRoomStateTests.m
+++ b/MatrixSDKTests/MXRoomStateTests.m
@@ -49,7 +49,7 @@
 {
     if (mxSession)
     {
-        [matrixSDKTestsData closeMXSession:mxSession];
+        [mxSession close];
         mxSession = nil;
     }
     

--- a/MatrixSDKTests/MXRoomStateTests.m
+++ b/MatrixSDKTests/MXRoomStateTests.m
@@ -52,6 +52,9 @@
         [matrixSDKTestsData closeMXSession:mxSession];
         mxSession = nil;
     }
+    
+    matrixSDKTestsData = nil;
+    
     [super tearDown];
 }
 

--- a/MatrixSDKTests/MXRoomSummaryTests.m
+++ b/MatrixSDKTests/MXRoomSummaryTests.m
@@ -71,6 +71,8 @@ NSString *uisiString = @"The sender's device has not sent us the keys for this m
         observer = nil;
     }
 
+    matrixSDKTestsData = nil;
+
     [super tearDown];
 }
 

--- a/MatrixSDKTests/MXRoomTests.m
+++ b/MatrixSDKTests/MXRoomTests.m
@@ -47,7 +47,7 @@
 {
     if (mxSession)
     {
-        [matrixSDKTestsData closeMXSession:mxSession];
+        [mxSession close];
         mxSession = nil;
     }
 

--- a/MatrixSDKTests/MXRoomTests.m
+++ b/MatrixSDKTests/MXRoomTests.m
@@ -50,6 +50,9 @@
         [matrixSDKTestsData closeMXSession:mxSession];
         mxSession = nil;
     }
+
+    matrixSDKTestsData = nil;
+    
     [super tearDown];
 }
 

--- a/MatrixSDKTests/MXSelfSignedHomeserverTests.m
+++ b/MatrixSDKTests/MXSelfSignedHomeserverTests.m
@@ -97,6 +97,8 @@
             return NO;
         }];
 
+        [matrixSDKTestsData retain:mxRestClient];
+
         // Check the instance is usable
         XCTAssert(mxRestClient);
         [mxRestClient createRoom:nil visibility:0 roomAlias:nil topic:nil success:^(MXCreateRoomResponse *response) {

--- a/MatrixSDKTests/MXSelfSignedHomeserverTests.m
+++ b/MatrixSDKTests/MXSelfSignedHomeserverTests.m
@@ -42,6 +42,8 @@
 
 - (void)tearDown
 {
+    matrixSDKTestsData = nil;
+
     [super tearDown];
 }
 

--- a/MatrixSDKTests/MXSessionTests.m
+++ b/MatrixSDKTests/MXSessionTests.m
@@ -51,7 +51,7 @@
 {
     if (mxSession)
     {
-        [matrixSDKTestsData closeMXSession:mxSession];
+        [mxSession close];
         mxSession = nil;
     }
 

--- a/MatrixSDKTests/MXSessionTests.m
+++ b/MatrixSDKTests/MXSessionTests.m
@@ -60,6 +60,8 @@
         [[NSNotificationCenter defaultCenter] removeObserver:observer];
         observer = nil;
     }
+    
+    matrixSDKTestsData = nil;
 
     [super tearDown];
 }

--- a/MatrixSDKTests/MXStoreTests.m
+++ b/MatrixSDKTests/MXStoreTests.m
@@ -1358,6 +1358,8 @@
                 [bobStore2 openWithCredentials:matrixSDKTestsData.bobCredentials onComplete:^{
 
                     id<MXStore> aliceStore = [[mxStoreClass alloc] init];
+                    [matrixSDKTestsData retain:aliceStore];
+                    
                     [aliceStore openWithCredentials:matrixSDKTestsData.aliceCredentials onComplete:^{
 
                         id<MXStore> bobStore3 = [[mxStoreClass alloc] init];

--- a/MatrixSDKTests/MXStoreTests.m
+++ b/MatrixSDKTests/MXStoreTests.m
@@ -51,7 +51,7 @@
 {
     if (mxSession)
     {
-        [matrixSDKTestsData closeMXSession:mxSession];
+        [mxSession close];
         mxSession = nil;
     }
 
@@ -1359,7 +1359,7 @@
 
                     id<MXStore> aliceStore = [[mxStoreClass alloc] init];
                     [matrixSDKTestsData retain:aliceStore];
-                    
+
                     [aliceStore openWithCredentials:matrixSDKTestsData.aliceCredentials onComplete:^{
 
                         id<MXStore> bobStore3 = [[mxStoreClass alloc] init];

--- a/MatrixSDKTests/MXStoreTests.m
+++ b/MatrixSDKTests/MXStoreTests.m
@@ -61,6 +61,8 @@
         observer = nil;
     }
 
+    matrixSDKTestsData = nil;
+
     [super tearDown];
 }
 

--- a/MatrixSDKTests/MXUserTests.m
+++ b/MatrixSDKTests/MXUserTests.m
@@ -42,7 +42,7 @@
 {
     if (mxSession)
     {
-        [matrixSDKTestsData closeMXSession:mxSession];
+        [mxSession close];
         mxSession = nil;
     }
 

--- a/MatrixSDKTests/MXUserTests.m
+++ b/MatrixSDKTests/MXUserTests.m
@@ -221,8 +221,8 @@
 
             XCTAssertNotNil(mxSession.myUser);
 
-            XCTAssert([mxSession.myUser.displayname isEqualToString:kMXTestsAliceDisplayName]);
-            XCTAssert([mxSession.myUser.avatarUrl isEqualToString:kMXTestsAliceAvatarURL]);
+            XCTAssertEqualObjects(mxSession.myUser.displayname, kMXTestsAliceDisplayName);
+            XCTAssertEqualObjects(mxSession.myUser.avatarUrl, kMXTestsAliceAvatarURL);
 
             [expectation fulfill];
 

--- a/MatrixSDKTests/MXUserTests.m
+++ b/MatrixSDKTests/MXUserTests.m
@@ -45,6 +45,9 @@
         [matrixSDKTestsData closeMXSession:mxSession];
         mxSession = nil;
     }
+
+    matrixSDKTestsData = nil;
+    
     [super tearDown];
 }
 

--- a/MatrixSDKTests/MXVoIPTests.m
+++ b/MatrixSDKTests/MXVoIPTests.m
@@ -45,7 +45,7 @@
 {
     if (mxSession)
     {
-        [matrixSDKTestsData closeMXSession:mxSession];
+        [mxSession close];
         mxSession = nil;
     }
 

--- a/MatrixSDKTests/MXVoIPTests.m
+++ b/MatrixSDKTests/MXVoIPTests.m
@@ -48,6 +48,9 @@
         [matrixSDKTestsData closeMXSession:mxSession];
         mxSession = nil;
     }
+
+    matrixSDKTestsData = nil;
+    
     [super tearDown];
 }
 

--- a/MatrixSDKTests/MatrixSDKTestsData.h
+++ b/MatrixSDKTests/MatrixSDKTestsData.h
@@ -136,12 +136,6 @@ FOUNDATION_EXPORT NSString * const kMXTestsAliceAvatarURL;
 
 - (void)for:(MXRestClient *)mxRestClient2 andRoom:(NSString*)roomId sendMessages:(NSUInteger)messagesCount success:(void (^)(void))success;
 
-// Close the session
-// Before closing, it checks if the session must be cleaning.
-// Cleaning means making the user leave all private rooms so that requests to the
-// home server db require (much) less time
-- (void)closeMXSession:(MXSession*)mxSession;
-
 
 #pragma mark Reference keeping
 // Retain an object for the life of this MatrixSDKTestsData instance

--- a/MatrixSDKTests/MatrixSDKTestsData.h
+++ b/MatrixSDKTests/MatrixSDKTestsData.h
@@ -142,4 +142,9 @@ FOUNDATION_EXPORT NSString * const kMXTestsAliceAvatarURL;
 // home server db require (much) less time
 - (void)closeMXSession:(MXSession*)mxSession;
 
+
+#pragma mark Reference keeping
+// Retain an object for the life of this MatrixSDKTestsData instance
+- (void)retain:(NSObject*)object;
+
 @end

--- a/MatrixSDKTests/MatrixSDKTestsData.m
+++ b/MatrixSDKTests/MatrixSDKTestsData.m
@@ -826,12 +826,7 @@ NSString * const kMXTestsAliceAvatarURL = @"mxc://matrix.org/kciiXusgZFKuNLIfLqm
 }
 
 
-
-- (void)closeMXSession:(MXSession*)mxSession
-{
-    [mxSession close];
-}
-
+#pragma mark Reference keeping
 - (void)retain:(NSObject*)object
 {
     [retainedObjects addObject:object];

--- a/MatrixSDKTests/MatrixSDKTestsData.m
+++ b/MatrixSDKTests/MatrixSDKTestsData.m
@@ -42,11 +42,10 @@ NSString * const kMXTestsAliceAvatarURL = @"mxc://matrix.org/kciiXusgZFKuNLIfLqm
 @interface MatrixSDKTestsData ()
 {
     NSDate *startDate;
+
+    NSMutableArray <NSObject*> *retainedObjects;
 }
 @end
-
-MXRestClient *accountToClean;
-NSMutableArray *roomsToClean;
 
 @implementation MatrixSDKTestsData
 
@@ -56,8 +55,14 @@ NSMutableArray *roomsToClean;
     if (self)
     {
         startDate = [NSDate date];
+        retainedObjects = [NSMutableArray array];
     }
     return self;
+}
+
+- (void)dealloc
+{
+    retainedObjects = [NSMutableArray array];
 }
 
 - (void)getBobCredentials:(void (^)(void))success
@@ -74,6 +79,7 @@ NSMutableArray *roomsToClean;
 
         MXRestClient *mxRestClient = [[MXRestClient alloc] initWithHomeServer:kMXTestsHomeServerURL
                                             andOnUnrecognizedCertificateBlock:nil];
+        [self retain:mxRestClient];
 
         // First, try register the user
         [mxRestClient registerWithLoginType:kMXLoginFlowTypeDummy username:bobUniqueUser password:MXTESTS_BOB_PWD success:^(MXCredentials *credentials) {
@@ -108,10 +114,11 @@ NSMutableArray *roomsToClean;
 {
     [self getBobCredentials:^{
         
-        MXRestClient *restClient = [[MXRestClient alloc] initWithCredentials:self.bobCredentials
+        MXRestClient *mxRestClient = [[MXRestClient alloc] initWithCredentials:self.bobCredentials
                                            andOnUnrecognizedCertificateBlock:nil];
+        [self retain:mxRestClient];
         
-        success(restClient);
+        success(mxRestClient);
     }];
 }
 
@@ -127,28 +134,11 @@ NSMutableArray *roomsToClean;
 
     [self getBobCredentials:^{
         
-        MXRestClient *restClient = [[MXRestClient alloc] initWithCredentials:self.bobCredentials
+        MXRestClient *mxRestClient = [[MXRestClient alloc] initWithCredentials:self.bobCredentials
                                            andOnUnrecognizedCertificateBlock:nil];
+        [self retain:mxRestClient];
 
-        if (accountToClean)
-        {
-            NSLog(@"Start cleaning user data (%tu rooms) from %@ ...", roomsToClean.count, testCase.name);
-
-            // Before giving the hand to the test, clean the rooms of the user.
-            // It is done now rather than at the end of each test because
-            // once [expectation fulfill] is called, the system allows no more HTTP requests.
-            [self leaveAllRoomsAsync:roomsToClean onComplete:^{
-                accountToClean = nil;
-
-                NSLog(@"End of cleaning user data");
-
-                readyToTest(restClient, expectation);
-            }];
-        }
-        else
-        {
-            readyToTest(restClient, expectation);
-        }
+        readyToTest(mxRestClient, expectation);
     }];
     
     if (testCase)
@@ -354,6 +344,7 @@ NSMutableArray *roomsToClean;
 {
     [self doMXRestClientTestWithBob:testCase readyToTest:^(MXRestClient *bobRestClient, XCTestExpectation *expectation) {
         MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        [self retain:mxSession];
 
         [mxSession start:^{
 
@@ -372,6 +363,7 @@ NSMutableArray *roomsToClean;
     [self doMXRestClientTestWithBobAndARoomWithMessages:testCase readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
         
         MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        [self retain:mxSession];
         
         [mxSession start:^{
             MXRoom *room = [mxSession roomWithRoomId:roomId];
@@ -390,6 +382,7 @@ NSMutableArray *roomsToClean;
     [self doMXRestClientTestWithBobAndThePublicRoom:testCase readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
         
         MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        [self retain:mxSession];
         
         [mxSession start:^{
             MXRoom *room = [mxSession roomWithRoomId:roomId];
@@ -406,6 +399,7 @@ NSMutableArray *roomsToClean;
 {
     [self doMXRestClientTestWithBob:testCase readyToTest:^(MXRestClient *bobRestClient, XCTestExpectation *expectation) {
         MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        [self retain:mxSession];
 
         [mxSession setStore:store success:^{
 
@@ -427,6 +421,7 @@ NSMutableArray *roomsToClean;
 {
     [self doMXRestClientTestWithBob:testCase readyToTest:^(MXRestClient *bobRestClient, XCTestExpectation *expectation) {
         MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        [self retain:mxSession];
 
         [bobRestClient createRoom:@"A room" visibility:nil roomAlias:nil topic:nil success:^(MXCreateRoomResponse *response) {
 
@@ -466,6 +461,7 @@ NSMutableArray *roomsToClean;
 
         MXRestClient *mxRestClient = [[MXRestClient alloc] initWithHomeServer:kMXTestsHomeServerURL
                                             andOnUnrecognizedCertificateBlock:nil];
+        [self retain:mxRestClient];
 
         // First, try register the user
         [mxRestClient registerWithLoginType:kMXLoginFlowTypeDummy username:aliceUniqueUser password:MXTESTS_ALICE_PWD success:^(MXCredentials *credentials) {
@@ -502,6 +498,8 @@ NSMutableArray *roomsToClean;
         
         MXRestClient *aliceRestClient = [[MXRestClient alloc] initWithCredentials:self.aliceCredentials
                                                 andOnUnrecognizedCertificateBlock:nil];
+        [self retain:aliceRestClient];
+
         __block MXRestClient *aliceRestClient2 = aliceRestClient;
         
         // Set Alice displayname and avator
@@ -549,6 +547,7 @@ NSMutableArray *roomsToClean;
     [self doMXRestClientTestWithAlice:testCase readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation) {
 
         MXSession *aliceSession = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
+        [self retain:aliceSession];
 
         [aliceSession start:^{
 
@@ -564,6 +563,7 @@ NSMutableArray *roomsToClean;
 {
     [self doMXRestClientTestWithAlice:testCase readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation) {
         MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
+        [self retain:mxSession];
 
         [mxSession setStore:store success:^{
 
@@ -612,6 +612,8 @@ NSMutableArray *roomsToClean;
     [self doMXRestClientTestWithBobAndAliceInARoom:testCase readyToTest:^(MXRestClient *bobRestClient, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
         MXSession *bobSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        [self retain:bobSession];
+
         [bobSession start:^{
 
             readyToTest(bobSession, aliceRestClient, roomId, expectation);
@@ -674,6 +676,7 @@ NSMutableArray *roomsToClean;
 
         MXRestClient *mxRestClient = [[MXRestClient alloc] initWithHomeServer:kMXTestsHomeServerHttpsURL
                                             andOnUnrecognizedCertificateBlock:onUnrecognizedCertBlock];
+        [self retain:mxRestClient];
 
         // First, try register the user
         [mxRestClient registerWithLoginType:kMXLoginFlowTypeDummy username:bobUniqueUser password:MXTESTS_BOB_PWD success:^(MXCredentials *credentials) {
@@ -719,6 +722,7 @@ NSMutableArray *roomsToClean;
                                            andOnUnrecognizedCertificateBlock:^BOOL(NSData *certificate) {
                                                return YES;
                                            }];
+        [self retain:restClient];
 
         readyToTest(restClient, expectation);
     }];
@@ -734,6 +738,7 @@ NSMutableArray *roomsToClean;
 {
     [self doHttpsMXRestClientTestWithBob:testCase readyToTest:^(MXRestClient *bobRestClient, XCTestExpectation *expectation) {
         MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        [self retain:mxSession];
 
         [mxSession start:^{
 
@@ -758,11 +763,15 @@ NSMutableArray *roomsToClean;
 
         MXRestClient *mxRestClient = [[MXRestClient alloc] initWithHomeServer:kMXTestsHomeServerURL
                                             andOnUnrecognizedCertificateBlock:nil];
+        [self retain:mxRestClient];
 
         [mxRestClient loginWithLoginType:kMXLoginFlowTypePassword username:userId password:password success:^(MXCredentials *credentials) {
 
             MXRestClient *mxRestClient2 = [[MXRestClient alloc] initWithCredentials:credentials andOnUnrecognizedCertificateBlock:nil];
+            [self retain:mxRestClient2];
+
             MXSession *newSession = [[MXSession alloc] initWithMatrixRestClient:mxRestClient2];
+            [self retain:newSession];
 
             [newSession start:^{
 
@@ -790,11 +799,15 @@ NSMutableArray *roomsToClean;
 
         MXRestClient *mxRestClient = [[MXRestClient alloc] initWithHomeServer:kMXTestsHomeServerURL
                                             andOnUnrecognizedCertificateBlock:nil];
+        [self retain:mxRestClient];
 
         [mxRestClient loginWithLoginType:kMXLoginFlowTypePassword username:userId password:password success:^(MXCredentials *credentials) {
 
             MXRestClient *mxRestClient2 = [[MXRestClient alloc] initWithCredentials:credentials andOnUnrecognizedCertificateBlock:nil];
+            [self retain:mxRestClient2];
+
             MXSession *newSession = [[MXSession alloc] initWithMatrixRestClient:mxRestClient2];
+            [self retain:newSession];
 
             [newSession start:^{
 
@@ -816,56 +829,12 @@ NSMutableArray *roomsToClean;
 
 - (void)closeMXSession:(MXSession*)mxSession
 {
-    // If the user has more than 5 rooms, it worths to leave all of them.
-    // While the db is not optimised (see SYN-164), an initialSync request
-    // on an account with 100 rooms takes 35s. With less than 5 rooms, it takes less than 0.5s.
-    
-    // Ideally, to correctly reset the initial conditions, we should erase the home server db
-    // between each test but, as a client, it is not possible.
-    if (nil == accountToClean && mxSession.rooms.count >= 5)
-    {
-        roomsToClean = [NSMutableArray array];
-        for (MXRoom *room in mxSession.rooms)
-        {
-            if (NO == room.state.isJoinRulePublic && MXMembershipJoin == room.state.membership)
-            {
-                [roomsToClean addObject:room.state.roomId];
-            }
-        }
-
-        if (roomsToClean.count)
-        {
-            // Mark the account to clean
-            accountToClean = mxSession.matrixRestClient;
-        }
-    }
-
     [mxSession close];
 }
 
-- (void)leaveAllRoomsAsync:(NSMutableArray*)rooms onComplete:(void (^)(void))onComplete
+- (void)retain:(NSObject*)object
 {
-    if (rooms.count)
-    {
-        // Leave room one by one
-        NSString *roomId = [rooms lastObject];
-        [rooms removeLastObject];
-
-        NSLog(@"Leaving %@...", roomId);
-
-        [accountToClean leaveRoom:roomId success:^{
-
-            [self leaveAllRoomsAsync:rooms onComplete:onComplete];
-
-        } failure:^(NSError *error) {
-            NSLog(@"Warning: Cannot leave room: %@. Error: %@", roomId, error);
-            [self leaveAllRoomsAsync:rooms onComplete:onComplete];
-        }];
-    }
-    else
-    {
-        onComplete();
-    }
+    [retainedObjects addObject:object];
 }
 
 @end


### PR DESCRIPTION
To make them run again since last changes with MXWeakify/MXStrongify.

I removed `[MatrixSDKTestsData closeMXSession]` that was used years ago to clean synapse db from the client side  This is no more required since Synapse performance is much better today.

