### PR TITLE
 MXRoomState: Decouple room members from room state

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,8 @@ Improvements:
 Bug fix:
 
 API break:
-* MXRoomState: Remove displayName property. Use MXRoomSummary.displayName instead 
+* MXRoomState: Remove displayName property. Use MXRoomSummary.displayName instead.
+* MXRoomState: Create a MXRoomMembers property. All members getter methods has been to the new class.
 
 Changes in Matrix iOS SDK in 0.10.12 (2018-05-31)
 =============================================== 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Changes in Matrix iOS SDK in 0.11.0 ()
 
 Improvements:
 * MXRestClient: Add Matrix filter API
+* MXRoomState: Add a membersCount struct to store members stats independently from MXRoomMember objects.
 
 Bug fix:
 

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -86,6 +86,8 @@
 		326056861C76FDF2009D44AD /* MXEventTimeline.m in Sources */ = {isa = PBXBuildFile; fileRef = 326056841C76FDF1009D44AD /* MXEventTimeline.m */; };
 		32618E7120ED2DF500E1D2EA /* MXFilterJSONModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 32618E6F20ED2DF500E1D2EA /* MXFilterJSONModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		32618E7220ED2DF500E1D2EA /* MXFilterJSONModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 32618E7020ED2DF500E1D2EA /* MXFilterJSONModel.m */; };
+		32618E7B20EFA45B00E1D2EA /* MXRoomMembers.h in Headers */ = {isa = PBXBuildFile; fileRef = 32618E7920EFA45B00E1D2EA /* MXRoomMembers.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		32618E7C20EFA45B00E1D2EA /* MXRoomMembers.m in Sources */ = {isa = PBXBuildFile; fileRef = 32618E7A20EFA45B00E1D2EA /* MXRoomMembers.m */; };
 		32637ED41E5B00400011E20D /* MXDeviceList.h in Headers */ = {isa = PBXBuildFile; fileRef = 32637ED21E5B00400011E20D /* MXDeviceList.h */; };
 		32637ED51E5B00400011E20D /* MXDeviceList.m in Sources */ = {isa = PBXBuildFile; fileRef = 32637ED31E5B00400011E20D /* MXDeviceList.m */; };
 		3264DB911CEC528D00B99881 /* MXAccountData.h in Headers */ = {isa = PBXBuildFile; fileRef = 3264DB8F1CEC528D00B99881 /* MXAccountData.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -355,6 +357,8 @@
 		326056841C76FDF1009D44AD /* MXEventTimeline.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXEventTimeline.m; sourceTree = "<group>"; };
 		32618E6F20ED2DF500E1D2EA /* MXFilterJSONModel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXFilterJSONModel.h; sourceTree = "<group>"; };
 		32618E7020ED2DF500E1D2EA /* MXFilterJSONModel.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXFilterJSONModel.m; sourceTree = "<group>"; };
+		32618E7920EFA45B00E1D2EA /* MXRoomMembers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXRoomMembers.h; sourceTree = "<group>"; };
+		32618E7A20EFA45B00E1D2EA /* MXRoomMembers.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXRoomMembers.m; sourceTree = "<group>"; };
 		32637ED21E5B00400011E20D /* MXDeviceList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXDeviceList.h; sourceTree = "<group>"; };
 		32637ED31E5B00400011E20D /* MXDeviceList.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXDeviceList.m; sourceTree = "<group>"; };
 		3264DB8F1CEC528D00B99881 /* MXAccountData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXAccountData.h; sourceTree = "<group>"; };
@@ -597,6 +601,8 @@
 				32E226A51D06AC9F00E6CA54 /* MXPeekingRoom.m */,
 				3265CB361A14C43E00E24B2F /* MXRoomState.h */,
 				3265CB371A14C43E00E24B2F /* MXRoomState.m */,
+				32618E7920EFA45B00E1D2EA /* MXRoomMembers.h */,
+				32618E7A20EFA45B00E1D2EA /* MXRoomMembers.m */,
 				32481A821C03572900782AD3 /* MXRoomAccountData.h */,
 				32481A831C03572900782AD3 /* MXRoomAccountData.m */,
 				3220093619EFA4C9008DE41D /* MXEventListener.h */,
@@ -1199,6 +1205,7 @@
 				324BE4681E3FADB1008D99D4 /* MXMegolmExportEncryption.h in Headers */,
 				32CAB10B1A925B41008C5BB9 /* MXHTTPOperation.h in Headers */,
 				32F945F81FAB83D900622468 /* MXIncomingRoomKeyRequestCancellation.h in Headers */,
+				32618E7B20EFA45B00E1D2EA /* MXRoomMembers.h in Headers */,
 				3240969D1F9F751600DBA607 /* MXPushRuleSenderNotificationPermissionConditionChecker.h in Headers */,
 				32F634AB1FC5E3480054EF49 /* MXEventDecryptionResult.h in Headers */,
 				322A51C71D9BBD3C00C8536D /* MXOlmDevice.h in Headers */,
@@ -1441,6 +1448,7 @@
 				32A31BC920D401FC005916C7 /* MXRoomFilter.m in Sources */,
 				32A151471DAF7C0C00400192 /* MXDeviceInfo.m in Sources */,
 				32A1515C1DB525DA00400192 /* NSObject+sortedKeys.m in Sources */,
+				32618E7C20EFA45B00E1D2EA /* MXRoomMembers.m in Sources */,
 				F03EF5091DF071D5009DF592 /* MXEncryptedAttachments.m in Sources */,
 				32FA10CF1FA1C9F700E54233 /* MXOutgoingRoomKeyRequest.m in Sources */,
 				32322A4C1E575F65005DD155 /* MXAllowedCertificates.m in Sources */,
@@ -1708,6 +1716,7 @@
 			baseConfigurationReference = B1F1AE550CF4C15B653DDE6E /* Pods-MatrixSDKTests.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
@@ -1737,6 +1746,7 @@
 			baseConfigurationReference = 0BCFBADF157F3C8C43112BD6 /* Pods-MatrixSDKTests.release.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -339,7 +339,7 @@ NSTimeInterval kMXCryptoUploadOneTimeKeysPeriod = 60.0; // one minute
 
     // XXX what about rooms where invitees can see the content?
     NSMutableArray *roomMembers = [NSMutableArray array];
-    for (MXRoomMember *roomMember in room.state.joinedMembers)
+    for (MXRoomMember *roomMember in room.state.members.joinedMembers)
     {
         [roomMembers addObject:roomMember.userId];
     }
@@ -471,7 +471,7 @@ NSTimeInterval kMXCryptoUploadOneTimeKeysPeriod = 60.0; // one minute
     {
         // Get user ids in this room
         NSMutableArray *userIds = [NSMutableArray array];
-        for (MXRoomMember *member in room.state.joinedMembers)
+        for (MXRoomMember *member in room.state.members.joinedMembers)
         {
             [userIds addObject:member.userId];
         }
@@ -712,7 +712,7 @@ NSTimeInterval kMXCryptoUploadOneTimeKeysPeriod = 60.0; // one minute
     {
         if (room.state.isEncrypted)
         {
-            MXRoomMember *member = [room.state memberWithUserId:userId];
+            MXRoomMember *member = [room.state.members memberWithUserId:userId];
             if (member && member.membership == MXMembershipJoin)
             {
                 [userRooms addObject:room.roomId];
@@ -1450,7 +1450,7 @@ NSTimeInterval kMXCryptoUploadOneTimeKeysPeriod = 60.0; // one minute
     NSLog(@"[MXCrypto] setEncryptionInRoom: Enabling encryption in %@; starting to track device lists for all users therein", roomId);
 
     MXRoom *room = [_mxSession roomWithRoomId:roomId];
-    for (MXRoomMember *member in room.state.joinedMembers)
+    for (MXRoomMember *member in room.state.members.joinedMembers)
     {
         [_deviceList startTrackingDeviceList:member.userId];
     }
@@ -1921,7 +1921,7 @@ NSTimeInterval kMXCryptoUploadOneTimeKeysPeriod = 60.0; // one minute
     }
 
     NSString *userId = event.stateKey;
-    MXRoomMember *member = [[_mxSession roomWithRoomId:event.roomId].state memberWithUserId:userId];
+    MXRoomMember *member = [[_mxSession roomWithRoomId:event.roomId].state.members memberWithUserId:userId];
 
     if (member && member.membership == MXMembershipJoin)
     {

--- a/MatrixSDK/Data/MXEventTimeline.m
+++ b/MatrixSDK/Data/MXEventTimeline.m
@@ -729,7 +729,7 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
         {
             MXUser *user = [room.mxSession getOrCreateUser:event.sender];
 
-            MXRoomMember *roomMember = [_state memberWithUserId:event.sender];
+            MXRoomMember *roomMember = [_state.members memberWithUserId:event.sender];
             if (roomMember && MXMembershipJoin == roomMember.membership)
             {
                 [user updateWithRoomMemberEvent:event roomMember:roomMember inMatrixSession:room.mxSession];

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -189,7 +189,7 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
 - (void)handleInviteDirectFlag
 {
     // Handle here invite data to decide if it is direct or not
-    MXRoomMember *myUser = [self.state memberWithUserId:mxSession.myUser.userId];
+    MXRoomMember *myUser = [self.state.members memberWithUserId:mxSession.myUser.userId];
     BOOL isDirect = NO;
     
     if (myUser.originalEvent.content[@"is_direct"])
@@ -2290,7 +2290,7 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
         if (!newDirectUserId)
         {
             // By default mark as direct this room for the oldest joined member.
-            NSArray<MXRoomMember *> *members = self.state.joinedMembers;
+            NSArray<MXRoomMember *> *members = self.state.members.joinedMembers;
             MXRoomMember *oldestJoinedMember;
             
             for (MXRoomMember *member in members)
@@ -2312,7 +2312,7 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
             if (!newDirectUserId)
             {
                 // Consider the first invited member if none has joined
-                members = [self.state membersWithMembership:MXMembershipInvite];
+                members = [self.state.members membersWithMembership:MXMembershipInvite];
                 
                 MXRoomMember *oldestInvitedMember;
                 for (MXRoomMember *member in members)

--- a/MatrixSDK/Data/MXRoomMembers.h
+++ b/MatrixSDK/Data/MXRoomMembers.h
@@ -1,0 +1,102 @@
+/*
+ Copyright 2018 New Vector Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "MXEvent.h"
+#import "MXRoomMember.h"
+
+@class MXRoomState, MXSession;
+
+/**
+ `MXRoomMembers` holds room members of a given room.
+
+ Room members are part of room state events but, for performance reason (they can
+ be very very numerous), they are store aside other room state events.
+ */
+@interface MXRoomMembers : NSObject <NSCopying>
+
+/**
+ Create a `MXRoomMembers` instance.
+
+ // @TODO(lazy-loading): Remove those dependencies:
+ @paran state the room state it depends on.
+ @param matrixSession the session to the home server.
+
+ @return The newly-initialized MXRoomMembers.
+ */
+- (instancetype)initWithRoomState:(MXRoomState*)state andMatrixSession:(MXSession*)matrixSession;
+
+/**
+ A copy of the list of room members.
+ */
+@property (nonatomic, readonly) NSArray<MXRoomMember*> *members;
+
+/**
+ A copy of the list of joined room members.
+ */
+@property (nonatomic, readonly) NSArray<MXRoomMember*> *joinedMembers;
+
+/**
+ Return the member with the given user id.
+
+ @param userId the id of the member to retrieve.
+ @return the room member.
+ */
+- (MXRoomMember*)memberWithUserId:(NSString*)userId;
+
+/**
+ Return a display name for a member.
+ It is his displayname member or, if nil, his userId.
+ Disambiguate members who have the same displayname in the room by adding his userId.
+ */
+- (NSString*)memberName:(NSString*)userId;
+
+/**
+ Return a display name for a member suitable to compare and sort members list
+ */
+- (NSString*)memberSortedName:(NSString*)userId;
+
+/**
+ Return the list of members with a given membership.
+
+ @param membership the membership to look for.
+ @return an array of MXRoomMember objects.
+ */
+- (NSArray<MXRoomMember*>*)membersWithMembership:(MXMembership)membership;
+
+/**
+ A copy of the list of room members excluding the conference user.
+ */
+// @TODO(lazy-loading): Nasty. Can be removed?
+- (NSArray<MXRoomMember*>*)membersWithoutConferenceUser;
+
+/**
+ Return the list of members with a given membership with or without the conference user.
+
+ @param membership the membership to look for.
+ @param includeConferenceUser NO to filter the conference user.
+ @return an array of MXRoomMember objects.
+ */
+// @TODO(lazy-loading): Nasty. Can be removed?
+- (NSArray<MXRoomMember*>*)membersWithMembership:(MXMembership)membership includeConferenceUser:(BOOL)includeConferenceUser;
+
+
+#pragma mark - State events handling
+
+- (void)handleStateEvent:(MXEvent*)event;
+
+@end

--- a/MatrixSDK/Data/MXRoomMembers.m
+++ b/MatrixSDK/Data/MXRoomMembers.m
@@ -1,0 +1,294 @@
+/*
+ Copyright 2018 New Vector Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXRoomMembers.h"
+
+#import "MXRoomState.h"
+#import "MXSession.h"
+#import "MXSDKOptions.h"
+
+@interface MXRoomMembers ()
+{
+    // @TODO(lazy-loading): Remove those dependencies
+    MXSession *mxSession;
+    MXRoomState *state;
+
+    /**
+     Members ordered by userId.
+     */
+    NSMutableDictionary<NSString*, MXRoomMember*> *members;
+
+    /**
+     Track the usage of members displaynames in order to disambiguate them if necessary,
+     ie if the same displayname is used by several users, we have to update their displaynames.
+     displayname -> count (= how many members of the room uses this displayname)
+     */
+    NSMutableDictionary<NSString*, NSNumber*> *membersNamesInUse;
+}
+@end
+
+@implementation MXRoomMembers
+
+- (instancetype)initWithRoomState:(MXRoomState *)roomState andMatrixSession:(MXSession*)matrixSession
+{
+    self = [super init];
+    if (self)
+    {
+        mxSession = matrixSession;
+        state = roomState;
+
+        members = [NSMutableDictionary dictionary];
+        membersNamesInUse = [NSMutableDictionary dictionary];
+    }
+    return self;
+}
+
+- (NSArray<MXRoomMember *> *)members
+{
+    return [members allValues];
+}
+
+- (NSArray<MXRoomMember *> *)joinedMembers
+{
+    return [self membersWithMembership:MXMembershipJoin];
+}
+
+#pragma mark - Memberships
+- (MXRoomMember*)memberWithUserId:(NSString *)userId
+{
+    return members[userId];
+}
+
+- (NSString*)memberName:(NSString*)userId
+{
+    // Sanity check (ignore the request if the room state is not initialized yet)
+    if (!userId.length || !membersNamesInUse)
+    {
+        return nil;
+    }
+
+    NSString *displayName;
+
+    // Get the user display name from the member list of the room
+    MXRoomMember *member = [self memberWithUserId:userId];
+    if (member && member.displayname.length)
+    {
+        displayName = member.displayname;
+    }
+
+    if (displayName)
+    {
+        // Do we need to disambiguate it?
+        NSNumber *memberNameCount = membersNamesInUse[displayName];
+        if (memberNameCount && [memberNameCount unsignedIntegerValue] > 1)
+        {
+            // There are more than one member that uses the same displayname, so, yes, disambiguate it
+            displayName = [NSString stringWithFormat:@"%@ (%@)", displayName, userId];
+        }
+    }
+    else
+    {
+        // By default, use the user ID
+        displayName = userId;
+    }
+
+    return displayName;
+}
+
+- (NSString*)memberSortedName:(NSString*)userId
+{
+    // Get the user display name from the member list of the room
+    MXRoomMember *member = [self memberWithUserId:userId];
+    NSString *displayName = member.displayname;
+
+    // Do not disambiguate here members who have the same displayname in the room (see memberName:).
+
+    if (!displayName)
+    {
+        // By default, use the user ID
+        displayName = userId;
+    }
+
+    return displayName;
+}
+
+- (NSArray<MXRoomMember*>*)membersWithMembership:(MXMembership)theMembership
+{
+    NSMutableArray *membersWithMembership = [NSMutableArray array];
+    for (MXRoomMember *roomMember in members.allValues)
+    {
+        if (roomMember.membership == theMembership)
+        {
+            [membersWithMembership addObject:roomMember];
+        }
+    }
+    return membersWithMembership;
+}
+
+- (NSArray<MXRoomMember *> *)membersWithoutConferenceUser
+{
+    NSArray<MXRoomMember *> *membersWithoutConferenceUser;
+
+    if (state.isConferenceUserRoom)
+    {
+        // Show everyone in a 1:1 room with a conference user
+        membersWithoutConferenceUser = self.members;
+    }
+    else if (![self memberWithUserId:state.conferenceUserId])
+    {
+        // There is no conference user. No need to filter
+        membersWithoutConferenceUser = self.members;
+    }
+    else
+    {
+        // Filter the conference user from the list
+        NSMutableDictionary<NSString*, MXRoomMember*> *membersWithoutConferenceUserDict = [NSMutableDictionary dictionaryWithDictionary:members];
+        [membersWithoutConferenceUserDict removeObjectForKey:state.conferenceUserId];
+        membersWithoutConferenceUser = membersWithoutConferenceUserDict.allValues;
+    }
+
+    return membersWithoutConferenceUser;
+}
+
+- (NSArray<MXRoomMember *> *)membersWithMembership:(MXMembership)theMembership includeConferenceUser:(BOOL)includeConferenceUser
+{
+    NSArray<MXRoomMember *> *membersWithMembership;
+
+    if (includeConferenceUser || state.isConferenceUserRoom)
+    {
+        // Show everyone in a 1:1 room with a conference user
+        membersWithMembership = [self membersWithMembership:theMembership];
+    }
+    else
+    {
+        MXRoomMember *conferenceUserMember = [self memberWithUserId:state.conferenceUserId];
+        if (!conferenceUserMember || conferenceUserMember.membership != theMembership)
+        {
+            // The conference user is not in list of members with the passed  membership
+            membersWithMembership = [self membersWithMembership:theMembership];
+        }
+        else
+        {
+            NSMutableDictionary *membersWithMembershipDict = [NSMutableDictionary dictionaryWithCapacity:members.count];
+            for (MXRoomMember *roomMember in members.allValues)
+            {
+                if (roomMember.membership == theMembership)
+                {
+                    membersWithMembershipDict[roomMember.userId] = roomMember;
+                }
+            }
+
+            [membersWithMembershipDict removeObjectForKey:state.conferenceUserId];
+            membersWithMembership = membersWithMembershipDict.allValues;
+        }
+    }
+
+    return membersWithMembership;
+}
+
+#pragma mark - State events handling
+- (void)handleStateEvent:(MXEvent*)event
+{
+    switch (event.eventType)
+    {
+        case MXEventTypeRoomMember:
+        {
+            // Remove the previous MXRoomMember of this user from membersNamesInUse
+            NSString *userId = event.stateKey;
+            MXRoomMember *oldRoomMember = members[userId];
+            if (oldRoomMember && oldRoomMember.displayname)
+            {
+                NSNumber *memberNameCount = membersNamesInUse[oldRoomMember.displayname];
+                if (memberNameCount)
+                {
+                    NSUInteger count = [memberNameCount unsignedIntegerValue];
+                    if (count)
+                    {
+                        count--;
+                    }
+
+                    if (count)
+                    {
+                        membersNamesInUse[oldRoomMember.displayname] = @(count);
+                    }
+                    else
+                    {
+                        [membersNamesInUse removeObjectForKey:oldRoomMember.displayname];
+                    }
+                }
+            }
+
+            MXRoomMember *roomMember = [[MXRoomMember alloc] initWithMXEvent:event andEventContent:[state contentOfEvent:event]];
+            if (roomMember)
+            {
+                /// Update membersNamesInUse
+                if (roomMember.displayname)
+                {
+                    NSUInteger count = 1;
+
+                    NSNumber *memberNameCount = membersNamesInUse[roomMember.displayname];
+                    if (memberNameCount)
+                    {
+                        // We have several users using the same displayname
+                        count = [memberNameCount unsignedIntegerValue];
+                        count++;
+                    }
+
+                    membersNamesInUse[roomMember.displayname] = @(count);
+                }
+
+                members[roomMember.userId] = roomMember;
+
+                // Handle here the case where the member has no defined avatar.
+                if (nil == roomMember.avatarUrl && ![MXSDKOptions sharedInstance].disableIdenticonUseForUserAvatar)
+                {
+                    // Force to use an identicon url
+                    roomMember.avatarUrl = [mxSession.matrixRestClient urlOfIdenticon:roomMember.userId];
+                }
+            }
+            else
+            {
+                // The user is no more part of the room. Remove him.
+                // This case happens during back pagination: we remove here users when they are not in the room yet.
+                [members removeObjectForKey:event.stateKey];
+            }
+
+            break;
+        }
+
+        default:
+            break;
+    }
+}
+
+#pragma mark - NSCopying
+- (id)copyWithZone:(NSZone *)zone
+{
+    MXRoomMembers *membersCopy = [[MXRoomMembers allocWithZone:zone] init];
+
+    membersCopy->mxSession = mxSession;
+    membersCopy->state = state;
+
+    // Same thing here. MXRoomMember objects in members are also immutable. A new instance of it is created each time
+    // the sdk receives room member event, even if it is an update of an existing member like a
+    // membership change (ex: "invited" -> "joined")
+    membersCopy->members = [[NSMutableDictionary allocWithZone:zone] initWithDictionary:members];
+
+    membersCopy->membersNamesInUse = [[NSMutableDictionary allocWithZone:zone] initWithDictionary:membersNamesInUse];
+
+    return membersCopy;
+}
+@end

--- a/MatrixSDK/Data/MXRoomMembers.m
+++ b/MatrixSDK/Data/MXRoomMembers.m
@@ -282,12 +282,12 @@
     membersCopy->mxSession = mxSession;
     membersCopy->state = state;
 
-    // Same thing here. MXRoomMember objects in members are also immutable. A new instance of it is created each time
+    // MXRoomMember objects in members are immutable. A new instance of it is created each time
     // the sdk receives room member event, even if it is an update of an existing member like a
     // membership change (ex: "invited" -> "joined")
-    membersCopy->members = [[NSMutableDictionary allocWithZone:zone] initWithDictionary:members];
+    membersCopy->members = [members copyWithZone:zone];
 
-    membersCopy->membersNamesInUse = [[NSMutableDictionary allocWithZone:zone] initWithDictionary:membersNamesInUse];
+    membersCopy->membersNamesInUse = [membersNamesInUse copyWithZone:zone];
 
     return membersCopy;
 }

--- a/MatrixSDK/Data/MXRoomMembers.m
+++ b/MatrixSDK/Data/MXRoomMembers.m
@@ -285,9 +285,9 @@
     // MXRoomMember objects in members are immutable. A new instance of it is created each time
     // the sdk receives room member event, even if it is an update of an existing member like a
     // membership change (ex: "invited" -> "joined")
-    membersCopy->members = [members copyWithZone:zone];
+    membersCopy->members = [members mutableCopyWithZone:zone];
 
-    membersCopy->membersNamesInUse = [membersNamesInUse copyWithZone:zone];
+    membersCopy->membersNamesInUse = [membersNamesInUse mutableCopyWithZone:zone];
 
     return membersCopy;
 }

--- a/MatrixSDK/Data/MXRoomState.h
+++ b/MatrixSDK/Data/MXRoomState.h
@@ -19,7 +19,7 @@
 
 #import "MXEvent.h"
 #import "MXJSONModels.h"
-#import "MXRoomMember.h"
+#import "MXRoomMembers.h"
 #import "MXRoomThirdPartyInvite.h"
 #import "MXRoomPowerLevels.h"
 #import "MXEnumConstants.h"
@@ -53,14 +53,9 @@
 @property (nonatomic, readonly) NSArray<MXEvent *> *stateEvents;
 
 /**
- A copy of the list of room members.
+ Room members of the room.
  */
-@property (nonatomic, readonly) NSArray<MXRoomMember*> *members;
-
-/**
- A copy of the list of joined room members.
- */
-@property (nonatomic, readonly) NSArray<MXRoomMember*> *joinedMembers;
+@property (nonatomic, readonly) MXRoomMembers *members;
 
 /**
 A copy of the list of third party invites (actually MXRoomThirdPartyInvite instances).
@@ -199,12 +194,14 @@ Use MXRoomSummary.displayname to get a computed room display name.
 - (NSArray<MXEvent*> *)stateEventsWithType:(MXEventTypeString)eventType NS_REFINED_FOR_SWIFT;
 
 /**
- Return the member with the given user id.
- 
- @param userId the id of the member to retrieve.
- @return the room member.
+ According to the direction of the instance, we are interested either by
+ the content of the event or its prev_content.
+
+ @param event the event to get the content from.
+
+ @return content or prev_content dictionary.
  */
-- (MXRoomMember*)memberWithUserId:(NSString*)userId;
+- (NSDictionary<NSString *, id> *)contentOfEvent:(MXEvent*)event;
 
 /**
  Return the member who was invited by a 3pid medium with the given token.
@@ -228,32 +225,12 @@ Use MXRoomSummary.displayname to get a computed room display name.
 - (MXRoomThirdPartyInvite*)thirdPartyInviteWithToken:(NSString*)thirdPartyInviteToken;
 
 /**
- Return a display name for a member.
- It is his displayname member or, if nil, his userId.
- Disambiguate members who have the same displayname in the room by adding his userId.
- */
-- (NSString*)memberName:(NSString*)userId;
-
-/**
- Return a display name for a member suitable to compare and sort members list
- */
-- (NSString*)memberSortedName:(NSString*)userId;
-
-/**
  Normalize (between 0 and 1) the power level of a member compared to other members.
  
  @param userId the id of the member to consider.
  @return power level in [0, 1] interval.
  */
 - (float)memberNormalizedPowerLevel:(NSString*)userId;
-
-/**
- Return the list of members with a given membership.
- 
- @param membership the membership to look for.
- @return an array of MXRoomMember objects.
- */
-- (NSArray<MXRoomMember*>*)membersWithMembership:(MXMembership)membership;
 
 
 # pragma mark - Conference call
@@ -273,17 +250,4 @@ Use MXRoomSummary.displayname to get a computed room display name.
  */
 @property (nonatomic, readonly) NSString *conferenceUserId;
 
-/**
- A copy of the list of room members excluding the conference user.
- */
-- (NSArray<MXRoomMember*>*)membersWithoutConferenceUser;
-
-/**
- Return the list of members with a given membership with or without the conference user.
-
- @param membership the membership to look for.
- @param includeConferenceUser NO to filter the conference user.
- @return an array of MXRoomMember objects.
- */
-- (NSArray<MXRoomMember*>*)membersWithMembership:(MXMembership)membership includeConferenceUser:(BOOL)includeConferenceUser;
 @end

--- a/MatrixSDK/Data/MXRoomState.h
+++ b/MatrixSDK/Data/MXRoomState.h
@@ -24,6 +24,17 @@
 #import "MXRoomPowerLevels.h"
 #import "MXEnumConstants.h"
 
+/**
+ Room members counts.
+ */
+typedef struct
+{
+    NSUInteger members;
+    NSUInteger joined;
+    NSUInteger invited;
+} MXRoomStateMembersCount;
+
+
 @class MXSession;
 
 /**
@@ -37,7 +48,7 @@
 @interface MXRoomState : NSObject <NSCopying>
 
 /**
- The room ID
+ The room id.
  */
 @property (nonatomic, readonly) NSString *roomId;
 
@@ -56,6 +67,11 @@
  Room members of the room.
  */
 @property (nonatomic, readonly) MXRoomMembers *members;
+
+/**
+ Room members counts.
+ */
+@property (nonatomic, readonly) MXRoomStateMembersCount membersCount;
 
 /**
 A copy of the list of third party invites (actually MXRoomThirdPartyInvite instances).

--- a/MatrixSDK/Data/MXRoomState.m
+++ b/MatrixSDK/Data/MXRoomState.m
@@ -33,11 +33,6 @@
     NSMutableDictionary<NSString*, NSMutableArray<MXEvent*>*> *stateEvents;
 
     /**
-     Members ordered by userId.
-     */
-    NSMutableDictionary<NSString*, MXRoomMember*> *members;
-    
-    /**
      The room aliases. The key is the domain.
      */
     NSMutableDictionary<NSString*, MXEvent*> *roomAliases;
@@ -56,13 +51,6 @@
      Maximum power level observed in power level list
      */
     NSInteger maxPowerLevel;
-
-    /**
-     Track the usage of members displaynames in order to disambiguate them if necessary,
-     ie if the same displayname is used by several users, we have to update their displaynames.
-     displayname -> count (= how many members of the room uses this displayname)
-     */
-    NSMutableDictionary<NSString*, NSNumber*> *membersNamesInUse;
 
     /**
      Cache for [self memberWithThirdPartyInviteToken].
@@ -93,10 +81,9 @@
         _isLive = isLive;
         
         stateEvents = [NSMutableDictionary dictionary];
-        members = [NSMutableDictionary dictionary];
+        _members = [[MXRoomMembers alloc] initWithRoomState:self andMatrixSession:mxSession];
         roomAliases = [NSMutableDictionary dictionary];
         thirdPartyInvites = [NSMutableDictionary dictionary];
-        membersNamesInUse = [NSMutableDictionary dictionary];
         membersWithThirdPartyInviteTokenCache = [NSMutableDictionary dictionary];
     }
     return self;
@@ -172,7 +159,7 @@
     }
 
     // Members are also state events
-    for (MXRoomMember *roomMember in self.members)
+    for (MXRoomMember *roomMember in self.members.members)
     {
         [state addObject:roomMember.originalEvent];
     }
@@ -190,16 +177,6 @@
     }
 
     return state;
-}
-
-- (NSArray<MXRoomMember *> *)members
-{
-    return [members allValues];
-}
-
-- (NSArray<MXRoomMember *> *)joinedMembers
-{
-    return [self membersWithMembership:MXMembershipJoin];
 }
 
 - (NSArray<MXRoomThirdPartyInvite *> *)thirdPartyInvites
@@ -348,7 +325,7 @@
     MXMembership result;
     
     // Find the current value in room state events
-    MXRoomMember *user = [self memberWithUserId:mxSession.matrixRestClient.credentials.userId];
+    MXRoomMember *user = [self.members memberWithUserId:mxSession.matrixRestClient.credentials.userId];
     if (user)
     {
         result = user.membership;
@@ -375,74 +352,19 @@
 #pragma mark - State events handling
 - (void)handleStateEvent:(MXEvent*)event
 {
+    // Process the update on room members
+    [_members handleStateEvent:event];
+
     switch (event.eventType)
     {
         case MXEventTypeRoomMember:
         {
-            // Remove the previous MXRoomMember of this user from membersNamesInUse
-            NSString *userId = event.stateKey;
-            MXRoomMember *oldRoomMember = members[userId];
-            if (oldRoomMember && oldRoomMember.displayname)
+            NSDictionary *content = [self contentOfEvent:event];
+            if (content[@"third_party_invite"][@"signed"][@"token"])
             {
-                NSNumber *memberNameCount = membersNamesInUse[oldRoomMember.displayname];
-                if (memberNameCount)
-                {
-                    NSUInteger count = [memberNameCount unsignedIntegerValue];
-                    if (count)
-                    {
-                        count--;
-                    }
-
-                    if (count)
-                    {
-                        membersNamesInUse[oldRoomMember.displayname] = @(count);
-                    }
-                    else
-                    {
-                        [membersNamesInUse removeObjectForKey:oldRoomMember.displayname];
-                    }
-                }
-            }
-
-            MXRoomMember *roomMember = [[MXRoomMember alloc] initWithMXEvent:event andEventContent:[self contentOfEvent:event]];
-            if (roomMember)
-            {
-                /// Update membersNamesInUse
-                if (roomMember.displayname)
-                {
-                    NSUInteger count = 1;
-
-                    NSNumber *memberNameCount = membersNamesInUse[roomMember.displayname];
-                    if (memberNameCount)
-                    {
-                        // We have several users using the same displayname
-                        count = [memberNameCount unsignedIntegerValue];
-                        count++;
-                    }
-
-                    membersNamesInUse[roomMember.displayname] = @(count);
-                }
-
-                members[roomMember.userId] = roomMember;
-
-                // Handle here the case where the member has no defined avatar.
-                if (nil == roomMember.avatarUrl && ![MXSDKOptions sharedInstance].disableIdenticonUseForUserAvatar)
-                {
-                    // Force to use an identicon url
-                    roomMember.avatarUrl = [mxSession.matrixRestClient urlOfIdenticon:roomMember.userId];
-                }
-
                 // Cache room member event that is successor of a third party invite event
-                if (roomMember.thirdPartyInviteToken)
-                {
-                    membersWithThirdPartyInviteTokenCache[roomMember.thirdPartyInviteToken] = roomMember;
-                }
-            }
-            else
-            {
-                // The user is no more part of the room. Remove him.
-                // This case happens during back pagination: we remove here users when they are not in the room yet.
-                [members removeObjectForKey:event.stateKey];
+                MXRoomMember *roomMember = [[MXRoomMember alloc] initWithMXEvent:event andEventContent:content];
+                membersWithThirdPartyInviteTokenCache[roomMember.thirdPartyInviteToken] = roomMember;
             }
 
             // In case of invite, process the provided but incomplete room state
@@ -453,10 +375,14 @@
                     [self handleStateEvent:inviteRoomStateEvent];
                 }
             }
-            else if (_isLive && self.membership == MXMembershipJoin && members.count > 2 && [roomMember.userId isEqualToString:self.conferenceUserId])
+            else if (_isLive && self.membership == MXMembershipJoin && _members.members.count > 2)
             {
-                // Forward the change of the conference user membership to the call manager
-                [mxSession.callManager handleConferenceUserUpdate:roomMember inRoom:_roomId];
+                MXRoomMember *roomMember = [[MXRoomMember alloc] initWithMXEvent:event andEventContent:content];
+                if ([roomMember.userId isEqualToString:self.conferenceUserId])
+                {
+                    // Forward the change of the conference user membership to the call manager
+                    [mxSession.callManager handleConferenceUserUpdate:roomMember inRoom:_roomId];
+                }
             }
 
             break;
@@ -524,13 +450,6 @@
     return stateEvents[eventType];
 }
 
-
-#pragma mark - Memberships
-- (MXRoomMember*)memberWithUserId:(NSString *)userId
-{
-    return members[userId];
-}
-
 - (MXRoomMember *)memberWithThirdPartyInviteToken:(NSString *)thirdPartyInviteToken
 {
     return membersWithThirdPartyInviteTokenCache[thirdPartyInviteToken];
@@ -541,65 +460,13 @@
     return thirdPartyInvites[thirdPartyInviteToken];
 }
 
-- (NSString*)memberName:(NSString*)userId
-{
-    // Sanity check (ignore the request if the room state is not initialized yet)
-    if (!userId.length || !membersNamesInUse)
-    {
-        return nil;
-    }
-
-    NSString *displayName;
-
-    // Get the user display name from the member list of the room
-    MXRoomMember *member = [self memberWithUserId:userId];
-    if (member && member.displayname.length)
-    {
-        displayName = member.displayname;
-    }
-
-    if (displayName)
-    {
-        // Do we need to disambiguate it?
-        NSNumber *memberNameCount = membersNamesInUse[displayName];
-        if (memberNameCount && [memberNameCount unsignedIntegerValue] > 1)
-        {
-            // There are more than one member that uses the same displayname, so, yes, disambiguate it
-            displayName = [NSString stringWithFormat:@"%@ (%@)", displayName, userId];
-        }
-    }
-    else
-    {
-        // By default, use the user ID
-        displayName = userId;
-    }
-
-    return displayName;
-}
-
-- (NSString*)memberSortedName:(NSString*)userId
-{
-    // Get the user display name from the member list of the room
-    MXRoomMember *member = [self memberWithUserId:userId];
-    NSString *displayName = member.displayname;
-    
-    // Do not disambiguate here members who have the same displayname in the room (see memberName:).
-    
-    if (!displayName)
-    {
-        // By default, use the user ID
-        displayName = userId;
-    }
-    
-    return displayName;
-}
-
 - (float)memberNormalizedPowerLevel:(NSString*)userId
 {
     float powerLevel = 0;
     
-    // Get the user display name from the member list of the room
-    MXRoomMember *member = [self memberWithUserId:userId];
+    // Get the user from the member list of the room
+    // @TODO(lazy-loading): We should not need it. This is not the job of the SDK to filter information like this
+    MXRoomMember *member = [self.members memberWithUserId:userId];
     
     // Ignore banned and left (kicked) members
     if (member.membership != MXMembershipLeave && member.membership != MXMembershipBan)
@@ -611,26 +478,12 @@
     return powerLevel;
 }
 
-- (NSArray<MXRoomMember*>*)membersWithMembership:(MXMembership)theMembership
-{
-    NSMutableArray *membersWithMembership = [NSMutableArray array];
-    for (MXRoomMember *roomMember in members.allValues)
-    {
-        if (roomMember.membership == theMembership)
-        {
-            [membersWithMembership addObject:roomMember];
-        }
-    }
-    return membersWithMembership;
-}
-
-
 # pragma mark - Conference call
 - (BOOL)isOngoingConferenceCall
 {
     BOOL isOngoingConferenceCall = NO;
 
-    MXRoomMember *conferenceUserMember = [self memberWithUserId:self.conferenceUserId];
+    MXRoomMember *conferenceUserMember = [self.members memberWithUserId:self.conferenceUserId];
     if (conferenceUserMember)
     {
         isOngoingConferenceCall = (conferenceUserMember.membership == MXMembershipJoin);
@@ -644,16 +497,9 @@
     BOOL isConferenceUserRoom = NO;
 
     // A conference user room is a 1:1 room with a conference user
-    if (members.count == 2)
+    if (self.members.members.count == 2 && [self.members memberWithUserId:self.conferenceUserId])
     {
-        for (NSString *memberUserId in members)
-        {
-            if ([MXCallManager isConferenceUser:memberUserId])
-            {
-                isConferenceUserRoom = YES;
-                break;
-            }
-        }
+        isConferenceUserRoom = YES;
     }
 
     return isConferenceUserRoom;
@@ -667,68 +513,6 @@
     }
     return conferenceUserId;
 }
-
-- (NSArray<MXRoomMember *> *)membersWithoutConferenceUser
-{
-    NSArray<MXRoomMember *> *membersWithoutConferenceUser;
-
-    if (self.isConferenceUserRoom)
-    {
-        // Show everyone in a 1:1 room with a conference user
-        membersWithoutConferenceUser = self.members;
-    }
-    else if (![self memberWithUserId:self.conferenceUserId])
-    {
-        // There is no conference user. No need to filter
-        membersWithoutConferenceUser = self.members;
-    }
-    else
-    {
-        // Filter the conference user from the list
-        NSMutableDictionary<NSString*, MXRoomMember*> *membersWithoutConferenceUserDict = [NSMutableDictionary dictionaryWithDictionary:members];
-        [membersWithoutConferenceUserDict removeObjectForKey:self.conferenceUserId];
-        membersWithoutConferenceUser = membersWithoutConferenceUserDict.allValues;
-    }
-
-    return membersWithoutConferenceUser;
-}
-
-- (NSArray<MXRoomMember *> *)membersWithMembership:(MXMembership)theMembership includeConferenceUser:(BOOL)includeConferenceUser
-{
-    NSArray<MXRoomMember *> *membersWithMembership;
-
-    if (includeConferenceUser || self.isConferenceUserRoom)
-    {
-        // Show everyone in a 1:1 room with a conference user
-        membersWithMembership = [self membersWithMembership:theMembership];
-    }
-    else
-    {
-        MXRoomMember *conferenceUserMember = [self memberWithUserId:self.conferenceUserId];
-        if (!conferenceUserMember || conferenceUserMember.membership != theMembership)
-        {
-            // The conference user is not in list of members with the passed  membership
-            membersWithMembership = [self membersWithMembership:theMembership];
-        }
-        else
-        {
-            NSMutableDictionary *membersWithMembershipDict = [NSMutableDictionary dictionaryWithCapacity:members.count];
-            for (MXRoomMember *roomMember in members.allValues)
-            {
-                if (roomMember.membership == theMembership)
-                {
-                    membersWithMembershipDict[roomMember.userId] = roomMember;
-                }
-            }
-
-            [membersWithMembershipDict removeObjectForKey:self.conferenceUserId];
-            membersWithMembership = membersWithMembershipDict.allValues;
-        }
-    }
-
-    return membersWithMembership;
-}
-
 
 #pragma mark - NSCopying
 - (id)copyWithZone:(NSZone *)zone
@@ -748,10 +532,10 @@
         stateCopy->stateEvents[key] = [[NSMutableArray allocWithZone:zone] initWithArray:stateEvents[key]];
     }
 
-    // Same thing here. MXRoomMembers are also immutable. A new instance of it is created each time
+    // Same thing here. MXRoomMember objects in members are also immutable. A new instance of it is created each time
     // the sdk receives room member event, even if it is an update of an existing member like a
     // membership change (ex: "invited" -> "joined")
-    stateCopy->members = [[NSMutableDictionary allocWithZone:zone] initWithDictionary:members];
+    stateCopy->_members = [_members copyWithZone:zone];
     
     stateCopy->roomAliases = [[NSMutableDictionary allocWithZone:zone] initWithDictionary:roomAliases];
 
@@ -761,8 +545,6 @@
     
     stateCopy->membership = membership;
 
-    stateCopy->membersNamesInUse = [[NSMutableDictionary allocWithZone:zone] initWithDictionary:membersNamesInUse];
-    
     stateCopy->powerLevels = [powerLevels copy];
     stateCopy->maxPowerLevel = maxPowerLevel;
 

--- a/MatrixSDK/Data/MXRoomState.m
+++ b/MatrixSDK/Data/MXRoomState.m
@@ -359,6 +359,13 @@
     {
         case MXEventTypeRoomMember:
         {
+            // Update counters from self.members
+            // @TODO(lazy-loading): these values will be provided by the coming
+            // room summary in the matrix spec (https://github.com/matrix-org/matrix-doc/issues/688).
+            _membersCount.members = _members.members.count;
+            _membersCount.joined = _members.joinedMembers.count;
+            _membersCount.invited =  [_members membersWithMembership:MXMembershipInvite].count;
+
             NSDictionary *content = [self contentOfEvent:event];
             if (content[@"third_party_invite"][@"signed"][@"token"])
             {
@@ -536,6 +543,8 @@
     // the sdk receives room member event, even if it is an update of an existing member like a
     // membership change (ex: "invited" -> "joined")
     stateCopy->_members = [_members copyWithZone:zone];
+
+    stateCopy->_membersCount = _membersCount;
     
     stateCopy->roomAliases = [[NSMutableDictionary allocWithZone:zone] initWithDictionary:roomAliases];
 

--- a/MatrixSDK/Data/MXRoomState.m
+++ b/MatrixSDK/Data/MXRoomState.m
@@ -539,9 +539,6 @@
         stateCopy->stateEvents[key] = [[NSMutableArray allocWithZone:zone] initWithArray:stateEvents[key]];
     }
 
-    // Same thing here. MXRoomMember objects in members are also immutable. A new instance of it is created each time
-    // the sdk receives room member event, even if it is an update of an existing member like a
-    // membership change (ex: "invited" -> "joined")
     stateCopy->_members = [_members copyWithZone:zone];
 
     stateCopy->_membersCount = _membersCount;

--- a/MatrixSDK/NotificationCenter/Checker/MXPushRuleRoomMemberCountConditionChecker.m
+++ b/MatrixSDK/NotificationCenter/Checker/MXPushRuleRoomMemberCountConditionChecker.m
@@ -88,23 +88,23 @@
             {
                 if (nil == op || [op isEqualToString:@"=="])
                 {
-                    isSatisfied = (value == room.state.members.members.count);
+                    isSatisfied = (value == room.state.membersCount.members);
                 }
                 else if ([op isEqualToString:@"<"])
                 {
-                    isSatisfied = (value < room.state.members.members.count);
+                    isSatisfied = (value < room.state.membersCount.members);
                 }
                 else if ([op isEqualToString:@">"])
                 {
-                    isSatisfied = (value > room.state.members.members.count);
+                    isSatisfied = (value > room.state.membersCount.members);
                 }
                 else if ([op isEqualToString:@">="])
                 {
-                    isSatisfied = (value >= room.state.members.members.count);
+                    isSatisfied = (value >= room.state.membersCount.members);
                 }
                 else if ([op isEqualToString:@"<="])
                 {
-                    isSatisfied = (value <= room.state.members.members.count);
+                    isSatisfied = (value <= room.state.membersCount.members);
                 }
             }
         }

--- a/MatrixSDK/NotificationCenter/Checker/MXPushRuleRoomMemberCountConditionChecker.m
+++ b/MatrixSDK/NotificationCenter/Checker/MXPushRuleRoomMemberCountConditionChecker.m
@@ -88,23 +88,23 @@
             {
                 if (nil == op || [op isEqualToString:@"=="])
                 {
-                    isSatisfied = (value == room.state.members.count);
+                    isSatisfied = (value == room.state.members.members.count);
                 }
                 else if ([op isEqualToString:@"<"])
                 {
-                    isSatisfied = (value < room.state.members.count);
+                    isSatisfied = (value < room.state.members.members.count);
                 }
                 else if ([op isEqualToString:@">"])
                 {
-                    isSatisfied = (value > room.state.members.count);
+                    isSatisfied = (value > room.state.members.members.count);
                 }
                 else if ([op isEqualToString:@">="])
                 {
-                    isSatisfied = (value >= room.state.members.count);
+                    isSatisfied = (value >= room.state.members.members.count);
                 }
                 else if ([op isEqualToString:@"<="])
                 {
-                    isSatisfied = (value <= room.state.members.count);
+                    isSatisfied = (value <= room.state.members.members.count);
                 }
             }
         }

--- a/MatrixSDK/VoIP/MXCall.m
+++ b/MatrixSDK/VoIP/MXCall.m
@@ -96,12 +96,12 @@ NSString *const kMXCallStateDidChange = @"kMXCallStateDidChange";
         _endReason = MXCallEndReasonUnknown;
 
         // Consider we are using a conference call when there are more than 2 users
-        _isConferenceCall = (2 < _room.state.joinedMembers.count);
+        _isConferenceCall = (2 < _room.state.members.joinedMembers.count);
         
         // Set caleeId only for regular calls
         if (!_isConferenceCall)
         {
-            for (MXRoomMember *roomMember in _room.state.joinedMembers)
+            for (MXRoomMember *roomMember in _room.state.members.joinedMembers)
             {
                 if (![roomMember.userId isEqualToString:_callerId])
                 {

--- a/MatrixSDK/VoIP/MXCall.m
+++ b/MatrixSDK/VoIP/MXCall.m
@@ -96,7 +96,7 @@ NSString *const kMXCallStateDidChange = @"kMXCallStateDidChange";
         _endReason = MXCallEndReasonUnknown;
 
         // Consider we are using a conference call when there are more than 2 users
-        _isConferenceCall = (2 < _room.state.members.joinedMembers.count);
+        _isConferenceCall = (2 < _room.state.membersCount.joined);
         
         // Set caleeId only for regular calls
         if (!_isConferenceCall)

--- a/MatrixSDK/VoIP/MXCallManager.m
+++ b/MatrixSDK/VoIP/MXCallManager.m
@@ -203,9 +203,9 @@ static NSString *const kMXCallManagerFallbackSTUNServer = @"stun:stun.l.google.c
     
     MXRoom *room = [_mxSession roomWithRoomId:roomId];
 
-    if (room && 1 < room.state.members.joinedMembers.count)
+    if (room && 1 < room.state.membersCount.joined)
     {
-        if (2 == room.state.members.joinedMembers.count)
+        if (2 == room.state.membersCount.joined)
         {
             // Do a peer to peer, one to one call
             MXCall *call = [[MXCall alloc] initWithRoomId:roomId andCallManager:self];
@@ -269,7 +269,7 @@ static NSString *const kMXCallManagerFallbackSTUNServer = @"stun:stun.l.google.c
     }
     else
     {
-        NSLog(@"[MXCallManager] placeCallInRoom: ERROR: Cannot place call in %@. Members count: %tu", roomId, room.state.members.joinedMembers.count);
+        NSLog(@"[MXCallManager] placeCallInRoom: ERROR: Cannot place call in %@. Members count: %tu", roomId, room.state.membersCount.joined);
 
         if (failure)
         {
@@ -590,7 +590,7 @@ NSString *const kMXCallManagerConferenceUserDomain  = @"matrix.org";
     MXRoom *conferenceUserRoom;
     for (MXRoom *room in _mxSession.rooms)
     {
-        if (room.state.members.members.count == 2 && [room.state.members memberWithUserId:conferenceUserId])
+        if (room.state.membersCount.members == 2 && [room.state.members memberWithUserId:conferenceUserId])
         {
             conferenceUserRoom = room;
         }

--- a/MatrixSDK/VoIP/MXCallManager.m
+++ b/MatrixSDK/VoIP/MXCallManager.m
@@ -203,9 +203,9 @@ static NSString *const kMXCallManagerFallbackSTUNServer = @"stun:stun.l.google.c
     
     MXRoom *room = [_mxSession roomWithRoomId:roomId];
 
-    if (room && 1 < room.state.joinedMembers.count)
+    if (room && 1 < room.state.members.joinedMembers.count)
     {
-        if (2 == room.state.joinedMembers.count)
+        if (2 == room.state.members.joinedMembers.count)
         {
             // Do a peer to peer, one to one call
             MXCall *call = [[MXCall alloc] initWithRoomId:roomId andCallManager:self];
@@ -269,7 +269,7 @@ static NSString *const kMXCallManagerFallbackSTUNServer = @"stun:stun.l.google.c
     }
     else
     {
-        NSLog(@"[MXCallManager] placeCallInRoom: ERROR: Cannot place call in %@. Members count: %tu", roomId, room.state.joinedMembers.count);
+        NSLog(@"[MXCallManager] placeCallInRoom: ERROR: Cannot place call in %@. Members count: %tu", roomId, room.state.members.joinedMembers.count);
 
         if (failure)
         {
@@ -561,7 +561,7 @@ NSString *const kMXCallManagerConferenceUserDomain  = @"matrix.org";
 {
     NSString *conferenceUserId = [MXCallManager conferenceUserIdForRoom:room.roomId];
 
-    MXRoomMember *conferenceUserMember = [room.state memberWithUserId:conferenceUserId];
+    MXRoomMember *conferenceUserMember = [room.state.members memberWithUserId:conferenceUserId];
     if (conferenceUserMember && conferenceUserMember.membership == MXMembershipJoin)
     {
         success();
@@ -590,7 +590,7 @@ NSString *const kMXCallManagerConferenceUserDomain  = @"matrix.org";
     MXRoom *conferenceUserRoom;
     for (MXRoom *room in _mxSession.rooms)
     {
-        if (room.state.members.count == 2 && [room.state memberWithUserId:conferenceUserId])
+        if (room.state.members.members.count == 2 && [room.state.members memberWithUserId:conferenceUserId])
         {
             conferenceUserRoom = room;
         }

--- a/MatrixSDKTests/MXPeekingRoomTests.m
+++ b/MatrixSDKTests/MXPeekingRoomTests.m
@@ -73,7 +73,7 @@
                     XCTAssertEqual(mxSession.rooms.count, 0, @"MXPeekingRoom must not be listed by mxSession.rooms");
                     XCTAssertEqual(peekingRoom.roomId, room.roomId);
 
-                    XCTAssertEqual(peekingRoom.state.members.count, 1, @"The MXPeekingRoom state must be known now");
+                    XCTAssertEqual(peekingRoom.state.members.members.count, 1, @"The MXPeekingRoom state must be known now");
 
                     [mxSession stopPeeking:peekingRoom];
 
@@ -127,14 +127,14 @@
         mxSession = mxSession2;
 
         XCTAssertEqual(mxSession.rooms.count, 1);
-        XCTAssertEqual(room.state.members.count, 1);
+        XCTAssertEqual(room.state.members.members.count, 1);
 
         [mxSession peekInRoomWithRoomId:room.roomId success:^(MXPeekingRoom *peekingRoom) {
 
             XCTAssertEqual(mxSession.rooms.count, 1, @"MXPeekingRoom must not be listed by mxSession.rooms");
             XCTAssertEqual(peekingRoom.roomId, room.roomId);
 
-            XCTAssertEqual(peekingRoom.state.members.count, 1, @"The MXPeekingRoom state must be known now");
+            XCTAssertEqual(peekingRoom.state.members.members.count, 1, @"The MXPeekingRoom state must be known now");
 
             [mxSession stopPeeking:peekingRoom];
 

--- a/MatrixSDKTests/MXPeekingRoomTests.m
+++ b/MatrixSDKTests/MXPeekingRoomTests.m
@@ -73,7 +73,7 @@
                     XCTAssertEqual(mxSession.rooms.count, 0, @"MXPeekingRoom must not be listed by mxSession.rooms");
                     XCTAssertEqual(peekingRoom.roomId, room.roomId);
 
-                    XCTAssertEqual(peekingRoom.state.members.members.count, 1, @"The MXPeekingRoom state must be known now");
+                    XCTAssertEqual(peekingRoom.state.membersCount.members, 1, @"The MXPeekingRoom state must be known now");
 
                     [mxSession stopPeeking:peekingRoom];
 
@@ -126,15 +126,18 @@
 
         mxSession = mxSession2;
 
+        NSLog(@"___ %@", @(room.state.membersCount.members));
+        NSLog(@"___ %@", @(room.state.members.members.count));
+
         XCTAssertEqual(mxSession.rooms.count, 1);
-        XCTAssertEqual(room.state.members.members.count, 1);
+        XCTAssertEqual(room.state.membersCount.members, 1);
 
         [mxSession peekInRoomWithRoomId:room.roomId success:^(MXPeekingRoom *peekingRoom) {
 
             XCTAssertEqual(mxSession.rooms.count, 1, @"MXPeekingRoom must not be listed by mxSession.rooms");
             XCTAssertEqual(peekingRoom.roomId, room.roomId);
 
-            XCTAssertEqual(peekingRoom.state.members.members.count, 1, @"The MXPeekingRoom state must be known now");
+            XCTAssertEqual(peekingRoom.state.membersCount.members, 1, @"The MXPeekingRoom state must be known now");
 
             [mxSession stopPeeking:peekingRoom];
 

--- a/MatrixSDKTests/MXRoomStateDynamicTests.m
+++ b/MatrixSDKTests/MXRoomStateDynamicTests.m
@@ -393,8 +393,8 @@
 
                     NSLog(@"eventCount: %tu - %@", eventCount, event);
                     
-                    MXRoomMember *beforeEventAliceMember = [roomState memberWithUserId:aliceRestClient.credentials.userId];
-                    MXRoomMember *aliceMember = [room.state memberWithUserId:aliceRestClient.credentials.userId];
+                    MXRoomMember *beforeEventAliceMember = [roomstate.members memberWithUserId:aliceRestClient.credentials.userId];
+                    MXRoomMember *aliceMember = [room.state.members memberWithUserId:aliceRestClient.credentials.userId];
                     
                     // Check each expected event and their roomState contect
                     // Events are received in the reverse order
@@ -569,8 +569,8 @@
             __block NSUInteger eventCount = 0;
             [room listenToEventsOfTypes:nil onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
                 
-                MXRoomMember *beforeEventAliceMember = [roomState memberWithUserId:matrixSDKTestsData.aliceCredentials.userId];
-                MXRoomMember *aliceMember = [room.state memberWithUserId:matrixSDKTestsData.aliceCredentials.userId];
+                MXRoomMember *beforeEventAliceMember = [roomstate.members memberWithUserId:matrixSDKTestsData.aliceCredentials.userId];
+                MXRoomMember *aliceMember = [room.state.members memberWithUserId:matrixSDKTestsData.aliceCredentials.userId];
                 
                 // Check each expected event and their roomState contect
                 // Events are live. Then comes in order

--- a/MatrixSDKTests/MXRoomStateDynamicTests.m
+++ b/MatrixSDKTests/MXRoomStateDynamicTests.m
@@ -405,7 +405,7 @@
                             XCTAssertEqual(event.eventType, MXEventTypeRoomMessage);
                             
                             XCTAssertEqual(roomState.members.count, 2);
-                            XCTAssertEqual(room.state.members.count, 2);
+                            XCTAssertEqual(room.state.membersCount.members, 2);
                             
                             XCTAssertEqual(beforeEventAliceMember.membership, MXMembershipLeave);
                             XCTAssertEqual(aliceMember.membership, MXMembershipLeave);
@@ -420,7 +420,7 @@
                             XCTAssertEqual(event.eventType, MXEventTypeRoomMember);
                             
                             XCTAssertEqual(roomState.members.count, 2);
-                            XCTAssertEqual(room.state.members.count, 2);
+                            XCTAssertEqual(room.state.membersCount.members, 2);
                             
                             XCTAssertEqual(beforeEventAliceMember.membership, MXMembershipJoin);
                             XCTAssertEqual(aliceMember.membership, MXMembershipLeave);
@@ -434,7 +434,7 @@
                             XCTAssertEqual(event.eventType, MXEventTypeRoomMessage);
                             
                             XCTAssertEqual(roomState.members.count, 2);
-                            XCTAssertEqual(room.state.members.count, 2);
+                            XCTAssertEqual(room.state.membersCount.members, 2);
                             
                             XCTAssertEqual(beforeEventAliceMember.membership, MXMembershipJoin);
                             XCTAssertEqual(aliceMember.membership, MXMembershipLeave);
@@ -448,7 +448,7 @@
                             XCTAssertEqual(event.eventType, MXEventTypeRoomMember);
                             
                             XCTAssertEqual(roomState.members.count, 2);
-                            XCTAssertEqual(room.state.members.count, 2);
+                            XCTAssertEqual(room.state.membersCount.members, 2);
                             
                             XCTAssertEqual(beforeEventAliceMember.membership, MXMembershipJoin);
                             XCTAssertEqual(aliceMember.membership, MXMembershipLeave);
@@ -462,7 +462,7 @@
                             XCTAssertEqual(event.eventType, MXEventTypeRoomMessage);
                             
                             XCTAssertEqual(roomState.members.count, 2);
-                            XCTAssertEqual(room.state.members.count, 2);
+                            XCTAssertEqual(room.state.membersCount.members, 2);
                             
                             XCTAssertEqual(beforeEventAliceMember.membership, MXMembershipJoin);
                             XCTAssertEqual(aliceMember.membership, MXMembershipLeave);
@@ -476,7 +476,7 @@
                             XCTAssertEqual(event.eventType, MXEventTypeRoomMember);
                             
                             XCTAssertEqual(roomState.members.count, 2);
-                            XCTAssertEqual(room.state.members.count, 2);
+                            XCTAssertEqual(room.state.membersCount.members, 2);
                             
                             XCTAssertEqual(beforeEventAliceMember.membership, MXMembershipInvite);
                             XCTAssertEqual(aliceMember.membership, MXMembershipLeave);
@@ -491,7 +491,7 @@
                             XCTAssertEqual(event.eventType, MXEventTypeRoomMessage);
                             
                             XCTAssertEqual(roomState.members.count, 2);
-                            XCTAssertEqual(room.state.members.count, 2);
+                            XCTAssertEqual(room.state.membersCount.members, 2);
                             
                             XCTAssertEqual(beforeEventAliceMember.membership, MXMembershipInvite);
                             XCTAssertEqual(aliceMember.membership, MXMembershipLeave);
@@ -505,7 +505,7 @@
                             XCTAssertEqual(event.eventType, MXEventTypeRoomMember);
                             
                             XCTAssertEqual(roomState.members.count, 1);
-                            XCTAssertEqual(room.state.members.count, 2);
+                            XCTAssertEqual(room.state.membersCount.members, 2);
                             
                             XCTAssertEqual(aliceMember.membership, MXMembershipLeave);
                             XCTAssertNil(aliceMember.displayname);
@@ -519,7 +519,7 @@
                             XCTAssertEqual(event.eventType, MXEventTypeRoomMessage);
                             
                             XCTAssertEqual(roomState.members.count, 1);
-                            XCTAssertEqual(room.state.members.count, 2);
+                            XCTAssertEqual(room.state.membersCount.members, 2);
                             
                             XCTAssertEqual(aliceMember.membership, MXMembershipLeave);
                             XCTAssertNil(aliceMember.displayname);
@@ -581,7 +581,7 @@
                         XCTAssertEqual(event.eventType, MXEventTypeRoomMessage);
                         
                         XCTAssertEqual(roomState.members.count, 1);
-                        XCTAssertEqual(room.state.members.count, 1);
+                        XCTAssertEqual(room.state.membersCount.members, 1);
                         
                         // Alice member doest not exist at that time
                         XCTAssertNil(beforeEventAliceMember);
@@ -593,7 +593,7 @@
                         XCTAssertEqual(event.eventType, MXEventTypeRoomMember);
                         
                         XCTAssertEqual(roomState.members.count, 1);
-                        XCTAssertEqual(room.state.members.count, 2);
+                        XCTAssertEqual(room.state.membersCount.members, 2);
                         
                         XCTAssertEqual(aliceMember.membership, MXMembershipInvite);
                         XCTAssertNil(aliceMember.displayname);
@@ -607,7 +607,7 @@
                         XCTAssertEqual(event.eventType, MXEventTypeRoomMessage);
                         
                         XCTAssertEqual(roomState.members.count, 2);
-                        XCTAssertEqual(room.state.members.count, 2);
+                        XCTAssertEqual(room.state.membersCount.members, 2);
                         
                         XCTAssertEqual(beforeEventAliceMember.membership, MXMembershipInvite);
                         XCTAssertEqual(aliceMember.membership, MXMembershipInvite);
@@ -621,7 +621,7 @@
                         XCTAssertEqual(event.eventType, MXEventTypeRoomMember);
                         
                         XCTAssertEqual(roomState.members.count, 2);
-                        XCTAssertEqual(room.state.members.count, 2);
+                        XCTAssertEqual(room.state.membersCount.members, 2);
                         
                         XCTAssertEqual(beforeEventAliceMember.membership, MXMembershipInvite);
                         XCTAssertEqual(aliceMember.membership, MXMembershipJoin);
@@ -636,7 +636,7 @@
                         XCTAssertEqual(event.eventType, MXEventTypeRoomMessage);
                         
                         XCTAssertEqual(roomState.members.count, 2);
-                        XCTAssertEqual(room.state.members.count, 2);
+                        XCTAssertEqual(room.state.membersCount.members, 2);
                         
                         XCTAssertEqual(beforeEventAliceMember.membership, MXMembershipJoin);
                         XCTAssertEqual(aliceMember.membership, MXMembershipJoin);
@@ -650,7 +650,7 @@
                         XCTAssertEqual(event.eventType, MXEventTypeRoomMember);
                         
                         XCTAssertEqual(roomState.members.count, 2);
-                        XCTAssertEqual(room.state.members.count, 2);
+                        XCTAssertEqual(room.state.membersCount.members, 2);
                         
                         XCTAssertEqual(beforeEventAliceMember.membership, MXMembershipJoin);
                         XCTAssertEqual(aliceMember.membership, MXMembershipJoin);
@@ -664,7 +664,7 @@
                         XCTAssertEqual(event.eventType, MXEventTypeRoomMessage);
                         
                         XCTAssertEqual(roomState.members.count, 2);
-                        XCTAssertEqual(room.state.members.count, 2);
+                        XCTAssertEqual(room.state.membersCount.members, 2);
                         
                         XCTAssertEqual(beforeEventAliceMember.membership, MXMembershipJoin);
                         XCTAssertEqual(aliceMember.membership, MXMembershipJoin);
@@ -678,7 +678,7 @@
                         XCTAssertEqual(event.eventType, MXEventTypeRoomMember);
                         
                         XCTAssertEqual(roomState.members.count, 2);
-                        XCTAssertEqual(room.state.members.count, 2);
+                        XCTAssertEqual(room.state.membersCount.members, 2);
                         
                         XCTAssertEqual(beforeEventAliceMember.membership, MXMembershipJoin);
                         XCTAssertEqual(aliceMember.membership, MXMembershipLeave);
@@ -692,7 +692,7 @@
                         XCTAssertEqual(event.eventType, MXEventTypeRoomMessage);
                         
                         XCTAssertEqual(roomState.members.count, 2);
-                        XCTAssertEqual(room.state.members.count, 2);
+                        XCTAssertEqual(room.state.membersCount.members, 2);
                         
                         XCTAssertEqual(beforeEventAliceMember.membership, MXMembershipLeave);
                         XCTAssertEqual(aliceMember.membership, MXMembershipLeave);

--- a/MatrixSDKTests/MXRoomStateTests.m
+++ b/MatrixSDKTests/MXRoomStateTests.m
@@ -823,7 +823,7 @@
                     XCTAssertEqual(newRoom.state.membership, MXMembershipInvite);
                     
                     // The room has 2 members (Alice & Bob)
-                    XCTAssertEqual(newRoom.state.members.members.count, 2);
+                    XCTAssertEqual(newRoom.state.membersCount.members, 2);
 
                     MXRoomMember *alice = [newRoom.state.members memberWithUserId:aliceRestClient.credentials.userId];
                     XCTAssertNotNil(alice);
@@ -873,7 +873,7 @@
                             XCTAssertEqual(newRoom.state.membership, MXMembershipInvite);
 
                             // The room has 2 members (Alice & Bob)
-                            XCTAssertEqual(newRoom.state.members.members.count, 2);
+                            XCTAssertEqual(newRoom.state.membersCount.members, 2);
 
                             MXRoomMember *alice = [newRoom.state.members memberWithUserId:aliceRestClient.credentials.userId];
                             XCTAssertNotNil(alice);
@@ -953,7 +953,7 @@
                         
                         // Now, we must have more information about the room
                         // Check its new state
-                        XCTAssertEqual(newRoom.state.members.members.count, 2);
+                        XCTAssertEqual(newRoom.state.membersCount.members, 2);
                         XCTAssert([newRoom.state.topic isEqualToString:@"We test room invitation here"], @"Wrong topic. Found: %@", newRoom.state.topic);
                         
                         XCTAssertEqual(newRoom.state.membership, MXMembershipJoin);
@@ -1008,7 +1008,7 @@
                         // Now, we must have more information about the room
                         // Check its new state
                         XCTAssertEqual(newRoom.state.isJoinRulePublic, YES);
-                        XCTAssertEqual(newRoom.state.members.members.count, 2);
+                        XCTAssertEqual(newRoom.state.membersCount.members, 2);
                         XCTAssert([newRoom.state.topic isEqualToString:@"We test room invitation here"], @"Wrong topic. Found: %@", newRoom.state.topic);
                         
                         XCTAssertEqual(newRoom.state.membership, MXMembershipJoin);
@@ -1116,7 +1116,7 @@
                     MXRoom *room = [mxSession roomWithRoomId:event.roomId];
 
                     XCTAssert(room);
-                    XCTAssertEqual(room.state.members.members.count, 2, @"If this count is wrong, the room state is invalid");
+                    XCTAssertEqual(room.state.membersCount.members, 2, @"If this count is wrong, the room state is invalid");
 
                     [expectation fulfill];
                 }

--- a/MatrixSDKTests/MXRoomStateTests.m
+++ b/MatrixSDKTests/MXRoomStateTests.m
@@ -638,17 +638,17 @@
             MXRoom *room = [mxSession roomWithRoomId:roomId];
             XCTAssertNotNil(room);
             
-            NSArray *members = room.state.members;
+            NSArray *members = room.state.members.members;
             XCTAssertEqual(members.count, 1, "There must be only one member: mxBob, the creator");
             
-            for (MXRoomMember *member in room.state.members)
+            for (MXRoomMember *member in room.state.members.members)
             {
                 XCTAssertTrue([member.userId isEqualToString:bobRestClient.credentials.userId], "This must be mxBob");
             }
             
-            XCTAssertNotNil([room.state memberWithUserId:bobRestClient.credentials.userId], @"Bob must be retrieved");
+            XCTAssertNotNil([room.state.members memberWithUserId:bobRestClient.credentials.userId], @"Bob must be retrieved");
             
-            XCTAssertNil([room.state memberWithUserId:@"NonExistingUserId"], @"getMember must return nil if the user does not exist");
+            XCTAssertNil([room.state.members memberWithUserId:@"NonExistingUserId"], @"getMember must return nil if the user does not exist");
             
             [expectation fulfill];
             
@@ -666,12 +666,12 @@
         mxSession = mxSession2;
 
         NSString *bobUserId = matrixSDKTestsData.bobCredentials.userId;
-        NSString *bobMemberName = [room.state  memberName:bobUserId];
+        NSString *bobMemberName = [room.state.members memberName:bobUserId];
         
         XCTAssertNotNil(bobMemberName);
         XCTAssertFalse([bobMemberName isEqualToString:@""], @"bobMemberName must not be an empty string");
         
-        XCTAssert([[room.state memberName:@"NonExistingUserId"] isEqualToString:@"NonExistingUserId"], @"memberName must return his id if the user does not exist");
+        XCTAssert([[room.state.members memberName:@"NonExistingUserId"] isEqualToString:@"NonExistingUserId"], @"memberName must return his id if the user does not exist");
         
         [expectation fulfill];
     }];
@@ -708,7 +708,7 @@
 }
 
 // Test the room display name formatting: "roomName (roomAlias)"
-// KO before
+// KO before <- To remove
 - (void)testDisplayName1
 {
     [matrixSDKTestsData doMXSessionTestWithBobAndThePublicRoom:self readyToTest:^(MXSession *mxSession2, MXRoom *room, XCTestExpectation *expectation) {
@@ -823,9 +823,9 @@
                     XCTAssertEqual(newRoom.state.membership, MXMembershipInvite);
                     
                     // The room has 2 members (Alice & Bob)
-                    XCTAssertEqual(newRoom.state.members.count, 2);
+                    XCTAssertEqual(newRoom.state.members.members.count, 2);
 
-                    MXRoomMember *alice = [newRoom.state memberWithUserId:aliceRestClient.credentials.userId];
+                    MXRoomMember *alice = [newRoom.state.members memberWithUserId:aliceRestClient.credentials.userId];
                     XCTAssertNotNil(alice);
                     XCTAssertEqual(alice.membership, MXMembershipInvite);
                     XCTAssert([alice.originUserId isEqualToString:bobRestClient.credentials.userId], @"Wrong inviter: %@", alice.originUserId);
@@ -873,9 +873,9 @@
                             XCTAssertEqual(newRoom.state.membership, MXMembershipInvite);
 
                             // The room has 2 members (Alice & Bob)
-                            XCTAssertEqual(newRoom.state.members.count, 2);
+                            XCTAssertEqual(newRoom.state.members.members.count, 2);
 
-                            MXRoomMember *alice = [newRoom.state memberWithUserId:aliceRestClient.credentials.userId];
+                            MXRoomMember *alice = [newRoom.state.members memberWithUserId:aliceRestClient.credentials.userId];
                             XCTAssertNotNil(alice);
                             XCTAssertEqual(alice.membership, MXMembershipInvite);
                             XCTAssert([alice.originUserId isEqualToString:bobRestClient.credentials.userId], @"Wrong inviter: %@", alice.originUserId);
@@ -953,7 +953,7 @@
                         
                         // Now, we must have more information about the room
                         // Check its new state
-                        XCTAssertEqual(newRoom.state.members.count, 2);
+                        XCTAssertEqual(newRoom.state.members.members.count, 2);
                         XCTAssert([newRoom.state.topic isEqualToString:@"We test room invitation here"], @"Wrong topic. Found: %@", newRoom.state.topic);
                         
                         XCTAssertEqual(newRoom.state.membership, MXMembershipJoin);
@@ -1008,7 +1008,7 @@
                         // Now, we must have more information about the room
                         // Check its new state
                         XCTAssertEqual(newRoom.state.isJoinRulePublic, YES);
-                        XCTAssertEqual(newRoom.state.members.count, 2);
+                        XCTAssertEqual(newRoom.state.members.members.count, 2);
                         XCTAssert([newRoom.state.topic isEqualToString:@"We test room invitation here"], @"Wrong topic. Found: %@", newRoom.state.topic);
                         
                         XCTAssertEqual(newRoom.state.membership, MXMembershipJoin);
@@ -1116,7 +1116,7 @@
                     MXRoom *room = [mxSession roomWithRoomId:event.roomId];
 
                     XCTAssert(room);
-                    XCTAssertEqual(room.state.members.count, 2, @"If this count is wrong, the room state is invalid");
+                    XCTAssertEqual(room.state.members.members.count, 2, @"If this count is wrong, the room state is invalid");
 
                     [expectation fulfill];
                 }

--- a/MatrixSDKTests/MXRoomTests.m
+++ b/MatrixSDKTests/MXRoomTests.m
@@ -212,12 +212,12 @@
                     MXRoom *room = [mxSession roomWithRoomId:roomId];
 
                     XCTAssertEqual(room.state.membership, MXMembershipInvite);
-                    XCTAssertEqual(room.state.members.members.count, 2, @"The room state information is limited while the room is joined");
+                    XCTAssertEqual(room.state.membersCount.members, 2, @"The room state information is limited while the room is joined");
 
                     [room join:^{
 
                         XCTAssertEqual(room.state.membership, MXMembershipJoin);
-                        XCTAssertEqual(room.state.members.members.count, 2, @"The room state must be fully known (after an initialSync on the room");
+                        XCTAssertEqual(room.state.membersCount.members, 2, @"The room state must be fully known (after an initialSync on the room");
 
                         [expectation fulfill];
 

--- a/MatrixSDKTests/MXRoomTests.m
+++ b/MatrixSDKTests/MXRoomTests.m
@@ -66,7 +66,7 @@
         __block NSString *sentMessageEventID;
         __block NSString *receivedMessageEventID;
         
-        void (^checkEventIDs)() = ^ void ()
+        void (^checkEventIDs)(void) = ^ void ()
         {
             if (sentMessageEventID && receivedMessageEventID)
             {
@@ -212,12 +212,12 @@
                     MXRoom *room = [mxSession roomWithRoomId:roomId];
 
                     XCTAssertEqual(room.state.membership, MXMembershipInvite);
-                    XCTAssertEqual(room.state.members.count, 2, @"The room state information is limited while the room is joined");
+                    XCTAssertEqual(room.state.members.members.count, 2, @"The room state information is limited while the room is joined");
 
                     [room join:^{
 
                         XCTAssertEqual(room.state.membership, MXMembershipJoin);
-                        XCTAssertEqual(room.state.members.count, 2, @"The room state must be fully known (after an initialSync on the room");
+                        XCTAssertEqual(room.state.members.members.count, 2, @"The room state must be fully known (after an initialSync on the room");
 
                         [expectation fulfill];
 

--- a/MatrixSDKTests/MXSessionTests.m
+++ b/MatrixSDKTests/MXSessionTests.m
@@ -578,7 +578,7 @@
             BOOL isSync = (room.state.membership != MXMembershipInvite && room.state.membership != MXMembershipUnknown);
             XCTAssertTrue(isSync, @"The callback must be called once the room has been initialSynced");
 
-            XCTAssertEqual(1, room.state.members.members.count, @"Bob must be the only one. members: %@", room.state.members);
+            XCTAssertEqual(1, room.state.membersCount.members, @"Bob must be the only one. members: %@", room.state.members);
 
             [expectation fulfill];
 

--- a/MatrixSDKTests/MXSessionTests.m
+++ b/MatrixSDKTests/MXSessionTests.m
@@ -578,7 +578,7 @@
             BOOL isSync = (room.state.membership != MXMembershipInvite && room.state.membership != MXMembershipUnknown);
             XCTAssertTrue(isSync, @"The callback must be called once the room has been initialSynced");
 
-            XCTAssertEqual(1, room.state.members.count, @"Bob must be the only one. members: %@", room.state.members);
+            XCTAssertEqual(1, room.state.members.members.count, @"Bob must be the only one. members: %@", room.state.members);
 
             [expectation fulfill];
 

--- a/MatrixSDKTests/MXUserTests.m
+++ b/MatrixSDKTests/MXUserTests.m
@@ -133,6 +133,7 @@
     [self doTestWithBobAndAliceActiveInARoom:^(MXRestClient *bobRestClient, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
         MXUser *mxAlice = [mxSession userWithUserId:aliceRestClient.credentials.userId];
+        XCTAssert(mxAlice);
 
         [mxAlice listenToUserUpdate:^(MXEvent *event) {
 
@@ -155,6 +156,7 @@
     [self doTestWithBobAndAliceActiveInARoom:^(MXRestClient *bobRestClient, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
         MXUser *mxAlice = [mxSession userWithUserId:aliceRestClient.credentials.userId];
+        XCTAssert(mxAlice);
 
         [mxAlice listenToUserUpdate:^(MXEvent *event) {
 
@@ -185,6 +187,7 @@
     [self doTestWithBobAndAliceActiveInARoom:^(MXRestClient *bobRestClient, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
         MXUser *mxAlice = [mxSession userWithUserId:aliceRestClient.credentials.userId];
+        XCTAssert(mxAlice);
 
         [mxAlice listenToUserUpdate:^(MXEvent *event) {
 


### PR DESCRIPTION
Part 1: Move methods into a dedicated class, MXRoomMembers.

https://github.com/vector-im/riot-ios/issues/1931