### PR TITLE
MXSession: Add the supportedMatrixVersions method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@ Changes in Matrix iOS SDK in 0.11.2 (2018-08-)
 ===============================================
 
 Improvements:
+ * MXSession: Add the supportedMatrixVersions method getting versions of the specification supported by the homeserver.
  * MXRestClient: Add testUserRegistration to check earlier if a username can be registered.
  * MXError: Add kMXErrCodeStringResourceLimitExceeded to manage homeserver resource quota (vector-im/riot-ios/issues/1937).
  * MXError: Define constant strings for keys and values that can be found in a Matrix JSON dictionary error.

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -59,6 +59,8 @@
 		323EF7471C7CB4C7000DC98C /* MXEventTimelineTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 323EF7461C7CB4C7000DC98C /* MXEventTimelineTests.m */; };
 		323F3F9320D3F0C700D26D6A /* MXRoomEventFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 323F3F9120D3F0C700D26D6A /* MXRoomEventFilter.m */; };
 		323F3F9420D3F0C700D26D6A /* MXRoomEventFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 323F3F9220D3F0C700D26D6A /* MXRoomEventFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		323F8864212D4E470001C73C /* MXMatrixVersions.h in Headers */ = {isa = PBXBuildFile; fileRef = 323F8862212D4E470001C73C /* MXMatrixVersions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		323F8865212D4E480001C73C /* MXMatrixVersions.m in Sources */ = {isa = PBXBuildFile; fileRef = 323F8863212D4E470001C73C /* MXMatrixVersions.m */; };
 		324095221AFA432F00D81C97 /* MXCallStackCall.h in Headers */ = {isa = PBXBuildFile; fileRef = 3240951E1AFA432F00D81C97 /* MXCallStackCall.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3240969D1F9F751600DBA607 /* MXPushRuleSenderNotificationPermissionConditionChecker.h in Headers */ = {isa = PBXBuildFile; fileRef = 3240969B1F9F751600DBA607 /* MXPushRuleSenderNotificationPermissionConditionChecker.h */; };
 		3240969E1F9F751600DBA607 /* MXPushRuleSenderNotificationPermissionConditionChecker.m in Sources */ = {isa = PBXBuildFile; fileRef = 3240969C1F9F751600DBA607 /* MXPushRuleSenderNotificationPermissionConditionChecker.m */; };
@@ -348,6 +350,8 @@
 		323EF7461C7CB4C7000DC98C /* MXEventTimelineTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXEventTimelineTests.m; sourceTree = "<group>"; };
 		323F3F9120D3F0C700D26D6A /* MXRoomEventFilter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXRoomEventFilter.m; sourceTree = "<group>"; };
 		323F3F9220D3F0C700D26D6A /* MXRoomEventFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXRoomEventFilter.h; sourceTree = "<group>"; };
+		323F8862212D4E470001C73C /* MXMatrixVersions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXMatrixVersions.h; sourceTree = "<group>"; };
+		323F8863212D4E470001C73C /* MXMatrixVersions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXMatrixVersions.m; sourceTree = "<group>"; };
 		3240951E1AFA432F00D81C97 /* MXCallStackCall.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXCallStackCall.h; sourceTree = "<group>"; };
 		3240969B1F9F751600DBA607 /* MXPushRuleSenderNotificationPermissionConditionChecker.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXPushRuleSenderNotificationPermissionConditionChecker.h; sourceTree = "<group>"; };
 		3240969C1F9F751600DBA607 /* MXPushRuleSenderNotificationPermissionConditionChecker.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXPushRuleSenderNotificationPermissionConditionChecker.m; sourceTree = "<group>"; };
@@ -847,6 +851,8 @@
 				B17982F22119E4A1001FD722 /* MXRoomCreateContent.m */,
 				B17982EF2119E49F001FD722 /* MXRoomPredecessorInfo.h */,
 				B17982F32119E4A1001FD722 /* MXRoomPredecessorInfo.m */,
+				323F8862212D4E470001C73C /* MXMatrixVersions.h */,
+				323F8863212D4E470001C73C /* MXMatrixVersions.m */,
 			);
 			path = JSONModels;
 			sourceTree = "<group>";
@@ -1223,6 +1229,7 @@
 				3245A7521AF7B2930001D8A7 /* MXCallManager.h in Headers */,
 				C6FE1EF01E65C4F7008587E4 /* MXAnalyticsDelegate.h in Headers */,
 				92634B7F1EF2A37A00DB9F60 /* MXCallAudioSessionConfigurator.h in Headers */,
+				323F8864212D4E470001C73C /* MXMatrixVersions.h in Headers */,
 				3291D4D41A68FFEB00C3BA41 /* MXFileRoomStore.h in Headers */,
 				320BBF431D6C81550079890E /* MXEventsEnumeratorOnArray.h in Headers */,
 				32B76EA320FDE2BE00B095F6 /* MXRoomMembersCount.h in Headers */,
@@ -1536,6 +1543,7 @@
 				F0C34CBB1C18C93700C36F09 /* MXSDKOptions.m in Sources */,
 				320BBF441D6C81550079890E /* MXEventsEnumeratorOnArray.m in Sources */,
 				32618E7220ED2DF500E1D2EA /* MXFilterJSONModel.m in Sources */,
+				323F8865212D4E480001C73C /* MXMatrixVersions.m in Sources */,
 				320DFDDC19DD99B60068622A /* MXRoom.m in Sources */,
 				F08B8D5D1E014711006171A8 /* NSData+MatrixSDK.m in Sources */,
 				3291D4D51A68FFEB00C3BA41 /* MXFileRoomStore.m in Sources */,

--- a/MatrixSDK/JSONModels/MXMatrixVersions.h
+++ b/MatrixSDK/JSONModels/MXMatrixVersions.h
@@ -1,0 +1,53 @@
+/*
+ Copyright 2018 New Vector Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import "MXJSONModel.h"
+
+/**
+ Features declared in the matrix specification.
+ */
+struct MXMatrixVersionsFeatureStruct
+{
+    // Room members lazy loading
+    __unsafe_unretained NSString * const lazyLoadMembers;
+};
+extern const struct MXMatrixVersionsFeatureStruct MXMatrixVersionsFeature;
+
+/**
+ `MXMatrixVersions` represents the versions of the Matrix specification supported
+ by the home server.
+ It is returned by the /versions API.
+ */
+@interface MXMatrixVersions : MXJSONModel
+
+/**
+ The versions supported by the server.
+ */
+@property (nonatomic) NSArray<NSString *> *versions;
+
+/**
+ The unstable features supported by the server.
+
+ */
+@property (nonatomic) NSDictionary<NSString*, NSNumber*> *unstableFeatures;
+
+/**
+ Check whether the server supports the room members lazy loading.
+ */
+@property (nonatomic, readonly) BOOL supportLazyLoadMembers;
+
+@end

--- a/MatrixSDK/JSONModels/MXMatrixVersions.m
+++ b/MatrixSDK/JSONModels/MXMatrixVersions.m
@@ -1,0 +1,41 @@
+/*
+ Copyright 2018 New Vector Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXMatrixVersions.h"
+
+const struct MXMatrixVersionsFeatureStruct MXMatrixVersionsFeature = {
+    .lazyLoadMembers = @"m.lazy_load_members"
+};
+
+@implementation MXMatrixVersions
+
++ (id)modelFromJSON:(NSDictionary *)JSONDictionary
+{
+    MXMatrixVersions *matrixVersions = [[MXMatrixVersions alloc] init];
+    if (matrixVersions)
+    {
+        MXJSONModelSetArray(matrixVersions.versions, JSONDictionary[@"versions"]);
+        MXJSONModelSetDictionary(matrixVersions.unstableFeatures, JSONDictionary[@"unstable_features"]);
+    }
+    return matrixVersions;
+}
+
+- (BOOL)supportLazyLoadMembers
+{
+    return [self.unstableFeatures[MXMatrixVersionsFeature.lazyLoadMembers] boolValue];
+}
+
+@end

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -32,7 +32,7 @@
 #import "MXEventTimeline.h"
 #import "MXJSONModels.h"
 #import "MXFilterJSONModel.h"
-
+#import "MXMatrixVersions.h"
 
 #pragma mark - Constants definitions
 /**
@@ -173,6 +173,21 @@ typedef enum : NSUInteger
 -(id)initWithCredentials:(MXCredentials*)credentials andOnUnrecognizedCertificateBlock:(MXHTTPClientOnUnrecognizedCertificate)onUnrecognizedCertBlock NS_REFINED_FOR_SWIFT;
 
 - (void)close;
+
+
+#pragma mark - Server administration
+/**
+ Gets the versions of the specification supported by the server.
+
+ @param success A block object called when the operation succeeds. It provides
+                the supported spec versions.
+ @param failure A block object called when the operation fails.
+
+ @return a MXHTTPOperation instance.
+ */
+- (MXHTTPOperation*)supportedMatrixVersions:(void (^)(MXMatrixVersions *matrixVersions))success
+                        failure:(void (^)(NSError *error))failure;
+
 
 #pragma mark - Registration operations
 /**

--- a/MatrixSDK/MXSession.h
+++ b/MatrixSDK/MXSession.h
@@ -606,6 +606,17 @@ typedef void (^MXOnBackgroundSyncFail)(NSError *error);
  */
 - (void)enableCrypto:(BOOL)enableCrypto success:(void (^)(void))success failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
+/**
+ Get the versions of the specification supported by the server.
+
+ @param success A block object called when the operation succeeds. It provides
+                the supported spec versions.
+ @param failure A block object called when the operation fails.
+
+ @return a MXHTTPOperation instance.
+ */
+- (MXHTTPOperation*)supportedMatrixVersions:(void (^)(MXMatrixVersions *matrixVersions))success failure:(void (^)(NSError *error))failure;
+
 
 #pragma mark - Rooms operations
 /**

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -1483,6 +1483,11 @@ typedef void (^MXOnResumeDone)(void);
     }
 }
 
+- (MXHTTPOperation*)supportedMatrixVersions:(void (^)(MXMatrixVersions *))success failure:(void (^)(NSError *))failure
+{
+    return [matrixRestClient supportedMatrixVersions:success failure:failure];
+}
+
 
 #pragma mark - Rooms operations
 

--- a/MatrixSDKTests/MXRestClientNoAuthAPITests.m
+++ b/MatrixSDKTests/MXRestClientNoAuthAPITests.m
@@ -84,6 +84,55 @@
 }
 
 
+#pragma mark - Server administration
+- (void)testSupportedMatrixVersions
+{
+    XCTestExpectation *expectation = [self expectationWithDescription:@"asyncTest"];
+
+    [mxRestClient supportedMatrixVersions:^(MXMatrixVersions *matrixVersions) {
+
+        XCTAssertNotNil(matrixVersions);
+        XCTAssertNotNil(matrixVersions.versions);
+
+        // Check supported spec version at the time of writing this test
+        XCTAssert([matrixVersions.versions containsObject:@"r0.0.1"]);
+        XCTAssert([matrixVersions.versions containsObject:@"r0.1.0"]);
+        XCTAssert([matrixVersions.versions containsObject:@"r0.2.0"]);
+        XCTAssert([matrixVersions.versions containsObject:@"r0.3.0"]);
+
+        [expectation fulfill];
+
+    } failure:^(NSError *error) {
+        XCTFail(@"The request should not fail - NSError: %@", error);
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:10 handler:nil];
+}
+
+// At the time of introducing this test, MXMatrixVersions.supportLazyLoadMembers
+// was stored in MXMatrixVersions.unstableFeatures.
+// Make sure that, in future versions of the spec, supportLazyLoadMembers is still YES
+// wherever it will be stored.
+- (void)testSupportedMatrixVersionsSupportLazyLoadMembers
+{
+    XCTestExpectation *expectation = [self expectationWithDescription:@"asyncTest"];
+
+    [mxRestClient supportedMatrixVersions:^(MXMatrixVersions *matrixVersions) {
+
+        XCTAssert(matrixVersions.supportLazyLoadMembers);
+
+        [expectation fulfill];
+
+    } failure:^(NSError *error) {
+        XCTFail(@"The request should not fail - NSError: %@", error);
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:10 handler:nil];
+}
+
+
 #pragma mark - Registration operations
 - (void)testGetRegisterSession
 {


### PR DESCRIPTION
to get versions of the specification supported by the homeserver.

Needed for https://github.com/vector-im/riot-ios/issues/1931.