### PR TITLE
Room summary computation: Use the matrix room summaries algo even if LL is off

### DIFF
--- a/MatrixSDK/Data/MXRoomSummary.m
+++ b/MatrixSDK/Data/MXRoomSummary.m
@@ -426,7 +426,9 @@ NSString *const kMXRoomSummaryDidChangeNotification = @"kMXRoomSummaryDidChangeN
         self->updatedWithStateEvents = NO;
 
         // Handle room summary sent by the home server
-        if (roomSync.summary)
+        // Call the method too in case of non lazy loading and no server room summary.
+        // This will share the same algorithm to compute room name, avatar, members count.
+        if (roomSync.summary || updated)
         {
             updated |= [self.mxSession.roomSummaryUpdateDelegate session:self.mxSession updateRoomSummary:self withServerRoomSummary:roomSync.summary roomState:roomState];
         }

--- a/MatrixSDK/Data/MXRoomSummaryUpdater.m
+++ b/MatrixSDK/Data/MXRoomSummaryUpdater.m
@@ -291,6 +291,14 @@
         summary.displayname = roomState.canonicalAlias;
         updated = YES;
     }
+    // If the room has an alias, use that
+    // Note: This is out of Matrix spec for the moment but we need it to keep
+    // same room names as before the Matrix room summaries introduction
+    else if (roomState.aliases.count)
+    {
+        summary.displayname = roomState.aliases.firstObject;
+        updated = YES;
+    }
     // Else, use Matrix room summaries and heroes
     else if (serverRoomSummary)
     {

--- a/MatrixSDK/Data/MXRoomSummaryUpdater.m
+++ b/MatrixSDK/Data/MXRoomSummaryUpdater.m
@@ -175,48 +175,18 @@
 
     if (summary.membership == MXMembershipInvite)
     {
-        updated = [self session:session updateInvitedRoomSummary:summary withStateEvents:stateEvents roomState:roomState];
+        // The server does not send yet room summary for invited rooms (https://github.com/matrix-org/matrix-doc/issues/1679)
+        // but we could reuse same computation algos as joined rooms.
+        // Note that leads to a bug in case someone invites us in a non 1:1 room with no avatar.
+        // In this case, the summary avatar would be the inviter avatar.
+        // We need more information from the homeserver to solve it. The issue above should help to fix it
+        // Note: we have this bug since day #1
+        updated = [self session:session updateRoomSummary:summary withServerRoomSummary:nil roomState:roomState];
     }
 
     return updated;
 }
 
-- (BOOL)session:(MXSession *)session updateInvitedRoomSummary:(MXRoomSummary *)summary withStateEvents:(NSArray<MXEvent *> *)stateEvents roomState:(MXRoomState*)roomState
-{
-    BOOL updated = NO;
-
-    // TODO: There is bug here if someone invites us in a non 1:1 room with no avatar.
-    // In this case, the summary avatar would be the inviter avatar.
-    // We need more information from the homeserver (https://github.com/matrix-org/matrix-doc/issues/1679)
-    // Note: we have this bug since day #1
-    if (roomState.membersCount.members == 2)
-    {
-        MXRoomMember *otherMember;
-        for (MXRoomMember *member in roomState.members.members)
-        {
-            if (![member.userId isEqualToString:session.myUser.userId])
-            {
-                otherMember = member;
-                break;
-            }
-        }
-
-        if (!summary.displayname)
-        {
-            summary.displayname = otherMember.displayname;
-            updated = YES;
-        }
-
-        if (!summary.avatar)
-        {
-            summary.avatar = otherMember.avatarUrl;
-            updated = YES;
-        }
-    }
-
-    return updated;
-}
-                 
 #pragma mark - Private
 
 // Hide tombstoned room from user only if the user joined the replacement room


### PR DESCRIPTION
With this PR, computations of name, avatar and members count use the same code if matrix room summary is available or not, which depends on LL activation.
Even invitations share now the same code too.

Along development, there was some update in the spec. The goal is to have same room names in Riot as before. You can see spec updates in comments updates along commits.

Commits can be reviewed one by one.

Should fix unexpected empty rooms (https://github.com/vector-im/riot-ios/issues/2020).
