### PR TITLE
Push notifications: Add description methods to MXPushRule & MXPushRuleAction

### DIFF
--- a/MatrixSDK/JSONModels/MXJSONModels.m
+++ b/MatrixSDK/JSONModels/MXJSONModels.m
@@ -628,6 +628,11 @@ NSString *const kMXPushRuleConditionStringSenderNotificationPermission  = @"send
     return pushRule;
 }
 
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<MXPushRule: %p> ruleId: %@ - isDefault: %@ - enabled: %@ - actions: %@", self, _ruleId, @(_isDefault), @(_enabled), _actions];
+}
+
 @end
 
 @implementation MXPushRuleAction
@@ -640,6 +645,11 @@ NSString *const kMXPushRuleConditionStringSenderNotificationPermission  = @"send
         _actionType = MXPushRuleActionTypeCustom;
     }
     return self;
+}
+
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<MXPushRuleAction: %p> action: %@ - parameters: %@", self, _action, _parameters];
 }
 
 @end


### PR DESCRIPTION
to track https://github.com/vector-im/riot-ios/issues/2264 and have better logs than:

```
2019-03-04 10:17:05.344 Riot[12486:3586757] [AppDelegate][Push] handleLocalNotificationsForAccount: eventsToNotify: (
        {
        "event_id" = "$xxxxxx:matrix.org";
        "push_rule" = "<MXPushRule: 0x283439240>";
        "room_id" = "!Iyuoiosad:matrix.org";
    }
)
```

This PR gives:
```
(lldb) po rule
<MXPushRule: 0x6000036b0100> ruleId: .m.rule.contains_display_name - isDefault: 1 - enabled: 1 - actions: (
    "<MXPushRuleAction: 0x600002e6d720> action: notify - parameters: (null)",
    "<MXPushRuleAction: 0x600002e6d7c0> action: set_tweak - parameters: {\n    \"set_tweak\" = sound;\n    value = default;\n}",
    "<MXPushRuleAction: 0x600002e6d900> action: set_tweak - parameters: {\n    \"set_tweak\" = highlight;\n}"
)
```