### PR TITLE
Fix an occurence of null displayname issue

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Improvements:
  
 Bug Fix:
  * MXRestClient: [avatarUrlForUser:success:failure]: the returned url is always nil, thanks to @asydorov (PR #580) and @giomfo.
+ * MXRoomSummary: fix null Direct Chat displayname / avatar issue caused by limited syncs
 
 API break:
  * MXMediaManager: [downloadMediaFromURL:andSaveAtFilePath:success:failure:] is removed, use [downloadMediaFromMatrixContentURI:withType:inFolder:success:failure] or [downloadThumbnailFromMatrixContentURI:withType:inFolder:toFitViewSize:withMethod:success:failure] instead.

--- a/MatrixSDK/Data/MXRoomSummary.m
+++ b/MatrixSDK/Data/MXRoomSummary.m
@@ -141,7 +141,17 @@ NSString *const kMXRoomSummaryDidChangeNotification = @"kMXRoomSummaryDidChangeN
     [room state:^(MXRoomState *roomState) {
         MXStrongifyAndReturnIfNil(self);
 
-        if ([self.mxSession.roomSummaryUpdateDelegate session:self.mxSession updateRoomSummary:self withStateEvents:roomState.stateEvents roomState:roomState])
+        BOOL updated = [self.mxSession.roomSummaryUpdateDelegate session:self.mxSession updateRoomSummary:self withStateEvents:roomState.stateEvents roomState:roomState];
+
+        if (self.displayname == nil || self.avatar == nil)
+        {
+            // Avatar and displayname may not be recomputed from the state event list if
+            // the latter does not contain any `name` or `avatar` event. So, in this case,
+            // we reapply the Matrix name/avatar calculation algorithm.
+            updated |= [self.mxSession.roomSummaryUpdateDelegate session:self.mxSession updateRoomSummary:self withServerRoomSummary:nil roomState:roomState];
+        }
+
+        if (updated)
         {
             [self save:YES];
         }


### PR DESCRIPTION
Hi there,

After having upgraded our Matrix client app to use matrix-ios-sdk v0.11.5, we noticed that some rooms happen to lose their display name and avatar on a seemingly random basis.
I can see from PR #599 that you are also facing similar issues.

From user feedbacks, it appears that Direct chats are the most affected.

I could reproduce this problem with the latest Riot iOS client, so I guess v0.11.6 does not fix that.

Steps to reproduce :
- with Riot iOS client, create a Direct Chat with some user **Foo**
- kill Riot iOS app
- from another client (e.g the webclient), go to the **Foo** chat, and send ~25 messages (enough to trigger a `limited` sync)
- now open Riot iOS : "sometimes" (about half the time from my tests) you'll find that the **Foo** chat has been renamed **Empty room**, and has lost its avatar (used to be **Foo** avatar, now it's the first letter of the `roomId`)

What happens is that :

1. due to the large number of messages sent, Riot receives a `limited` sync of the chat.
2. In `MXEventTimeline.handleJoinedRoomSync`, this limited sync triggers a `kMXRoomDidFlushDataNotification` notification.
3. This notification is handled by `MXRoomSummary.resetRoomStateData`, which resets the chat avatar, displayname, topic and aliases, and tries to recompute them from state events.
4. Unfortunately, the state event list of the direct chat does not contain enough information to recompute a displayname or an avatar.
5. If the `limited` sync data also contains a server room summary, then the displayname and avatar are restored soon after, in `MXRoomSummary.handleJoinedRoomSync`
6. Yet if the sync data does not contain the server room summary, the displayname and avatar are now reset for good (the null value is persisted), until the user either clears the cache or logs out & in.

I came up with the following workaround, which I submit to your approval : since the summary can't be recomputed from the state events, we can still reconstruct it by calling the standard Matrix name/avatar computation algorithm, via the update delegate's `session:updateRoomSummary:withServerRoomSummary:roomState:` method, passing it a `nil` server room summary.
(A similar trick is already used to compute the room summary of invited rooms in `session:updateRoomSummary:withStateEvents:roomState:`)

Not sure this fix is the most relevant (maybe this should be fixed on the server side after all, by sending the server room summary more often ?), but at least it can start a discussion ^^

Thank you !

Signed-off-by: Hervé Bérenger <herve.berenger@fabernovel.com>
