### PR TITLE
Lazy-loading: MXRoom: Avoid race condition with the /members request

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Improvements:
  * MXSession: Add MXSessionStateSyncError state and MXSession.syncError to manage homeserver resource quota on /sync requests (vector-im/riot-ios/issues/1937).
  * MXError: Add kMXErrCodeStringResourceLimitExceeded to manage homeserver resource quota (vector-im/riot-ios/issues/1937).
  * MXError: Define constant strings for keys and values that can be found in a Matrix JSON dictionary error.
+ * Tests: MXHTTPClient_Private.h: Add method to set fake delay in HTTP requests.
  
 Bug fix:
  * MXError: MXError lost NSError.userInfo information.

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -339,6 +339,7 @@
 		322A51C51D9BBD3C00C8536D /* MXOlmDevice.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXOlmDevice.h; sourceTree = "<group>"; };
 		322A51C61D9BBD3C00C8536D /* MXOlmDevice.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXOlmDevice.m; sourceTree = "<group>"; };
 		322A51D71D9E846800C8536D /* MXCryptoTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXCryptoTests.m; sourceTree = "<group>"; };
+		322DB456212EB8E600F4EFE9 /* MXHTTPClient_Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXHTTPClient_Private.h; sourceTree = "<group>"; };
 		32322A471E57264E005DD155 /* MXSelfSignedHomeserverTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXSelfSignedHomeserverTests.m; sourceTree = "<group>"; };
 		32322A491E575F65005DD155 /* MXAllowedCertificates.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXAllowedCertificates.h; sourceTree = "<group>"; };
 		32322A4A1E575F65005DD155 /* MXAllowedCertificates.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXAllowedCertificates.m; sourceTree = "<group>"; };
@@ -680,6 +681,7 @@
 				F03EF5021DF01596009DF592 /* MXLRUCache.h */,
 				F03EF5031DF01596009DF592 /* MXLRUCache.m */,
 				320DFDD719DD99B60068622A /* MXHTTPClient.h */,
+				322DB456212EB8E600F4EFE9 /* MXHTTPClient_Private.h */,
 				320DFDD819DD99B60068622A /* MXHTTPClient.m */,
 				32CAB1091A925B41008C5BB9 /* MXHTTPOperation.h */,
 				32CAB10A1A925B41008C5BB9 /* MXHTTPOperation.m */,

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -77,6 +77,12 @@ FOUNDATION_EXPORT NSString *const kMXAccountDataKeyIgnoredUser;
  */
 FOUNDATION_EXPORT NSString *const kMXRestClientErrorDomain;
 
+/**
+ Parameters that can be used in [MXRestClient membersOfRoom:withParameters:...].
+ */
+FOUNDATION_EXPORT NSString *const kMXMembersOfRoomParametersAt;
+FOUNDATION_EXPORT NSString *const kMXMembersOfRoomParametersMembership;
+FOUNDATION_EXPORT NSString *const kMXMembersOfRoomParametersNotMembership;
 
 /**
  Methods of thumnailing supported by the Matrix content repository.
@@ -1211,6 +1217,23 @@ typedef enum : NSUInteger
 - (MXHTTPOperation*)membersOfRoom:(NSString*)roomId
                           success:(void (^)(NSArray *roomMemberEvents))success
                           failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
+
+/**
+ Get a list of members for this room.
+
+ @param roomId the id of the room.
+ @param parameters additional parameters for the request. Check kMXMembersOfRoomParameters*.
+
+ @param success A block object called when the operation succeeds. It provides an array of `MXEvent`
+ objects  which type is m.room.member.
+ @param failure A block object called when the operation fails.
+
+ @return a MXHTTPOperation instance.
+ */
+- (MXHTTPOperation*)membersOfRoom:(NSString*)roomId
+                   withParameters:(NSDictionary*)parameters
+                          success:(void (^)(NSArray *roomMemberEvents))success
+                          failure:(void (^)(NSError *error))failure ;
 
 /**
  Get a list of all the current state events for this room.

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -68,6 +68,13 @@ NSString *const kMX3PIDMediumMSISDN = @"msisdn";
 NSString *const kMXRestClientErrorDomain = @"kMXRestClientErrorDomain";
 
 /**
+ Parameters that can be used in [MXRestClient membersOfRoom:withParameters:...].
+ */
+NSString *const kMXMembersOfRoomParametersAt            = @"at";
+NSString *const kMXMembersOfRoomParametersMembership    = @"membership";
+NSString *const kMXMembersOfRoomParametersNotMembership = @"not_membership";
+
+/**
  Authentication flow: register or login
  */
 typedef enum
@@ -2149,12 +2156,20 @@ MXAuthAction;
                           success:(void (^)(NSArray *roomMemberEvents))success
                           failure:(void (^)(NSError *error))failure
 {
+    return [self membersOfRoom:roomId withParameters:nil success:success failure:failure];
+}
+
+- (MXHTTPOperation*)membersOfRoom:(NSString*)roomId
+                   withParameters:(NSDictionary*)parameters
+                          success:(void (^)(NSArray *roomMemberEvents))success
+                          failure:(void (^)(NSError *error))failure
+{
     NSString *path = [NSString stringWithFormat:@"%@/rooms/%@/members", apiPathPrefix, roomId];
 
     MXWeakify(self);
     return [httpClient requestWithMethod:@"GET"
                                     path:path
-                              parameters:nil
+                              parameters:parameters
                                  success:^(NSDictionary *JSONResponse) {
                                      MXStrongifyAndReturnIfNil(self);
 

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -384,6 +384,8 @@ typedef void (^MXOnResumeDone)(void);
            onServerSyncDone:(void (^)(void))onServerSyncDone
                     failure:(void (^)(NSError *error))failure;
 {
+    NSLog(@"[MXSession] startWithSyncFilter: %@", syncFilter);
+
     if (syncFilter)
     {
         // Build or retrieve the filter before launching the event stream
@@ -396,7 +398,7 @@ typedef void (^MXOnResumeDone)(void);
         } failure:^(NSError *error) {
             MXStrongifyAndReturnIfNil(self);
 
-            NSLog(@"[MXSesssion] startWithSyncFilter: WARNING: Impossible to create the filter. Use no filter in /sync");
+            NSLog(@"[MXSession] startWithSyncFilter: WARNING: Impossible to create the filter. Use no filter in /sync");
             [self startWithSyncFilterId:nil onServerSyncDone:onServerSyncDone failure:failure];
         }];
     }

--- a/MatrixSDK/Utils/MXHTTPClient_Private.h
+++ b/MatrixSDK/Utils/MXHTTPClient_Private.h
@@ -1,0 +1,45 @@
+/*
+ Copyright 2018 New Vector Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXHTTPClient.h"
+
+/**
+ The `MXHTTPClient_Private` extension exposes internal operations like methods
+ required for testing.
+
+ Note: These methods are too intrusive. We should implement our own NSURLProtocol
+ a la OHHTTPStubs and manage only a delay, not stub data.
+ The issue is that AFNetworking does not use the shared NSURLSessionConfiguration so
+ that [NSURLProtocol registerClass:] does not work which makes things longer to implement.
+
+ FTR, OHHTTPStubs solves that by doing some swizzling (https://github.com/AliSoftware/OHHTTPStubs/blob/c7c96546db35d5bb15f027b42b9208e57f6c4289/OHHTTPStubs/Sources/NSURLSession/OHHTTPStubs%2BNSURLSessionConfiguration.m#L54).
+ */
+@interface MXHTTPClient ()
+
+/**
+ Set a delay in the reponse of requests containing `string` in their path.
+
+ @param delayMs the delay in milliseconds. 0 to remove it.
+ @param string a pattern in the request path.
+ */
++ (void)setDelay:(NSUInteger)delayMs toRequestsContainingString:(NSString*)string;
+
+/**
+ Remove all created delays.
+ */
++ (void)removeAllDelays;
+
+@end


### PR DESCRIPTION
https://github.com/vector-im/riot-ios/issues/1931

This PR contains also some changes in MXHTTPClient that allow to add delays in http requests response for testing. I am not happy about how it is intrusive but there is no quick solution for that.