### PR TITLE
MXSession: Add MXSessionStateSyncError state and MXSession.syncError 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Changes in Matrix iOS SDK in 0.11.2 (2018-08-)
 
 Improvements:
  * MXRestClient: Add testUserRegistration to check earlier if a username can be registered.
+ * MXSession: Add MXSessionStateSyncError state and MXSession.syncError to manage homeserver resource quota on /sync requests (vector-im/riot-ios/issues/1937).
  * MXError: Add kMXErrCodeStringResourceLimitExceeded to manage homeserver resource quota (vector-im/riot-ios/issues/1937).
  * MXError: Define constant strings for keys and values that can be found in a Matrix JSON dictionary error.
  

--- a/MatrixSDK/MXSession.h
+++ b/MatrixSDK/MXSession.h
@@ -30,6 +30,7 @@
 #import "MXCallManager.h"
 #import "MXCrypto.h"
 #import "MXGroup.h"
+#import "MXError.h"
 
 /**
  `MXSessionState` represents the states in the life cycle of a MXSession instance.
@@ -80,6 +81,15 @@ typedef enum : NSUInteger
      MXSessionStateRunning.
      */
     MXSessionStateHomeserverNotReachable,
+
+    /**
+     The homeserver returned a temporary error when trying to sync.
+     Check `MXSession.syncError` to get this error.
+
+     @discussion
+     The Matrix session will automatically go back MXSessionStateRunning once possible.
+     */
+    MXSessionStateSyncError,
 
     /**
      The session has been paused.
@@ -331,6 +341,11 @@ FOUNDATION_EXPORT NSString *const kMXSessionNoRoomTag;
  The current state of the session.
  */
 @property (nonatomic, readonly) MXSessionState state;
+
+/**
+ The current state of the session.
+ */
+@property (nonatomic, readonly) MXError *syncError;
 
 /**
  The flag indicating whether the initial sync has been done.

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -1253,11 +1253,13 @@ typedef void (^MXOnResumeDone)(void);
         // on 64 bits devices, the error codes are huge integers.
         int32_t code = (int32_t)error.code;
 
-        if (code == kCFURLErrorCancelled)
+        if ([error.domain isEqualToString:NSURLErrorDomain]
+            && code == kCFURLErrorCancelled)
         {
             NSLog(@"[MXSession] The connection has been cancelled.");
         }
-        else if ((code == kCFURLErrorTimedOut) && serverTimeout == 0)
+        else if ([error.domain isEqualToString:NSURLErrorDomain]
+                 && code == kCFURLErrorTimedOut && serverTimeout == 0)
         {
             NSLog(@"[MXSession] The connection has been timeout.");
             // The reconnection attempt failed on timeout: there is no data to retrieve from server

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -1178,132 +1178,135 @@ typedef void (^MXOnResumeDone)(void);
         }];
 
     } failure:^(NSError *error) {
-        MXStrongifyAndReturnIfNil(self);
-        
-        // Make sure [MXSession close] or [MXSession pause] has not been called before the server response
-        if (!self->eventStreamRequest)
+        [self handleServerSyncError:error forRequestWithServerTimeout:serverTimeout success:success failure:failure];
+    }];
+}
+
+- (void)handleServerSyncError:(NSError*)error forRequestWithServerTimeout:(NSUInteger)serverTimeout success:(void (^)(void))success failure:(void (^)(NSError *error))failure
+{
+    // Make sure [MXSession close] or [MXSession pause] has not been called before the server response
+    if (!self->eventStreamRequest)
+    {
+        return;
+    }
+
+    // Check whether the token is valid
+    if ([self isUnknownTokenError:error])
+    {
+        // Do nothing more because without a valid access_token, the session is useless
+        return;
+    }
+
+    // Handle failure during catch up first
+    if (self->onBackgroundSyncFail)
+    {
+        NSLog(@"[MXSession] background Sync fails %@", error);
+
+        // Operations on session may occur during this block. For example, [MXSession close] may be triggered.
+        // We run a copy of the block to prevent app from crashing if the block is released by one of these operations.
+        MXOnBackgroundSyncFail onBackgroundSyncFailCpy = [self->onBackgroundSyncFail copy];
+        onBackgroundSyncFailCpy(error);
+        self->onBackgroundSyncFail = nil;
+
+        // check that the application was not resumed while catching up in background
+        if (self.state == MXSessionStateBackgroundSyncInProgress)
         {
-            return;
-        }
-        
-        // Check whether the token is valid
-        if ([self isUnknownTokenError:error])
-        {
-            // Do nothing more because without a valid access_token, the session is useless
-            return;
-        }
-        
-        // Handle failure during catch up first
-        if (self->onBackgroundSyncFail)
-        {
-            NSLog(@"[MXSession] background Sync fails %@", error);
-            
-            // Operations on session may occur during this block. For example, [MXSession close] may be triggered.
-            // We run a copy of the block to prevent app from crashing if the block is released by one of these operations.
-            MXOnBackgroundSyncFail onBackgroundSyncFailCpy = [self->onBackgroundSyncFail copy];
-            onBackgroundSyncFailCpy(error);
-            self->onBackgroundSyncFail = nil;
-            
-            // check that the application was not resumed while catching up in background
-            if (self.state == MXSessionStateBackgroundSyncInProgress)
+            // Check that none required the session to keep running
+            if (self.preventPauseCount)
             {
-                // Check that none required the session to keep running
-                if (self.preventPauseCount)
-                {
-                    // Delay the pause by calling the reliable `pause` method.
-                    [self pause];
-                }
-                else
-                {
-                    NSLog(@"[MXSession] go to paused ");
-                    self->eventStreamRequest = nil;
-                    [self setState:MXSessionStatePaused];
-                    return;
-                }
+                // Delay the pause by calling the reliable `pause` method.
+                [self pause];
             }
             else
             {
-                NSLog(@"[MXSession] resume after a background Sync");
+                NSLog(@"[MXSession] go to paused ");
+                self->eventStreamRequest = nil;
+                [self setState:MXSessionStatePaused];
+                return;
             }
-        }
-        
-        // Check whether the caller wants to handle error himself
-        if (failure)
-        {
-            failure(error);
         }
         else
         {
-            // Handle error here
-            // on 64 bits devices, the error codes are huge integers.
-            int32_t code = (int32_t)error.code;
-            
-            if (code == kCFURLErrorCancelled)
+            NSLog(@"[MXSession] resume after a background Sync");
+        }
+    }
+
+    // Check whether the caller wants to handle error himself
+    if (failure)
+    {
+        failure(error);
+    }
+    else
+    {
+        // Handle error here
+        // on 64 bits devices, the error codes are huge integers.
+        int32_t code = (int32_t)error.code;
+
+        if (code == kCFURLErrorCancelled)
+        {
+            NSLog(@"[MXSession] The connection has been cancelled.");
+        }
+        else if ((code == kCFURLErrorTimedOut) && serverTimeout == 0)
+        {
+            NSLog(@"[MXSession] The connection has been timeout.");
+            // The reconnection attempt failed on timeout: there is no data to retrieve from server
+            [self->eventStreamRequest cancel];
+            self->eventStreamRequest = nil;
+
+            // Notify the reconnection attempt has been done.
+            [[NSNotificationCenter defaultCenter] postNotificationName:kMXSessionDidSyncNotification
+                                                                object:self
+                                                              userInfo:@{
+                                                                         kMXSessionNotificationErrorKey: error
+                                                                         }];
+
+            // Switch back to the long poll management
+            [self serverSyncWithServerTimeout:SERVER_TIMEOUT_MS success:nil failure:nil clientTimeout:CLIENT_TIMEOUT_MS setPresence:nil];
+        }
+        else
+        {
+            // Inform the app there is a problem with the connection to the homeserver
+            [self setState:MXSessionStateHomeserverNotReachable];
+
+            // Check if it is a network connectivity issue
+            AFNetworkReachabilityManager *networkReachabilityManager = [AFNetworkReachabilityManager sharedManager];
+            NSLog(@"[MXSession] events stream broken. Network reachability: %d", networkReachabilityManager.isReachable);
+
+            if (networkReachabilityManager.isReachable)
             {
-                NSLog(@"[MXSession] The connection has been cancelled.");
-            }
-            else if ((code == kCFURLErrorTimedOut) && serverTimeout == 0)
-            {
-                NSLog(@"[MXSession] The connection has been timeout.");
-                // The reconnection attempt failed on timeout: there is no data to retrieve from server
-                [self->eventStreamRequest cancel];
-                self->eventStreamRequest = nil;
-                
-                // Notify the reconnection attempt has been done.
-                [[NSNotificationCenter defaultCenter] postNotificationName:kMXSessionDidSyncNotification
-                                                                    object:self
-                                                                  userInfo:@{
-                                                                             kMXSessionNotificationErrorKey: error
-                                                                             }];
-                
-                // Switch back to the long poll management
-                [self serverSyncWithServerTimeout:SERVER_TIMEOUT_MS success:nil failure:nil clientTimeout:CLIENT_TIMEOUT_MS setPresence:nil];
+                // The problem is not the network
+                // Relaunch the request in a random near futur.
+                // Random time it used to avoid all Matrix clients to retry all in the same time
+                // if there is server side issue like server restart
+                dispatch_time_t delayTime = dispatch_time(DISPATCH_TIME_NOW, [MXHTTPClient timeForRetry:self->eventStreamRequest] * NSEC_PER_MSEC);
+                dispatch_after(delayTime, dispatch_get_main_queue(), ^(void) {
+
+                    if (self->eventStreamRequest)
+                    {
+                        NSLog(@"[MXSession] Retry resuming events stream");
+                        [self setState:MXSessionStateSyncInProgress];
+                        [self serverSyncWithServerTimeout:0 success:success failure:nil clientTimeout:CLIENT_TIMEOUT_MS setPresence:nil];
+                    }
+                });
             }
             else
             {
-                // Inform the app there is a problem with the connection to the homeserver
-                [self setState:MXSessionStateHomeserverNotReachable];
-                
-                // Check if it is a network connectivity issue
-                AFNetworkReachabilityManager *networkReachabilityManager = [AFNetworkReachabilityManager sharedManager];
-                NSLog(@"[MXSession] events stream broken. Network reachability: %d", networkReachabilityManager.isReachable);
-                
-                if (networkReachabilityManager.isReachable)
-                {
-                    // The problem is not the network
-                    // Relaunch the request in a random near futur.
-                    // Random time it used to avoid all Matrix clients to retry all in the same time
-                    // if there is server side issue like server restart
-                    dispatch_time_t delayTime = dispatch_time(DISPATCH_TIME_NOW, [MXHTTPClient timeForRetry:self->eventStreamRequest] * NSEC_PER_MSEC);
-                    dispatch_after(delayTime, dispatch_get_main_queue(), ^(void) {
-                        
-                        if (self->eventStreamRequest)
-                        {
-                            NSLog(@"[MXSession] Retry resuming events stream");
-                            [self setState:MXSessionStateSyncInProgress];
-                            [self serverSyncWithServerTimeout:0 success:success failure:nil clientTimeout:CLIENT_TIMEOUT_MS setPresence:nil];
-                        }
-                    });
-                }
-                else
-                {
-                    // The device is not connected to the internet, wait for the connection to be up again before retrying
-                    __block __weak id reachabilityObserver =
-                    [[NSNotificationCenter defaultCenter] addObserverForName:AFNetworkingReachabilityDidChangeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *note) {
-                        
-                        if (networkReachabilityManager.isReachable && self->eventStreamRequest)
-                        {
-                            [[NSNotificationCenter defaultCenter] removeObserver:reachabilityObserver];
-                            
-                            NSLog(@"[MXSession] Retry resuming events stream");
-                            [self setState:MXSessionStateSyncInProgress];
-                            [self serverSyncWithServerTimeout:0 success:success failure:nil clientTimeout:CLIENT_TIMEOUT_MS setPresence:nil];
-                        }
-                    }];
-                }
+                // The device is not connected to the internet, wait for the connection to be up again before retrying
+                __block __weak id reachabilityObserver =
+                [[NSNotificationCenter defaultCenter] addObserverForName:AFNetworkingReachabilityDidChangeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *note) {
+
+                    if (networkReachabilityManager.isReachable && self->eventStreamRequest)
+                    {
+                        [[NSNotificationCenter defaultCenter] removeObserver:reachabilityObserver];
+
+                        NSLog(@"[MXSession] Retry resuming events stream");
+                        [self setState:MXSessionStateSyncInProgress];
+                        [self serverSyncWithServerTimeout:0 success:success failure:nil clientTimeout:CLIENT_TIMEOUT_MS setPresence:nil];
+                    }
+                }];
             }
         }
-    }];
+    }
 }
 
 - (void)handlePresenceEvent:(MXEvent *)event direction:(MXTimelineDirection)direction


### PR DESCRIPTION
to manage homeserver resource quota on /sync requests

Point 3 of of vector-im/riot-ios#1937
