### PR TITLE
Remove the automatic direct chats definition

### DIFF
--- a/MatrixSDK/Data/MXRoom.h
+++ b/MatrixSDK/Data/MXRoom.h
@@ -118,11 +118,6 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidFlushDataNotification;
 @property (nonatomic) NSString *directUserId;
 
 /**
- Indicate whether the room looks like a direct room ("heuristic method").
- */
-@property (nonatomic, readonly) BOOL looksLikeDirect;
-
-/**
  Tag this room as a direct one, or remove the direct tag.
 
  @discussion: When a room is tagged as direct without mentioning the concerned userId,

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -2205,27 +2205,6 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
     return (_directUserId != nil);
 }
 
-- (BOOL)looksLikeDirect
-{
-    BOOL kicked = NO;
-    if (self.state.membership == MXMembershipLeave)
-    {
-        MXRoomMember *member = [self.state memberWithUserId:mxSession.myUser.userId];
-        kicked = ![member.originalEvent.sender isEqualToString:mxSession.myUser.userId];
-    }
-    
-    if (self.state.membership == MXMembershipJoin || self.state.membership == MXMembershipBan || kicked)
-    {
-        // Consider as direct chats the 1:1 chats.
-        // Contrary to the web client we allow the tagged rooms (favorite/low priority...) to become direct.
-        if (self.state.members.count == 2)
-        {
-            return YES;
-        }
-    }
-    return NO;
-}
-
 - (MXHTTPOperation*)setIsDirect:(BOOL)isDirect
                      withUserId:(NSString*)userId
                         success:(void (^)(void))success


### PR DESCRIPTION
when the current direct chat dictionary is empty on server sync

This mechanism (named "background compatibility heuristic") may introduce wrong direct chats, and it is not relevant anymore