### PR TITLE
MXCrypto: Key backup: Ignore all whitespaces in recovery key

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes in Matrix iOS SDK in 0.12.2 (2019-01-)
 Improvements:
  * MXRoom: Add a sendAudioFile API to send file using msgType "m.audio", thanks to N-Pex (PR #616).
  * MXCrypto: Add key backup passphrase support (vector-im/riot-ios#2127).
+ * MXCrypto: Key backup: Ignore all whitespaces in recovery key (vector-im/riot-ios#2194).
 
 Bug Fix:
  * Crypto: Device deduplication method sometimes crashes (vector-im/riot-ios/issues/#2167).

--- a/MatrixSDK/Crypto/KeyBackup/MXRecoveryKey.m
+++ b/MatrixSDK/Crypto/KeyBackup/MXRecoveryKey.m
@@ -55,7 +55,11 @@ const UInt8 kOlmRecoveryKeyPrefix[] = {0x8B, 0x01};
 
 + (NSData *)decode:(NSString *)recoveryKey error:(NSError **)error
 {
-    NSString *recoveryKeyWithNoSpaces = [recoveryKey stringByReplacingOccurrencesOfString:@" " withString:@""];
+    NSString *recoveryKeyWithNoSpaces = [recoveryKey stringByReplacingOccurrencesOfString:@"\\s"
+                                                                               withString:@""
+                                                                                  options:NSRegularExpressionSearch
+                                                                                    range:NSMakeRange(0, recoveryKey.length)];
+
     NSMutableData *result = [[self decodeBase58:recoveryKeyWithNoSpaces] mutableCopy];
 
     if (!result)

--- a/MatrixSDKTests/MXCryptoBackupTests.m
+++ b/MatrixSDKTests/MXCryptoBackupTests.m
@@ -296,12 +296,16 @@
 
 - (void)testIsValidRecoveryKey
 {
-    NSString *recoveryKey         = @"EsTc LW2K PGiF wKEA 3As5 g5c4 BXwk qeeJ ZJV8 Q9fu gUMN UE4d";
+    NSString *recoveryKey1        = @"EsTc LW2K PGiF wKEA 3As5 g5c4 BXwk qeeJ ZJV8 Q9fu gUMN UE4d";
+    NSString *recoveryKey2        = @"EsTcLW2KPGiFwKEA3As5g5c4BXwkqeeJZJV8Q9fugUMNUE4d";
+    NSString *recoveryKey3        = @"EsTc LW2K PGiF wKEA 3As5 g5c4\r\nBXwk qeeJ ZJV8 Q9fu gUMN UE4d";
     NSString *invalidRecoveryKey1 = @"EsTc LW2K PGiF wKEA 3As5 g5c4 BXwk qeeJ ZJV8 Q9fu gUMN UE4e";
     NSString *invalidRecoveryKey2 = @"EsTc LW2K PGiF wKEA 3As5 g5c4 BXwk qeeJ ZJV8 Q9fu gUMN UE4f";
     NSString *invalidRecoveryKey3 = @"EqTc LW2K PGiF wKEA 3As5 g5c4 BXwk qeeJ ZJV8 Q9fu gUMN UE4d";
 
-    XCTAssertTrue([MXKeyBackup isValidRecoveryKey:recoveryKey]);
+    XCTAssertTrue([MXKeyBackup isValidRecoveryKey:recoveryKey1]);
+    XCTAssertTrue([MXKeyBackup isValidRecoveryKey:recoveryKey2]);
+    XCTAssertTrue([MXKeyBackup isValidRecoveryKey:recoveryKey3]);
     XCTAssertFalse([MXKeyBackup isValidRecoveryKey:invalidRecoveryKey1]);
     XCTAssertFalse([MXKeyBackup isValidRecoveryKey:invalidRecoveryKey2]);
     XCTAssertFalse([MXKeyBackup isValidRecoveryKey:invalidRecoveryKey3]);


### PR DESCRIPTION
Fixes vector-im/riot-ios#2194
