### PR TITLE
Add SwiftSupport subspec (again) to MatrixSDK in order to expose Swift refinements to a Swift/ObjC project

### DIFF
--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -54,24 +54,6 @@ Pod::Spec.new do |s|
     # Use WebRTC build at https://github.com/Anakros/WebRTC instead
     ss.ios.dependency 'WebRTC', '63.11.20455'
   end
-  
-
-  # This podspec has been disabled because we cannot lint SwiftSupport subspec with static libraries.
-  # pod lint returns:
-  #
-  # - ERROR | [iOS] [MatrixSDK/SwiftSupport] unknown: Encountered an unknown error (The following Swift pods cannot yet be integrated as static libraries:
-  #
-  # Please add "MatrixSDKExtensions/MXAnalyticsDelegate/GoogleAnalytics/**/*.{h,m}" files directly to your project and add 'GoogleAnalytics' pod to your podfile.
-
-  # s.subspec 'GoogleAnalytics' do |ss|
-  #   ss.ios.deployment_target = "8.0"
-    
-  #   ss.source_files  = "MatrixSDKExtensions/MXAnalyticsDelegate/GoogleAnalytics/**/*.{h,m}"
-    
-  #   ss.dependency 'MatrixSDK/Core'
-    
-  #   ss.ios.dependency 'GoogleAnalytics' 
-  # end
 
   s.subspec 'SwiftSupport' do |ss|    
     ss.source_files = "MatrixSDK", "MatrixSDK/**/*.{swift}"

--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -55,28 +55,28 @@ Pod::Spec.new do |s|
     ss.ios.dependency 'WebRTC', '63.11.20455'
   end
   
-  s.subspec 'GoogleAnalytics' do |ss|
-    ss.ios.deployment_target = "8.0"
-    
-    ss.source_files  = "MatrixSDKExtensions/MXAnalyticsDelegate/GoogleAnalytics/**/*.{h,m}"
-    
-    ss.dependency 'MatrixSDK/Core'
-    
-    ss.ios.dependency 'GoogleAnalytics' 
-  end
 
-#
-# This podspec has been disabled because it prevents from publishing the whole pod.
-# pod lint returns:
-#
-#    - ERROR | [iOS] [MatrixSDK/SwiftSupport] unknown: Encountered an unknown error (The following Swift pods cannot yet be integrated as static libraries:
-# 
-# The Swift pod `MatrixSDK` depends upon `AFNetworking`, `GZIP`, `OLMKit`, and `Realm`, which do not define modules. To opt into those targets generating module maps (which is necessary to import them from Swift when building as static libraries), you may set `use_modular_headers!` globally in your Podfile, or specify `:modular_headers => true` for particular dependencies.) during validation.
-#
-#  s.subspec 'SwiftSupport' do |ss|    
-#    ss.source_files = "MatrixSDK", "MatrixSDK/**/*.{swift}"
-#    
-#    ss.dependency 'MatrixSDK/Core'      
-#  end
+  # This podspec has been disabled because we cannot lint SwiftSupport subspec with static libraries.
+  # pod lint returns:
+  #
+  # - ERROR | [iOS] [MatrixSDK/SwiftSupport] unknown: Encountered an unknown error (The following Swift pods cannot yet be integrated as static libraries:
+  #
+  # Please add "MatrixSDKExtensions/MXAnalyticsDelegate/GoogleAnalytics/**/*.{h,m}" files directly to your project and add 'GoogleAnalytics' pod to your podfile.
+
+  # s.subspec 'GoogleAnalytics' do |ss|
+  #   ss.ios.deployment_target = "8.0"
+    
+  #   ss.source_files  = "MatrixSDKExtensions/MXAnalyticsDelegate/GoogleAnalytics/**/*.{h,m}"
+    
+  #   ss.dependency 'MatrixSDK/Core'
+    
+  #   ss.ios.dependency 'GoogleAnalytics' 
+  # end
+
+  s.subspec 'SwiftSupport' do |ss|    
+    ss.source_files = "MatrixSDK", "MatrixSDK/**/*.{swift}"
+   
+    ss.dependency 'MatrixSDK/Core'      
+  end
 
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -24,7 +24,7 @@ platform :ios do
 
   desc "Lint MatrixSDK podspec"
   lane :lint_pod_MatrixSDK do  	
-  	custom_pod_lib_lint(podspec: "../MatrixSDK.podspec", parameters: ['--use-libraries', '--allow-warnings'])
+  	custom_pod_lib_lint(podspec: "../MatrixSDK.podspec", parameters: ['--allow-warnings'])
   end
 
   desc "Lint SwiftMatrixSDK podspec"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -40,7 +40,7 @@ platform :ios do
 
   desc "Push MatrixSDK pod"
     lane :push_pod_MatrixSDK do  	
-  	pod_push(path: "MatrixSDK.podspec", use_libraries: true, allow_warnings: true)
+  	pod_push(path: "MatrixSDK.podspec", allow_warnings: true)
   end
 
   desc "Push SwiftMatrixSDK pod"


### PR DESCRIPTION
To make MatrixSDK pod lint works with Swift code we have to remove dependency to static libraries. So remove GoogleAnalytics subspec.

For the moment, to use Google Analytics, a developper have to add "MatrixSDKExtensions/MXAnalyticsDelegate/GoogleAnalytics/**/*.{h,m}" files directly to his project and add 'GoogleAnalytics' pod to his podfile.