### PR TITLE
MXHTTPClient: Send Access-Token as header instead of query param

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+Changes in Matrix iOS SDK in 0.11.6 (2018-10-)
+===============================================
+
+Improvements:
+MXHTTPClient: Send Access-Token as header instead of query param (vector-im/riot-ios/issues/2071).
+
 Changes in Matrix iOS SDK in 0.11.5 (2018-10-05)
 ===============================================
 


### PR DESCRIPTION
https://github.com/vector-im/riot-ios/issues/2071

No more need to be paranoid on access token leaks in logged HTTP paths.


The `logRequestFailure` in the code of this PR produces this kind of log:

```
2018-10-08 18:17:40.407117+0200 Riot[50864:943660] [MXHTTPClient] Request 0x6000026d5e80 failed for path: _matrix/client/r0/rooms/!pOUByvMMUGMJmuqVYi:matrix.org/messages - HTTP code: 403. Error: Error Domain=com.alamofire.error.serialization.response Code=-1011 "Request failed: forbidden (403)" UserInfo={NSLocalizedDescription=Request failed: forbidden (403), NSErrorFailingURLKey=https://matrix.org/_matrix/client/r0/rooms/!pOUByvMMUGMJmuqVYi:matrix.org/messages?dir=b&from=END&limit=30, com.alamofire.serialization.response.error.data=<7b226572 72636f64 65223a22 4d5f4755 4553545f 41434345 53535f46 4f524249 4444454e 222c2265 72726f72 223a2247 75657374 20616363 65737320 6e6f7420 616c6c6f 77656422 7d>, com.alamofire.serialization.response.error.response=<NSHTTPURLResponse: 0x600003e5ee20> { URL: https://matrix.org/_matrix/client/r0/rooms/!pOUByvMMUGMJmuqVYi:matrix.org/messages?dir=b&from=END&limit=30 } { Status Code: 403, Headers {
    "Access-Control-Allow-Origin" =     (
        "*"
    );
    "Cache-Control" =     (
        "no-cache, no-store, must-revalidate"
    );
    "Content-Encoding" =     (
        gzip
    );
    "Content-Type" =     (
        "application/json"
    );
    Date =     (
        "Mon, 08 Oct 2018 16:17:33 GMT"
    );
    Server =     (
        cloudflare
    );
    "access-control-allow-headers" =     (
        "Origin, X-Requested-With, Content-Type, Accept, Authorization"
    );
    "access-control-allow-methods" =     (
        "GET, POST, PUT, DELETE, OPTIONS"
    );
    "cf-ray" =     (
        "4669eb190be1b777-CDG"
    );
    "expect-ct" =     (
        "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\""
    );
} }}
```