### PR TITLE
Fix: Sends read receipts on login

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,7 @@ Improvements:
 
 Bug fix:
 * MXRestClient: Fix filter parameter in messagesForRoom. It must be sent as an inline JSON string.
+* Sends read receipts on login (vector-im/riot-ios/issues/1918).
 
 API break:
 * MXSession: [MXSession startWithMessagesLimit] has been removed. Use the more generic [MXSession startWithSyncFilter:].

--- a/MatrixSDK/Data/MXEventTimeline.m
+++ b/MatrixSDK/Data/MXEventTimeline.m
@@ -459,9 +459,6 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
     // Finalize initial sync
     if (isRoomInitialSync)
     {
-        // Initialise notification counters homeserver side
-        [room markAllAsRead];
-
         // Notify that room has been sync'ed
         // Delay it so that MXRoom.summary is computed before sending it
         dispatch_async(dispatch_get_main_queue(), ^{


### PR DESCRIPTION
vector-im/riot-ios/issues/1918

Remove a line introduced in #430 which is the root of this regression.