### PR TITLE
MXRoomSummary: Compute avatars for rooms that do not have one

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changes in Matrix iOS SDK in 0.11.4 ()
 Improvements:
 * MXRoom: Expose room members access in Swift (PR #562).
 * MXPeekingRoom: Create a MXPeekingRoomSummary class to represent their summary data.
+* MXRoomSummary: If no avatar, try to compute it from heroes.
+* MXRoomSummary: If no avatar for an invited room, try to compute it from available state events.
 
 Bug fix:
 * Lazy-Loading: Fix regression on peeking (vector-im/riot-ios/issues/2035).

--- a/MatrixSDK/Data/MXRoomSummaryUpdater.m
+++ b/MatrixSDK/Data/MXRoomSummaryUpdater.m
@@ -172,6 +172,47 @@
         }
     }
 
+    if (summary.membership == MXMembershipInvite)
+    {
+        updated = [self session:session updateInvitedRoomSummary:summary withStateEvents:stateEvents roomState:roomState];
+    }
+
+    return updated;
+}
+
+- (BOOL)session:(MXSession *)session updateInvitedRoomSummary:(MXRoomSummary *)summary withStateEvents:(NSArray<MXEvent *> *)stateEvents roomState:(MXRoomState*)roomState
+{
+    BOOL updated = NO;
+
+    // TODO: There is bug here if someone invites us in a non 1:1 room with no avatar.
+    // In this case, the summary avatar would be the inviter avatar.
+    // We need more information from the homeserver (https://github.com/matrix-org/matrix-doc/issues/1679)
+    // Note: we have this bug since day #1
+    if (roomState.membersCount.members == 2)
+    {
+        MXRoomMember *otherMember;
+        for (MXRoomMember *member in roomState.members.members)
+        {
+            if (![member.userId isEqualToString:session.myUser.userId])
+            {
+                otherMember = member;
+                break;
+            }
+        }
+
+        if (!summary.displayname)
+        {
+            summary.displayname = otherMember.displayname;
+            updated = YES;
+        }
+
+        if (!summary.avatar)
+        {
+            summary.avatar = otherMember.avatarUrl;
+            updated = YES;
+        }
+    }
+
     return updated;
 }
                  

--- a/MatrixSDK/Data/MXRoomSummaryUpdater.m
+++ b/MatrixSDK/Data/MXRoomSummaryUpdater.m
@@ -270,6 +270,12 @@
         updated |= [self updateSummaryDisplayname:summary session:session withServerRoomSummary:serverRoomSummary roomState:roomState];
     }
 
+    // Compute the avatar from summary heroes if there was no avatar
+    if (!roomState.avatar)
+    {
+        updated |= [self updateSummaryAvatar:summary session:session withServerRoomSummary:serverRoomSummary roomState:roomState];
+    }
+
     return updated;
 }
 
@@ -324,6 +330,21 @@
         }
 
         updated = YES;
+    }
+
+    return updated;
+}
+
+- (BOOL)updateSummaryAvatar:(MXRoomSummary *)summary session:(MXSession *)session withServerRoomSummary:(MXRoomSyncSummary *)serverRoomSummary roomState:(MXRoomState *)roomState
+{
+    BOOL updated = NO;
+
+    if (serverRoomSummary.heroes.count == 1)
+    {
+        MXRoomMember *otherMember = [roomState.members memberWithUserId:serverRoomSummary.heroes.firstObject];
+        summary.avatar = otherMember.avatarUrl;
+
+        updated |= !summary.avatar;
     }
 
     return updated;


### PR DESCRIPTION
Part of https://github.com/vector-im/riot-ios/issues/1931

Commits can be reviewed one by one.