### PR TITLE
Add sendAudioFile to send files using msgType m.audio

### DIFF
--- a/MatrixSDK/Contrib/Swift/Data/MXRoom.swift
+++ b/MatrixSDK/Contrib/Swift/Data/MXRoom.swift
@@ -266,7 +266,33 @@ public extension MXRoom {
         return __sendFile(localURL, mimeType: mimeType, localEcho: &localEcho, success: currySuccess(completion), failure: curryFailure(completion))
     }
     
+    /**
+     Send an audio file to the room.
+     
+     - parameters:
+     - localURL: the local filesystem path of the file to send.
+     - mimeType: the mime type of the file.
+     - localEcho: a pointer to a MXEvent object.
+     
+     This pointer is set to an actual MXEvent object
+     containing the local created event which should be used to echo the message in
+     the messages list until the resulting event come through the server sync.
+     For information, the identifier of the created local event has the prefix
+     `kMXEventLocalEventIdPrefix`.
+     
+     You may specify nil for this parameter if you do not want this information.
+     
+     You may provide your own MXEvent object, in this case only its send state is updated.
+     
+     - completion: A block object called when the operation completes.
+     - response: Provides the event id of the event generated on the home server on success.
+     
+     - returns: a `MXHTTPOperation` instance.
+     */
     
+    @nonobjc @discardableResult func sendAudioFile(localURL: URL, mimeType: String, localEcho: inout MXEvent?, completion: @escaping (_ response: MXResponse<String?>) -> Void) -> MXHTTPOperation {
+        return __sendAudioFile(localURL, mimeType: mimeType, localEcho: &localEcho, success: currySuccess(completion), failure: curryFailure(completion), keepActualFilename: false)
+    }
     
     /**
      Set the topic of the room.

--- a/MatrixSDK/Data/MXRoom.h
+++ b/MatrixSDK/Data/MXRoom.h
@@ -435,6 +435,26 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidFlushDataNotification;
                      failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
+ Send an audio file to the room.
+ 
+ @param fileLocalURL the local filesystem path of the file to send.
+ @param mimeType the mime type of the file.
+ @param localEcho a pointer to a MXEvent object (@see sendMessageWithContent: for details).
+ @param success A block object called when the operation succeeds. It returns
+ the event id of the event generated on the home server
+ @param failure A block object called when the operation fails.
+ @param keepActualName if YES, the filename in the local storage will be kept while sending.
+ 
+ @return a MXHTTPOperation instance.
+ */
+- (MXHTTPOperation*)sendAudioFile:(NSURL*)fileLocalURL
+                    mimeType:(NSString*)mimeType
+                   localEcho:(MXEvent**)localEcho
+                     success:(void (^)(NSString *eventId))success
+                     failure:(void (^)(NSError *error))failure
+          keepActualFilename:(BOOL)keepActualName NS_REFINED_FOR_SWIFT;
+
+/**
  Cancel a sending operation.
 
  Note that the local echo event will be not removed from the outgoing message queue.

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -1323,6 +1323,27 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
                      failure:(void (^)(NSError *error))failure
           keepActualFilename:(BOOL)keepActualName
 {
+    return [self sendFile:fileLocalURL msgType:kMXMessageTypeFile mimeType:mimeType localEcho:localEcho success:success failure:failure keepActualFilename:keepActualName];
+}
+
+- (MXHTTPOperation*)sendAudioFile:(NSURL*)fileLocalURL
+                    mimeType:(NSString*)mimeType
+                   localEcho:(MXEvent**)localEcho
+                     success:(void (^)(NSString *eventId))success
+                     failure:(void (^)(NSError *error))failure
+          keepActualFilename:(BOOL)keepActualName
+{
+    return [self sendFile:fileLocalURL msgType:kMXMessageTypeAudio mimeType:mimeType localEcho:localEcho success:success failure:failure keepActualFilename:keepActualName];
+}
+
+- (MXHTTPOperation*)sendFile:(NSURL*)fileLocalURL
+                     msgType:(NSString*)msgType
+                    mimeType:(NSString*)mimeType
+                   localEcho:(MXEvent**)localEcho
+                     success:(void (^)(NSString *eventId))success
+                     failure:(void (^)(NSError *error))failure
+          keepActualFilename:(BOOL)keepActualName
+{
     __block MXRoomOperation *roomOperation;
     
     NSData *fileData = [NSData dataWithContentsOfFile:fileLocalURL.path];
@@ -1358,7 +1379,7 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
     
     // Prepare the message content for building an echo message
     NSMutableDictionary *msgContent = [@{
-                                         @"msgtype": kMXMessageTypeFile,
+                                         @"msgtype": msgType,
                                          @"body": filename,
                                          @"url": fakeMediaURI,
                                          @"info": @{

--- a/changelog.d/616.feature
+++ b/changelog.d/616.feature
@@ -1,0 +1,1 @@
+Add a sendAudioFile API to send file using msgType "m.audio".


### PR DESCRIPTION
As far as I could tell, there was no (easy) way to send an audio file (using msgType "m.audio").

Signed-off-by: N-Pex <npexdev@gmail.com>