### PR TITLE
MXMediaManager: Support the media download from a Matrix Content Scanner

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Improvements:
  * MXMediaManager/MXMediaLoader: Do not allow non-mxc content URLs.
  * MXMediaManager: Add a constructor based on a homeserver URL, to handle directly the Matrix Content URI (mxc://...).
  * MXSession: Add a MediaManager instance to handle the media stored on the Matrix Content repository.
+ * MXMediaManager: Support the media download from a Matrix Content Scanner (Antivirus Server).
  * Swift: Add explicit public initializer to MX3PID struct, thanks to @tladesignz (PR #594).
  * Tests: Make MXRealmCryptoStore work the first time tests are launched on simulators for iOS 11 and higher.
  

--- a/MatrixSDK/MXEnumConstants.m
+++ b/MatrixSDK/MXEnumConstants.m
@@ -27,7 +27,7 @@ NSString *const kMXContentPrefixPath = @"_matrix/media/v1";
 /**
  Prefix used in path of antivirus server API requests.
  */
-NSString *const kMXAntivirusAPIPrefixPathUnstable = @"_matrix/media_proxy/unstable/";
+NSString *const kMXAntivirusAPIPrefixPathUnstable = @"_matrix/media_proxy/unstable";
 
 /**
  Membership definitions - String version

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -1573,8 +1573,10 @@ typedef void (^MXOnResumeDone)(void);
     _antivirusServerURL = antivirusServerURL;
     // Update the current restClient
     [matrixRestClient setAntivirusServer:antivirusServerURL];
+    // Update the media manager
+    [mediaManager setAntivirusServerURL:antivirusServerURL];
     
-    // TODO: configure here a scan manager, and update the media manager.
+    // TODO: configure here a scan manager.
 }
 
 #pragma mark - Rooms operations

--- a/MatrixSDK/Utils/Media/MXMediaLoader.h
+++ b/MatrixSDK/Utils/Media/MXMediaLoader.h
@@ -201,7 +201,7 @@ extern NSString *const kMXMediaUploadIdPrefix;
  Download data from the provided URL with optionally a dictionary of data to post.
  
  @param url remote media url.
- @param data (optional) a dictionary of data sent as as a JSON object in the message body.
+ @param data (optional) a dictionary of data sent as a JSON object in the message body.
  @param downloadId the download identifier.
  @param filePath output file in which downloaded media must be saved.
  @param success a block called when the operation succeeds.

--- a/MatrixSDK/Utils/Media/MXMediaLoader.h
+++ b/MatrixSDK/Utils/Media/MXMediaLoader.h
@@ -198,6 +198,23 @@ extern NSString *const kMXMediaUploadIdPrefix;
                      failure:(blockMXMediaLoader_onError)failure;
 
 /**
+ Download data from the provided URL with optionally a dictionary of data to post.
+ 
+ @param url remote media url.
+ @param data (optional) a dictionary of data sent as as a JSON object in the message body.
+ @param downloadId the download identifier.
+ @param filePath output file in which downloaded media must be saved.
+ @param success a block called when the operation succeeds.
+ @param failure a block called when the operation fails.
+ */
+- (void)downloadMediaFromURL:(NSString *)url
+                    withData:(NSDictionary *)data
+                  identifier:(NSString *)downloadId
+           andSaveAtFilePath:(NSString *)filePath
+                     success:(blockMXMediaLoader_onSuccess)success
+                     failure:(blockMXMediaLoader_onError)failure;
+
+/**
  Initialise a media loader to upload data to a matrix content repository.
  Note: An upload could be a subpart of a global upload. For example, upload a video can be split in two parts :
  1 - upload the thumbnail -> initialRange = 0, range = 0.1 : assume that the thumbnail upload is 10% of the upload process

--- a/MatrixSDK/Utils/Media/MXMediaLoader.m
+++ b/MatrixSDK/Utils/Media/MXMediaLoader.m
@@ -109,6 +109,16 @@ NSString *const kMXMediaUploadIdPrefix = @"upload-";
                      success:(blockMXMediaLoader_onSuccess)success
                      failure:(blockMXMediaLoader_onError)failure
 {
+    [self downloadMediaFromURL:url withData:nil identifier:downloadId andSaveAtFilePath:filePath success:success failure:failure];
+}
+
+- (void)downloadMediaFromURL:(NSString *)url
+                    withData:(NSDictionary *)data
+                  identifier:(NSString *)downloadId
+           andSaveAtFilePath:(NSString *)filePath
+                     success:(blockMXMediaLoader_onSuccess)success
+                     failure:(blockMXMediaLoader_onError)failure
+{
     // Report provided params
     _downloadMediaURL = url;
     _downloadId = downloadId;
@@ -123,7 +133,21 @@ NSString *const kMXMediaUploadIdPrefix = @"upload-";
     NSURL *nsURL = [NSURL URLWithString:url];
     downloadData = [[NSMutableData alloc] init];
     
-    downloadConnection = [[NSURLConnection alloc] initWithRequest:[NSURLRequest requestWithURL:nsURL] delegate:self];
+    if (data)
+    {
+        // Use an HTTP POST method to send this data as JSON object.
+        NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:nsURL];
+        request.HTTPMethod = @"POST";
+        [request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
+        request.HTTPBody = [NSJSONSerialization dataWithJSONObject:data options:0 error:nil];
+        
+        downloadConnection = [[NSURLConnection alloc] initWithRequest:request delegate:self];
+    }
+    else
+    {
+        // Use a GET method by default
+        downloadConnection = [[NSURLConnection alloc] initWithRequest:[NSURLRequest requestWithURL:nsURL] delegate:self];
+    }
 }
 
 - (void)connection:(NSURLConnection *)connection didReceiveResponse:(NSURLResponse *)response

--- a/MatrixSDK/Utils/Media/MXMediaManager.h
+++ b/MatrixSDK/Utils/Media/MXMediaManager.h
@@ -26,6 +26,7 @@
 #import <Cocoa/Cocoa.h>
 #endif
 
+@class MXEncryptedContentFile;
 
 /**
  The predefined folder for avatar thumbnail.
@@ -56,6 +57,18 @@ extern NSString *const kMXMediaManagerDefaultCacheFolder;
  The homeserver URL.
  */
 @property (nonatomic, readonly) NSString *homeserverURL;
+
+/**
+ The antivirus server URL (nil by default).
+ Set a non-null url to enable the antivirus server use.
+ */
+@property (nonatomic) NSString *antivirusServerURL;
+
+/**
+ The Client-Server API prefix to use for the antivirus server
+ By default, it is defined by the constant kMXAntivirusAPIPrefixPathUnstable.
+ */
+@property (nonatomic) NSString *antivirusServerPathPrefix;
 
 
 #pragma mark - File handling
@@ -251,6 +264,30 @@ extern NSString *const kMXMediaManagerDefaultCacheFolder;
                                              withMethod:(MXThumbnailingMethod)thumbnailingMethod
                                                 success:(void (^)(NSString *outputFilePath))success
                                                 failure:(void (^)(NSError *error))failure;
+
+/**
+ Download encrypted data from the Matrix Content repository.
+ 
+ @param encryptedContentFile the encrypted Matrix Content details.
+ @param folder the cache folder to use (may be nil). kMXMediaManagerDefaultCacheFolder is used by default.
+ @param success a block called when the download succeeds. This block gets the path of the resulting file.
+ @param failure a block called when the download fails
+ @return a media loader in order to let the user cancel this action.
+ */
+- (MXMediaLoader*)downloadEncryptedMediaFromMatrixContentFile:(MXEncryptedContentFile *)encryptedContentFile
+                                                     inFolder:(NSString *)folder
+                                                      success:(void (^)(NSString *outputFilePath))success
+                                                      failure:(void (^)(NSError *error))failure;
+
+/**
+ Download encrypted data from the Matrix Content repository.
+ 
+ @param encryptedContentFile the encrypted Matrix Content details.
+ @param folder the cache folder to use (may be nil). kMXMediaManagerDefaultCacheFolder is used by default.
+ @return a media loader in order to let the user cancel this action.
+ */
+- (MXMediaLoader*)downloadEncryptedMediaFromMatrixContentFile:(MXEncryptedContentFile *)encryptedContentFile
+                                                     inFolder:(NSString *)folder;
 
 /**
  Check whether a download is already running with a specific download identifier.

--- a/MatrixSDK/Utils/Media/MXMediaManager.m
+++ b/MatrixSDK/Utils/Media/MXMediaManager.m
@@ -479,6 +479,7 @@ static MXLRUCache* imagesCacheLruCache = nil;
     if (!mediaURL)
     {
         NSLog(@"[MXMediaManager] downloadMediaFromMatrixContentURI: invalid media content URI");
+        if (failure) failure(nil);
         return nil;
     }
     
@@ -517,6 +518,7 @@ static MXLRUCache* imagesCacheLruCache = nil;
     if (!mediaURL)
     {
         NSLog(@"[MXMediaManager] downloadThumbnailFromMatrixContentURI: invalid media content URI");
+        if (failure) failure(nil);
         return nil;
     }
     
@@ -641,6 +643,7 @@ static MXLRUCache* imagesCacheLruCache = nil;
     if (!downloadMediaURL)
     {
         NSLog(@"[MXMediaManager] downloadEncryptedMediaFromMatrixContentFile: invalid media content URI");
+        if (failure) failure(nil);
         return nil;
     }
     

--- a/MatrixSDK/Utils/Media/MXMediaManager.m
+++ b/MatrixSDK/Utils/Media/MXMediaManager.m
@@ -22,6 +22,8 @@
 
 #import "MXMediaManager.h"
 
+#import "MXEncryptedContentFile.h"
+
 #import "MXSDKOptions.h"
 
 #import "MXLRUCache.h"
@@ -51,6 +53,8 @@ static NSUInteger storageCacheSize = 0;
     if (self)
     {
         _homeserverURL = homeserverURL;
+        _antivirusServerURL = nil;
+        _antivirusServerPathPrefix = kMXAntivirusAPIPrefixPathUnstable;
     }
     return self;
 }
@@ -75,6 +79,21 @@ static NSMutableDictionary* uploadTableById = nil;
         }
     }
     return sharedMediaManager;
+}
+
+#pragma mark - Antivirus server API
+
+- (void)setAntivirusServerURL:(NSString *)antivirusServerURL
+{
+    if (antivirusServerURL.length)
+    {
+        _antivirusServerURL = [antivirusServerURL copy];
+    }
+    else
+    {
+        // Disable antivirus use
+        _antivirusServerURL = nil;
+    }
 }
 
 #pragma mark - File handling
@@ -357,7 +376,18 @@ static MXLRUCache* imagesCacheLruCache = nil;
     // Replace the "mxc://" scheme by the absolute http location of the content
     if ([mxContentURI hasPrefix:kMXContentUriScheme])
     {
-        NSString *mxMediaPrefix = [NSString stringWithFormat:@"%@/%@/download/", _homeserverURL, kMXContentPrefixPath];
+        NSString *mxMediaPrefix;
+        
+        // Check whether an antivirus server is present
+        if (_antivirusServerURL)
+        {
+            mxMediaPrefix = [NSString stringWithFormat:@"%@/%@/download/", _antivirusServerURL, _antivirusServerPathPrefix];
+        }
+        else
+        {
+            mxMediaPrefix = [NSString stringWithFormat:@"%@/%@/download/", _homeserverURL, kMXContentPrefixPath];
+        }
+        
         contentURL = [mxContentURI stringByReplacingOccurrencesOfString:kMXContentUriScheme withString:mxMediaPrefix];
         
         // Remove the auto generated image tag from the URL
@@ -460,8 +490,9 @@ static MXLRUCache* imagesCacheLruCache = nil;
     
     // Create a media loader to download data
     return [MXMediaManager downloadMedia:mediaURL
-                          withIdentifier:downloadId
-                       andSaveAtFilePath:filePath
+                                withData:nil
+                           andIdentifier:downloadId
+                          saveAtFilePath:filePath
                                  success:success
                                  failure:failure];
 }
@@ -497,22 +528,24 @@ static MXLRUCache* imagesCacheLruCache = nil;
     
     // Create a media loader to download data
     return [MXMediaManager downloadMedia:mediaURL
-                          withIdentifier:downloadId
-                       andSaveAtFilePath:filePath
+                                withData:nil
+                           andIdentifier:downloadId
+                          saveAtFilePath:filePath
                                  success:success
                                  failure:failure];
 }
 
 // Private
 + (MXMediaLoader*)downloadMedia:(NSString *)mediaURL
-                 withIdentifier:(NSString *)downloadId
-              andSaveAtFilePath:(NSString *)filePath
+                       withData:(NSDictionary *)data
+                  andIdentifier:(NSString *)downloadId
+                 saveAtFilePath:(NSString *)filePath
                         success:(void (^)(NSString *outputFilePath))success
                         failure:(void (^)(NSError *error))failure
 {
     MXMediaLoader *mediaLoader;
     
-    // Check whether there is a loader for this filePath in downloadTable.
+    // Check whether there is a loader for this download id in downloadTable.
     mediaLoader = [MXMediaManager existingDownloaderWithIdentifier:downloadId];
     if (mediaLoader)
     {
@@ -560,9 +593,10 @@ static MXLRUCache* imagesCacheLruCache = nil;
         }
         [downloadTable setValue:mediaLoader forKey:downloadId];
         
-        // Launch download
+        // Launch the download
         [mediaLoader downloadMediaFromURL:mediaURL
-                           withIdentifier:downloadId
+                                 withData:data
+                               identifier:downloadId
                         andSaveAtFilePath:filePath
                                   success:^(NSString *outputFilePath) {
                                       
@@ -579,6 +613,59 @@ static MXLRUCache* imagesCacheLruCache = nil;
     }
     
     return mediaLoader;
+}
+
+- (MXMediaLoader*)downloadEncryptedMediaFromMatrixContentFile:(MXEncryptedContentFile *)encryptedContentFile
+                                                     inFolder:(NSString *)folder
+                                                      success:(void (^)(NSString *outputFilePath))success
+                                                      failure:(void (^)(NSError *error))failure
+{
+    // Check the provided mxc URI by resolving it into a download URL.
+    NSString *mxContentURI = encryptedContentFile.url;
+    NSString *downloadMediaURL;
+    NSDictionary *dataToPost;
+    
+    // Check whether an antivirus is present.
+    if (_antivirusServerURL && [mxContentURI hasPrefix:kMXContentUriScheme])
+    {
+        // In this case, the same URL is used to download all the encrypted content.
+        // The encrypted content file is sent in the request body.
+        downloadMediaURL = [NSString stringWithFormat:@"%@/%@/download_encrypted", _antivirusServerURL, _antivirusServerPathPrefix];
+        dataToPost = @{@"file": encryptedContentFile.JSONDictionary};
+    }
+    else
+    {
+        downloadMediaURL = [self urlOfContent:mxContentURI];
+    }
+    
+    if (!downloadMediaURL)
+    {
+        NSLog(@"[MXMediaManager] downloadEncryptedMediaFromMatrixContentFile: invalid media content URI");
+        return nil;
+    }
+    
+    // Build the outpout file path from mxContentURI, and other inputs.
+    NSString *filePath = [MXMediaManager cachePathForMatrixContentURI:mxContentURI
+                                                              andType:encryptedContentFile.mimetype
+                                                             inFolder:folder];
+    
+    // Build the download id from mxContentURI.
+    NSString *downloadId = [MXMediaManager downloadIdForMatrixContentURI:mxContentURI
+                                                                inFolder:folder];
+    
+    // Create a media loader to download data
+    return [MXMediaManager downloadMedia:downloadMediaURL
+                                withData:dataToPost
+                           andIdentifier:downloadId
+                          saveAtFilePath:filePath
+                                 success:success
+                                 failure:failure];
+}
+
+- (MXMediaLoader*)downloadEncryptedMediaFromMatrixContentFile:(MXEncryptedContentFile *)encryptedContentFile
+                                                     inFolder:(NSString *)folder
+{
+    return [self downloadEncryptedMediaFromMatrixContentFile:encryptedContentFile inFolder:folder success:nil failure:nil];
 }
 
 + (MXMediaLoader*)existingDownloaderWithIdentifier:(NSString *)downloadId


### PR DESCRIPTION
This option is enabled by setting the new `antivirusServerURL` property