### PR TITLE
Crypto: Improve key import performance

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ Improvements:
  * MXKeyBackup: Implement the true deleteKeyBackupVersion Client-Server API.
  * MXKeyBackup: Declare backup trust using new `PUT /room_keys/version/{version}` API (vector-im/riot-ios/issues/2223).
  * Crypto: Cancel share request on restore/import (vector-im/riot-ios/issues/#2232).
+ * Crypto: Improve key import performance (vector-im/riot-ios/issues/#2248).
 
 Bug Fix:
  * Crypto: Device deduplication method sometimes crashes (vector-im/riot-ios/issues/#2167).

--- a/MatrixSDK/Crypto/Algorithms/MXDecrypting.h
+++ b/MatrixSDK/Crypto/Algorithms/MXDecrypting.h
@@ -22,7 +22,7 @@
 #import "MXEventDecryptionResult.h"
 #import "MXIncomingRoomKeyRequest.h"
 
-@class MXCrypto, MXMegolmSessionData;
+@class MXCrypto, MXOlmInboundGroupSession;
 
 
 @protocol MXDecrypting <NSObject>
@@ -57,13 +57,12 @@
 - (void)onRoomKeyEvent:(MXEvent*)event;
 
 /**
- Import a room key.
+ Notification that a room key has been imported.
 
  @param backUp YES to back up them to the homeserver.
  @param session the session data to import.
- @return YES if the key has been imported.
  */
-- (BOOL)importRoomKey:(MXMegolmSessionData*)session backUp:(BOOL)backUp;
+- (void)didImportRoomKey:(MXOlmInboundGroupSession*)session backUp:(BOOL)backUp;
 
 /**
  Determine if we have the keys necessary to respond to a room key request.

--- a/MatrixSDK/Crypto/Algorithms/MXDecrypting.h
+++ b/MatrixSDK/Crypto/Algorithms/MXDecrypting.h
@@ -59,10 +59,9 @@
 /**
  Notification that a room key has been imported.
 
- @param backUp YES to back up them to the homeserver.
  @param session the session data to import.
  */
-- (void)didImportRoomKey:(MXOlmInboundGroupSession*)session backUp:(BOOL)backUp;
+- (void)didImportRoomKey:(MXOlmInboundGroupSession*)session;
 
 /**
  Determine if we have the keys necessary to respond to a room key request.

--- a/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmDecryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmDecryption.m
@@ -240,18 +240,8 @@
     [self retryDecryption:senderKey sessionId:content[@"session_id"]];
 }
 
-- (void)didImportRoomKey:(MXOlmInboundGroupSession *)session backUp:(BOOL)backUp
+- (void)didImportRoomKey:(MXOlmInboundGroupSession *)session
 {
-    // Do not back up the key if it comes from a backup recovery
-    if (backUp)
-    {
-        [crypto.backup maybeSendKeyBackup];
-    }
-    else
-    {
-        [crypto.store markBackupDoneForInboundGroupSessions:@[session]];
-    }
-
     // cancel any outstanding room key requests for this session
     [crypto cancelRoomKeyRequest:@{
                                    @"algorithm": kMXCryptoMegolmAlgorithm,

--- a/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmDecryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmDecryption.m
@@ -240,34 +240,28 @@
     [self retryDecryption:senderKey sessionId:content[@"session_id"]];
 }
 
-- (BOOL)importRoomKey:(MXMegolmSessionData *)session backUp:(BOOL)backUp
+- (void)didImportRoomKey:(MXOlmInboundGroupSession *)session backUp:(BOOL)backUp
 {
-    BOOL imported = [olmDevice importInboundGroupSession:session];
-    if (imported)
+    // Do not back up the key if it comes from a backup recovery
+    if (backUp)
     {
-        // Do not back up the key if it comes from a backup recovery
-        if (backUp)
-        {
-            [crypto.backup maybeSendKeyBackup];
-        }
-        else
-        {
-            [crypto.store markBackupDoneForInboundGroupSessionWithId:session.sessionId andSenderKey:session.senderKey];
-        }
-
-        // cancel any outstanding room key requests for this session
-        [crypto cancelRoomKeyRequest:@{
-                                       @"algorithm": session.algorithm,
-                                       @"room_id": session.roomId,
-                                       @"session_id": session.sessionId,
-                                       @"sender_key": session.senderKey
-                                       }];
-
-        // Have another go at decrypting events sent with this session
-        [self retryDecryption:session.senderKey sessionId:session.sessionId];
+        [crypto.backup maybeSendKeyBackup];
+    }
+    else
+    {
+        [crypto.store markBackupDoneForInboundGroupSessionWithId:session.session.sessionIdentifier andSenderKey:session.senderKey];
     }
 
-    return imported;
+    // cancel any outstanding room key requests for this session
+    [crypto cancelRoomKeyRequest:@{
+                                   @"algorithm": kMXCryptoMegolmAlgorithm,
+                                   @"room_id": session.roomId,
+                                   @"session_id": session.session.sessionIdentifier,
+                                   @"sender_key": session.senderKey
+                                   }];
+
+    // Have another go at decrypting events sent with this session
+    [self retryDecryption:session.senderKey sessionId:session.session.sessionIdentifier];
 }
 
 - (BOOL)hasKeysForKeyRequest:(MXIncomingRoomKeyRequest*)keyRequest

--- a/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmDecryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmDecryption.m
@@ -249,7 +249,7 @@
     }
     else
     {
-        [crypto.store markBackupDoneForInboundGroupSessionWithId:session.session.sessionIdentifier andSenderKey:session.senderKey];
+        [crypto.store markBackupDoneForInboundGroupSessions:@[session]];
     }
 
     // cancel any outstanding room key requests for this session

--- a/MatrixSDK/Crypto/Algorithms/Olm/MXOlmDecryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Olm/MXOlmDecryption.m
@@ -236,7 +236,7 @@
     // No impact for olm
 }
 
-- (void)didImportRoomKey:(MXOlmInboundGroupSession *)session backUp:(BOOL)backUp
+- (void)didImportRoomKey:(MXOlmInboundGroupSession *)session
 {
     // No impact for olm
 }

--- a/MatrixSDK/Crypto/Algorithms/Olm/MXOlmDecryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Olm/MXOlmDecryption.m
@@ -236,10 +236,9 @@
     // No impact for olm
 }
 
-- (BOOL)importRoomKey:(MXMegolmSessionData *)session backUp:(BOOL)backUp
+- (void)didImportRoomKey:(MXOlmInboundGroupSession *)session backUp:(BOOL)backUp
 {
     // No impact for olm
-    return NO;
 }
 
 - (BOOL)hasKeysForKeyRequest:(MXIncomingRoomKeyRequest*)keyRequest

--- a/MatrixSDK/Crypto/Data/Store/MXCryptoStore.h
+++ b/MatrixSDK/Crypto/Data/Store/MXCryptoStore.h
@@ -211,11 +211,11 @@
 
 
 /**
- Store an inbound group session.
+ Store inbound group sessions.
 
- @param session the inbound group session and its context.
+ @param sessions inbound group sessions.
  */
-- (void)storeInboundGroupSession:(MXOlmInboundGroupSession*)session;
+- (void)storeInboundGroupSessions:(NSArray<MXOlmInboundGroupSession *>*)sessions;
 
 /**
  Retrieve an inbound group session.

--- a/MatrixSDK/Crypto/Data/Store/MXCryptoStore.h
+++ b/MatrixSDK/Crypto/Data/Store/MXCryptoStore.h
@@ -248,12 +248,11 @@
 - (void)resetBackupMarkers;
 
 /**
- Mark an inbound group session as backed up on the user homeserver.
+ Mark inbound group sessions as backed up on the user homeserver.
 
- @param sessionId the session identifier.
- @param senderKey the base64-encoded curve25519 key of the sender.
+ @param sessions inbound group sessions.
  */
-- (void)markBackupDoneForInboundGroupSessionWithId:(NSString*)sessionId andSenderKey:(NSString*)senderKey;
+- (void)markBackupDoneForInboundGroupSessions:(NSArray<MXOlmInboundGroupSession *>*)sessions;
 
 /**
  Retrieve inbound group sessions that are not yet backed up.

--- a/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
+++ b/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
@@ -796,20 +796,23 @@ RLM_ARRAY_TYPE(MXRealmOlmInboundGroupSession)
     }];
 }
 
-- (void)markBackupDoneForInboundGroupSessionWithId:(NSString*)sessionId andSenderKey:(NSString*)senderKey
+- (void)markBackupDoneForInboundGroupSessions:(NSArray<MXOlmInboundGroupSession *>*)sessions
 {
     RLMRealm *realm = self.realm;
     [realm transactionWithBlock:^{
 
-        NSString *sessionIdSenderKey = [MXRealmOlmInboundGroupSession primaryKeyWithSessionId:sessionId
-                                                                                    senderKey:senderKey];
-        MXRealmOlmInboundGroupSession *realmSession = [MXRealmOlmInboundGroupSession objectsInRealm:realm where:@"sessionIdSenderKey = %@", sessionIdSenderKey].firstObject;
-
-        if (realmSession)
+        for (MXOlmInboundGroupSession *session in sessions)
         {
-            realmSession.backedUp = @(YES);
+            NSString *sessionIdSenderKey = [MXRealmOlmInboundGroupSession primaryKeyWithSessionId:session.session.sessionIdentifier
+                                                                                        senderKey:session.senderKey];
+            MXRealmOlmInboundGroupSession *realmSession = [MXRealmOlmInboundGroupSession objectsInRealm:realm where:@"sessionIdSenderKey = %@", sessionIdSenderKey].firstObject;
 
-            [realm addOrUpdateObject:realmSession];
+            if (realmSession)
+            {
+                realmSession.backedUp = @(YES);
+
+                [realm addOrUpdateObject:realmSession];
+            }
         }
     }];
 }

--- a/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
+++ b/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
@@ -678,41 +678,44 @@ RLM_ARRAY_TYPE(MXRealmOlmInboundGroupSession)
     return sessionsWithDevice;
 }
 
-- (void)storeInboundGroupSession:(MXOlmInboundGroupSession*)session
+- (void)storeInboundGroupSessions:(NSArray<MXOlmInboundGroupSession *>*)sessions
 {
-    __block BOOL isNew = NO;
+    __block NSUInteger newCount = 0;
     NSDate *startDate = [NSDate date];
 
     RLMRealm *realm = self.realm;
     [realm transactionWithBlock:^{
 
-        NSString *sessionIdSenderKey = [MXRealmOlmInboundGroupSession primaryKeyWithSessionId:session.session.sessionIdentifier
-                                                                                    senderKey:session.senderKey];
-        MXRealmOlmInboundGroupSession *realmSession = [MXRealmOlmInboundGroupSession objectsInRealm:realm where:@"sessionIdSenderKey = %@", sessionIdSenderKey].firstObject;
-        if (realmSession)
+        for (MXOlmInboundGroupSession *session in sessions)
         {
-            // Update the existing one
-            realmSession.olmInboundGroupSessionData = [NSKeyedArchiver archivedDataWithRootObject:session];
-        }
-        else
-        {
-            // Create it
-            isNew = YES;
             NSString *sessionIdSenderKey = [MXRealmOlmInboundGroupSession primaryKeyWithSessionId:session.session.sessionIdentifier
                                                                                         senderKey:session.senderKey];
-            realmSession = [[MXRealmOlmInboundGroupSession alloc] initWithValue:@{
-                                                                                  @"sessionId": session.session.sessionIdentifier,
-                                                                                  @"senderKey": session.senderKey,
-                                                                                  @"sessionIdSenderKey": sessionIdSenderKey,
-                                                                                  @"olmInboundGroupSessionData": [NSKeyedArchiver archivedDataWithRootObject:session]
-                                                                                  }];
+            MXRealmOlmInboundGroupSession *realmSession = [MXRealmOlmInboundGroupSession objectsInRealm:realm where:@"sessionIdSenderKey = %@", sessionIdSenderKey].firstObject;
+            if (realmSession)
+            {
+                // Update the existing one
+                realmSession.olmInboundGroupSessionData = [NSKeyedArchiver archivedDataWithRootObject:session];
+            }
+            else
+            {
+                // Create it
+                newCount++;
+                NSString *sessionIdSenderKey = [MXRealmOlmInboundGroupSession primaryKeyWithSessionId:session.session.sessionIdentifier
+                                                                                            senderKey:session.senderKey];
+                realmSession = [[MXRealmOlmInboundGroupSession alloc] initWithValue:@{
+                                                                                      @"sessionId": session.session.sessionIdentifier,
+                                                                                      @"senderKey": session.senderKey,
+                                                                                      @"sessionIdSenderKey": sessionIdSenderKey,
+                                                                                      @"olmInboundGroupSessionData": [NSKeyedArchiver archivedDataWithRootObject:session]
+                                                                                      }];
 
-            [realm addObject:realmSession];
+                [realm addObject:realmSession];
+            }
         }
     }];
 
 
-    NSLog(@"[MXRealmCryptoStore] storeInboundGroupSession (%@) %@ in %.0fms", (isNew?@"NEW":@"UPDATE"), session.session.sessionIdentifier, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+    NSLog(@"[MXRealmCryptoStore] storeInboundGroupSessions: store %@ keys (%@ new) in %.0fms", @(sessions.count), @(newCount), [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 }
 
 - (MXOlmInboundGroupSession*)inboundGroupSessionWithId:(NSString*)sessionId andSenderKey:(NSString*)senderKey

--- a/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.m
+++ b/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.m
@@ -99,10 +99,11 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
 
 - (void)checkAndStartWithKeyBackupVersion:(nullable MXKeyBackupVersion*)keyBackupVersion
 {
+    NSLog(@"[MXKeyBackup] checkAndStartWithKeyBackupVersion: %@", keyBackupVersion.version);
+ 
     self->_keyBackupVersion = keyBackupVersion;
     if (!self.keyBackupVersion)
     {
-        NSLog(@"[MXKeyBackup] checkAndStartKeyBackup: Found no key backup version on the homeserver");
         [self resetKeyBackupData];
         self.state = MXKeyBackupStateDisabled;
         return;
@@ -112,7 +113,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
 
     if (trustInfo.usable)
     {
-        NSLog(@"[MXKeyBackup] checkAndStartKeyBackup: Found usable key backup. version: %@", keyBackupVersion.version);
+        NSLog(@"[MXKeyBackup] checkAndStartWithKeyBackupVersion: Found usable key backup. version: %@", keyBackupVersion.version);
 
         // Check the version we used at the previous app run
         NSString *versionInStore = mxSession.crypto.store.backupVersion;
@@ -127,7 +128,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
     }
     else
     {
-        NSLog(@"[MXKeyBackup] checkAndStartKeyBackup: No usable key backup. version: %@", keyBackupVersion.version);
+        NSLog(@"[MXKeyBackup] checkAndStartWithKeyBackupVersion: No usable key backup. version: %@", keyBackupVersion.version);
 
         if (mxSession.crypto.store.backupVersion)
         {
@@ -938,6 +939,8 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
                                    success:(void (^)(void))success
                                    failure:(void (^)(NSError * _Nonnull))failure
 {
+    NSLog(@"[MXKeyBackup] trustKeyBackupVersion:trust: %@. trust: %@", keyBackupVersion.version, @(trust));
+
     MXHTTPOperation *operation = [MXHTTPOperation new];
 
     MXWeakify(self);
@@ -1027,6 +1030,8 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
                                    success:(void (^)(void))success
                                    failure:(void (^)(NSError * _Nonnull))failure
 {
+    NSLog(@"[MXKeyBackup] trustKeyBackupVersion:withRecoveryKey: %@", keyBackupVersion.version);
+
     MXHTTPOperation *operation = [MXHTTPOperation new];
 
     MXWeakify(self);
@@ -1061,6 +1066,8 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
                                    success:(void (^)(void))success
                                    failure:(void (^)(NSError * _Nonnull))failure
 {
+    NSLog(@"[MXKeyBackup] trustKeyBackupVersion:withPassword: %@", keyBackupVersion.version);
+
     MXHTTPOperation *operation = [MXHTTPOperation new];
 
     MXWeakify(self);

--- a/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.m
+++ b/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.m
@@ -291,10 +291,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
         NSLog(@"[MXKeyBackup] sendKeyBackup: 5a - Request complete");
 
         // Mark keys as backed up
-        for (MXOlmInboundGroupSession *session in sessions)
-        {
-            [self->mxSession.crypto.store markBackupDoneForInboundGroupSessionWithId:session.session.sessionIdentifier andSenderKey:session.senderKey];
-        }
+        [self->mxSession.crypto.store markBackupDoneForInboundGroupSessions:sessions];
 
         if (sessions.count < kMXKeyBackupSendKeysMaxCount)
         {

--- a/MatrixSDK/Crypto/KeySharing/MXOutgoingRoomKeyRequestManager.m
+++ b/MatrixSDK/Crypto/KeySharing/MXOutgoingRoomKeyRequestManager.m
@@ -97,13 +97,13 @@ NSUInteger const SEND_KEY_REQUESTS_DELAY_MS = 500;
 {
     MXOutgoingRoomKeyRequest *request = [cryptoStore outgoingRoomKeyRequestWithRequestBody:requestBody];
 
-    NSLog(@"[MXOutgoingRoomKeyRequestManager] cancelRoomKeyRequest:andResend:%@: request.requestId: %@. state: %@", @(resend), request.requestId,  @(request.state));
-
     if (!request)
     {
         // no request was made for this key
         return;
     }
+
+    NSLog(@"[MXOutgoingRoomKeyRequestManager] cancelRoomKeyRequest:andResend:%@: request.requestId: %@. state: %@", @(resend), request.requestId,  @(request.state));
 
     switch (request.state)
     {

--- a/MatrixSDK/Crypto/MXOlmDevice.h
+++ b/MatrixSDK/Crypto/MXOlmDevice.h
@@ -230,12 +230,12 @@ Determine if an incoming messages is a prekey message matching an existing sessi
                   exportFormat:(BOOL)exportFormat;
 
 /**
- Add a previously-exported inbound group session to the session store.
+ Add previously-exported inbound group sessions to the session store.
 
- @param data the session data.
- @return YES if the key has been imported.
+ @param data the group sessions data.
+ @return the imported keys.
  */
-- (BOOL)importInboundGroupSession:(MXMegolmSessionData*)data;
+- (NSArray<MXOlmInboundGroupSession *>*)importInboundGroupSessions:(NSArray<MXMegolmSessionData *>*)inboundGroupSessionsData;
 
 /**
  Decrypt a received message with an inbound group session.

--- a/MatrixSDKTests/MXCryptoBackupTests.m
+++ b/MatrixSDKTests/MXCryptoBackupTests.m
@@ -243,7 +243,7 @@
 
         // - Check backup keys after having marked one as backed up
         MXOlmInboundGroupSession *session = sessions.firstObject;
-        [aliceSession.crypto.store markBackupDoneForInboundGroupSessionWithId:session.session.sessionIdentifier andSenderKey:session.senderKey];
+        [aliceSession.crypto.store markBackupDoneForInboundGroupSessions:@[session]];
         sessions = [aliceSession.crypto.store inboundGroupSessionsToBackup:100];
         XCTAssertEqual(sessions.count, sessionsCount - 1);
         XCTAssertEqual([aliceSession.crypto.store inboundGroupSessionsCount:NO], sessionsCount);


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-ios/issues/2248

Before:
`[MXCrypto] importMegolmSessionDatas: Imported 5925 keys from 5925 provided keys in 698677ms`
After: 
`[MXCrypto] importMegolmSessionDatas: Imported 5954 keys from 5955 provided keys in 28534ms`

There is still room for improvement, specifically for the key backup recovery. 
`[alg didImportRoomKey:session];` triggers a load of key share request cancellation requests that takes 30s on my account. This delays the trust request made by that screen because the request is put at the end of the queue :/
