### PR TITLE
Key Backup: add passphrase support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Changes in Matrix iOS SDK in 0.12.2 (2019-01-)
 
 Improvements:
  * MXRoom: Add a sendAudioFile API to send file using msgType "m.audio", thanks to N-Pex (PR #616).
- * MXCrypto: Add the MXKeyBackup passphrase support (vector-im/riot-ios#2127).
+ * MXCrypto: Add key backup passphrase support (vector-im/riot-ios#2127).
 
 Bug Fix:
  * Crypto: Device deduplication method sometimes crashes (vector-im/riot-ios/issues/#2167).

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Changes in Matrix iOS SDK in 0.12.2 (2019-01-)
 
 Improvements:
  * MXRoom: Add a sendAudioFile API to send file using msgType "m.audio", thanks to N-Pex (PR #616).
+ * MXCrypto: Add the MXKeyBackup passphrase support (vector-im/riot-ios#2127).
 
 Bug Fix:
  * Crypto: Device deduplication method sometimes crashes (vector-im/riot-ios/issues/#2167).

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -76,6 +76,8 @@
 		324095221AFA432F00D81C97 /* MXCallStackCall.h in Headers */ = {isa = PBXBuildFile; fileRef = 3240951E1AFA432F00D81C97 /* MXCallStackCall.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3240969D1F9F751600DBA607 /* MXPushRuleSenderNotificationPermissionConditionChecker.h in Headers */ = {isa = PBXBuildFile; fileRef = 3240969B1F9F751600DBA607 /* MXPushRuleSenderNotificationPermissionConditionChecker.h */; };
 		3240969E1F9F751600DBA607 /* MXPushRuleSenderNotificationPermissionConditionChecker.m in Sources */ = {isa = PBXBuildFile; fileRef = 3240969C1F9F751600DBA607 /* MXPushRuleSenderNotificationPermissionConditionChecker.m */; };
+		32442FB121EDD21300D2411B /* MXKeyBackupPassword.h in Headers */ = {isa = PBXBuildFile; fileRef = 32442FAF21EDD21300D2411B /* MXKeyBackupPassword.h */; };
+		32442FB221EDD21300D2411B /* MXKeyBackupPassword.m in Sources */ = {isa = PBXBuildFile; fileRef = 32442FB021EDD21300D2411B /* MXKeyBackupPassword.m */; };
 		3245A7501AF7B2930001D8A7 /* MXCall.h in Headers */ = {isa = PBXBuildFile; fileRef = 3245A74C1AF7B2930001D8A7 /* MXCall.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3245A7511AF7B2930001D8A7 /* MXCall.m in Sources */ = {isa = PBXBuildFile; fileRef = 3245A74D1AF7B2930001D8A7 /* MXCall.m */; };
 		3245A7521AF7B2930001D8A7 /* MXCallManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 3245A74E1AF7B2930001D8A7 /* MXCallManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -443,6 +445,8 @@
 		3240951E1AFA432F00D81C97 /* MXCallStackCall.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXCallStackCall.h; sourceTree = "<group>"; };
 		3240969B1F9F751600DBA607 /* MXPushRuleSenderNotificationPermissionConditionChecker.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXPushRuleSenderNotificationPermissionConditionChecker.h; sourceTree = "<group>"; };
 		3240969C1F9F751600DBA607 /* MXPushRuleSenderNotificationPermissionConditionChecker.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXPushRuleSenderNotificationPermissionConditionChecker.m; sourceTree = "<group>"; };
+		32442FAF21EDD21300D2411B /* MXKeyBackupPassword.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXKeyBackupPassword.h; sourceTree = "<group>"; };
+		32442FB021EDD21300D2411B /* MXKeyBackupPassword.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXKeyBackupPassword.m; sourceTree = "<group>"; };
 		3245A74C1AF7B2930001D8A7 /* MXCall.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXCall.h; sourceTree = "<group>"; };
 		3245A74D1AF7B2930001D8A7 /* MXCall.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXCall.m; sourceTree = "<group>"; };
 		3245A74E1AF7B2930001D8A7 /* MXCallManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXCallManager.h; sourceTree = "<group>"; };
@@ -1159,6 +1163,8 @@
 				32FFB4ED217DC0E900C96002 /* MXKeyBackup_Private.h */,
 				32FFB4EE217E146A00C96002 /* MXRecoveryKey.h */,
 				32FFB4EF217E146A00C96002 /* MXRecoveryKey.m */,
+				32442FAF21EDD21300D2411B /* MXKeyBackupPassword.h */,
+				32442FB021EDD21300D2411B /* MXKeyBackupPassword.m */,
 			);
 			path = KeyBackup;
 			sourceTree = "<group>";
@@ -1624,6 +1630,7 @@
 				B146D4D521A5A44E00D8C2C6 /* MXScanRealmProvider.h in Headers */,
 				32F634AB1FC5E3480054EF49 /* MXEventDecryptionResult.h in Headers */,
 				322A51C71D9BBD3C00C8536D /* MXOlmDevice.h in Headers */,
+				32442FB121EDD21300D2411B /* MXKeyBackupPassword.h in Headers */,
 				320DFDE419DD99B60068622A /* MXRestClient.h in Headers */,
 				3265CB381A14C43E00E24B2F /* MXRoomState.h in Headers */,
 				3283F7781EAF30F700C1688C /* MXBugReportRestClient.h in Headers */,
@@ -1958,6 +1965,7 @@
 				32A9E8261EF4026E0081358A /* MXUIKitBackgroundModeHandler.m in Sources */,
 				B146D4F721A5BB9F00D8C2C6 /* MXRealmMediaScanStore.m in Sources */,
 				322A51C81D9BBD3C00C8536D /* MXOlmDevice.m in Sources */,
+				32442FB221EDD21300D2411B /* MXKeyBackupPassword.m in Sources */,
 				329FB17A1A0A74B100A5E88E /* MXTools.m in Sources */,
 				329D3E631E251027002E2F1E /* MXRoomSummaryUpdater.m in Sources */,
 				B146D4D821A5A44E00D8C2C6 /* MXScanRealmInMemoryProvider.m in Sources */,

--- a/MatrixSDK/Crypto/Data/MXCryptoConstants.h
+++ b/MatrixSDK/Crypto/Data/MXCryptoConstants.h
@@ -1,6 +1,7 @@
 /*
  Copyright 2016 OpenMarket Ltd
  Copyright 2017 Vector Creations Ltd
+ Copyright 2019 New Vector Ltd
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -62,5 +63,6 @@ typedef enum : NSUInteger
     MXKeyBackupErrorInvalidStateCode,
     MXKeyBackupErrorInvalidParametersCode,
     MXKeyBackupErrorCannotDeriveKeyCode,
+    MXKeyBackupErrorInvalidRecoveryKeyCode,
     MXKeyBackupErrorMissingPrivateKeySaltCode,
 } MXKeyBackupErrorCode;

--- a/MatrixSDK/Crypto/Data/MXCryptoConstants.h
+++ b/MatrixSDK/Crypto/Data/MXCryptoConstants.h
@@ -62,4 +62,5 @@ typedef enum : NSUInteger
     MXKeyBackupErrorInvalidStateCode,
     MXKeyBackupErrorInvalidParametersCode,
     MXKeyBackupErrorCannotDeriveKeyCode,
+    MXKeyBackupErrorMissingPrivateKeySaltCode,
 } MXKeyBackupErrorCode;

--- a/MatrixSDK/Crypto/Data/MXCryptoConstants.h
+++ b/MatrixSDK/Crypto/Data/MXCryptoConstants.h
@@ -60,5 +60,6 @@ FOUNDATION_EXPORT NSString *const MXKeyBackupErrorDomain;
 typedef enum : NSUInteger
 {
     MXKeyBackupErrorInvalidStateCode,
-    MXKeyBackupErrorInvalidParametersCode
+    MXKeyBackupErrorInvalidParametersCode,
+    MXKeyBackupErrorCannotDeriveKeyCode,
 } MXKeyBackupErrorCode;

--- a/MatrixSDK/Crypto/KeyBackup/Data/MXMegolmBackupAuthData.h
+++ b/MatrixSDK/Crypto/KeyBackup/Data/MXMegolmBackupAuthData.h
@@ -31,6 +31,17 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) NSString *publicKey;
 
 /**
+ In case of a backup created from a password, the salt associated with the backup
+ private key.
+ */
+@property (nonatomic, nullable) NSString *privateKeySalt;
+
+/**
+ In case of a backup created from a password, the number of key derivations.
+ */
+@property (nonatomic) NSUInteger privateKeyIterations;
+
+/**
  Signatures of the public key.
  */
 @property (nonatomic) NSDictionary<NSString*, NSDictionary*> *signatures;

--- a/MatrixSDK/Crypto/KeyBackup/Data/MXMegolmBackupAuthData.m
+++ b/MatrixSDK/Crypto/KeyBackup/Data/MXMegolmBackupAuthData.m
@@ -26,6 +26,8 @@
     if (megolmBackupAuthData)
     {
         MXJSONModelSetString(megolmBackupAuthData.publicKey, JSONDictionary[@"public_key"]);
+        MXJSONModelSetString(megolmBackupAuthData.privateKeySalt, JSONDictionary[@"private_key_salt"]);
+        MXJSONModelSetUInteger(megolmBackupAuthData.privateKeyIterations, JSONDictionary[@"private_key_iterations"]);
         MXJSONModelSetDictionary(megolmBackupAuthData.signatures, JSONDictionary[@"signatures"]);
     }
 
@@ -38,6 +40,16 @@
 
     JSONDictionary[@"public_key"] = _publicKey;
 
+    if (_privateKeySalt)
+    {
+        JSONDictionary[@"private_key_salt"] = _privateKeySalt;
+    }
+
+    if (_privateKeySalt)
+    {
+        JSONDictionary[@"private_key_iterations"] = @(_privateKeyIterations);
+    }
+
     if (_signatures)
     {
         JSONDictionary[@"signatures"] = _signatures;
@@ -48,9 +60,21 @@
 
 - (NSDictionary *)signalableJSONDictionary
 {
-    return @{
-             @"public_key": _publicKey
-             };
+    NSMutableDictionary *signalableJSONDictionary = [NSMutableDictionary dictionary];
+
+    signalableJSONDictionary[@"public_key"] = _publicKey;
+
+    if (_privateKeySalt)
+    {
+        signalableJSONDictionary[@"private_key_salt"] = _privateKeySalt;
+    }
+
+    if (_privateKeySalt)
+    {
+        signalableJSONDictionary[@"private_key_iterations"] = @(_privateKeyIterations);
+    }
+
+    return signalableJSONDictionary;
 }
 
 @end

--- a/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.h
+++ b/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.h
@@ -104,16 +104,18 @@ FOUNDATION_EXPORT NSString *const kMXKeyBackupDidStateChangeNotification;
 #pragma mark - Backup management
 
 /**
- Get information about the current backup version defined on the homeserver.
+ Get information about a backup version defined on the homeserver.
 
- It can be different than `self.keyBackupVersion`.
+ @param version the backup version.
+        nil returns the current backup version. It can be different than `self.keyBackupVersion`.
 
  @param success A block object called when the operation succeeds.
  @param failure A block object called when the operation fails.
 
  @return a MXHTTPOperation instance.
  */
-- (MXHTTPOperation*)version:(void (^)(MXKeyBackupVersion * _Nullable keyBackupVersion))success
+- (MXHTTPOperation*)version:(nullable NSString *)version
+                    success:(void (^)(MXKeyBackupVersion * _Nullable keyBackupVersion))success
                     failure:(void (^)(NSError *error))failure;
 
 /**

--- a/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.h
+++ b/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.h
@@ -134,11 +134,15 @@ FOUNDATION_EXPORT NSString *const kMXKeyBackupDidStateChangeNotification;
  The returned `MXMegolmBackupCreationInfo` object has a `recoveryKey` member with
  the user-facing recovery key string.
 
+ @param password an optional passphrase string that can be entered by the user
+        when restoring the backup as an alternative to entering the recovery key.
+
  @param success A block object called when the operation succeeds.
  @param failure A block object called when the operation fails
  */
-- (void)prepareKeyBackupVersion:(void (^)(MXMegolmBackupCreationInfo *keyBackupCreationInfo))success
-                        failure:(nullable void (^)(NSError *error))failure;
+- (void)prepareKeyBackupVersionWithPassword:(nullable NSString *)password
+                                    success:(void (^)(MXMegolmBackupCreationInfo *keyBackupCreationInfo))success
+                                    failure:(nullable void (^)(NSError *error))failure;
 
 /**
  Create a new key backup version and enable it, using the information return from
@@ -208,7 +212,7 @@ FOUNDATION_EXPORT NSString *const kMXKeyBackupDidStateChangeNotification;
 + (BOOL)isValidRecoveryKey:(NSString*)recoveryKey;
 
 /**
- Restore a backup from a given backup version stored on the homeserver.
+ Restore a backup with a recovery key from a given backup version stored on the homeserver.
 
  @param version the backup version to restore from.
  @param recoveryKey the recovery key to decrypt the retrieved backup.
@@ -222,7 +226,28 @@ FOUNDATION_EXPORT NSString *const kMXKeyBackupDidStateChangeNotification;
  @return a MXHTTPOperation instance.
  */
 - (MXHTTPOperation*)restoreKeyBackup:(NSString*)version
-                         recoveryKey:(NSString*)recoveryKey
+                     withRecoveryKey:(NSString*)recoveryKey
+                                room:(nullable NSString*)roomId
+                             session:(nullable NSString*)sessionId
+                             success:(nullable void (^)(NSUInteger total, NSUInteger imported))success
+                             failure:(nullable void (^)(NSError *error))failure;
+
+/**
+ Restore a backup with a password from a given backup version stored on the homeserver.
+
+ @param version the backup version to restore from.
+ @param password the password to decrypt the retrieved backup.
+ @param roomId the id of the room to get backup data from.
+ @param sessionId the id of the session to restore.
+
+ @param success A block object called when the operation succeeds.
+ It provides the number of found keys and the number of successfully imported keys.
+ @param failure A block object called when the operation fails.
+
+ @return a MXHTTPOperation instance.
+ */
+- (MXHTTPOperation*)restoreKeyBackup:(NSString*)version
+                        withPassword:(NSString*)password
                                 room:(nullable NSString*)roomId
                              session:(nullable NSString*)sessionId
                              success:(nullable void (^)(NSUInteger total, NSUInteger imported))success

--- a/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.m
+++ b/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.m
@@ -792,7 +792,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
 
             if (sessionsFromHSCount && !sessionDatas.count)
             {
-                // If we fail to decrypt any session, we have a credential problem
+                // If we fail to decrypt all sessions, we have a credential problem
                 NSLog(@"[MXKeyBackup] restoreKeyBackup: Invalid recovery key or password");
                 if (failure)
                 {

--- a/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.m
+++ b/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.m
@@ -842,6 +842,16 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
         MXMegolmBackupAuthData *authData = [MXMegolmBackupAuthData modelFromJSON:keyBackupVersion.authData];
         if (!authData.privateKeySalt || !authData.privateKeyIterations)
         {
+            if (failure)
+            {
+                NSLog(@"[MXKeyBackup] restoreKeyBackup: Salt and/or iterations not found: this backup cannot be restored with a passphrase");
+                NSError *error = [NSError errorWithDomain:MXKeyBackupErrorDomain
+                                                     code:MXKeyBackupErrorMissingPrivateKeySaltCode
+                                                 userInfo:@{
+                                                            NSLocalizedDescriptionKey: @"Salt and/or iterations not found: this backup cannot be restored with a passphrase"
+                                                            }];
+                failure(error);
+            }
             return;
         }
 

--- a/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.m
+++ b/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.m
@@ -73,7 +73,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
     self.state = MXKeyBackupStateCheckingBackUpOnHomeserver;
 
     MXWeakify(self);
-    [self version:^(MXKeyBackupVersion * _Nullable keyBackupVersion) {
+    [self version:nil success:^(MXKeyBackupVersion * _Nullable keyBackupVersion) {
         MXStrongifyAndReturnIfNil(self);
 
         MXWeakify(self);
@@ -361,10 +361,10 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
 
 #pragma mark - Backup management
 
-- (MXHTTPOperation *)version:(void (^)(MXKeyBackupVersion * _Nullable))success failure:(void (^)(NSError * _Nonnull))failure
+- (MXHTTPOperation *)version:(NSString *)version success:(void (^)(MXKeyBackupVersion * _Nullable))success failure:(void (^)(NSError * _Nonnull))failure
 {
     // Use mxSession.matrixRestClient to respond to the main thread as this method is public
-    return [mxSession.matrixRestClient keyBackupVersion:success failure:^(NSError *error) {
+    return [mxSession.matrixRestClient keyBackupVersion:version success:success failure:^(NSError *error) {
 
         // Workaround because the homeserver currently returns  M_NOT_FOUND when there is
         // no key backup

--- a/MatrixSDK/Crypto/KeyBackup/MXKeyBackupPassword.h
+++ b/MatrixSDK/Crypto/KeyBackup/MXKeyBackupPassword.h
@@ -1,0 +1,50 @@
+/*
+ Copyright 2019 New Vector Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ Utility to compute a backup private key from a password and vice-versa.
+ */
+@interface MXKeyBackupPassword : NSObject
+
+/**
+ Compute a private key from a password.
+
+ @param password the password to use.
+ @param salt the salt used to generate the private key.
+ @param iterations number of key derivations done on the generated private key.
+ @param error the output error.
+ @return a private key.
+ */
++ (nullable NSData *)generatePrivateKeyWithPassword:(NSString*)password salt:(NSString**)salt iterations:(NSUInteger*)iterations error:(NSError * _Nullable *)error;
+
+/**
+ Retrieve a private key from {password, salt, iterations)
+
+ @param password the password used to generated the private key.
+ @param salt the salt.
+ @param iterations number of key derivations
+ @param error the output error
+ @return a private key.
+ */
++ (nullable NSData *)retrievePrivateKeyWithPassword:(NSString*)password salt:(NSString*)salt iterations:(NSUInteger)iterations error:(NSError * _Nullable *)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixSDK/Crypto/KeyBackup/MXKeyBackupPassword.m
+++ b/MatrixSDK/Crypto/KeyBackup/MXKeyBackupPassword.m
@@ -1,0 +1,102 @@
+/*
+ Copyright 2019 New Vector Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXKeyBackupPassword.h"
+
+#import "MXTools.h"
+#import "MXCryptoConstants.h"
+
+#import <OLMKit/OLMKit.h>
+
+#import <Security/Security.h>
+#import <CommonCrypto/CommonDigest.h>
+#import <CommonCrypto/CommonCryptor.h>
+#import <CommonCrypto/CommonKeyDerivation.h>
+
+#pragma mark - Constants
+
+static NSUInteger const kSaltLength = 32;
+static NSUInteger const kDefaultIterations = 500000;
+
+
+@implementation MXKeyBackupPassword
+
++ (NSData *)generatePrivateKeyWithPassword:(NSString *)password salt:(NSString *__autoreleasing *)salt iterations:(NSUInteger *)iterations error:(NSError *__autoreleasing  _Nullable *)error
+{
+    *salt = [[MXTools generateSecret] substringWithRange:NSMakeRange(0, kSaltLength)];
+    *iterations = kDefaultIterations;
+
+    NSData *privateKey = [self deriveKey:password salt:*salt iterations:kDefaultIterations error:error];
+
+    return privateKey;
+}
+
++ (NSData *)retrievePrivateKeyWithPassword:(NSString *)password salt:(NSString *)salt iterations:(NSUInteger)iterations error:(NSError *__autoreleasing  _Nullable *)error
+{
+    return [self deriveKey:password salt:salt iterations:iterations error:error];
+}
+
+
+#pragma mark - Private methods
+
+/**
+ Compute a private key by deriving a password and a salt strings.
+
+ @param password the password.
+ @param salt the salt.
+ @param iterations number of derivations.
+ @param error the output error.
+ @return a private key.
+ */
++ (nullable NSData *)deriveKey:(NSString*)password salt:(NSString*)salt iterations:(NSUInteger)iterations error:(NSError *__autoreleasing  _Nullable *)error
+{
+    NSDate *startDate = [NSDate date];
+
+    NSData *passwordData = [password dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *saltData = [salt dataUsingEncoding:NSUTF8StringEncoding];
+
+    NSMutableData *derivedKey = [NSMutableData dataWithLength:[OLMPkDecryption privateKeyLength]];
+
+    int result =  CCKeyDerivationPBKDF(kCCPBKDF2,
+                                   passwordData.bytes,
+                                   passwordData.length,
+                                   saltData.bytes,
+                                   saltData.length,
+                                   kCCPRFHmacAlgSHA512,
+                                   (uint)iterations,
+                                   derivedKey.mutableBytes,
+                                   derivedKey.length);
+
+    NSLog(@"[MXKeyBackupPassword] deriveKey: %tu iterations took %.0fms", iterations, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+
+    if (result != kCCSuccess)
+    {
+        derivedKey = nil;
+
+        if (*error)
+        {
+            *error = [NSError errorWithDomain:MXKeyBackupErrorDomain
+                                                 code:MXKeyBackupErrorCannotDeriveKeyCode
+                                             userInfo:@{
+                                                        NSLocalizedDescriptionKey: [NSString stringWithFormat:@"CCKeyDerivationPBKDF fails: %@", @(result)]
+                                                        }];
+        }
+    }
+
+    return derivedKey;
+}
+
+@end

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -2090,14 +2090,17 @@ FOUNDATION_EXPORT NSString *const kMXMembersOfRoomParametersNotMembership;
                                    failure:(void (^)(NSError *error))failure;
 
 /**
- Get information about the current version.
+ Get information about a backup version.
+
+ @param version the backup version. Nil returns the current backup version.
 
  @param success A block object called when the operation succeeds.
  @param failure A block object called when the operation fails.
 
  @return a MXHTTPOperation instance.
  */
-- (MXHTTPOperation*)keyBackupVersion:(void (^)(MXKeyBackupVersion *keyBackupVersion))success
+- (MXHTTPOperation*)keyBackupVersion:(NSString*)version
+                             success:(void (^)(MXKeyBackupVersion *keyBackupVersion))success
                              failure:(void (^)(NSError *error))failure;
 
 /**

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -3930,12 +3930,19 @@ MXAuthAction;
                                  }];
 }
 
-- (MXHTTPOperation*)keyBackupVersion:(void (^)(MXKeyBackupVersion *keyBackupVersion))success
-                             failure:(void (^)(NSError *error))failure
+- (MXHTTPOperation*)keyBackupVersion:(NSString*)version
+                             success:(void (^)(MXKeyBackupVersion *keyBackupVersion))success
+                             failure:(void (^)(NSError *error))failure;
 {
+    NSMutableString *path = [NSMutableString stringWithFormat:@"%@/room_keys/version", kMXAPIPrefixPathUnstable];
+    if (version)
+    {
+        [path appendFormat:@"/%@", version];
+    }
+
     MXWeakify(self);
     return [httpClient requestWithMethod:@"GET"
-                                    path:[NSString stringWithFormat:@"%@/room_keys/version", kMXAPIPrefixPathUnstable]
+                                    path:path
                               parameters:nil
                                  success:^(NSDictionary *JSONResponse) {
                                      MXStrongifyAndReturnIfNil(self);

--- a/MatrixSDKTests/MXCryptoBackupTests.m
+++ b/MatrixSDKTests/MXCryptoBackupTests.m
@@ -691,6 +691,40 @@
 }
 
 /**
+ - Do an e2e backup to the homeserver with a recovery key
+ - Log Alice on a new device
+ - Try to restore the e2e backup with a wrong recovery key
+ - It must fail
+ */
+- (void)testRestoreKeyBackupWithAWrongRecoveryKey
+{
+    // - Do an e2e backup to the homeserver with a recovery key
+    // - Log Alice on a new device
+    [self createKeyBackupScenarioWithPassword:nil readyToTest:^(NSString *version, MXMegolmBackupCreationInfo *keyBackupCreationInfo, NSArray<MXOlmInboundGroupSession *> *aliceKeys, MXSession *aliceSession, MXSession *bobSession, NSString *roomId, XCTestExpectation *expectation) {
+
+        // - Try to restore the e2e backup with a wrong recovery key
+        [aliceSession.crypto.backup restoreKeyBackup:version
+                                     withRecoveryKey:@"EsTc LW2K PGiF wKEA 3As5 g5c4 BXwk qeeJ ZJV8 Q9fu gUMN UE4d"
+                                                room:nil session:nil
+                                             success:^(NSUInteger total, NSUInteger imported)
+         {
+             // - It must fail
+             XCTFail(@"It must fail");
+
+             [expectation fulfill];
+
+         } failure:^(NSError * _Nonnull error) {
+
+             // - It must fail
+             XCTAssertEqualObjects(error.domain, MXKeyBackupErrorDomain);
+             XCTAssertEqual(error.code, MXKeyBackupErrorInvalidRecoveryKeyCode);
+
+             [expectation fulfill];
+         }];
+    }];
+}
+
+/**
  - Do an e2e backup to the homeserver with a password
  - Log Alice on a new device
  - Restore the e2e backup with the password
@@ -717,6 +751,40 @@
 
          } failure:^(NSError * _Nonnull error) {
              XCTFail(@"The request should not fail - NSError: %@", error);
+             [expectation fulfill];
+         }];
+    }];
+}
+
+/**
+ - Do an e2e backup to the homeserver with a password
+ - Log Alice on a new device
+ - Try to restore the e2e backup with a wrong password
+ - It must fail
+ */
+- (void)testRestoreKeyBackupWithAWrongPassword
+{
+    // - Do an e2e backup to the homeserver with a password
+    // - Log Alice on a new device
+    [self createKeyBackupScenarioWithPassword:@"password" readyToTest:^(NSString *version, MXMegolmBackupCreationInfo *keyBackupCreationInfo, NSArray<MXOlmInboundGroupSession *> *aliceKeys, MXSession *aliceSession, MXSession *bobSession, NSString *roomId, XCTestExpectation *expectation) {
+
+        // - Try to restore the e2e backup with a wrong password
+        [aliceSession.crypto.backup restoreKeyBackup:version
+                                        withPassword:@"WrongPassword"
+                                                room:nil session:nil
+                                             success:^(NSUInteger total, NSUInteger imported)
+         {
+             // - It must fail
+             XCTFail(@"It must fail");
+
+             [expectation fulfill];
+
+         } failure:^(NSError * _Nonnull error) {
+
+             // - It must fail
+             XCTAssertEqualObjects(error.domain, MXKeyBackupErrorDomain);
+             XCTAssertEqual(error.code, MXKeyBackupErrorInvalidRecoveryKeyCode);
+
              [expectation fulfill];
          }];
     }];

--- a/MatrixSDKTests/MXCryptoBackupTests.m
+++ b/MatrixSDKTests/MXCryptoBackupTests.m
@@ -21,6 +21,7 @@
 
 #import "MXCrypto_Private.h"
 #import "MXRecoveryKey.h"
+#import "MXKeybackupPassword.h"
 
 @interface MXKeyBackup (Testing)
 
@@ -304,6 +305,60 @@
     XCTAssertFalse([MXKeyBackup isValidRecoveryKey:invalidRecoveryKey1]);
     XCTAssertFalse([MXKeyBackup isValidRecoveryKey:invalidRecoveryKey2]);
     XCTAssertFalse([MXKeyBackup isValidRecoveryKey:invalidRecoveryKey3]);
+}
+
+/**
+ Check `MXKeyBackupPassword` utilities bijection.
+ */
+- (void)testPassword
+{
+    NSString *password = @"password";
+    NSString *salt;
+    NSUInteger iterations;
+    NSError *error;
+
+    NSData *generatedPrivateKey = [MXKeyBackupPassword generatePrivateKeyWithPassword:password salt:&salt iterations:&iterations error:&error];
+
+    XCTAssertNil(error);
+    XCTAssertNotNil(salt);
+    XCTAssertEqual(salt.length, 32);        // kSaltLength
+    XCTAssertEqual(iterations, 500000);     // kDefaultIterations
+    XCTAssertNotNil(generatedPrivateKey);
+    XCTAssertEqual(generatedPrivateKey.length, [OLMPkDecryption privateKeyLength]);
+
+    NSData *retrievedPrivateKey = [MXKeyBackupPassword retrievePrivateKeyWithPassword:password salt:salt iterations:iterations error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(retrievedPrivateKey);
+    XCTAssertEqual(retrievedPrivateKey.length, [OLMPkDecryption privateKeyLength]);
+    XCTAssertEqualObjects(retrievedPrivateKey, generatedPrivateKey);
+}
+
+/**
+ Check `[MXKeyBackupPassword retrievePrivateKeyWithPassword:]` with data coming from
+ another platform.
+ */
+- (void)testPasswordInteroperability
+{
+    // This data has been generated from riot-web
+    NSString *password = @"This is a passphrase!";
+    NSString *salt = @"TO0lxhQ9aYgGfMsclVWPIAublg8h9Nlu";
+    NSUInteger iterations = 500000;
+    UInt8 privateKeyBytes[] = {
+        116, 224, 229, 224, 9, 3, 178, 162,
+        120, 23, 108, 218, 22, 61, 241, 200,
+        235, 173, 236, 100, 115, 247, 33, 132,
+        195, 154, 64, 158, 184, 148, 20, 85
+    };
+    NSData *privateKey = [NSData dataWithBytes:privateKeyBytes length:sizeof(privateKeyBytes)];
+    
+    NSError *error;
+    NSData *retrievedPrivateKey = [MXKeyBackupPassword retrievePrivateKeyWithPassword:password salt:salt iterations:iterations error:&error];
+    XCTAssertNil(error);
+
+    XCTAssertNotNil(retrievedPrivateKey);
+    XCTAssertEqual(retrievedPrivateKey.length, [OLMPkDecryption privateKeyLength]);
+
+    XCTAssertEqualObjects(retrievedPrivateKey, privateKey);
 }
 
 /**

--- a/MatrixSDKTests/MXCryptoBackupTests.m
+++ b/MatrixSDKTests/MXCryptoBackupTests.m
@@ -90,7 +90,7 @@
         [aliceRestClient createKeyBackupVersion:keyBackupVersion success:^(NSString *version) {
 
             // - Get the current version from the server
-            [aliceRestClient keyBackupVersion:^(MXKeyBackupVersion *keyBackupVersion2) {
+            [aliceRestClient keyBackupVersion:nil success:^(MXKeyBackupVersion *keyBackupVersion2) {
 
                 // - Check they match
                 XCTAssertNotNil(keyBackupVersion2);


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-ios/issues/2127.

There is also an update in `restoreKeyBackup` so that it fails in case of bad recovery key (or password now) instead of succeeding with 0 keys imported.