### PR TITLE
BF: Escape room v3 event ids in permalinks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Improvements:
 
 Bug Fix:
  * Crypto: Fix crash in MXKeyBackup (vector-im/riot-ios/issues/#2281).
+ * Escape room v3 event ids in permalinks (vector-im/riot-ios/issues/2277).
 
 Changes in Matrix iOS SDK in 0.12.2 (2019-02-15)
 ===============================================

--- a/MatrixSDK/Utils/MXTools.m
+++ b/MatrixSDK/Utils/MXTools.m
@@ -377,12 +377,12 @@ NSCharacterSet *uriComponentCharset;
 #pragma mark - Permalink
 + (NSString *)permalinkToRoom:(NSString *)roomIdOrAlias
 {
-    return [NSString stringWithFormat:@"%@/#/%@", kMXMatrixDotToUrl, roomIdOrAlias];
+    return [NSString stringWithFormat:@"%@/#/%@", kMXMatrixDotToUrl, [MXTools encodeURIComponent:roomIdOrAlias]];
 }
 
 + (NSString *)permalinkToEvent:(NSString *)eventId inRoom:(NSString *)roomIdOrAlias
 {
-    return [NSString stringWithFormat:@"%@/#/%@/%@", kMXMatrixDotToUrl, roomIdOrAlias, eventId];
+    return [NSString stringWithFormat:@"%@/#/%@/%@", kMXMatrixDotToUrl, [MXTools encodeURIComponent:roomIdOrAlias], [MXTools encodeURIComponent:eventId]];
 
 }
 


### PR DESCRIPTION
Fixes vector-im/riot-ios/issues/2277
