### PR TITLE
BF: Rooms notifications counts and rooms order was wrong after restart

### DIFF
--- a/MatrixSDK/Data/MXRoomSummary.m
+++ b/MatrixSDK/Data/MXRoomSummary.m
@@ -89,6 +89,7 @@ NSString *const kMXRoomSummaryDidChangeNotification = @"kMXRoomSummaryDidChangeN
     if (!_mxSession)
     {
         _mxSession = mxSession;
+        store = mxSession.store;
 
         // Listen to the event sent state changes
         // This is used to follow evolution of local echo events


### PR DESCRIPTION
Fix a regression introduced by https://github.com/matrix-org/matrix-ios-sdk/pull/563
MXRoomSummary unfortunately still needs a reference to the store to read other data.