### PR TITLE
Disable CallKit in China (#1941)

### DIFF
--- a/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.m
+++ b/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.m
@@ -192,7 +192,14 @@ NSString * const kMXCallKitAdapterAudioSessionDidActive = @"kMXCallKitAdapterAud
 
 + (BOOL)callKitAvailable
 {
-    return [NSProcessInfo.processInfo isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){10,0,0}];
+	if (@available(iOS 10.0, *)) {
+		// CallKit currently illegal in China
+		// https://github.com/vector-im/riot-ios/issues/1941
+
+		return ![NSLocale.currentLocale.countryCode isEqual: @"CN"];
+	}
+
+	return false;
 }
 
 #pragma mark - CXProviderDelegate


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-ios/issues/1941
Fixes https://github.com/vector-im/riot-ios/issues/1891

I decided to just disable in the same way that we disable it if you are on iOS 9.

I think it would be pointless to display the grayed out CallKit settings to Chinese users and add a new string that says basically sorry we can't give you this feature.