### PR TITLE
Key backup: restoreKeyBackup methods now check if the recovery key is valid

### DIFF
--- a/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.h
+++ b/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.h
@@ -233,7 +233,7 @@ FOUNDATION_EXPORT NSString *const kMXKeyBackupDidStateChangeNotification;
 /**
  Restore a backup with a recovery key from a given backup version stored on the homeserver.
 
- @param version the backup version to restore from.
+ @param keyBackupVersion the backup version to restore from.
  @param recoveryKey the recovery key to decrypt the retrieved backup.
  @param roomId the id of the room to get backup data from.
  @param sessionId the id of the session to restore.
@@ -244,7 +244,7 @@ FOUNDATION_EXPORT NSString *const kMXKeyBackupDidStateChangeNotification;
  
  @return a MXHTTPOperation instance.
  */
-- (MXHTTPOperation*)restoreKeyBackup:(NSString*)version
+- (MXHTTPOperation*)restoreKeyBackup:(MXKeyBackupVersion*)keyBackupVersion
                      withRecoveryKey:(NSString*)recoveryKey
                                 room:(nullable NSString*)roomId
                              session:(nullable NSString*)sessionId
@@ -254,7 +254,7 @@ FOUNDATION_EXPORT NSString *const kMXKeyBackupDidStateChangeNotification;
 /**
  Restore a backup with a password from a given backup version stored on the homeserver.
 
- @param version the backup version to restore from.
+ @param keyBackupVersion the backup version to restore from.
  @param password the password to decrypt the retrieved backup.
  @param roomId the id of the room to get backup data from.
  @param sessionId the id of the session to restore.
@@ -265,7 +265,7 @@ FOUNDATION_EXPORT NSString *const kMXKeyBackupDidStateChangeNotification;
 
  @return a MXHTTPOperation instance.
  */
-- (MXHTTPOperation*)restoreKeyBackup:(NSString*)version
+- (MXHTTPOperation*)restoreKeyBackup:(MXKeyBackupVersion*)keyBackupVersion
                         withPassword:(NSString*)password
                                 room:(nullable NSString*)roomId
                              session:(nullable NSString*)sessionId

--- a/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.m
+++ b/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.m
@@ -1335,6 +1335,14 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
     return [MXRecoveryKey encode:recoveryKeyData];
 }
 
+/**
+ Check if a recovery key matches key backup authentication data.
+
+ @param recoveryKey the recovery key to challenge.
+ @param keyBackupVersion the backup and its auth data.
+ @param error the encountered error in case of failure.
+ @return YES if successful.
+ */
 - (BOOL)isValidRecoveryKey:(NSString*)recoveryKey forKeyBackupVersion:(MXKeyBackupVersion*)keyBackupVersion error:(NSError **)error
 {
     // Build PK decryption instance with the recovery key

--- a/MatrixSDKTests/MXCryptoBackupTests.m
+++ b/MatrixSDKTests/MXCryptoBackupTests.m
@@ -679,7 +679,7 @@
     [self createKeyBackupScenarioWithPassword:nil readyToTest:^(NSString *version, MXMegolmBackupCreationInfo *keyBackupCreationInfo, NSArray<MXOlmInboundGroupSession *> *aliceKeys, MXSession *aliceSession, MXSession *bobSession, NSString *roomId, XCTestExpectation *expectation) {
 
         // - Restore the e2e backup with recovery key
-        [aliceSession.crypto.backup restoreKeyBackup:version
+        [aliceSession.crypto.backup restoreKeyBackup:aliceSession.crypto.backup.keyBackupVersion
                                      withRecoveryKey:keyBackupCreationInfo.recoveryKey
                                                 room:nil session:nil
                                              success:^(NSUInteger total, NSUInteger imported)
@@ -709,7 +709,7 @@
     [self createKeyBackupScenarioWithPassword:nil readyToTest:^(NSString *version, MXMegolmBackupCreationInfo *keyBackupCreationInfo, NSArray<MXOlmInboundGroupSession *> *aliceKeys, MXSession *aliceSession, MXSession *bobSession, NSString *roomId, XCTestExpectation *expectation) {
 
         // - Try to restore the e2e backup with a wrong recovery key
-        [aliceSession.crypto.backup restoreKeyBackup:version
+        [aliceSession.crypto.backup restoreKeyBackup:aliceSession.crypto.backup.keyBackupVersion
                                      withRecoveryKey:@"EsTc LW2K PGiF wKEA 3As5 g5c4 BXwk qeeJ ZJV8 Q9fu gUMN UE4d"
                                                 room:nil session:nil
                                              success:^(NSUInteger total, NSUInteger imported)
@@ -745,7 +745,7 @@
     [self createKeyBackupScenarioWithPassword:password readyToTest:^(NSString *version, MXMegolmBackupCreationInfo *keyBackupCreationInfo, NSArray<MXOlmInboundGroupSession *> *aliceKeys, MXSession *aliceSession, MXSession *bobSession, NSString *roomId, XCTestExpectation *expectation) {
 
         // - Restore the e2e backup with the password
-        [aliceSession.crypto.backup restoreKeyBackup:version
+        [aliceSession.crypto.backup restoreKeyBackup:aliceSession.crypto.backup.keyBackupVersion
                                         withPassword:password
                                                 room:nil session:nil
                                              success:^(NSUInteger total, NSUInteger imported)
@@ -775,7 +775,7 @@
     [self createKeyBackupScenarioWithPassword:@"password" readyToTest:^(NSString *version, MXMegolmBackupCreationInfo *keyBackupCreationInfo, NSArray<MXOlmInboundGroupSession *> *aliceKeys, MXSession *aliceSession, MXSession *bobSession, NSString *roomId, XCTestExpectation *expectation) {
 
         // - Try to restore the e2e backup with a wrong password
-        [aliceSession.crypto.backup restoreKeyBackup:version
+        [aliceSession.crypto.backup restoreKeyBackup:aliceSession.crypto.backup.keyBackupVersion
                                         withPassword:@"WrongPassword"
                                                 room:nil session:nil
                                              success:^(NSUInteger total, NSUInteger imported)
@@ -811,7 +811,7 @@
     [self createKeyBackupScenarioWithPassword:password readyToTest:^(NSString *version, MXMegolmBackupCreationInfo *keyBackupCreationInfo, NSArray<MXOlmInboundGroupSession *> *aliceKeys, MXSession *aliceSession, MXSession *bobSession, NSString *roomId, XCTestExpectation *expectation) {
 
         // - Restore the e2e backup with the recovery key.
-        [aliceSession.crypto.backup restoreKeyBackup:version
+        [aliceSession.crypto.backup restoreKeyBackup:aliceSession.crypto.backup.keyBackupVersion
                                      withRecoveryKey:keyBackupCreationInfo.recoveryKey
                                                 room:nil session:nil
                                              success:^(NSUInteger total, NSUInteger imported)
@@ -841,7 +841,7 @@
     [self createKeyBackupScenarioWithPassword:nil readyToTest:^(NSString *version, MXMegolmBackupCreationInfo *keyBackupCreationInfo, NSArray<MXOlmInboundGroupSession *> *aliceKeys, MXSession *aliceSession, MXSession *bobSession, NSString *roomId, XCTestExpectation *expectation) {
 
         // - Try to restore the e2e backup with a password
-        [aliceSession.crypto.backup restoreKeyBackup:version
+        [aliceSession.crypto.backup restoreKeyBackup:aliceSession.crypto.backup.keyBackupVersion
                                         withPassword:@"password"
                                                 room:nil session:nil
                                              success:^(NSUInteger total, NSUInteger imported)
@@ -1090,7 +1090,7 @@
         XCTAssertTrue(unSentRequest != nil || sentRequest != nil);
 
         // - Restore the e2e backup with recovery key
-        [aliceSession.crypto.backup restoreKeyBackup:version
+        [aliceSession.crypto.backup restoreKeyBackup:aliceSession.crypto.backup.keyBackupVersion
                                      withRecoveryKey:keyBackupCreationInfo.recoveryKey
                                                 room:nil session:nil
                                              success:^(NSUInteger total, NSUInteger imported)


### PR DESCRIPTION
This improves the previous behavior where we needed to have a **non empty** backup to determine if the recovery key was valid.

This PR comes with some factorisation and a small API break.
