### PR TITLE
Enable lazy-loading for timelines on permalinks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Improvements:
 * MXRoomSummary: add isConferenceUserRoom.
 * MXStore: Add Obj-C annotations.
 * MXFileStore: Add a setting to set which data to preload ([MXFileStore setPreloadOptions:]).
+* Manage the new summary API from the homeserver( MSC: https://docs.google.com/document/d/11i14UI1cUz-OJ0knD5BFu7fmT6Fo327zvMYqfSAR7xs/edit#).
 
 Bug fix:
 * MXRestClient: Fix filter parameter in messagesForRoom. It must be sent as an inline JSON string.
@@ -25,6 +26,7 @@ API break:
 * MXRoomState: Remove displayName property. Use MXRoomSummary.displayName instead.
 * MXRoomState: Create a MXRoomMembers property. All members getter methods has been to the new class.
 * MXStore: Make the stateOfRoom method asynchronous.
+* MXRestClient: contextOfEvent: Add a filter parameter.
 
 Changes in Matrix iOS SDK in 0.10.12 (2018-05-31)
 =============================================== 

--- a/MatrixSDK/Contrib/Swift/MXRestClient.swift
+++ b/MatrixSDK/Contrib/Swift/MXRestClient.swift
@@ -1208,13 +1208,14 @@ public extension MXRestClient {
         - eventId: the id of the event to get context around.
         - roomId: the id of the room to get events from.
         - limit: the maximum number of messages to return.
+        - filter the filter to pass in the request. Can be nil.
         - completion: A block object called when the operation completes.
         - response: Provides the model created from the homeserver JSON response on success.
      
      - returns: a `MXHTTPOperation` instance.
      */
-    @nonobjc @discardableResult func context(ofEvent eventId: String, inRoom roomId: String, limit: UInt, completion: @escaping (_ response: MXResponse<MXEventContext>) -> Void) -> MXHTTPOperation {
-        return __context(ofEvent: eventId, inRoom: roomId, limit: limit, success: currySuccess(completion), failure: curryFailure(completion))
+    @nonobjc @discardableResult func context(ofEvent eventId: String, inRoom roomId: String, limit: UInt, filter: MXRoomEventFilter? = nil, completion: @escaping (_ response: MXResponse<MXEventContext>) -> Void) -> MXHTTPOperation {
+        return __context(ofEvent: eventId, inRoom: roomId, limit: limit, filter:filter, success: currySuccess(completion), failure: curryFailure(completion))
     }
     
     

--- a/MatrixSDK/Data/MXEventTimeline.m
+++ b/MatrixSDK/Data/MXEventTimeline.m
@@ -527,10 +527,13 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
     }
 
     // Process additional state events (this happens in case of lazy loading)
-    if (paginatedResponse.state.count && direction == MXTimelineDirectionBackwards)
+    if (paginatedResponse.state.count)
     {
-        // Enrich the timeline root state with the additional state events observed during back pagination
-        [self handleStateEvents:paginatedResponse.state direction:MXTimelineDirectionForwards];
+        if (direction == MXTimelineDirectionBackwards)
+        {
+            // Enrich the timeline root state with the additional state events observed during back pagination
+            [self handleStateEvents:paginatedResponse.state direction:MXTimelineDirectionForwards];
+        }
 
         // Enrich intermediate room state while paginating
         [self handleStateEvents:paginatedResponse.state  direction:direction];

--- a/MatrixSDK/Data/MXEventTimeline.m
+++ b/MatrixSDK/Data/MXEventTimeline.m
@@ -190,9 +190,16 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
     forwardsPaginationToken = nil;
     hasReachedHomeServerForwardsPaginationEnd = NO;
 
+    MXRoomEventFilter *filter;
+    if (room.mxSession.syncWithLazyLoadOfRoomMembers)
+    {
+        filter = [MXRoomEventFilter new];
+        filter.lazyLoadMembers = YES;
+    }
+
     // Get the context around the initial event
     MXWeakify(self);
-    return [room.mxSession.matrixRestClient contextOfEvent:_initialEventId inRoom:room.roomId limit:limit success:^(MXEventContext *eventContext) {
+    return [room.mxSession.matrixRestClient contextOfEvent:_initialEventId inRoom:room.roomId limit:limit filter:filter success:^(MXEventContext *eventContext) {
         MXStrongifyAndReturnIfNil(self);
 
         // And fill the timelime with received data

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -1154,7 +1154,7 @@ typedef enum : NSUInteger
  @param from the token to start getting results from.
  @param direction `MXTimelineDirectionForwards` or `MXTimelineDirectionBackwards`
  @param limit (optional, use -1 to not defined this value) the maximum number of messages to return.
- @param roomEventFilter to filter returned events with.
+ @param roomEventFilter the filter to pass in the request. Can be nil.
 
  @param success A block object called when the operation succeeds. It provides a `MXPaginationResponse` object.
  @param failure A block object called when the operation fails.
@@ -1314,6 +1314,7 @@ typedef enum : NSUInteger
  @param eventId the id of the event to get context around.
  @param roomId the id of the room to get events from.
  @param limit the maximum number of messages to return.
+ @param filter the filter to pass in the request. Can be nil.
 
  @param success A block object called when the operation succeeds. It provides the model created from
  the homeserver JSON response.
@@ -1324,6 +1325,7 @@ typedef enum : NSUInteger
 - (MXHTTPOperation*)contextOfEvent:(NSString*)eventId
                             inRoom:(NSString*)roomId
                              limit:(NSUInteger)limit
+                            filter:(MXRoomEventFilter*)filter
                            success:(void (^)(MXEventContext *eventContext))success
                            failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
@@ -1868,7 +1870,7 @@ typedef enum : NSUInteger
  Search a text in room messages.
 
  @param textPattern the text to search for in message body.
- @param roomEventFilter a nullable dictionary which defines the room event filtering during the search request.
+ @param roomEventFilter the filter to pass in the request. Can be nil.
  @param beforeLimit the number of events to get before the matching results.
  @param afterLimit the number of events to get after the matching results.
  @param nextBatch the token to pass for doing pagination from a previous response.

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -2357,7 +2357,7 @@ MXAuthAction;
                                           {
                                               NSLog(@"[MXRestClient] eventWithEventId: The homeserver does not support `/rooms/{roomId}/event/{eventId}` API. Try with `/context`");
 
-                                              MXHTTPOperation *operation2 = [self contextOfEvent:eventId inRoom:roomId limit:1 success:^(MXEventContext *eventContext) {
+                                              MXHTTPOperation *operation2 = [self contextOfEvent:eventId inRoom:roomId limit:1 filter:nil success:^(MXEventContext *eventContext) {
 
                                                   if (success)
                                                   {
@@ -2378,17 +2378,24 @@ MXAuthAction;
 - (MXHTTPOperation*)contextOfEvent:(NSString*)eventId
                             inRoom:(NSString*)roomId
                              limit:(NSUInteger)limit
+                            filter:(MXRoomEventFilter*)filter
                            success:(void (^)(MXEventContext *eventContext))success
                            failure:(void (^)(NSError *error))failure
 {
     NSString *path = [NSString stringWithFormat:@"%@/rooms/%@/context/%@", apiPathPrefix, roomId, eventId];
 
+    NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
+    parameters[@"limit"] = @(limit);
+
+    if (filter)
+    {
+        parameters[@"filter"] = filter.dictionary;
+    }
+
     MXWeakify(self);
     return [httpClient requestWithMethod:@"GET"
                                     path:path
-                              parameters:@{
-                                           @"limit": [NSNumber numberWithInteger:limit]
-                                           }
+                              parameters:parameters
                                  success:^(NSDictionary *JSONResponse) {
                                      MXStrongifyAndReturnIfNil(self);
 

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -2389,7 +2389,7 @@ MXAuthAction;
 
     if (filter)
     {
-        parameters[@"filter"] = filter.dictionary;
+        parameters[@"filter"] = filter.jsonString;
     }
 
     MXWeakify(self);

--- a/MatrixSDKTests/MXLazyLoadingTests.m
+++ b/MatrixSDKTests/MXLazyLoadingTests.m
@@ -28,6 +28,9 @@ NSString * const bobMessage = @"I am Bob";
 @interface MXLazyLoadingTests : XCTestCase
 {
     MatrixSDKTestsData *matrixSDKTestsData;
+
+    // The id of the message by Bob in the scenario
+    NSString *bobMessageEventId;
 }
 
 @end
@@ -95,6 +98,8 @@ Common initial conditions:
 
                             // - Bob sends a message
                             [roomFromBobPOV sendTextMessage:bobMessage success:^(NSString *eventId) {
+
+                                bobMessageEventId = eventId;
 
                                 // - Alice sends 50 messages
                                 [matrixSDKTestsData for:aliceRestClient andRoom:roomId sendMessages:50 success:^{
@@ -806,6 +811,220 @@ Common initial conditions:
 - (void)testPermalinkRoomStateWithLazyLoadingOFF
 {
     [self checkPermalinkRoomStateWithLazyLoading:NO];
+}
+
+
+// Test lazy loaded members sent by the HS when paginating backward from a permalink
+// When paginating back to the beginning, lazy loaded room state passed in pagination callback must be updated with Bob, then Charlie and Dave.
+// Almost the same test as `checkRoomStateWhilePaginatingWithLazyLoading`.
+- (void)checkPermalinkRoomStateWhilePaginatingBackwardWithLazyLoading:(BOOL)lazyLoading
+{
+    [self createScenarioWithLazyLoading:lazyLoading readyToTest:^(MXSession *aliceSession, MXSession *bobSession, MXSession *charlieSession, NSString *roomId, XCTestExpectation *expectation) {
+
+        MXRoomSummary *summary = [aliceSession roomSummaryWithRoomId:roomId];
+        MXRoom *room = [aliceSession roomWithRoomId:roomId];
+
+        MXEventTimeline *eventTimeline = [room timelineOnEvent:summary.lastMessageEventId];
+
+        __block NSUInteger messageCount = 0;
+        [eventTimeline listenToEvents:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
+
+            switch (++messageCount)
+            {
+                case 1:
+                    XCTAssertEqualObjects(event.sender, aliceSession.myUser.userId);
+
+                    if (lazyLoading)
+                    {
+                        XCTAssertNil([roomState.members memberWithUserId:bobSession.myUser.userId]);
+                        XCTAssertNil([eventTimeline.state.members memberWithUserId:bobSession.myUser.userId]);
+                        XCTAssertNil([eventTimeline.state.members memberWithUserId:charlieSession.myUser.userId]);
+                    }
+                    else
+                    {
+                        XCTAssertNotNil([roomState.members memberWithUserId:bobSession.myUser.userId]);
+                    }
+
+                    XCTAssertNotNil([eventTimeline.state.members memberWithUserId:aliceSession.myUser.userId]);
+                    break;
+
+                case 50:
+                    if (lazyLoading)
+                    {
+                        // Disabled because the HS sends too early the Bob membership event (but not Charlie nor Dave)
+                        //XCTAssertNil([roomState.members memberWithUserId:bobSession.myUser.userId]);
+                        //XCTAssertNil([eventTimeline.state.members memberWithUserId:bobSession.myUser.userId]);
+                        XCTAssertNil([eventTimeline.state.members memberWithUserId:charlieSession.myUser.userId]);
+                    }
+                    else
+                    {
+                        XCTAssertNotNil([roomState.members memberWithUserId:bobSession.myUser.userId]);
+                    }
+
+                    XCTAssertNotNil([eventTimeline.state.members memberWithUserId:aliceSession.myUser.userId]);
+                    break;
+                case 51:
+                    XCTAssert([roomState.members memberWithUserId:bobSession.myUser.userId]);
+
+                    if (lazyLoading)
+                    {
+                        XCTAssertNil([roomState.members memberWithUserId:charlieSession.myUser.userId]);
+                        XCTAssertNil([eventTimeline.state.members memberWithUserId:charlieSession.myUser.userId]);
+                    }
+                    else
+                    {
+                        XCTAssert([roomState.members memberWithUserId:charlieSession.myUser.userId]);
+                    }
+
+                    // The room state of the room should have been enriched
+                    XCTAssertNotNil([eventTimeline.state.members memberWithUserId:bobSession.myUser.userId]);
+
+                    break;
+
+                case 110:
+                    XCTAssertNotNil([eventTimeline.state.members memberWithUserId:aliceSession.myUser.userId]);
+                    XCTAssertNotNil([eventTimeline.state.members memberWithUserId:bobSession.myUser.userId]);
+                    XCTAssertNotNil([eventTimeline.state.members memberWithUserId:charlieSession.myUser.userId]);
+                    break;
+
+                default:
+                    break;
+            }
+        }];
+
+        [eventTimeline resetPaginationAroundInitialEventWithLimit:0 success:^{
+
+            // Paginate the 50 last message where there is only Alice talking
+            [eventTimeline paginate:50 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^{
+
+                // Pagine a bit more to get Bob's message
+                [eventTimeline paginate:25 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^{
+
+                    // Paginate all to get a full room state
+                    [eventTimeline paginate:100 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^{
+
+                        XCTAssertGreaterThan(messageCount, 110, @"The test has not fully run");
+
+                        [expectation fulfill];
+
+                    } failure:^(NSError *error) {
+                        XCTFail(@"The operation should not fail - NSError: %@", error);
+                        [expectation fulfill];
+                    }];
+
+                } failure:^(NSError *error) {
+                    XCTFail(@"The operation should not fail - NSError: %@", error);
+                    [expectation fulfill];
+                }];
+
+            } failure:^(NSError *error) {
+                XCTFail(@"The operation should not fail - NSError: %@", error);
+                [expectation fulfill];
+            }];
+        }
+        failure:^(NSError *error) {
+            XCTFail(@"The operation should not fail - NSError: %@", error);
+            [expectation fulfill];
+        }];
+    }];
+}
+
+- (void)testPermalinkRoomStateWhilePaginatingBackward
+{
+    [self checkPermalinkRoomStateWhilePaginatingBackwardWithLazyLoading:YES];
+}
+
+- (void)testPermalinkRoomStateWhilePaginatingWithLazyLoadingOFF
+{
+    [self checkPermalinkRoomStateWhilePaginatingBackwardWithLazyLoading:NO];
+}
+
+
+// Test lazy loaded members sent by the HS when paginating forward
+// - Come back to Bob message
+// - We should only know Bob membership
+// - Paginate forward to get Alice next message
+// - We should know Alice membership now
+- (void)checkPermalinkRoomStateWhilePaginatingForwardWithLazyLoading:(BOOL)lazyLoading
+{
+    [self createScenarioWithLazyLoading:lazyLoading readyToTest:^(MXSession *aliceSession, MXSession *bobSession, MXSession *charlieSession, NSString *roomId, XCTestExpectation *expectation) {
+
+        MXRoom *room = [aliceSession roomWithRoomId:roomId];
+
+        MXEventTimeline *eventTimeline = [room timelineOnEvent:bobMessageEventId];
+
+        __block NSUInteger messageCount = 0;
+        [eventTimeline listenToEvents:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
+
+            switch (++messageCount)
+            {
+                case 1:
+                    // Bob message
+                    // - We should only know Bob membership
+                    XCTAssertEqualObjects(event.sender, bobSession.myUser.userId);
+
+                    if (lazyLoading)
+                    {
+                        XCTAssertNil([eventTimeline.state.members memberWithUserId:aliceSession.myUser.userId]);
+                        XCTAssertNil([eventTimeline.state.members memberWithUserId:charlieSession.myUser.userId]);
+                    }
+                    else
+                    {
+                        XCTAssertNotNil([roomState.members memberWithUserId:aliceSession.myUser.userId]);
+                    }
+
+                    XCTAssertNotNil([eventTimeline.state.members memberWithUserId:bobSession.myUser.userId]);
+                    break;
+
+                case 2:
+                    // First next message from Alice
+                    // - We should know Alice membership now
+                    XCTAssertEqualObjects(event.sender, aliceSession.myUser.userId);
+
+                    if (lazyLoading)
+                    {
+                        XCTAssertNil([eventTimeline.state.members memberWithUserId:charlieSession.myUser.userId]);
+                    }
+
+                    XCTAssertNotNil([eventTimeline.state.members memberWithUserId:aliceSession.myUser.userId]);
+                    XCTAssertNotNil([eventTimeline.state.members memberWithUserId:bobSession.myUser.userId]);
+                    break;
+
+                default:
+                    break;
+            }
+        }];
+
+        // - Come back to Bob message
+        [eventTimeline resetPaginationAroundInitialEventWithLimit:0 success:^{
+
+            // - Paginate forward to get Alice next message
+            [eventTimeline paginate:1 direction:MXTimelineDirectionForwards onlyFromStore:NO complete:^{
+
+                XCTAssertGreaterThanOrEqual(messageCount, 2, @"The test has not fully run");
+
+                [expectation fulfill];
+
+            } failure:^(NSError *error) {
+                XCTFail(@"The operation should not fail - NSError: %@", error);
+                [expectation fulfill];
+            }];
+
+        } failure:^(NSError *error) {
+            XCTFail(@"The operation should not fail - NSError: %@", error);
+            [expectation fulfill];
+        }];
+    }];
+}
+
+- (void)testPermalinkRoomStateWhilePaginatingForward
+{
+    [self checkPermalinkRoomStateWhilePaginatingForwardWithLazyLoading:YES];
+}
+
+- (void)testPermalinkRoomStateWhilePaginatingForwardWithLazyLoadingOFF
+{
+    [self checkPermalinkRoomStateWhilePaginatingForwardWithLazyLoading:NO];
 }
 
 

--- a/MatrixSDKTests/MXRestClientTests.m
+++ b/MatrixSDKTests/MXRestClientTests.m
@@ -945,7 +945,7 @@
             MXEvent *eventAfter = roomInitialSync.messages.chunk[6];
 
             // Get the context around it
-            [bobRestClient contextOfEvent:event.eventId inRoom:roomId limit:10 success:^(MXEventContext *eventContext) {
+            [bobRestClient contextOfEvent:event.eventId inRoom:roomId limit:10 filter:nil success:^(MXEventContext *eventContext) {
 
                 XCTAssertNotNil(eventContext);
                 XCTAssertNotNil(eventContext.start);


### PR DESCRIPTION
That does not work yet as expected on server side but the client is ready

I have also added one test on search.

Still part of https://github.com/vector-im/riot-ios/issues/1931.