### PR TITLE
MXSession: configure antivirus scanner use.

### DIFF
--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -123,7 +123,7 @@ typedef enum : NSUInteger
 @interface MXRestClient : NSObject
 
 /**
- The homeserver.
+ The homeserver URL.
  */
 @property (nonatomic, readonly) NSString *homeserver;
 
@@ -150,22 +150,22 @@ typedef enum : NSUInteger
 @property (nonatomic) NSString *contentPathPrefix;
 
 /**
- The identity server.
+ The identity server URL.
  By default, it points to the defined home server. If needed, change it by setting
  this property.
  */
 @property (nonatomic) NSString *identityServer;
 
 /**
- The antivirus server.
- By default, it points to the defined home server. If needed, change it by setting
- this property.
+ The antivirus server URL (nil by default).
+ Set a non-null url to enable the antivirus scanner use.
  */
 @property (nonatomic) NSString *antivirusServer;
 
 /**
  The Client-Server API prefix to use for the antivirus server
  By default, it is defined by the constant kMXAntivirusAPIPrefixPathUnstable.
+ In case of a custom path prefix use, set it before settings the antivirus server url.
  */
 @property (nonatomic) NSString *antivirusServerPathPrefix;
 

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -157,9 +157,8 @@ MXAuthAction;
                              }
                          }];
         
-        // By default, use the same address for the identity server, and the antivirus server
+        // By default, use the same address for the identity server
         self.identityServer = homeserver;
-        self.antivirusServer = homeserver;
 
         completionQueue = dispatch_get_main_queue();
 
@@ -223,9 +222,8 @@ MXAuthAction;
                              }
                          }];
         
-        // By default, use the same address for the identity server, and the antivirus server
+        // By default, use the same address for the identity server
         self.identityServer = homeserver;
-        self.antivirusServer = homeserver;
 
         completionQueue = dispatch_get_main_queue();
 
@@ -3543,9 +3541,18 @@ MXAuthAction;
 #pragma mark - Antivirus server API
 - (void)setAntivirusServer:(NSString *)antivirusServer
 {
-    _antivirusServer = [antivirusServer copy];
-    antivirusHttpClient = [[MXHTTPClient alloc] initWithBaseURL:[NSString stringWithFormat:@"%@/%@", antivirusServer, antivirusServerPathPrefix]
-                             andOnUnrecognizedCertificateBlock:nil];
+    if (antivirusServer.length)
+    {
+        _antivirusServer = [antivirusServer copy];
+        antivirusHttpClient = [[MXHTTPClient alloc] initWithBaseURL:[NSString stringWithFormat:@"%@/%@", antivirusServer, antivirusServerPathPrefix]
+                                  andOnUnrecognizedCertificateBlock:nil];
+    }
+    else
+    {
+        // Disable antivirus requests
+        _antivirusServer = nil;
+        antivirusHttpClient = nil;
+    }
 }
 
 - (MXHTTPOperation*)getAntivirusServerPublicKey:(void (^)(NSString *publicKey))success

--- a/MatrixSDK/MXSession.h
+++ b/MatrixSDK/MXSession.h
@@ -632,6 +632,11 @@ typedef void (^MXOnBackgroundSyncFail)(NSError *error);
  */
 - (MXHTTPOperation*)supportedMatrixVersions:(void (^)(MXMatrixVersions *matrixVersions))success failure:(void (^)(NSError *error))failure;
 
+/**
+ The antivirus server URL (nil by default).
+ Set a non-null url to configure the antivirus scanner use.
+ */
+@property (nonatomic) NSString *antivirusServerURL;
 
 #pragma mark - Rooms operations
 /**

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -1566,6 +1566,14 @@ typedef void (^MXOnResumeDone)(void);
     return [matrixRestClient supportedMatrixVersions:success failure:failure];
 }
 
+- (void)setAntivirusServerURL:(NSString *)antivirusServerURL
+{
+    _antivirusServerURL = antivirusServerURL;
+    // Update the current restClient
+    [matrixRestClient setAntivirusServer:antivirusServerURL];
+    
+    // TODO: configure here a scan manager, and update the media manager.
+}
 
 #pragma mark - Rooms operations
 


### PR DESCRIPTION
The antivirus url is null by default.
Set a non null url to configure the antivirus scanner.
This url is applied to the current rest client to enable the antivirus server API use.