### PR TITLE
BF: MXError lost NSError.userInfo information.

### DIFF
--- a/MatrixSDK/MXError.m
+++ b/MatrixSDK/MXError.m
@@ -104,7 +104,7 @@ NSInteger const kMXNSErrorCode = 6;
 
 - (NSError *)createNSError
 {
-    NSMutableDictionary *userInfo = [NSMutableDictionary dictionaryWithDictionary:_userInfo];
+    NSMutableDictionary *userInfo = _userInfo ? [NSMutableDictionary dictionaryWithDictionary:_userInfo] : [NSMutableDictionary dictionary];
     
     if (self.errcode)
     {


### PR DESCRIPTION
Fix Giom's remark in https://github.com/matrix-org/matrix-ios-sdk/pull/548