### PR TITLE
MXEvent: Move `invite_room_state` to the correct place in the client-server API

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changes in Matrix iOS SDK in 0.11.6 (2018-10-)
 Improvements:
 MXHTTPClient: Send Access-Token as header instead of query param (vector-im/riot-ios/issues/2071).
 
+Bug fix:
+* MXEvent: Move `invite_room_state` to the correct place in the client-server API (vector-im/riot-ios/issues/2010).
+
 Changes in Matrix iOS SDK in 0.11.5 (2018-10-05)
 ===============================================
 

--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -32,11 +32,11 @@ Pod::Spec.new do |s|
       ss.source_files = "MatrixSDK", "MatrixSDK/**/*.{h,m}"
       
       ss.dependency 'AFNetworking', '~> 3.2.0'
-      ss.dependency 'GZIP', '~> 1.2.1'
+      ss.dependency 'GZIP', '~> 1.2.2'
 
       # Requirements for e2e encryption
       ss.dependency 'OLMKit', '~> 2.3.0'
-      ss.dependency 'Realm', '~> 3.9.0'
+      ss.dependency 'Realm', '~> 3.11.0'
   end
 
   s.subspec 'JingleCallStack' do |ss|

--- a/MatrixSDK/JSONModels/MXEvent.m
+++ b/MatrixSDK/JSONModels/MXEvent.m
@@ -162,9 +162,9 @@ NSString *const kMXEventIdentifierKey = @"kMXEventIdentifierKey";
             MXJSONModelSetDictionary(event.redactedBecause, event.unsignedData[@"redacted_because"]);
         }
         
-        if (JSONDictionary[@"invite_room_state"])
+        if (JSONDictionary[@"unsigned"][@"invite_room_state"])
         {
-            MXJSONModelSetMXJSONModelArray(event.inviteRoomState, MXEvent, JSONDictionary[@"invite_room_state"]);
+            MXJSONModelSetMXJSONModelArray(event.inviteRoomState, MXEvent, JSONDictionary[@"unsigned"][@"invite_room_state"]);
         }
 
         [event finalise];

--- a/MatrixSDKTests/MXRoomSummaryTests.m
+++ b/MatrixSDKTests/MXRoomSummaryTests.m
@@ -168,6 +168,13 @@ NSString *uisiString = @"The sender's device has not sent us the keys for this m
     return [updater session:session updateRoomSummary:summary withStateEvents:stateEvents roomState:roomState];
 }
 
+- (BOOL)session:(MXSession *)session updateRoomSummary:(MXRoomSummary *)summary withServerRoomSummary:(MXRoomSyncSummary *)serverRoomSummary roomState:(MXRoomState *)roomState
+{
+    // Do a classic update
+    MXRoomSummaryUpdater *updater = [MXRoomSummaryUpdater roomSummaryUpdaterForSession:session];
+    return [updater session:session updateRoomSummary:summary withServerRoomSummary:serverRoomSummary roomState:roomState];
+}
+
 - (void)test
 {
     [matrixSDKTestsData doMXSessionTestWithBobAndARoomWithMessages:self readyToTest:^(MXSession *mxSession, MXRoom *room, XCTestExpectation *expectation) {

--- a/Podfile
+++ b/Podfile
@@ -5,12 +5,12 @@ source 'https://github.com/CocoaPods/Specs.git'
 
 target "MatrixSDK" do
 pod 'AFNetworking', '~> 3.2.0'
-pod 'GZIP', '~> 1.2.1'
+pod 'GZIP', '~> 1.2.2'
 
 pod 'OLMKit', '~> 2.3.0', :inhibit_warnings => true
 #pod 'OLMKit', :path => '../olm/OLMKit.podspec'
 
-pod 'Realm', '~> 3.9.0'
+pod 'Realm', '~> 3.11.0'
 
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -14,21 +14,21 @@ PODS:
   - AFNetworking/Serialization (3.2.1)
   - AFNetworking/UIKit (3.2.1):
     - AFNetworking/NSURLSession
-  - GZIP (1.2.1)
+  - GZIP (1.2.2)
   - OLMKit (2.3.0):
     - OLMKit/olmc (= 2.3.0)
     - OLMKit/olmcpp (= 2.3.0)
   - OLMKit/olmc (2.3.0)
   - OLMKit/olmcpp (2.3.0)
-  - Realm (3.9.0):
-    - Realm/Headers (= 3.9.0)
-  - Realm/Headers (3.9.0)
+  - Realm (3.11.0):
+    - Realm/Headers (= 3.11.0)
+  - Realm/Headers (3.11.0)
 
 DEPENDENCIES:
   - AFNetworking (~> 3.2.0)
-  - GZIP (~> 1.2.1)
+  - GZIP (~> 1.2.2)
   - OLMKit (~> 2.3.0)
-  - Realm (~> 3.9.0)
+  - Realm (~> 3.11.0)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
@@ -39,10 +39,10 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   AFNetworking: b6f891fdfaed196b46c7a83cf209e09697b94057
-  GZIP: 7ee835f989fb3c6ea79005fc90b8fa6af710a70d
+  GZIP: 12374d285e3b5d46cfcd480700fcfc7e16caf4f1
   OLMKit: dd79cdc5fab9ec04c940a901e025195b7801f306
-  Realm: 3d36f208bf3aff8335dc3298742140182bde4edb
+  Realm: 92f09a102692b96a9a10e9617f214f15c5ab85fc
 
-PODFILE CHECKSUM: 88df2da194bf206647b8562c359335b286c080f2
+PODFILE CHECKSUM: 3acf25c5b7ee01853f358c23cfcec3711163dc75
 
 COCOAPODS: 1.6.0.beta.1

--- a/SwiftMatrixSDK.podspec
+++ b/SwiftMatrixSDK.podspec
@@ -26,10 +26,10 @@ Pod::Spec.new do |s|
   s.requires_arc  = true
 
   s.dependency 'AFNetworking', '~> 3.2.0'
-  s.dependency 'GZIP', '~> 1.2.1'
+  s.dependency 'GZIP', '~> 1.2.2'
   
   # Requirements for e2e encryption
   s.dependency 'OLMKit', '~> 2.2.2'
-  s.dependency 'Realm', '~> 3.9.0'
+  s.dependency 'Realm', '~> 3.11.0'
 
 end


### PR DESCRIPTION
Fixes vector-im/riot-ios/issues/2010

This PR comes with some maintenance on the SDK. Check commit one by one.

I was not able to make synapse send such event but at least the code now matches the matrix CS API described in the issue.

Here is what I got when invited by email from a user from another HS that did not know me:

![ima_0949967](https://user-images.githubusercontent.com/8418515/46804747-bfe96300-cd63-11e8-90fc-d2bf131ec8c3.png)


