### PR TITLE
[MXRestClient] URI encode filename when uploading a file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+Changes in Matrix iOS SDK in 0.12.4 (2019-xx-xx)
+===============================================
+
+Bug Fix:
+* MXRestClient: Fix file upload with filename containing whitespace (PR #645).
+
 Changes in Matrix iOS SDK in 0.12.3 (2019-03-08)
 ===============================================
 

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -3279,7 +3279,7 @@ MXAuthAction;
 
     if (filename.length)
     {
-        path = [path stringByAppendingString:[NSString stringWithFormat:@"?filename=%@", filename]];
+        path = [path stringByAppendingString:[NSString stringWithFormat:@"?filename=%@", [MXTools encodeURIComponent:filename]]];
     }
 
     MXWeakify(self);


### PR DESCRIPTION
Fix file upload with filename containing whitespace