### PR TITLE
Raise iOS deployment target to iOS 9

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Improvements:
  * MXKeyBackup: Add MXKeyBackupStateNotTrusted state.
  * MXKeyBackup: Do not reset MXKeyBackup.keyBackupVersion in error states.
  * MXKeyBackup: Implement the true deleteKeyBackupVersion Client-Server API.
+ * Podspec: Raise the deployment target for iOS to iOS 9 (#629).
 
 Bug Fix:
  * Crypto: Device deduplication method sometimes crashes (vector-im/riot-ios/issues/#2167).
@@ -16,7 +17,7 @@ Bug Fix:
  * MXSession/Swift: fix expected return type from createRoom.
 
 API break:
-* MXKeyBackup: Rename isKeyBackupTrusted to trustForKeyBackupVersion.
+ * MXKeyBackup: Rename isKeyBackupTrusted to trustForKeyBackupVersion.
 
 Changes in Matrix iOS SDK in 0.12.1 (2019-01-04)
 ===============================================

--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
   
   s.requires_arc  = true
   
-  s.ios.deployment_target = "8.0"
+  s.ios.deployment_target = "9.0"
   s.osx.deployment_target = "10.10"
   
   s.default_subspec = 'Core'

--- a/SwiftMatrixSDK.podspec
+++ b/SwiftMatrixSDK.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.author             = { "matrix.org" => "support@matrix.org" }
   s.social_media_url   = "http://twitter.com/matrixdotorg"
 
-  s.ios.deployment_target = "8.0"
+  s.ios.deployment_target = "9.0"
   s.osx.deployment_target = "10.10"
 
   s.source       = { :git => "https://github.com/matrix-org/matrix-ios-sdk.git", :tag => "v#{s.version}" }


### PR DESCRIPTION
All iOS devices that support iOS 8 also support iOS 9.
Riot builds fine with this change.

Signed-off-by: Fridtjof Mund <2780577+fridtjof@users.noreply.github.com>