### PR TITLE
Login: Handle well-known data in the login response

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes in Matrix iOS SDK in 0.12.3 (2019-02-)
 Improvements:
  * Maintenance: Update cocopoads and pods. Automatic update to Swift4.2.
  * MXCredentials: Create a new data model for it, separated from the CS API response data model (new MXLoginResponse class).
+ * Login: Handle well-known data in the login response - MSC1730 (vector-im/riot-ios/issues/2298).
 
 Bug Fix:
  * Crypto: Fix crash in MXKeyBackup (vector-im/riot-ios/issues/#2281).

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Changes in Matrix iOS SDK in 0.12.3 (2019-02-)
 
 Improvements:
  * Maintenance: Update cocopoads and pods. Automatic update to Swift4.2.
+ * MXCredentials: Create a new data model for it, separated from the CS API response data model (new MXLoginResponse class).
 
 Bug Fix:
  * Crypto: Fix crash in MXKeyBackup (vector-im/riot-ios/issues/#2281).

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -65,6 +65,10 @@
 		32322A4C1E575F65005DD155 /* MXAllowedCertificates.m in Sources */ = {isa = PBXBuildFile; fileRef = 32322A4A1E575F65005DD155 /* MXAllowedCertificates.m */; };
 		3233606F1A403A0D0071A488 /* MXFileStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 3233606D1A403A0D0071A488 /* MXFileStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		323360701A403A0D0071A488 /* MXFileStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 3233606E1A403A0D0071A488 /* MXFileStore.m */; };
+		323547D42226D3F500F15F94 /* MXWellKnown.m in Sources */ = {isa = PBXBuildFile; fileRef = 323547D22226D3F500F15F94 /* MXWellKnown.m */; };
+		323547D52226D3F500F15F94 /* MXWellKnown.h in Headers */ = {isa = PBXBuildFile; fileRef = 323547D32226D3F500F15F94 /* MXWellKnown.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		323547D82226D5D600F15F94 /* MXWellKnownBaseConfig.h in Headers */ = {isa = PBXBuildFile; fileRef = 323547D62226D5D600F15F94 /* MXWellKnownBaseConfig.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		323547D92226D5D600F15F94 /* MXWellKnownBaseConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = 323547D72226D5D600F15F94 /* MXWellKnownBaseConfig.m */; };
 		323547DC2226FC5700F15F94 /* MXCredentials.h in Headers */ = {isa = PBXBuildFile; fileRef = 323547DA2226FC5700F15F94 /* MXCredentials.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		323547DD2226FC5700F15F94 /* MXCredentials.m in Sources */ = {isa = PBXBuildFile; fileRef = 323547DB2226FC5700F15F94 /* MXCredentials.m */; };
 		323C5A081A70E53500FB0549 /* MXToolsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 323C5A071A70E53500FB0549 /* MXToolsTests.m */; };
@@ -438,6 +442,10 @@
 		32322A4A1E575F65005DD155 /* MXAllowedCertificates.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXAllowedCertificates.m; sourceTree = "<group>"; };
 		3233606D1A403A0D0071A488 /* MXFileStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXFileStore.h; sourceTree = "<group>"; };
 		3233606E1A403A0D0071A488 /* MXFileStore.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXFileStore.m; sourceTree = "<group>"; };
+		323547D22226D3F500F15F94 /* MXWellKnown.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXWellKnown.m; sourceTree = "<group>"; };
+		323547D32226D3F500F15F94 /* MXWellKnown.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXWellKnown.h; sourceTree = "<group>"; };
+		323547D62226D5D600F15F94 /* MXWellKnownBaseConfig.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXWellKnownBaseConfig.h; sourceTree = "<group>"; };
+		323547D72226D5D600F15F94 /* MXWellKnownBaseConfig.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXWellKnownBaseConfig.m; sourceTree = "<group>"; };
 		323547DA2226FC5700F15F94 /* MXCredentials.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXCredentials.h; sourceTree = "<group>"; };
 		323547DB2226FC5700F15F94 /* MXCredentials.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXCredentials.m; sourceTree = "<group>"; };
 		323C5A071A70E53500FB0549 /* MXToolsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXToolsTests.m; sourceTree = "<group>"; };
@@ -978,6 +986,17 @@
 			path = MXFileStore;
 			sourceTree = "<group>";
 		};
+		323547D12226D3F500F15F94 /* AutoDiscovery */ = {
+			isa = PBXGroup;
+			children = (
+				323547D62226D5D600F15F94 /* MXWellKnownBaseConfig.h */,
+				323547D72226D5D600F15F94 /* MXWellKnownBaseConfig.m */,
+				323547D32226D3F500F15F94 /* MXWellKnown.h */,
+				323547D22226D3F500F15F94 /* MXWellKnown.m */,
+			);
+			path = AutoDiscovery;
+			sourceTree = "<group>";
+		};
 		323F3F9020D3F0C700D26D6A /* Filters */ = {
 			isa = PBXGroup;
 			children = (
@@ -1065,6 +1084,7 @@
 		3281E8B219E42DFE00976E1A /* JSONModels */ = {
 			isa = PBXGroup;
 			children = (
+				323547D12226D3F500F15F94 /* AutoDiscovery */,
 				3275FD9121A6B46600B9C13D /* Authentication */,
 				3281E8B319E42DFE00976E1A /* MXJSONModel.h */,
 				3281E8B419E42DFE00976E1A /* MXJSONModel.m */,
@@ -1560,6 +1580,7 @@
 				32954019216385F100E300FC /* MXServerNoticeContent.h in Headers */,
 				327187851DA7D0220071C818 /* MXOlmDecryption.h in Headers */,
 				32D7767D1A27860600FC4AA2 /* MXMemoryStore.h in Headers */,
+				323547D52226D3F500F15F94 /* MXWellKnown.h in Headers */,
 				32FFB4F0217E146A00C96002 /* MXRecoveryKey.h in Headers */,
 				32CE6FB81A409B1F00317F1E /* MXFileStoreMetaData.h in Headers */,
 				32A31BC820D401FC005916C7 /* MXRoomFilter.h in Headers */,
@@ -1630,6 +1651,7 @@
 				32A31BC420D3FFB0005916C7 /* MXFilter.h in Headers */,
 				32A151481DAF7C0C00400192 /* MXKey.h in Headers */,
 				32BBAE6D2178E99100D85F46 /* MXKeyBackupVersion.h in Headers */,
+				323547D82226D5D600F15F94 /* MXWellKnownBaseConfig.h in Headers */,
 				32A151461DAF7C0C00400192 /* MXDeviceInfo.h in Headers */,
 				32CAB1071A91EA34008C5BB9 /* MXPushRuleRoomMemberCountConditionChecker.h in Headers */,
 				C61A4CC41E5F38CB00442158 /* SwiftMatrixSDK.h in Headers */,
@@ -1942,6 +1964,7 @@
 				3275FD9921A6B53300B9C13D /* MXLoginPolicyData.m in Sources */,
 				3240969E1F9F751600DBA607 /* MXPushRuleSenderNotificationPermissionConditionChecker.m in Sources */,
 				71DE22E01BC7C51200284153 /* MXReceiptData.m in Sources */,
+				323547D92226D5D600F15F94 /* MXWellKnownBaseConfig.m in Sources */,
 				327E37B71A974F75007F026F /* MXLogger.m in Sources */,
 				324BE4691E3FADB1008D99D4 /* MXMegolmExportEncryption.m in Sources */,
 				32A31BBF20D3F2EC005916C7 /* MXFilterObject.m in Sources */,
@@ -1989,6 +2012,7 @@
 				C6F935891E5B3BE600FC34BF /* MXEventTimeline.swift in Sources */,
 				C6F9358B1E5B3BE600FC34BF /* MXJSONModels.swift in Sources */,
 				32FA10C21FA1C9EE00E54233 /* MXOutgoingRoomKeyRequestManager.m in Sources */,
+				323547D42226D3F500F15F94 /* MXWellKnown.m in Sources */,
 				320DFDE519DD99B60068622A /* MXRestClient.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -65,6 +65,8 @@
 		32322A4C1E575F65005DD155 /* MXAllowedCertificates.m in Sources */ = {isa = PBXBuildFile; fileRef = 32322A4A1E575F65005DD155 /* MXAllowedCertificates.m */; };
 		3233606F1A403A0D0071A488 /* MXFileStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 3233606D1A403A0D0071A488 /* MXFileStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		323360701A403A0D0071A488 /* MXFileStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 3233606E1A403A0D0071A488 /* MXFileStore.m */; };
+		323547DC2226FC5700F15F94 /* MXCredentials.h in Headers */ = {isa = PBXBuildFile; fileRef = 323547DA2226FC5700F15F94 /* MXCredentials.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		323547DD2226FC5700F15F94 /* MXCredentials.m in Sources */ = {isa = PBXBuildFile; fileRef = 323547DB2226FC5700F15F94 /* MXCredentials.m */; };
 		323C5A081A70E53500FB0549 /* MXToolsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 323C5A071A70E53500FB0549 /* MXToolsTests.m */; };
 		323E0C5B1A306D7A00A31D73 /* MXEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 323E0C591A306D7A00A31D73 /* MXEvent.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		323E0C5C1A306D7A00A31D73 /* MXEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 323E0C5A1A306D7A00A31D73 /* MXEvent.m */; };
@@ -436,6 +438,8 @@
 		32322A4A1E575F65005DD155 /* MXAllowedCertificates.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXAllowedCertificates.m; sourceTree = "<group>"; };
 		3233606D1A403A0D0071A488 /* MXFileStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXFileStore.h; sourceTree = "<group>"; };
 		3233606E1A403A0D0071A488 /* MXFileStore.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXFileStore.m; sourceTree = "<group>"; };
+		323547DA2226FC5700F15F94 /* MXCredentials.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXCredentials.h; sourceTree = "<group>"; };
+		323547DB2226FC5700F15F94 /* MXCredentials.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXCredentials.m; sourceTree = "<group>"; };
 		323C5A071A70E53500FB0549 /* MXToolsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXToolsTests.m; sourceTree = "<group>"; };
 		323E0C591A306D7A00A31D73 /* MXEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXEvent.h; sourceTree = "<group>"; };
 		323E0C5A1A306D7A00A31D73 /* MXEvent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXEvent.m; sourceTree = "<group>"; };
@@ -824,6 +828,8 @@
 				320BBF3A1D6C7D9D0079890E /* EventsEnumerator */,
 				323F3F9020D3F0C700D26D6A /* Filters */,
 				32114A831A262CE000FF2EC4 /* Store */,
+				323547DA2226FC5700F15F94 /* MXCredentials.h */,
+				323547DB2226FC5700F15F94 /* MXCredentials.m */,
 				F0173EAA1FCF0E8800B5F6A3 /* MXGroup.h */,
 				F0173EAB1FCF0E8900B5F6A3 /* MXGroup.m */,
 				320DFDCA19DD99B60068622A /* MXRoom.h */,
@@ -1583,6 +1589,7 @@
 				32B76EA320FDE2BE00B095F6 /* MXRoomMembersCount.h in Headers */,
 				32C6F93319DD814400EA4E9C /* MatrixSDK.h in Headers */,
 				324BE46C1E422766008D99D4 /* MXMegolmSessionData.h in Headers */,
+				323547DC2226FC5700F15F94 /* MXCredentials.h in Headers */,
 				021AFBA62179E91900742B2C /* MXEncryptedContentKey.h in Headers */,
 				327187891DA7DCE50071C818 /* MXOlmEncryption.h in Headers */,
 				32A1514E1DAF897600400192 /* MXOlmSessionResult.h in Headers */,
@@ -1926,6 +1933,7 @@
 				02CAD43A217DD12F0074700B /* MXContentScanEncryptedBody.m in Sources */,
 				F03EF5091DF071D5009DF592 /* MXEncryptedAttachments.m in Sources */,
 				B172857D2100D4F60052C51E /* MXSendReplyEventDefaultStringLocalizations.m in Sources */,
+				323547DD2226FC5700F15F94 /* MXCredentials.m in Sources */,
 				32FA10CF1FA1C9F700E54233 /* MXOutgoingRoomKeyRequest.m in Sources */,
 				32322A4C1E575F65005DD155 /* MXAllowedCertificates.m in Sources */,
 				F03EF5051DF01596009DF592 /* MXLRUCache.m in Sources */,

--- a/MatrixSDK/Crypto/Data/Store/MXCryptoStore.h
+++ b/MatrixSDK/Crypto/Data/Store/MXCryptoStore.h
@@ -22,6 +22,7 @@
 #ifdef MX_CRYPTO
 
 #import "MXJSONModels.h"
+#import "MXCredentials.h"
 
 #import <OLMKit/OLMKit.h>
 #import "MXOlmSession.h"

--- a/MatrixSDK/Data/MXCredentials.h
+++ b/MatrixSDK/Data/MXCredentials.h
@@ -32,6 +32,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) NSString *homeServer;
 
 /**
+ The identity server url (ex: "https://vector.im").
+ */
+@property (nonatomic) NSString *identityServer;
+
+/**
  The obtained user id.
  */
 @property (nonatomic) NSString *userId;
@@ -78,11 +83,13 @@ NS_ASSUME_NONNULL_BEGIN
  Create credentials from a login or register response.
 
  @param loginResponse the login or register response.
- @param homeServer the homeserver URL to use if we cannot trust loginResponse data
+ @param homeServer the homeserver URL to use if we cannot trust loginResponse data.
+ @param identityServer the identity server URL to use if not provided in loginResponse data.
  @return a MXCredentials instance.
  */
 - (instancetype)initWithLoginResponse:(MXLoginResponse*)loginResponse
-                withDefaultHomeServer:(NSString*)homeServer;
+                withDefaultHomeServer:(NSString*)homeServer
+            withDefaultIdentityServer:(NSString*)identityServer;
 
 @end
 

--- a/MatrixSDK/Data/MXCredentials.h
+++ b/MatrixSDK/Data/MXCredentials.h
@@ -29,42 +29,42 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  The homeserver url (ex: "https://matrix.org").
  */
-@property (nonatomic) NSString *homeServer;
+@property (nonatomic, nullable) NSString *homeServer;
 
 /**
  The identity server url (ex: "https://vector.im").
  */
-@property (nonatomic) NSString *identityServer;
+@property (nonatomic, nullable) NSString *identityServer;
 
 /**
  The obtained user id.
  */
-@property (nonatomic) NSString *userId;
+@property (nonatomic, nullable) NSString *userId;
 
 /**
  The access token to create a MXRestClient
  */
-@property (nonatomic) NSString *accessToken;
+@property (nonatomic, nullable) NSString *accessToken;
 
 /**
  The device id.
  */
-@property (nonatomic) NSString *deviceId;
+@property (nonatomic, nullable) NSString *deviceId;
 
 /**
  The homeserver name (ex: "matrix.org").
  */
-- (NSString *)homeServerName;
+- (nullable NSString *)homeServerName;
 
 /**
  The server certificate trusted by the user (nil when the server is trusted by the device).
  */
-@property (nonatomic) NSData *allowedCertificate;
+@property (nonatomic, nullable) NSData *allowedCertificate;
 
 /**
  The ignored server certificate (set when the user ignores a certificate change).
  */
-@property (nonatomic) NSData *ignoredCertificate;
+@property (nonatomic, nullable) NSData *ignoredCertificate;
 
 
 /**
@@ -76,8 +76,8 @@ NS_ASSUME_NONNULL_BEGIN
  @return a MXCredentials instance.
  */
 - (instancetype)initWithHomeServer:(NSString*)homeServer
-                            userId:(NSString*)userId
-                       accessToken:(NSString*)accessToken;
+                            userId:(nullable NSString*)userId
+                       accessToken:(nullable NSString*)accessToken;
 
 /**
  Create credentials from a login or register response.
@@ -87,7 +87,7 @@ NS_ASSUME_NONNULL_BEGIN
  @return a MXCredentials instance.
  */
 - (instancetype)initWithLoginResponse:(MXLoginResponse*)loginResponse
-                andDefaultCredentials:(MXCredentials*)defaultCredentials;
+                andDefaultCredentials:(nullable MXCredentials*)defaultCredentials;
 
 @end
 

--- a/MatrixSDK/Data/MXCredentials.h
+++ b/MatrixSDK/Data/MXCredentials.h
@@ -21,7 +21,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- The `MXCredentials` class contains credentials to communicate with the  Matrix
+ The `MXCredentials` class contains credentials to communicate with the Matrix
  Client-Server API.
  */
 @interface MXCredentials : NSObject

--- a/MatrixSDK/Data/MXCredentials.h
+++ b/MatrixSDK/Data/MXCredentials.h
@@ -1,0 +1,89 @@
+/*
+ Copyright 2019 New Vector Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+@class MXLoginResponse;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ The `MXCredentials` class contains credentials to communicate with the  Matrix
+ Client-Server API.
+ */
+@interface MXCredentials : NSObject
+
+/**
+ The homeserver url (ex: "https://matrix.org").
+ */
+@property (nonatomic) NSString *homeServer;
+
+/**
+ The obtained user id.
+ */
+@property (nonatomic) NSString *userId;
+
+/**
+ The access token to create a MXRestClient
+ */
+@property (nonatomic) NSString *accessToken;
+
+/**
+ The device id.
+ */
+@property (nonatomic) NSString *deviceId;
+
+/**
+ The homeserver name (ex: "matrix.org").
+ */
+- (NSString *)homeServerName;
+
+/**
+ The server certificate trusted by the user (nil when the server is trusted by the device).
+ */
+@property (nonatomic) NSData *allowedCertificate;
+
+/**
+ The ignored server certificate (set when the user ignores a certificate change).
+ */
+@property (nonatomic) NSData *ignoredCertificate;
+
+
+/**
+ Simple MXCredentials construtor
+
+ @param homeServer the homeserver URL.
+ @param userId the user id.
+ @param accessToken the user access token.
+ @return a MXCredentials instance.
+ */
+- (instancetype)initWithHomeServer:(NSString*)homeServer
+                            userId:(NSString*)userId
+                       accessToken:(NSString*)accessToken;
+
+/**
+ Create credentials from a login or register response.
+
+ @param loginResponse the login or register response.
+ @param homeServer the homeserver URL to use if we cannot trust loginResponse data
+ @return a MXCredentials instance.
+ */
+- (instancetype)initWithLoginResponse:(MXLoginResponse*)loginResponse
+                withDefaultHomeServer:(NSString*)homeServer;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixSDK/Data/MXCredentials.h
+++ b/MatrixSDK/Data/MXCredentials.h
@@ -83,13 +83,11 @@ NS_ASSUME_NONNULL_BEGIN
  Create credentials from a login or register response.
 
  @param loginResponse the login or register response.
- @param homeServer the homeserver URL to use if we cannot trust loginResponse data.
- @param identityServer the identity server URL to use if not provided in loginResponse data.
+ @param defaultCredentials credentials to use if loginResponse data cannot be trusted or missing.
  @return a MXCredentials instance.
  */
 - (instancetype)initWithLoginResponse:(MXLoginResponse*)loginResponse
-                withDefaultHomeServer:(NSString*)homeServer
-            withDefaultIdentityServer:(NSString*)identityServer;
+                andDefaultCredentials:(MXCredentials*)defaultCredentials;
 
 @end
 

--- a/MatrixSDK/Data/MXCredentials.m
+++ b/MatrixSDK/Data/MXCredentials.m
@@ -42,8 +42,15 @@
         _accessToken = loginResponse.accessToken;
         _deviceId = loginResponse.deviceId;
 
-        // Workaround: HS does not return the right URL. Use the passed one
-        _homeServer = homeServer;
+        // Use wellknown data first
+        _homeServer = loginResponse.wellknown.homeServer.baseUrl;
+
+        if (!_homeServer)
+        {
+            // Workaround: HS does not return the right URL in loginResponse.homeserver.
+            // Use the passed one instead
+            _homeServer = homeServer;
+        }
     }
     return self;
 }

--- a/MatrixSDK/Data/MXCredentials.m
+++ b/MatrixSDK/Data/MXCredentials.m
@@ -34,6 +34,7 @@
 
 - (instancetype)initWithLoginResponse:(MXLoginResponse *)loginResponse
                 withDefaultHomeServer:(NSString *)homeServer
+            withDefaultIdentityServer:(NSString*)identityServer
 {
     self = [super init];
     if (self)
@@ -44,12 +45,18 @@
 
         // Use wellknown data first
         _homeServer = loginResponse.wellknown.homeServer.baseUrl;
+        _identityServer = loginResponse.wellknown.homeServer.baseUrl;
 
         if (!_homeServer)
         {
             // Workaround: HS does not return the right URL in loginResponse.homeserver.
             // Use the passed one instead
             _homeServer = homeServer;
+        }
+
+        if (!_identityServer)
+        {
+            _identityServer = identityServer;
         }
     }
     return self;

--- a/MatrixSDK/Data/MXCredentials.m
+++ b/MatrixSDK/Data/MXCredentials.m
@@ -1,0 +1,56 @@
+/*
+ Copyright 2019 New Vector Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXCredentials.h"
+
+#import "MXJSONModels.h"
+
+@implementation MXCredentials
+
+- (instancetype)initWithHomeServer:(NSString *)homeServer userId:(NSString *)userId accessToken:(NSString *)accessToken
+{
+    self = [super init];
+    if (self)
+    {
+        _homeServer = [homeServer copy];
+        _userId = [userId copy];
+        _accessToken = [accessToken copy];
+    }
+    return self;
+}
+
+- (instancetype)initWithLoginResponse:(MXLoginResponse *)loginResponse
+                withDefaultHomeServer:(NSString *)homeServer
+{
+    self = [super init];
+    if (self)
+    {
+        _userId = loginResponse.userId;
+        _accessToken = loginResponse.accessToken;
+        _deviceId = loginResponse.deviceId;
+
+        // Workaround: HS does not return the right URL. Use the passed one
+        _homeServer = homeServer;
+    }
+    return self;
+}
+
+- (NSString *)homeServerName
+{
+    return [NSURL URLWithString:_homeServer].host;
+}
+
+@end

--- a/MatrixSDK/Data/MXCredentials.m
+++ b/MatrixSDK/Data/MXCredentials.m
@@ -32,9 +32,8 @@
     return self;
 }
 
-- (instancetype)initWithLoginResponse:(MXLoginResponse *)loginResponse
-                withDefaultHomeServer:(NSString *)homeServer
-            withDefaultIdentityServer:(NSString*)identityServer
+- (instancetype)initWithLoginResponse:(MXLoginResponse*)loginResponse
+                andDefaultCredentials:(MXCredentials*)defaultCredentials
 {
     self = [super init];
     if (self)
@@ -51,12 +50,12 @@
         {
             // Workaround: HS does not return the right URL in loginResponse.homeserver.
             // Use the passed one instead
-            _homeServer = homeServer;
+            _homeServer = [defaultCredentials.homeServer copy];
         }
 
         if (!_identityServer)
         {
-            _identityServer = identityServer;
+            _identityServer = [defaultCredentials.identityServer copy];
         }
     }
     return self;

--- a/MatrixSDK/Data/Store/MXStore.h
+++ b/MatrixSDK/Data/Store/MXStore.h
@@ -17,7 +17,7 @@
  */
 
 #import "MXEnumConstants.h"
-#import "MXJSONModels.h"
+#import "MXCredentials.h"
 #import "MXEvent.h"
 #import "MXReceiptData.h"
 #import "MXUser.h"

--- a/MatrixSDK/JSONModels/AutoDiscovery/MXWellKnown.h
+++ b/MatrixSDK/JSONModels/AutoDiscovery/MXWellKnown.h
@@ -1,0 +1,44 @@
+/*
+ Copyright 2019 New Vector Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "MXJSONModel.h"
+#import "MXWellKnownBaseConfig.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * https://matrix.org/docs/spec/client_server/r0.4.0.html#server-discovery
+ *
+ * {
+ *     "m.homeserver": {
+ *         "base_url": "https://matrix.org"
+ *     },
+ *     "m.identity_server": {
+ *         "base_url": "https://vector.im"
+ *     }
+ * }
+ */
+@interface MXWellKnown : MXJSONModel
+
+@property (nonatomic) MXWellKnownBaseConfig *homeServer;
+
+@property (nonatomic, nullable) MXWellKnownBaseConfig *identityServer;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixSDK/JSONModels/AutoDiscovery/MXWellKnown.m
+++ b/MatrixSDK/JSONModels/AutoDiscovery/MXWellKnown.m
@@ -1,0 +1,38 @@
+/*
+ Copyright 2019 New Vector Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXWellKnown.h"
+
+@implementation MXWellKnown
+
++ (instancetype)modelFromJSON:(NSDictionary *)JSONDictionary
+{
+    MXWellKnown *wellknown;
+
+    MXWellKnownBaseConfig *homeServerBaseConfig;
+    MXJSONModelSetMXJSONModel(homeServerBaseConfig, MXWellKnownBaseConfig, JSONDictionary[@"m.homeserver"]);
+    if (homeServerBaseConfig)
+    {
+        wellknown = [MXWellKnown new];
+        wellknown.homeServer = homeServerBaseConfig;
+
+        MXJSONModelSetMXJSONModel(wellknown.identityServer, MXWellKnownBaseConfig, JSONDictionary[@"m.identity_server"]);
+    }
+
+    return wellknown;
+}
+
+@end

--- a/MatrixSDK/JSONModels/AutoDiscovery/MXWellKnownBaseConfig.h
+++ b/MatrixSDK/JSONModels/AutoDiscovery/MXWellKnownBaseConfig.h
@@ -1,0 +1,36 @@
+/*
+ Copyright 2019 New Vector Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific languagMXWellKnowne governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "MXJSONModel.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * https://matrix.org/docs/spec/client_server/r0.4.0.html#server-discovery
+ *
+ * {
+ *     "base_url": "https://matrix.org"
+ * }
+ */
+@interface MXWellKnownBaseConfig : MXJSONModel
+
+@property (nonatomic) NSString *baseUrl;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixSDK/JSONModels/AutoDiscovery/MXWellKnownBaseConfig.m
+++ b/MatrixSDK/JSONModels/AutoDiscovery/MXWellKnownBaseConfig.m
@@ -1,0 +1,36 @@
+/*
+ Copyright 2019 New Vector Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXWellKnownBaseConfig.h"
+
+@implementation MXWellKnownBaseConfig
+
++ (instancetype)modelFromJSON:(NSDictionary *)JSONDictionary
+{
+    MXWellKnownBaseConfig *wellKnownBaseConfig;
+
+    NSString *baseUrl;
+    MXJSONModelSetString(baseUrl, JSONDictionary[@"base_url"]);
+    if (baseUrl)
+    {
+        wellKnownBaseConfig = [MXWellKnownBaseConfig new];
+        wellKnownBaseConfig.baseUrl = baseUrl;
+    }
+
+    return wellKnownBaseConfig;
+}
+
+@end

--- a/MatrixSDK/JSONModels/AutoDiscovery/MXWellKnownBaseConfig.m
+++ b/MatrixSDK/JSONModels/AutoDiscovery/MXWellKnownBaseConfig.m
@@ -26,6 +26,12 @@
     MXJSONModelSetString(baseUrl, JSONDictionary[@"base_url"]);
     if (baseUrl)
     {
+        // Trim the last slash to make the url usable
+        if ([baseUrl hasSuffix:@"/"])
+        {
+            baseUrl = [baseUrl substringToIndex:baseUrl.length - 1];
+        }
+
         wellKnownBaseConfig = [MXWellKnownBaseConfig new];
         wellKnownBaseConfig.baseUrl = baseUrl;
     }

--- a/MatrixSDK/JSONModels/MXJSONModels.h
+++ b/MatrixSDK/JSONModels/MXJSONModels.h
@@ -23,6 +23,7 @@
 #import "MXKeyBackupData.h"
 #import "MXMegolmBackupAuthData.h"
 #import "MXLoginTerms.h"
+#import "MXWellKnown.h"
 
 @class MXEvent, MXDeviceInfo, MXKey, MXUser;
 
@@ -289,6 +290,11 @@ FOUNDATION_EXPORT NSString *const kMXLoginIdentifierTypePhone;
      The device id.
      */
     @property (nonatomic) NSString *deviceId;
+
+    /**
+     Wellknown data.
+     */
+    @property (nonatomic) MXWellKnown *wellknown;
 
 @end
 

--- a/MatrixSDK/JSONModels/MXJSONModels.h
+++ b/MatrixSDK/JSONModels/MXJSONModels.h
@@ -266,19 +266,14 @@ FOUNDATION_EXPORT NSString *const kMXLoginIdentifierTypePhone;
 @end
 
 /**
- `MXCredentials` represents the response to a login or a register request.
+ `MXLoginResponse` represents the response to a login or a register request.
  */
-@interface MXCredentials : MXJSONModel
+@interface MXLoginResponse : MXJSONModel
 
     /**
      The home server url (ex: "https://matrix.org").
      */
-    @property (nonatomic) NSString *homeServer;
-
-    /**
-     The home server name (ex: "matrix.org").
-     */
-    @property (nonatomic, readonly) NSString *homeServerName;
+    @property (nonatomic) NSString *homeserver;
 
     /**
      The obtained user id.
@@ -294,23 +289,6 @@ FOUNDATION_EXPORT NSString *const kMXLoginIdentifierTypePhone;
      The device id.
      */
     @property (nonatomic) NSString *deviceId;
-
-    /**
-     The server certificate trusted by the user (nil when the server is trusted by the device).
-     */
-    @property (nonatomic) NSData *allowedCertificate;
-
-    /**
-     The ignored server certificate (set when the user ignores a certificate change).
-     */
-    @property (nonatomic) NSData *ignoredCertificate;
-
-    /**
-     Simple MXCredentials construtor
-     */
-    - (instancetype)initWithHomeServer:(NSString*)homeServer
-                                userId:(NSString*)userId
-                           accessToken:(NSString*)accessToken;
 
 @end
 

--- a/MatrixSDK/JSONModels/MXJSONModels.m
+++ b/MatrixSDK/JSONModels/MXJSONModels.m
@@ -201,37 +201,20 @@ NSString *const kMXLoginIdentifierTypePhone = @"m.id.phone";
 
 @end
 
-@implementation MXCredentials
+@implementation MXLoginResponse
 
 + (id)modelFromJSON:(NSDictionary *)JSONDictionary
 {
-    MXCredentials *credentials = [[MXCredentials alloc] init];
-    if (credentials)
+    MXLoginResponse *loginResponse = [[MXLoginResponse alloc] init];
+    if (loginResponse)
     {
-        MXJSONModelSetString(credentials.homeServer, JSONDictionary[@"home_server"]);
-        MXJSONModelSetString(credentials.userId, JSONDictionary[@"user_id"]);
-        MXJSONModelSetString(credentials.accessToken, JSONDictionary[@"access_token"]);
-        MXJSONModelSetString(credentials.deviceId, JSONDictionary[@"device_id"]);
+        MXJSONModelSetString(loginResponse.homeserver, JSONDictionary[@"home_server"]);
+        MXJSONModelSetString(loginResponse.userId, JSONDictionary[@"user_id"]);
+        MXJSONModelSetString(loginResponse.accessToken, JSONDictionary[@"access_token"]);
+        MXJSONModelSetString(loginResponse.deviceId, JSONDictionary[@"device_id"]);
     }
 
-    return credentials;
-}
-
-- (instancetype)initWithHomeServer:(NSString *)homeServer userId:(NSString *)userId accessToken:(NSString *)accessToken
-{
-    self = [super init];
-    if (self)
-    {
-        _homeServer = [homeServer copy];
-        _userId = [userId copy];
-        _accessToken = [accessToken copy];
-    }
-    return self;
-}
-
-- (NSString *)homeServerName
-{
-    return [NSURL URLWithString:_homeServer].host;
+    return loginResponse;
 }
 
 @end

--- a/MatrixSDK/JSONModels/MXJSONModels.m
+++ b/MatrixSDK/JSONModels/MXJSONModels.m
@@ -212,6 +212,7 @@ NSString *const kMXLoginIdentifierTypePhone = @"m.id.phone";
         MXJSONModelSetString(loginResponse.userId, JSONDictionary[@"user_id"]);
         MXJSONModelSetString(loginResponse.accessToken, JSONDictionary[@"access_token"]);
         MXJSONModelSetString(loginResponse.deviceId, JSONDictionary[@"device_id"]);
+        MXJSONModelSetMXJSONModel(loginResponse.wellknown, MXWellKnown, JSONDictionary[@"well_known"]);
     }
 
     return loginResponse;

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -90,14 +90,15 @@ FOUNDATION_EXPORT NSString *const kMXMembersOfRoomParametersNotMembership;
 @interface MXRestClient : NSObject
 
 /**
- The homeserver URL.
- */
-@property (nonatomic, readonly) NSString *homeserver;
-
-/**
- The user credentials on this home server.
+ Credentials for the Matrix Client-Server API.
  */
 @property (nonatomic, readonly) MXCredentials *credentials;
+
+/**
+ The homeserver URL.
+ Shortcut to credentials.homeServer.
+ */
+@property (nonatomic, readonly) NSString *homeserver;
 
 /**
  The homeserver suffix (for example ":matrix.org"). Available only when credentials have been set.
@@ -105,21 +106,8 @@ FOUNDATION_EXPORT NSString *const kMXMembersOfRoomParametersNotMembership;
 @property (nonatomic, readonly) NSString *homeserverSuffix;
 
 /**
- The Client-Server API prefix to use.
- By default, it is '_matrix/client/r0'. See kMXAPIPrefixPathR0 and kMXAPIPrefixPathUnstable for constants.
- */
-@property (nonatomic) NSString *apiPathPrefix;
-
-/**
- The Matrix content repository prefix to use.
- By default, it is defined by the constant kMXContentPrefixPath.
- */
-@property (nonatomic) NSString *contentPathPrefix;
-
-/**
  The identity server URL.
- By default, it points to the defined home server. If needed, change it by setting
- this property.
+ Shortcut to credentials.identityServer.
  */
 @property (nonatomic) NSString *identityServer;
 
@@ -135,6 +123,18 @@ FOUNDATION_EXPORT NSString *const kMXMembersOfRoomParametersNotMembership;
  In case of a custom path prefix use, set it before settings the antivirus server url.
  */
 @property (nonatomic) NSString *antivirusServerPathPrefix;
+
+/**
+ The Client-Server API prefix to use.
+ By default, it is '_matrix/client/r0'. See kMXAPIPrefixPathR0 and kMXAPIPrefixPathUnstable for constants.
+ */
+@property (nonatomic) NSString *apiPathPrefix;
+
+/**
+ The Matrix content repository prefix to use.
+ By default, it is defined by the constant kMXContentPrefixPath.
+ */
+@property (nonatomic) NSString *contentPathPrefix;
 
 /**
  The current trusted certificate (if any).

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -423,7 +423,13 @@ MXAuthAction;
 
 - (NSString*)registerFallback;
 {
-    return [[NSURL URLWithString:@"_matrix/static/client/register/" relativeToURL:[NSURL URLWithString:self.credentials.homeServer]] absoluteString];
+    NSString *registerFallback;
+
+    if (self.credentials.homeServer)
+    {
+        registerFallback = [[NSURL URLWithString:@"_matrix/static/client/register/" relativeToURL:[NSURL URLWithString:self.credentials.homeServer]] absoluteString];
+    }
+    return registerFallback;
 }
 
 - (MXHTTPOperation *)forgetPasswordForEmail:(NSString *)email
@@ -553,7 +559,13 @@ MXAuthAction;
 
 - (NSString*)loginFallback;
 {
-    return [[NSURL URLWithString:@"/_matrix/static/client/login/" relativeToURL:[NSURL URLWithString:self.credentials.homeServer]] absoluteString];
+    NSString *loginFallback;
+
+    if (self.credentials.homeServer)
+    {
+        loginFallback = [[NSURL URLWithString:@"/_matrix/static/client/login/" relativeToURL:[NSURL URLWithString:self.credentials.homeServer]] absoluteString];
+    }
+    return loginFallback;
 }
 
 
@@ -2758,6 +2770,11 @@ MXAuthAction;
                     success:(void (^)(void))success
                     failure:(void (^)(NSError *error))failure
 {
+    if (!self.credentials.identityServer)
+    {
+        NSLog(@"[MXRestClient] add3PID: Error: Missing identityServer");
+    }
+
     NSURL *identityServerURL = [NSURL URLWithString:self.credentials.identityServer];
     NSDictionary *parameters = @{
                                  @"three_pid_creds": @{

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -210,9 +210,16 @@ MXAuthAction;
                                  return NO;
                              }
                          }];
-        
-        // By default, use the same address for the identity server
-        self.identityServer = homeserver;
+
+        if (inCredentials.identityServer)
+        {
+            self.identityServer = inCredentials.identityServer;
+        }
+        else
+        {
+            // By default, use the same address for the identity server
+            self.identityServer = homeserver;
+        }
 
         completionQueue = dispatch_get_main_queue();
 
@@ -418,7 +425,8 @@ MXAuthAction;
 
                 // Update our credentials
                 self.credentials = [[MXCredentials alloc] initWithLoginResponse:loginResponse
-            withDefaultHomeServer:self->homeserver];
+                                                          withDefaultHomeServer:self.homeserver
+                                                      withDefaultIdentityServer:self.identityServer];
 
                 // Report the certificate trusted by user (if any)
                 self->credentials.allowedCertificate = self->httpClient.allowedCertificate;
@@ -559,7 +567,8 @@ MXAuthAction;
 
                        // Update our credentials
                        self.credentials = [[MXCredentials alloc] initWithLoginResponse:loginResponse
-                                                                 withDefaultHomeServer:self->homeserver];
+                                                                 withDefaultHomeServer:self.homeserver
+                                                             withDefaultIdentityServer:self.identityServer];
 
                        // Report the certificate trusted by user (if any)
                        self->credentials.allowedCertificate = self->httpClient.allowedCertificate;

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -127,58 +127,63 @@ MXAuthAction;
         contentPathPrefix = kMXContentPrefixPath;
         
         self.credentials = inCredentials;
-        
-        httpClient = [[MXHTTPClient alloc] initWithBaseURL:homeserver
-                                               accessToken:credentials.accessToken
-                         andOnUnrecognizedCertificateBlock:^BOOL(NSData *certificate) {
 
-                             // Check whether the provided certificate has been already trusted
-                             if ([[MXAllowedCertificates sharedInstance] isCertificateAllowed:certificate])
-                             {
-                                 return YES;
-                             }
-
-                             // Check whether the provided certificate is the already trusted by the user.
-                             if (inCredentials.allowedCertificate && [inCredentials.allowedCertificate isEqualToData:certificate])
-                             {
-                                 // Store the allowed certificate for further requests (from MXMediaManager)
-                                 [[MXAllowedCertificates sharedInstance] addCertificate:certificate];
-                                 return YES;
-                             }
-
-                             // Check whether the user has already ignored this certificate change.
-                             if (inCredentials.ignoredCertificate && [inCredentials.ignoredCertificate isEqualToData:certificate])
-                             {
-                                 return NO;
-                             }
-
-                             // Let the app ask the end user to verify it
-                             if (onUnrecognizedCertBlock)
-                             {
-                                 BOOL allowed = onUnrecognizedCertBlock(certificate);
-
-                                 if (allowed)
-                                 {
-                                     // Store the allowed certificate for further requests
-                                     [[MXAllowedCertificates sharedInstance] addCertificate:certificate];
-                                 }
-
-                                 return allowed;
-                             }
-                             else
-                             {
-                                 return NO;
-                             }
-                         }];
-
-        if (inCredentials.identityServer)
+        if (credentials.homeServer)
         {
-            self.identityServer = inCredentials.identityServer;
+            httpClient = [[MXHTTPClient alloc] initWithBaseURL:credentials.homeServer
+                                                   accessToken:credentials.accessToken
+                             andOnUnrecognizedCertificateBlock:^BOOL(NSData *certificate)
+                          {
+
+                              // Check whether the provided certificate has been already trusted
+                              if ([[MXAllowedCertificates sharedInstance] isCertificateAllowed:certificate])
+                              {
+                                  return YES;
+                              }
+
+                              // Check whether the provided certificate is the already trusted by the user.
+                              if (inCredentials.allowedCertificate && [inCredentials.allowedCertificate isEqualToData:certificate])
+                              {
+                                  // Store the allowed certificate for further requests (from MXMediaManager)
+                                  [[MXAllowedCertificates sharedInstance] addCertificate:certificate];
+                                  return YES;
+                              }
+
+                              // Check whether the user has already ignored this certificate change.
+                              if (inCredentials.ignoredCertificate && [inCredentials.ignoredCertificate isEqualToData:certificate])
+                              {
+                                  return NO;
+                              }
+
+                              // Let the app ask the end user to verify it
+                              if (onUnrecognizedCertBlock)
+                              {
+                                  BOOL allowed = onUnrecognizedCertBlock(certificate);
+
+                                  if (allowed)
+                                  {
+                                      // Store the allowed certificate for further requests
+                                      [[MXAllowedCertificates sharedInstance] addCertificate:certificate];
+                                  }
+
+                                  return allowed;
+                              }
+                              else
+                              {
+                                  return NO;
+                              }
+                          }];
         }
-        else
+
+
+        if (self.credentials.identityServer)
+        {
+            self.identityServer = self.credentials.identityServer;
+        }
+        else if (self.credentials.homeServer)
         {
             // By default, use the same address for the identity server
-            self.identityServer = homeserver;
+            self.identityServer = self.credentials.homeServer;
         }
 
         completionQueue = dispatch_get_main_queue();

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -125,7 +125,7 @@ MXAuthAction;
         antivirusServerPathPrefix = kMXAntivirusAPIPrefixPathUnstable;
         contentPathPrefix = kMXContentPrefixPath;
         
-        self.credentials = inCredentials;
+        credentials = inCredentials;
 
         if (credentials.homeServer)
         {
@@ -227,11 +227,6 @@ MXAuthAction;
     }
 
     return homeserverSuffix;
-}
-
-- (void)setCredentials:(MXCredentials *)inCredentials
-{
-    credentials = inCredentials;
 }
 
 - (NSData*)allowedCertificate
@@ -398,8 +393,8 @@ MXAuthAction;
                 MXJSONModelSetMXJSONModel(loginResponse, MXLoginResponse, JSONResponse);
 
                 // Update our credentials
-                self.credentials = [[MXCredentials alloc] initWithLoginResponse:loginResponse
-                                                          andDefaultCredentials:self.credentials];
+                self->credentials = [[MXCredentials alloc] initWithLoginResponse:loginResponse
+                                                           andDefaultCredentials:self.credentials];
 
                 // Report the certificate trusted by user (if any)
                 self->credentials.allowedCertificate = self->httpClient.allowedCertificate;
@@ -539,8 +534,8 @@ MXAuthAction;
                        MXJSONModelSetMXJSONModel(loginResponse, MXLoginResponse, JSONResponse);
 
                        // Update our credentials
-                       self.credentials = [[MXCredentials alloc] initWithLoginResponse:loginResponse
-                                                                 andDefaultCredentials:self.credentials];
+                       self->credentials = [[MXCredentials alloc] initWithLoginResponse:loginResponse
+                                                                  andDefaultCredentials:self.credentials];
 
                        // Report the certificate trusted by user (if any)
                        self->credentials.allowedCertificate = self->httpClient.allowedCertificate;

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -108,52 +108,12 @@ MXAuthAction;
 @implementation MXRestClient
 @synthesize homeserver, homeserverSuffix, credentials, apiPathPrefix, contentPathPrefix, completionQueue, antivirusServerPathPrefix;
 
--(id)initWithHomeServer:(NSString *)inHomeserver andOnUnrecognizedCertificateBlock:(MXHTTPClientOnUnrecognizedCertificate)onUnrecognizedCertBlock
+-(id)initWithHomeServer:(NSString *)homeserver andOnUnrecognizedCertificateBlock:(MXHTTPClientOnUnrecognizedCertificate)onUnrecognizedCertBlock
 {
-    self = [super init];
-    if (self)
-    {
-        homeserver = inHomeserver;
-        apiPathPrefix = kMXAPIPrefixPathR0;
-        antivirusServerPathPrefix = kMXAntivirusAPIPrefixPathUnstable;
-        contentPathPrefix = kMXContentPrefixPath;
-        
-        httpClient = [[MXHTTPClient alloc] initWithBaseURL:homeserver
-                                               accessToken:nil
-                         andOnUnrecognizedCertificateBlock:^BOOL(NSData *certificate) {
+    MXCredentials *credentials = [MXCredentials new];
+    credentials.homeServer = homeserver;
 
-                             if ([[MXAllowedCertificates sharedInstance] isCertificateAllowed:certificate])
-                             {
-                                 return YES;
-                             }
-
-                             // Let the app ask the end user to verify it
-                             if (onUnrecognizedCertBlock)
-                             {
-                                 BOOL allowed = onUnrecognizedCertBlock(certificate);
-
-                                 if (allowed)
-                                 {
-                                     // Store the allowed certificate for further requests
-                                     [[MXAllowedCertificates sharedInstance] addCertificate:certificate];
-                                 }
-
-                                 return allowed;
-                             }
-                             else
-                             {
-                                 return NO;
-                             }
-                         }];
-        
-        // By default, use the same address for the identity server
-        self.identityServer = homeserver;
-
-        completionQueue = dispatch_get_main_queue();
-
-        processingQueue = dispatch_queue_create("MXRestClient", DISPATCH_QUEUE_SERIAL);
-    }
-    return self;
+    return [self initWithCredentials:credentials andOnUnrecognizedCertificateBlock:onUnrecognizedCertBlock];
 }
 
 -(id)initWithCredentials:(MXCredentials*)inCredentials andOnUnrecognizedCertificateBlock:(MXHTTPClientOnUnrecognizedCertificate)onUnrecognizedCertBlock
@@ -425,8 +385,7 @@ MXAuthAction;
 
                 // Update our credentials
                 self.credentials = [[MXCredentials alloc] initWithLoginResponse:loginResponse
-                                                          withDefaultHomeServer:self.homeserver
-                                                      withDefaultIdentityServer:self.identityServer];
+                                                          andDefaultCredentials:self.credentials];
 
                 // Report the certificate trusted by user (if any)
                 self->credentials.allowedCertificate = self->httpClient.allowedCertificate;
@@ -567,8 +526,7 @@ MXAuthAction;
 
                        // Update our credentials
                        self.credentials = [[MXCredentials alloc] initWithLoginResponse:loginResponse
-                                                                 withDefaultHomeServer:self.homeserver
-                                                             withDefaultIdentityServer:self.identityServer];
+                                                                 andDefaultCredentials:self.credentials];
 
                        // Report the certificate trusted by user (if any)
                        self->credentials.allowedCertificate = self->httpClient.allowedCertificate;

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -413,11 +413,12 @@ MXAuthAction;
 
             [self dispatchProcessing:nil andCompletion:^{
 
-                // Update our credentials
-                self.credentials = [MXCredentials modelFromJSON:JSONResponse];
+                MXLoginResponse *loginResponse;
+                MXJSONModelSetMXJSONModel(loginResponse, MXLoginResponse, JSONResponse);
 
-                // Workaround: HS does not return the right URL. Use the one we used to make the request
-                self->credentials.homeServer = self->homeserver;
+                // Update our credentials
+                self.credentials = [[MXCredentials alloc] initWithLoginResponse:loginResponse
+            withDefaultHomeServer:self->homeserver];
 
                 // Report the certificate trusted by user (if any)
                 self->credentials.allowedCertificate = self->httpClient.allowedCertificate;
@@ -553,11 +554,12 @@ MXAuthAction;
                    [self dispatchProcessing:nil andCompletion:^{
                        MXStrongifyAndReturnIfNil(self);
 
-                       // Update our credentials
-                       self.credentials = [MXCredentials modelFromJSON:JSONResponse];
+                       MXLoginResponse *loginResponse;
+                       MXJSONModelSetMXJSONModel(loginResponse, MXLoginResponse, JSONResponse);
 
-                       // Workaround: HS does not return the right URL. Use the one we used to make the request
-                       self->credentials.homeServer = self->homeserver;
+                       // Update our credentials
+                       self.credentials = [[MXCredentials alloc] initWithLoginResponse:loginResponse
+                                                                 withDefaultHomeServer:self->homeserver];
 
                        // Report the certificate trusted by user (if any)
                        self->credentials.allowedCertificate = self->httpClient.allowedCertificate;


### PR DESCRIPTION
MXCredentials is a new separate data model that allows to manage well-known data in one place.

The PR has these 2 main changes
* MXCredentials: Create a new data model for it, separated from the CS API response data model (new MXLoginResponse class).
 * Login: Handle well-known data in the login response - MSC1730 (vector-im/riot-ios/issues/2298).

Other changes is about factorisation to use a central MXCredentials object.