### PR TITLE
Direct rooms: Fix possible race conditions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,11 @@ Changes in Matrix iOS SDK in 0.11.1 (2018-08-)
 ===============================================
 
 Improvements:
-* Tests: Add DirectRoomTests
+* Tests: Add DirectRoomTests to test direct rooms management.
+
+Bug fix:
+ * Direct rooms can be lost on an initial /sync (vector-im/riot-ios/issues/1983).
+ * Fix possible race conditions in direct rooms management.
 
 Changes in Matrix iOS SDK in 0.11.0 (2018-08-10)
 ===============================================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Improvements:
 Bug fix:
  * Direct rooms can be lost on an initial /sync (vector-im/riot-ios/issues/1983).
  * Fix possible race conditions in direct rooms management.
+ * Avoid to create an empty filter on each [MXSession start:]
 
 Changes in Matrix iOS SDK in 0.11.0 (2018-08-10)
 ===============================================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+Changes in Matrix iOS SDK in 0.11.1 (2018-08-)
+===============================================
+
+Improvements:
+* Tests: Add DirectRoomTests
+
 Changes in Matrix iOS SDK in 0.11.0 (2018-08-10)
 ===============================================
 

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -174,6 +174,11 @@
 		32B76EA520FDE85100B095F6 /* MXRoomMembersCount.m in Sources */ = {isa = PBXBuildFile; fileRef = 32B76EA420FDE85100B095F6 /* MXRoomMembersCount.m */; };
 		32BD34BE1E84134A006EDC0D /* MatrixSDKTestsE2EData.m in Sources */ = {isa = PBXBuildFile; fileRef = 32BD34BD1E84134A006EDC0D /* MatrixSDKTestsE2EData.m */; };
 		32BED28F1B00A23F00E668FE /* MXCallStack.h in Headers */ = {isa = PBXBuildFile; fileRef = 32BED28E1B00A23F00E668FE /* MXCallStack.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		32C03CB62123076F00D92712 /* DirectRoomTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 32C03CB52123076F00D92712 /* DirectRoomTests.m */; };
+		32C03CBB21231C2600D92712 /* Podfile in Resources */ = {isa = PBXBuildFile; fileRef = 32C03CB721231C2500D92712 /* Podfile */; };
+		32C03CBC21231C2600D92712 /* README.rst in Resources */ = {isa = PBXBuildFile; fileRef = 32C03CB821231C2500D92712 /* README.rst */; };
+		32C03CBD21231C2600D92712 /* CHANGES.rst in Resources */ = {isa = PBXBuildFile; fileRef = 32C03CB921231C2500D92712 /* CHANGES.rst */; };
+		32C03CBE21231C2600D92712 /* AUTHORS.rst in Resources */ = {isa = PBXBuildFile; fileRef = 32C03CBA21231C2500D92712 /* AUTHORS.rst */; };
 		32C235721F827F3800E38FC5 /* MXRoomOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 32C235701F827F3800E38FC5 /* MXRoomOperation.h */; };
 		32C235731F827F3800E38FC5 /* MXRoomOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 32C235711F827F3800E38FC5 /* MXRoomOperation.m */; };
 		32C6F93319DD814400EA4E9C /* MatrixSDK.h in Headers */ = {isa = PBXBuildFile; fileRef = 32C6F93219DD814400EA4E9C /* MatrixSDK.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -463,6 +468,11 @@
 		32BD34BC1E84134A006EDC0D /* MatrixSDKTestsE2EData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MatrixSDKTestsE2EData.h; sourceTree = "<group>"; };
 		32BD34BD1E84134A006EDC0D /* MatrixSDKTestsE2EData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MatrixSDKTestsE2EData.m; sourceTree = "<group>"; };
 		32BED28E1B00A23F00E668FE /* MXCallStack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXCallStack.h; sourceTree = "<group>"; };
+		32C03CB52123076F00D92712 /* DirectRoomTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DirectRoomTests.m; sourceTree = "<group>"; };
+		32C03CB721231C2500D92712 /* Podfile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Podfile; sourceTree = "<group>"; };
+		32C03CB821231C2500D92712 /* README.rst */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = README.rst; sourceTree = "<group>"; };
+		32C03CB921231C2500D92712 /* CHANGES.rst */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CHANGES.rst; sourceTree = "<group>"; };
+		32C03CBA21231C2500D92712 /* AUTHORS.rst */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = AUTHORS.rst; sourceTree = "<group>"; };
 		32C235701F827F3800E38FC5 /* MXRoomOperation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXRoomOperation.h; sourceTree = "<group>"; };
 		32C235711F827F3800E38FC5 /* MXRoomOperation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXRoomOperation.m; sourceTree = "<group>"; };
 		32C6F92D19DD814400EA4E9C /* MatrixSDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MatrixSDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -916,6 +926,10 @@
 		32C6F92319DD814400EA4E9C = {
 			isa = PBXGroup;
 			children = (
+				32C03CBA21231C2500D92712 /* AUTHORS.rst */,
+				32C03CB921231C2500D92712 /* CHANGES.rst */,
+				32C03CB721231C2500D92712 /* Podfile */,
+				32C03CB821231C2500D92712 /* README.rst */,
 				32C6F92F19DD814400EA4E9C /* MatrixSDK */,
 				32C6F93919DD814400EA4E9C /* MatrixSDKTests */,
 				32C6F92E19DD814400EA4E9C /* Products */,
@@ -972,6 +986,7 @@
 		32C6F93919DD814400EA4E9C /* MatrixSDKTests */ = {
 			isa = PBXGroup;
 			children = (
+				32C03CB52123076F00D92712 /* DirectRoomTests.m */,
 				320E1BC01E0AD674009635F5 /* MXRoomSummaryTests.m */,
 				32322A471E57264E005DD155 /* MXSelfSignedHomeserverTests.m */,
 				32E226A81D081CE200E6CA54 /* MXPeekingRoomTests.m */,
@@ -1384,6 +1399,10 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				32C03CBE21231C2600D92712 /* AUTHORS.rst in Resources */,
+				32C03CBD21231C2600D92712 /* CHANGES.rst in Resources */,
+				32C03CBB21231C2600D92712 /* Podfile in Resources */,
+				32C03CBC21231C2600D92712 /* README.rst in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1580,6 +1599,7 @@
 				32A27D1F19EC335300BAFADE /* MXRoomTests.m in Sources */,
 				32D8CAC219DEE6ED002AF8A0 /* MXRestClientNoAuthAPITests.m in Sources */,
 				32FCAB4D19E578860049C555 /* MXRestClientTests.m in Sources */,
+				32C03CB62123076F00D92712 /* DirectRoomTests.m in Sources */,
 				329FB17C1A0A963700A5E88E /* MXRoomMemberTests.m in Sources */,
 				3246BDC51A1A0789000A7D62 /* MXRoomStateDynamicTests.m in Sources */,
 				3264DB941CECA72900B99881 /* MXAccountDataTests.m in Sources */,

--- a/MatrixSDK/Contrib/Swift/MXSession.swift
+++ b/MatrixSDK/Contrib/Swift/MXSession.swift
@@ -227,20 +227,7 @@ public extension MXSession {
     @nonobjc var rooms: [MXRoom] {
         return __rooms()
     }
-    
-    
-    /**
-     Update the direct rooms list on homeserver side with the current value of the `directRooms` property.
-     
-     - parameters:
-        - completion: A block object called when the operation completes.
-        - response: Indicates whether the operation was successful.
-     
-     - returns: a `MXHTTPOperation` instance.
-     */
-    @nonobjc @discardableResult func uploadDirectRooms(completion: @escaping (_ response: MXResponse<Void>) -> Void) -> MXHTTPOperation {
-        return __uploadDirectRooms(currySuccess(completion), failure: curryFailure(completion))
-    }
+
     
     
 

--- a/MatrixSDK/Data/MXRoom.h
+++ b/MatrixSDK/Data/MXRoom.h
@@ -151,7 +151,7 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidFlushDataNotification;
  The user identifier for whom this room is tagged as direct (if any).
  nil if the room is not a direct chat.
  */
-@property (nonatomic) NSString *directUserId;
+@property (nonatomic, readonly) NSString *directUserId;
 
 /**
  Tag this room as a direct one, or remove the direct tag.

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -2920,7 +2920,7 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
     }
     else
     {
-        // Remove the
+        // Remove the direct user id
         operation = [self.mxSession setRoom:_roomId directWithUserId:nil success:success failure:failure];
     }
 

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -79,8 +79,6 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
         _typingUsers = [NSArray array];
         
         orderedOperations = [NSMutableArray array];
-        
-        _directUserId = nil;
 
         needToLoadLiveTimeline = NO;
     }
@@ -2817,7 +2815,25 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
 - (BOOL)isDirect
 {
     // Check whether this room is tagged as direct for one of the room members.
-    return (_directUserId != nil);
+    return (self.directUserId != nil);
+}
+
+- (NSString *)directUserId
+{
+    NSString *directUserId;
+
+    // Get the information from the user account data that is managed by MXSession
+    NSDictionary<NSString*, NSArray<NSString*>*> *directRooms = self.mxSession.directRooms;
+    for (NSString *userId in directRooms)
+    {
+        if ([directRooms[userId] containsObject:_roomId])
+        {
+            directUserId = userId;
+            break;
+        }
+    }
+
+    return directUserId;
 }
 
 - (MXHTTPOperation*)setIsDirect:(BOOL)isDirect
@@ -2827,63 +2843,20 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
 {
     MXHTTPOperation *operation;
 
-    NSString *myUserId = self.mxSession.myUser.userId;
-    NSMutableDictionary<NSString*, NSArray<NSString*>*> *directRooms = self.mxSession.directRooms;
-
-    if (isDirect == NO)
+    if (isDirect)
     {
-        if (self.directUserId)
+        if (userId)
         {
-            NSArray<NSString*> *savedRoomLists = directRooms[self.directUserId];
-            NSString *savedDirectUserId = self.directUserId;
-            NSMutableArray<NSString*> *roomLists = [NSMutableArray arrayWithArray:savedRoomLists];
-
-            [roomLists removeObject:self.roomId];
-
-            if (roomLists.count)
-            {
-                [directRooms setObject:roomLists forKey:self.directUserId];
-            }
-            else
-            {
-                [directRooms removeObjectForKey:self.directUserId];
-            }
-
-            // Update
-            self.directUserId = nil;
-
-            // Upload the updated direct rooms directory.
-            // mxSession will post the 'kMXSessionDirectRoomsDidChangeNotification' notification on success.
-            MXWeakify(self);
-            operation = [self.mxSession uploadDirectRooms:success failure:^(NSError *error) {
-                MXStrongifyAndReturnIfNil(self);
-
-                // Restore the previous configuration
-                if (savedRoomLists)
-                {
-                    self.directUserId = savedDirectUserId;
-                    [directRooms setObject:savedRoomLists forKey:self.directUserId];
-                }
-
-                if (failure)
-                {
-                    failure(error);
-                }
-
-            }];
+            operation = [self.mxSession setRoom:_roomId directWithUserId:userId success:success failure:failure];
         }
-    }
-    else if (!self.directUserId || (userId && ![userId isEqualToString:self.directUserId]))
-    {
-        // Here the room is not direct yet, or it is direct with the wrong user
-        __block NSString *newDirectUserId = userId;
-
-        if (!newDirectUserId)
+        else
         {
             // If there is no provided user id, find one
             MXWeakify(self);
             operation = [self members:^(MXRoomMembers *roomMembers) {
                 MXStrongifyAndReturnIfNil(self);
+
+                NSString *myUserId = self.mxSession.myUser.userId;
 
                 // By default mark as direct this room for the oldest joined member.
                 NSArray<MXRoomMember *> *members = roomMembers.joinedMembers;
@@ -2904,7 +2877,7 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
                     }
                 }
 
-                newDirectUserId = oldestJoinedMember.userId;
+                NSString * newDirectUserId = oldestJoinedMember.userId;
                 if (!newDirectUserId)
                 {
                     // Consider the first invited member if none has joined
@@ -2944,84 +2917,16 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
                 }
             } failure:failure];
         }
-        else
-        {
-            // Add the room id in the direct chats listed for this user.
-            // Check whether the room id is not already present (in this case `_directUserId` was not updated yet),
-            // this may happen during invite handling.
-            NSArray<NSString*> *savedNewDirectUserIdRoomLists = directRooms[newDirectUserId];
-            if (!savedNewDirectUserIdRoomLists || [savedNewDirectUserIdRoomLists indexOfObject:self.roomId] == NSNotFound)
-            {
-                NSArray<NSString*> *savedDirectUserIdRoomLists = nil;
-                NSString *savedDirectUserId = self.directUserId;
-
-                NSMutableArray *roomLists = (savedNewDirectUserIdRoomLists ? [NSMutableArray arrayWithArray:savedNewDirectUserIdRoomLists] : [NSMutableArray array]);
-                [roomLists addObject:self.roomId];
-                [directRooms setObject:roomLists forKey:newDirectUserId];
-
-                // Remove the room id for the current direct user if any
-                if (self.directUserId)
-                {
-                    savedDirectUserIdRoomLists = directRooms[self.directUserId];
-                    roomLists = [NSMutableArray arrayWithArray:savedDirectUserIdRoomLists];
-                    [roomLists removeObject:self.roomId];
-                    if (roomLists.count)
-                    {
-                        [directRooms setObject:roomLists forKey:self.directUserId];
-                    }
-                    else
-                    {
-                        [directRooms removeObjectForKey:self.directUserId];
-                    }
-                }
-
-                // Update
-                self.directUserId = newDirectUserId;
-
-                // Upload the updated direct rooms directory.
-                // mxSession will post the 'kMXSessionDirectRoomsDidChangeNotification' notification on success.
-                MXWeakify(self);
-                operation = [self.mxSession uploadDirectRooms:success failure:^(NSError *error) {
-                    MXStrongifyAndReturnIfNil(self);
-
-                    // Restore the previous configuration
-                    self.directUserId = savedDirectUserId;
-                    if (savedDirectUserIdRoomLists)
-                    {
-                        [directRooms setObject:savedDirectUserIdRoomLists forKey:self.directUserId];
-                    }
-
-                    if (savedNewDirectUserIdRoomLists)
-                    {
-                        [directRooms setObject:savedNewDirectUserIdRoomLists forKey:newDirectUserId];
-                    }
-                    else
-                    {
-                        [directRooms removeObjectForKey:newDirectUserId];
-                    }
-
-                    if (failure)
-                    {
-                        failure(error);
-                    }
-                }];
-            }
-            else
-            {
-                // Update directUserId field.
-                self.directUserId = newDirectUserId;
-            }
-        }
     }
-
-    // Here the room has already the right value for the direct tag
-    else if (success)
+    else
     {
-        success();
+        // Remove the
+        operation = [self.mxSession setRoom:_roomId directWithUserId:nil success:success failure:failure];
     }
 
     return operation;
 }
+
 
 #pragma mark - Crypto
 

--- a/MatrixSDK/Data/MXRoomSummary.m
+++ b/MatrixSDK/Data/MXRoomSummary.m
@@ -374,9 +374,14 @@ NSString *const kMXRoomSummaryDidChangeNotification = @"kMXRoomSummaryDidChangeN
     return [_mxSession.store localUnreadEventCount:_roomId withTypeIn:_mxSession.unreadEventTypes];
 }
 
+- (NSString *)directUserId
+{
+    return self.room.directUserId;
+}
+
 - (BOOL)isDirect
 {
-    return (_directUserId != nil);
+    return (self.directUserId != nil);
 }
 
 - (void)markAllAsRead
@@ -540,7 +545,6 @@ NSString *const kMXRoomSummaryDidChangeNotification = @"kMXRoomSummaryDidChangeN
         _isEncrypted = [aDecoder decodeBoolForKey:@"isEncrypted"];
         _notificationCount = (NSUInteger)[aDecoder decodeIntegerForKey:@"notificationCount"];
         _highlightCount = (NSUInteger)[aDecoder decodeIntegerForKey:@"highlightCount"];
-        _directUserId = [aDecoder decodeObjectForKey:@"directUserId"];
 
         _lastMessageEventId = [aDecoder decodeObjectForKey:@"lastMessageEventId"];
         _lastMessageOriginServerTs = [aDecoder decodeInt64ForKey:@"lastMessageOriginServerTs"];
@@ -582,7 +586,6 @@ NSString *const kMXRoomSummaryDidChangeNotification = @"kMXRoomSummaryDidChangeN
     [aCoder encodeBool:_isEncrypted forKey:@"isEncrypted"];
     [aCoder encodeInteger:(NSInteger)_notificationCount forKey:@"notificationCount"];
     [aCoder encodeInteger:(NSInteger)_highlightCount forKey:@"highlightCount"];
-    [aCoder encodeObject:[self room].directUserId forKey:@"directUserId"];
 
     // Store last message metadata
     [aCoder encodeObject:_lastMessageEventId forKey:@"lastMessageEventId"];

--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
@@ -25,7 +25,7 @@
 #import "MXSDKOptions.h"
 #import "MXTools.h"
 
-static NSUInteger const kMXFileVersion = 56;
+static NSUInteger const kMXFileVersion = 57;
 
 static NSString *const kMXFileStoreFolder = @"MXFileStore";
 static NSString *const kMXFileStoreMedaDataFile = @"MXFileStore";

--- a/MatrixSDK/MXSession.h
+++ b/MatrixSDK/MXSession.h
@@ -754,7 +754,6 @@ typedef void (^MXOnBackgroundSyncFail)(NSError *error);
  The list of the direct rooms by user identifiers.
  
  A dictionary where the keys are the user IDs and values are lists of room ID strings.
- of the 'direct' rooms for that user ID.
  */
 @property (nonatomic, readonly) NSDictionary<NSString*, NSArray<NSString*>*> *directRooms;
 
@@ -764,7 +763,6 @@ typedef void (^MXOnBackgroundSyncFail)(NSError *error);
  @return the MXRoom instance (nil if no room exists yet).
  */
 - (MXRoom *)directJoinedRoomWithUserId:(NSString*)userId;
-
 
 /**
  Set a room as direct with a user.

--- a/MatrixSDK/MXSession.h
+++ b/MatrixSDK/MXSession.h
@@ -748,33 +748,53 @@ typedef void (^MXOnBackgroundSyncFail)(NSError *error);
  */
 - (NSArray<MXRoom*>*)rooms NS_REFINED_FOR_SWIFT;
 
-/**
- Return the first joined direct chat listed in account data for this user.
- 
- @return the MXRoom instance (nil if no room exists yet).
- */
-- (MXRoom *)directJoinedRoomWithUserId:(NSString*)userId;
 
+#pragma mark - The user's direct rooms
 /**
  The list of the direct rooms by user identifiers.
  
  A dictionary where the keys are the user IDs and values are lists of room ID strings.
  of the 'direct' rooms for that user ID.
  */
-@property (nonatomic, readonly) NSMutableDictionary<NSString*, NSArray<NSString*>*> *directRooms;
+@property (nonatomic, readonly) NSDictionary<NSString*, NSArray<NSString*>*> *directRooms;
 
 /**
- Update the direct rooms list on homeserver side with the current value of the `directRooms` property.
- 
- The `kMXSessionDirectRoomsDidChangeNotification` notification is posted on success.
- 
+ Return the first joined direct chat listed in account data for this user.
+
+ @return the MXRoom instance (nil if no room exists yet).
+ */
+- (MXRoom *)directJoinedRoomWithUserId:(NSString*)userId;
+
+
+/**
+ Set a room as direct with a user.
+
+ @param roomId the id of the room.
+ @param userId the id of user with whom the room will be direct to. Nil removes existing direct user.
+
+ @param success A block object called when the operation succeeds.
+ @param failure A block object called when the operation fails.
+
+ @return a MXHTTPOperation instance.
+ */
+- (MXHTTPOperation*)setRoom:(NSString*)roomId
+           directWithUserId:(NSString*)userId
+                    success:(void (^)(void))success
+                    failure:(void (^)(NSError *error))failure;
+
+/**
+ Update the direct rooms list on homeserver side.
+
+ @param directRooms the new direct rooms list (user id -> [room ids]).
+
  @param success A block object called when the operation succeeds.
  @param failure A block object called when the operation fails.
  
  @return a MXHTTPOperation instance.
  */
-- (MXHTTPOperation*)uploadDirectRooms:(void (^)(void))success
-                              failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
+- (MXHTTPOperation*)uploadDirectRooms:(NSDictionary<NSString*, NSArray<NSString*>*> *)directRooms
+                              success:(void (^)(void))success
+                              failure:(void (^)(NSError *error))failure;
 
 /**
  Make sure that the `MXRoom` internal data for a list of rooms is preloaded.

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -373,19 +373,26 @@ typedef void (^MXOnResumeDone)(void);
            onServerSyncDone:(void (^)(void))onServerSyncDone
                     failure:(void (^)(NSError *error))failure;
 {
-    // Build or retrieve the filter before launching the event stream
-    MXWeakify(self);
-    [self setFilter:syncFilter success:^(NSString *filterId) {
-        MXStrongifyAndReturnIfNil(self);
+    if (syncFilter)
+    {
+        // Build or retrieve the filter before launching the event stream
+        MXWeakify(self);
+        [self setFilter:syncFilter success:^(NSString *filterId) {
+            MXStrongifyAndReturnIfNil(self);
 
-        [self startWithSyncFilterId:filterId onServerSyncDone:onServerSyncDone failure:failure];
+            [self startWithSyncFilterId:filterId onServerSyncDone:onServerSyncDone failure:failure];
 
-    } failure:^(NSError *error) {
-        MXStrongifyAndReturnIfNil(self);
+        } failure:^(NSError *error) {
+            MXStrongifyAndReturnIfNil(self);
 
-        NSLog(@"[MXSesssion] startWithSyncFilter: WARNING: Impossible to create the filter. Use no filter in /sync");
+            NSLog(@"[MXSesssion] startWithSyncFilter: WARNING: Impossible to create the filter. Use no filter in /sync");
+            [self startWithSyncFilterId:nil onServerSyncDone:onServerSyncDone failure:failure];
+        }];
+    }
+    else
+    {
         [self startWithSyncFilterId:nil onServerSyncDone:onServerSyncDone failure:failure];
-    }];
+    }
 }
 
 - (void)startWithSyncFilterId:(NSString *)syncFilterId onServerSyncDone:(void (^)(void))onServerSyncDone failure:(void (^)(NSError *))failure

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -1875,7 +1875,7 @@ typedef void (^MXOnResumeDone)(void);
         {
             if (![newDirectRooms[userId] containsObject:roomId])
             {
-                NSMutableArray *roomIds = [NSMutableArray arrayWithArray:newDirectRooms[userId]];
+                NSMutableArray *roomIds = (newDirectRooms[userId] ? [NSMutableArray arrayWithArray:newDirectRooms[userId]] : [NSMutableArray array]);
                 [roomIds addObject:roomId];
                 newDirectRooms[userId] = roomIds;
             }

--- a/MatrixSDKTests/DirectRoomTests.m
+++ b/MatrixSDKTests/DirectRoomTests.m
@@ -181,7 +181,7 @@
                         break;
                     }
 
-                    case 3: // TODO: should be 1
+                    case 1:
 
                         // -> The kMXSessionDirectRoomsDidChangeNotification must be received with the
                         //    room no more marked as direct

--- a/MatrixSDKTests/DirectRoomTests.m
+++ b/MatrixSDKTests/DirectRoomTests.m
@@ -1,0 +1,270 @@
+/*
+ Copyright 2018 New Vector Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "MatrixSDKTestsData.h"
+#import "MXSDKOptions.h"
+
+// Do not bother with retain cycles warnings in tests
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-retain-cycles"
+
+@interface DirectRoomTests : XCTestCase
+{
+    MatrixSDKTestsData *matrixSDKTestsData;
+}
+
+@end
+
+@implementation DirectRoomTests
+
+- (void)setUp
+{
+    [super setUp];
+
+    matrixSDKTestsData = [[MatrixSDKTestsData alloc] init];
+}
+
+- (void)tearDown
+{
+    [super tearDown];
+
+    matrixSDKTestsData = nil;
+}
+
+// - Bob & Alice in a room
+// - Bob must have no direct rooms at first
+// - Bob set the room as direct
+// -> On success the room must be tagged as direct
+- (void)testMXRoom_setIsDirect
+{
+    // - Bob & Alice in a room
+    [matrixSDKTestsData doMXSessionTestWithBobAndAliceInARoom:self readyToTest:^(MXSession *bobSession, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
+
+        // - Bob must have no direct rooms at first
+        XCTAssertEqual(bobSession.directRooms.count, 0);
+
+        MXRoom *room = [bobSession roomWithRoomId:roomId];
+        XCTAssertFalse(room.isDirect);
+
+        // - Bob set the room as direct
+        [room setIsDirect:YES withUserId:aliceRestClient.credentials.userId success:^{
+
+            // -> On success the room must be tagged as direct
+            XCTAssertTrue(room.isDirect);
+            XCTAssertEqualObjects(room.directUserId, aliceRestClient.credentials.userId);
+
+            XCTAssertEqual(bobSession.directRooms.count, 1);
+            XCTAssertEqual(bobSession.directRooms[aliceRestClient.credentials.userId].count, 1);
+            XCTAssertEqualObjects(bobSession.directRooms[aliceRestClient.credentials.userId].firstObject, roomId);
+
+            [expectation fulfill];
+
+        } failure:^(NSError *error) {
+            XCTFail(@"The operation should not fail - NSError: %@", error);
+            [expectation fulfill];
+        }];
+
+    }];
+}
+
+// - Bob & Alice in a room
+// - Bob must have no direct rooms at first
+// - Bob set the room as direct
+// -> The kMXSessionDirectRoomsDidChangeNotification must be received with the
+//    room marked as direct
+// - Bob removes the room from direct rooms
+// -> The kMXSessionDirectRoomsDidChangeNotification must be received with the
+//    room no more marked as direct
+- (void)testkMXSessionDirectRoomsDidChangeNotification_on_MXRoom_setIsDirect
+{
+    // - Bob & Alice in a room
+    [matrixSDKTestsData doMXSessionTestWithBobAndAliceInARoom:self readyToTest:^(MXSession *bobSession, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
+
+        // - Bob must have no direct rooms at first
+        XCTAssertEqual(bobSession.directRooms.count, 0);
+
+        MXRoom *room = [bobSession roomWithRoomId:roomId];
+        XCTAssertFalse(room.isDirect);
+
+
+        __block id observer;
+        __block NSUInteger count = 0;
+        observer = [[NSNotificationCenter defaultCenter] addObserverForName:kMXSessionDirectRoomsDidChangeNotification object:bobSession queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *note) {
+
+            if (observer)
+            {
+                switch (count++)
+                {
+                    case 0:
+                    {
+                        // -> The kMXSessionDirectRoomsDidChangeNotification must be received with the
+                        //    room marked as direct
+                        XCTAssertTrue(room.isDirect);
+                        XCTAssertEqualObjects(room.directUserId, aliceRestClient.credentials.userId);
+
+                        XCTAssertEqual(bobSession.directRooms.count, 1);
+                        XCTAssertEqual(bobSession.directRooms[aliceRestClient.credentials.userId].count, 1);
+                        XCTAssertEqualObjects(bobSession.directRooms[aliceRestClient.credentials.userId].firstObject, roomId);
+
+                        // - Bob removes the room from direct rooms
+                        [room setIsDirect:NO withUserId:nil success:nil failure:^(NSError *error) {
+                            XCTFail(@"The operation should not fail - NSError: %@", error);
+                            [expectation fulfill];
+                        }];
+
+                        break;
+                    }
+
+                    case 3: // TODO: should be 1
+
+                        // -> The kMXSessionDirectRoomsDidChangeNotification must be received with the
+                        //    room no more marked as direct
+                        XCTAssertFalse(room.isDirect);
+                        XCTAssertNil(room.directUserId);
+
+                        XCTAssertEqual(bobSession.directRooms.count, 0);
+
+                        [[NSNotificationCenter defaultCenter] removeObserver:observer];
+                        observer = nil;
+                        [expectation fulfill];
+
+                        break;
+
+                    default:
+                        break;
+                }
+            }
+        }];
+
+
+        // - Bob set the room as direct
+        [room setIsDirect:YES withUserId:aliceRestClient.credentials.userId success:nil failure:^(NSError *error) {
+            XCTFail(@"The operation should not fail - NSError: %@", error);
+            [expectation fulfill];
+        }];
+    }];
+}
+
+// - Alice invites Bob in a direct chat
+// -> Bob must see it as a direct room
+- (void)testDirectRoomInvite
+{
+    [matrixSDKTestsData doMXSessionTestWithBobAndAliceInARoom:self readyToTest:^(MXSession *bobSession, MXRestClient *aliceRestClient, NSString *aRoomId, XCTestExpectation *expectation) {
+
+        // Should be kMXSessionNewRoomNotification
+        __block id observer;
+        observer = [[NSNotificationCenter defaultCenter] addObserverForName:kMXSessionDirectRoomsDidChangeNotification object:bobSession queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *note) {
+
+            if (observer)
+            {
+                [[NSNotificationCenter defaultCenter] removeObserver:observer];
+                observer = nil;
+                
+                // -> Bob must see it as a direct room
+                XCTAssertEqual(bobSession.directRooms.count, 1);
+                XCTAssertEqual(bobSession.directRooms[aliceRestClient.credentials.userId].count, 1);
+
+                NSString *roomId = bobSession.directRooms[aliceRestClient.credentials.userId].firstObject;
+                MXRoom *room = [bobSession roomWithRoomId:roomId];
+
+                XCTAssertTrue(room.isDirect);
+                XCTAssertEqualObjects(room.directUserId, aliceRestClient.credentials.userId);
+
+                [expectation fulfill];
+            }
+        }];
+
+
+        // - Alice invites Bob in a direct chat
+        [aliceRestClient createRoom:nil visibility:kMXRoomDirectoryVisibilityPrivate roomAlias:nil topic:nil invite:@[bobSession.myUser.userId] invite3PID:nil isDirect:YES preset:kMXRoomPresetPrivateChat success:nil failure:^(NSError *error) {
+
+            XCTFail(@"The operation should not fail - NSError: %@", error);
+            [expectation fulfill];
+        }];
+    }];
+}
+
+// - Bob & Alice in a room
+// - Bob sets the room as direct
+// - Alice invites Bob in a direct chat
+// - Charlie invites Bob in a direct chat
+// - Bob does an initial /sync
+// -> He must still see 2 direct rooms with Alice and 1 with Charlie
+- (void)testDirectRoomsAfterInitialSync
+{
+    // - Bob & Alice in a room
+    [matrixSDKTestsData doMXSessionTestWithBobAndAliceInARoom:self readyToTest:^(MXSession *bobSession, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
+
+        [matrixSDKTestsData doMXSessionTestWithAUser:nil readyToTest:^(MXSession *charlieSession, XCTestExpectation *expectation2) {
+
+            __block id observer;
+            observer = [[NSNotificationCenter defaultCenter] addObserverForName:kMXSessionDirectRoomsDidChangeNotification object:bobSession queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *note) {
+
+                // Wait until we get the 3 direct rooms
+                if (observer
+                    && bobSession.directRooms[aliceRestClient.credentials.userId].count == 2
+                    && bobSession.directRooms[charlieSession.myUser.userId].count == 1)
+                {
+                    [[NSNotificationCenter defaultCenter] removeObserver:observer];
+                    observer = nil;
+
+                    // - Bob does an initial /sync
+                    MXSession *bobSession2 = [[MXSession alloc] initWithMatrixRestClient:bobSession.matrixRestClient];
+                    [matrixSDKTestsData retain:bobSession2];
+                    [bobSession close];
+
+                    [bobSession2 start:^{
+
+                        // -> He must still see 2 direct rooms with Alice and 1 with Charlie
+                        XCTAssertEqual(bobSession2.directRooms[aliceRestClient.credentials.userId].count, 2);
+                        XCTAssertEqual(bobSession2.directRooms[charlieSession.myUser.userId].count, 1);
+                        [expectation fulfill];
+
+                    } failure:^(NSError *error) {
+                        XCTFail(@"The operation should not fail - NSError: %@", error);
+                        [expectation fulfill];
+                    }];
+                }
+            }];
+
+
+            // - Bob set the room as direct
+            MXRoom *room = [bobSession roomWithRoomId:roomId];
+            [room setIsDirect:YES withUserId:aliceRestClient.credentials.userId success:nil failure:^(NSError *error) {
+                XCTFail(@"The operation should not fail - NSError: %@", error);
+                [expectation fulfill];
+            }];
+
+            // - Alice invites Bob in a direct chat
+            [aliceRestClient createRoom:nil visibility:kMXRoomDirectoryVisibilityPrivate roomAlias:nil topic:nil invite:@[bobSession.myUser.userId] invite3PID:nil isDirect:YES preset:kMXRoomPresetPrivateChat success:nil failure:^(NSError *error) {
+                XCTFail(@"The operation should not fail - NSError: %@", error);
+                [expectation fulfill];
+            }];
+
+            // - Charlie invites Bob in a direct chat
+            [charlieSession createRoom:nil visibility:kMXRoomDirectoryVisibilityPrivate roomAlias:nil topic:nil invite:@[bobSession.myUser.userId] invite3PID:nil isDirect:YES preset:kMXRoomPresetPrivateChat success:nil failure:^(NSError *error) {
+                XCTFail(@"The operation should not fail - NSError: %@", error);
+                [expectation fulfill];
+            }];
+        }];
+    }];
+}
+
+@end
+
+#pragma clang diagnostic pop

--- a/MatrixSDKTests/MXAccountDataTests.m
+++ b/MatrixSDKTests/MXAccountDataTests.m
@@ -93,24 +93,27 @@
                     if (notif.object == bobSession)
                     {
                         // Yield so that bobSession completes the saving to the cache.
+                        // TODO: Find a more accurate point of sync...
                         dispatch_async(dispatch_get_main_queue(), ^{
+                            dispatch_async(dispatch_get_main_queue(), ^{
 
-                            [bobSession close];
+                                [bobSession close];
 
-                            // Check the information have been permanently stored
-                            MXSession *bobSession2 = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
-                            MXFileStore *store2 = [[MXFileStore alloc] init];
-                            [bobSession2 setStore:store2 success:^{
+                                // Check the information have been permanently stored
+                                MXSession *bobSession2 = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+                                MXFileStore *store2 = [[MXFileStore alloc] init];
+                                [bobSession2 setStore:store2 success:^{
 
-                                XCTAssertEqual(bobSession2.ignoredUsers.count, 1);
-                                XCTAssertEqual([bobSession2 isUserIgnored:aliceRestClient.credentials.userId], YES);
+                                    XCTAssertEqual(bobSession2.ignoredUsers.count, 1);
+                                    XCTAssertEqual([bobSession2 isUserIgnored:aliceRestClient.credentials.userId], YES);
 
-                                [expectation fulfill];
+                                    [expectation fulfill];
 
-                            } failure:^(NSError *error) {
-                                XCTFail(@"Cannot set up intial test conditions - error: %@", error);
-                                [expectation fulfill];
-                            }];
+                                } failure:^(NSError *error) {
+                                    XCTFail(@"Cannot set up intial test conditions - error: %@", error);
+                                    [expectation fulfill];
+                                }];
+                            });
                         });
                     }
 
@@ -155,25 +158,28 @@
                     if (notif.object == bobSession)
                     {
                         // Yield so that bobSession completes the saving to the cache.
+                        // TODO: Find a more accurate point of sync...
                         dispatch_async(dispatch_get_main_queue(), ^{
+                            dispatch_async(dispatch_get_main_queue(), ^{
 
-                            [bobSession close];
+                                [bobSession close];
 
-                            // Check the information have been permanently stored
-                            MXSession *bobSession2 = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
-                            MXFileStore *store2 = [[MXFileStore alloc] init];
-                            [bobSession2 setStore:store2 success:^{
+                                // Check the information have been permanently stored
+                                MXSession *bobSession2 = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+                                MXFileStore *store2 = [[MXFileStore alloc] init];
+                                [bobSession2 setStore:store2 success:^{
 
-                                MXPushRulesResponse *pushRules2 = bobSession2.notificationCenter.rules;
+                                    MXPushRulesResponse *pushRules2 = bobSession2.notificationCenter.rules;
 
-                                XCTAssert([pushRules.JSONDictionary isEqualToDictionary:pushRules2.JSONDictionary], @"Push Rules has unexpectedly changed: \n%@\nto:\n%@", pushRules.JSONDictionary, pushRules2.JSONDictionary);
+                                    XCTAssert([pushRules.JSONDictionary isEqualToDictionary:pushRules2.JSONDictionary], @"Push Rules has unexpectedly changed: \n%@\nto:\n%@", pushRules.JSONDictionary, pushRules2.JSONDictionary);
 
-                                [expectation fulfill];
+                                    [expectation fulfill];
 
-                            } failure:^(NSError *error) {
-                                XCTFail(@"Cannot set up intial test conditions - error: %@", error);
-                                [expectation fulfill];
-                            }];
+                                } failure:^(NSError *error) {
+                                    XCTFail(@"Cannot set up intial test conditions - error: %@", error);
+                                    [expectation fulfill];
+                                }];
+                            });
                         });
                     }
                 }];

--- a/MatrixSDKTests/MXLazyLoadingTests.m
+++ b/MatrixSDKTests/MXLazyLoadingTests.m
@@ -1107,7 +1107,8 @@ Common initial conditions:
                     directRoomsDidChangeNotificationCountWhileStarting++;
 
                     // We must receive a single big update
-                    // Else we have a race condition like in https://github.com/vector-im/riot-ios/issues/1983
+                    // Else the code decided to update direct rooms while processing the /sync responce.
+                    // which means there is a race condition like in https://github.com/vector-im/riot-ios/issues/1983
                     XCTAssertEqual(aliceSession2.directRooms.count, 2);
                     XCTAssertEqual(aliceSession2.directRooms[bobSession.myUser.userId].count, 2);
                     XCTAssertEqual(aliceSession2.directRooms[charlieSession.myUser.userId].count, 1);

--- a/MatrixSDKTests/MXLazyLoadingTests.m
+++ b/MatrixSDKTests/MXLazyLoadingTests.m
@@ -1067,6 +1067,87 @@ Common initial conditions:
 }
 
 
+// Copied from testDirectRoomsAfterInitialSync
+// After the test scenario:
+// - Alice sets the room as direct
+// - Alice invites Bob in a direct chat
+// - Charlie invites Alice in a direct chat
+// - Alice does an initial /sync
+// -> Alice must still see 2 direct rooms with Alice and 1 with Charlie
+- (void)checkDirectRoomWithLazyLoading:(BOOL)lazyLoading
+{
+    [self createScenarioWithLazyLoading:lazyLoading readyToTest:^(MXSession *aliceSession, MXSession *bobSession, MXSession *charlieSession, NSString *roomId, XCTestExpectation *expectation) {
+
+        __block id observer;
+        observer = [[NSNotificationCenter defaultCenter] addObserverForName:kMXSessionDirectRoomsDidChangeNotification object:bobSession queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *note) {
+
+            // Wait until we get the 3 direct rooms
+            if (observer
+                && aliceSession.directRooms[bobSession.myUser.userId].count == 2
+                && aliceSession.directRooms[charlieSession.myUser.userId].count == 1)
+            {
+                [[NSNotificationCenter defaultCenter] removeObserver:observer];
+                observer = nil;
+
+                // - Bob does an initial /sync
+                MXSession *aliceSession2 = [[MXSession alloc] initWithMatrixRestClient:aliceSession.matrixRestClient];
+                [matrixSDKTestsData retain:aliceSession2];
+                [aliceSession close];
+
+                // Alice makes an initial /sync with lazy-loading enabled or not
+                MXFilterJSONModel *filter;
+                if (lazyLoading)
+                {
+                    filter = [MXFilterJSONModel syncFilterForLazyLoading];
+                }
+
+                [aliceSession2 startWithSyncFilter:filter onServerSyncDone:^{
+
+                    // -> He must still see 2 direct rooms with Alice and 1 with Charlie
+                    XCTAssertEqual(aliceSession2.directRooms[bobSession.myUser.userId].count, 2);
+                    XCTAssertEqual(aliceSession2.directRooms[charlieSession.myUser.userId].count, 1);
+                    [expectation fulfill];
+
+                } failure:^(NSError *error) {
+                    XCTFail(@"The operation should not fail - NSError: %@", error);
+                    [expectation fulfill];
+                }];
+            }
+        }];
+
+
+        // - Bob set the room as direct
+        MXRoom *room = [aliceSession roomWithRoomId:roomId];
+        [room setIsDirect:YES withUserId:bobSession.myUser.userId success:nil failure:^(NSError *error) {
+            XCTFail(@"The operation should not fail - NSError: %@", error);
+            [expectation fulfill];
+        }];
+
+        // - Alice invites Bob in a direct chat
+        [aliceSession createRoom:nil visibility:kMXRoomDirectoryVisibilityPrivate roomAlias:nil topic:nil invite:@[bobSession.myUser.userId] invite3PID:nil isDirect:YES preset:kMXRoomPresetPrivateChat success:nil failure:^(NSError *error) {
+            XCTFail(@"The operation should not fail - NSError: %@", error);
+            [expectation fulfill];
+        }];
+
+        // - Charlie invites Alice in a direct chat
+        [charlieSession createRoom:nil visibility:kMXRoomDirectoryVisibilityPrivate roomAlias:nil topic:nil invite:@[aliceSession.myUser.userId] invite3PID:nil isDirect:YES preset:kMXRoomPresetPrivateChat success:nil failure:^(NSError *error) {
+            XCTFail(@"The operation should not fail - NSError: %@", error);
+            [expectation fulfill];
+        }];
+    }];
+}
+
+- (void)testDirectRoom
+{
+    [self checkDirectRoomWithLazyLoading:YES];
+}
+
+- (void)testDirectRoomWithLazyLoadingOFF
+{
+    [self checkDirectRoomWithLazyLoading:NO];
+}
+
+
 /*
  @TODO(lazy-loading):
  - test read receipts


### PR DESCRIPTION
The main target was to fix https://github.com/vector-im/riot-ios/issues/1983, where the rooms sync data was parsed before parsing the direct rooms data contained in the user account data. This has been fixed in this [commit](https://github.com/matrix-org/matrix-ios-sdk/commit/2496e23d8ca9b88f6b1322f7b176eee4bbd08f30).

Other commits are preparations to:
-  have a single point of storage for direct rooms (MXSession.directRooms) to avoid inconsistent data. 
- make a single update of direct rooms at a time to avoid race conditions.
