### PR TITLE
MXSession: expose `[runOrQueueDirectRoomOperation:]`

### DIFF
--- a/MatrixSDK/MXSession.h
+++ b/MatrixSDK/MXSession.h
@@ -781,26 +781,9 @@ typedef void (^MXOnBackgroundSyncFail)(NSError *error);
                     failure:(void (^)(NSError *error))failure;
 
 /**
- Update the direct rooms list on homeserver side.
-
- @param directRooms the new direct rooms list (user id -> [room ids]).
-
- @param success A block object called when the operation succeeds.
- @param failure A block object called when the operation fails.
- 
- @return a MXHTTPOperation instance.
- */
-- (MXHTTPOperation*)uploadDirectRooms:(NSDictionary<NSString*, NSArray<NSString*>*> *)directRooms
-                              success:(void (^)(void))success
-                              failure:(void (^)(NSError *error))failure;
-
-/**
  Use this method to run or queue any other actions on the direct rooms to avoid race conditions.
  Run only one HTTP request in a block. If there is a pending action, the change will be applied
  on the updated direct rooms data.
- 
- Do not call `[setRoom:directWithUserId:success:failure:]` and `[uploadDirectRooms:success:failure:]`
- in the provided block.
  
  @param directRoomOperation A block object (use `[uploadDirectRoomsInOperationsQueue:success:failure:]`
  in this block if you need to upload the direct rooms dictionary).

--- a/MatrixSDK/MXSession.h
+++ b/MatrixSDK/MXSession.h
@@ -795,6 +795,34 @@ typedef void (^MXOnBackgroundSyncFail)(NSError *error);
                               failure:(void (^)(NSError *error))failure;
 
 /**
+ Use this method to run or queue any other actions on the direct rooms to avoid race conditions.
+ Run only one HTTP request in a block. If there is a pending action, the change will be applied
+ on the updated direct rooms data.
+ 
+ Do not call `[setRoom:directWithUserId:success:failure:]` and `[uploadDirectRooms:success:failure:]`
+ in the provided block.
+ 
+ @param directRoomOperation A block object (use `[uploadDirectRoomsInOperationsQueue:success:failure:]`
+ in this block if you need to upload the direct rooms dictionary).
+ */
+- (void)runOrQueueDirectRoomOperation:(dispatch_block_t)directRoomOperation;
+
+/**
+ Update the direct rooms list on homeserver side.
+ This method must be called in a block run by using `[runOrQueueDirectRoomOperation:]`
+ 
+ @param directRooms the new direct rooms list (user id -> [room ids]).
+ 
+ @param success A block object called when the operation succeeds.
+ @param failure A block object called when the operation fails.
+ 
+ @return a MXHTTPOperation instance.
+ */
+- (MXHTTPOperation*)uploadDirectRoomsInOperationsQueue:(NSDictionary<NSString *,NSArray<NSString *> *> *)directRooms
+                                               success:(void (^)(void))success
+                                               failure:(void (^)(NSError *))failure;
+
+/**
  Make sure that the `MXRoom` internal data for a list of rooms is preloaded.
 
  Thus, next async calls to their internal data (like [MXRoom liveTimeline:])

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -1960,10 +1960,9 @@ typedef void (^MXOnResumeDone)(void);
     }];
 }
 
-// To avoid race conditions, run one HTTP request at a time
-// If there is a pending HTTP request, the change will be applied on the updated direct rooms data
 - (void)runOrQueueDirectRoomOperation:(dispatch_block_t)directRoomOperation
 {
+    // If there is a pending HTTP request, the change will be applied on the updated direct rooms data
     [directRoomsOperationsQueue addObject:[directRoomOperation copy]];
     if (directRoomsOperationsQueue.count == 1)
     {


### PR DESCRIPTION
Use this method to run or queue any other actions on the direct rooms to avoid race conditions.
Run only one HTTP request in a block. If there is a pending action, the change will be applied on the updated direct rooms data.