### PR TITLE
 Crypto: Handle partially-shared sessions bette

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,14 @@
+Changes in Matrix iOS SDK in 0.12.5 (2019-03-)
+===============================================
+
+Improvements:
+ * Crypto: Handle partially-shared sessions better (vector-im/riot-ios/issues/2320).
+
 Changes in Matrix iOS SDK in 0.12.4 (2019-03-21)
 ===============================================
 
 Bug Fix:
-* MXRestClient: Fix file upload with filename containing whitespace (PR #645).
+ * MXRestClient: Fix file upload with filename containing whitespace (PR #645).
 
 Changes in Matrix iOS SDK in 0.12.3 (2019-03-08)
 ===============================================

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		322A51C71D9BBD3C00C8536D /* MXOlmDevice.h in Headers */ = {isa = PBXBuildFile; fileRef = 322A51C51D9BBD3C00C8536D /* MXOlmDevice.h */; };
 		322A51C81D9BBD3C00C8536D /* MXOlmDevice.m in Sources */ = {isa = PBXBuildFile; fileRef = 322A51C61D9BBD3C00C8536D /* MXOlmDevice.m */; };
 		322A51D81D9E846800C8536D /* MXCryptoTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 322A51D71D9E846800C8536D /* MXCryptoTests.m */; };
+		322D01C422492B0700150C68 /* MXCryptoShareTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 322D01C322492B0700150C68 /* MXCryptoShareTests.m */; };
 		32322A481E57264E005DD155 /* MXSelfSignedHomeserverTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 32322A471E57264E005DD155 /* MXSelfSignedHomeserverTests.m */; };
 		32322A4B1E575F65005DD155 /* MXAllowedCertificates.h in Headers */ = {isa = PBXBuildFile; fileRef = 32322A491E575F65005DD155 /* MXAllowedCertificates.h */; };
 		32322A4C1E575F65005DD155 /* MXAllowedCertificates.m in Sources */ = {isa = PBXBuildFile; fileRef = 32322A4A1E575F65005DD155 /* MXAllowedCertificates.m */; };
@@ -441,6 +442,7 @@
 		322A51C51D9BBD3C00C8536D /* MXOlmDevice.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXOlmDevice.h; sourceTree = "<group>"; };
 		322A51C61D9BBD3C00C8536D /* MXOlmDevice.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXOlmDevice.m; sourceTree = "<group>"; };
 		322A51D71D9E846800C8536D /* MXCryptoTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXCryptoTests.m; sourceTree = "<group>"; };
+		322D01C322492B0700150C68 /* MXCryptoShareTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXCryptoShareTests.m; sourceTree = "<group>"; };
 		322DB456212EB8E600F4EFE9 /* MXHTTPClient_Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXHTTPClient_Private.h; sourceTree = "<group>"; };
 		32322A471E57264E005DD155 /* MXSelfSignedHomeserverTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXSelfSignedHomeserverTests.m; sourceTree = "<group>"; };
 		32322A491E575F65005DD155 /* MXAllowedCertificates.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXAllowedCertificates.h; sourceTree = "<group>"; };
@@ -1304,6 +1306,7 @@
 		32C6F93919DD814400EA4E9C /* MatrixSDKTests */ = {
 			isa = PBXGroup;
 			children = (
+				322D01C322492B0700150C68 /* MXCryptoShareTests.m */,
 				32720DA1222EB5650086FFF5 /* MXAutoDiscoveryTests.m */,
 				32935F60216FA49D00A1BC24 /* MXCryptoBackupTests.m */,
 				32C03CB52123076F00D92712 /* DirectRoomTests.m */,
@@ -2087,6 +2090,7 @@
 				329FB17C1A0A963700A5E88E /* MXRoomMemberTests.m in Sources */,
 				3246BDC51A1A0789000A7D62 /* MXRoomStateDynamicTests.m in Sources */,
 				3264DB941CECA72900B99881 /* MXAccountDataTests.m in Sources */,
+				322D01C422492B0700150C68 /* MXCryptoShareTests.m in Sources */,
 				323EF7471C7CB4C7000DC98C /* MXEventTimelineTests.m in Sources */,
 				32E226A91D081CE200E6CA54 /* MXPeekingRoomTests.m in Sources */,
 			);

--- a/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmDecryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmDecryption.m
@@ -229,29 +229,41 @@
 
     [crypto.backup maybeSendKeyBackup];
 
-    // cancel any outstanding room key requests for this session
-    [crypto cancelRoomKeyRequest:@{
-                                   @"algorithm": content[@"algorithm"],
-                                   @"room_id": content[@"room_id"],
-                                   @"session_id": content[@"session_id"],
-                                   @"sender_key": senderKey
-                                   }];
+    MXWeakify(self);
+    [self retryDecryption:senderKey sessionId:content[@"session_id"] complete:^(BOOL allDecrypted) {
+        MXStrongifyAndReturnIfNil(self);
 
-    [self retryDecryption:senderKey sessionId:content[@"session_id"]];
+        if (allDecrypted)
+        {
+            // cancel any outstanding room key requests for this session
+            [self->crypto cancelRoomKeyRequest:@{
+                                                 @"algorithm": content[@"algorithm"],
+                                                 @"room_id": content[@"room_id"],
+                                                 @"session_id": content[@"session_id"],
+                                                 @"sender_key": senderKey
+                                                 }];
+        }
+    }];
 }
 
 - (void)didImportRoomKey:(MXOlmInboundGroupSession *)session
 {
-    // cancel any outstanding room key requests for this session
-    [crypto cancelRoomKeyRequest:@{
-                                   @"algorithm": kMXCryptoMegolmAlgorithm,
-                                   @"room_id": session.roomId,
-                                   @"session_id": session.session.sessionIdentifier,
-                                   @"sender_key": session.senderKey
-                                   }];
-
     // Have another go at decrypting events sent with this session
-    [self retryDecryption:session.senderKey sessionId:session.session.sessionIdentifier];
+    MXWeakify(self);
+    [self retryDecryption:session.senderKey sessionId:session.session.sessionIdentifier complete:^(BOOL allDecrypted) {
+        MXStrongifyAndReturnIfNil(self);
+
+        if (allDecrypted)
+        {
+            // cancel any outstanding room key requests for this session
+            [self->crypto cancelRoomKeyRequest:@{
+                                                 @"algorithm": kMXCryptoMegolmAlgorithm,
+                                                 @"room_id": session.roomId,
+                                                 @"session_id": session.session.sessionIdentifier,
+                                                 @"sender_key": session.senderKey
+                                                 }];
+        }
+    }];
 }
 
 - (BOOL)hasKeysForKeyRequest:(MXIncomingRoomKeyRequest*)keyRequest
@@ -334,9 +346,13 @@
 
  @param senderKey the sender key.
  @param sessionId the session id.
+ @param complete allDecrypted.
  */
-- (void)retryDecryption:(NSString*)senderKey sessionId:(NSString*)sessionId
+- (void)retryDecryption:(NSString*)senderKey sessionId:(NSString*)sessionId complete:(void (^)(BOOL allDecrypted))complete;
 {
+    __block BOOL allDecrypted = YES;
+    dispatch_group_t group = dispatch_group_create();
+
     NSString *k = [NSString stringWithFormat:@"%@|%@", senderKey, sessionId];
     NSDictionary<NSString*, NSDictionary<NSString*,MXEvent*>*> *pending = pendingEvents[k];
     if (pending)
@@ -355,6 +371,8 @@
                 }
                 else
                 {
+                    dispatch_group_enter(group);
+
                     // Go back to the main thread to retry to decrypt from the beginning of the chain.
                     // MXSession will then update MXEvent with clear content if successful
                     MXWeakify(self);
@@ -368,12 +386,19 @@
                         else
                         {
                             NSLog(@"[MXMegolmDecryption] retryDecryption: Still can't decrypt %@. Error: %@", event.eventId, event.decryptionError);
+                            allDecrypted = NO;
                         }
+
+                        dispatch_group_leave(group);
                     });
                 }
             }
         }
     }
+
+    dispatch_group_notify(group, crypto.decryptionQueue, ^{
+        complete(allDecrypted);
+    });
 }
 
 - (void)requestKeysForEvent:(MXEvent*)event

--- a/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmDecryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmDecryption.m
@@ -379,14 +379,22 @@
                     dispatch_async(dispatch_get_main_queue(), ^{
                         MXStrongifyAndReturnIfNil(self);
 
-                        if ([self->crypto.mxSession decryptEvent:event inTimeline:(timelineId.length ? timelineId : nil)])
+                        if (event.clearEvent)
                         {
-                            NSLog(@"[MXMegolmDecryption] retryDecryption: successful re-decryption of %@", event.eventId);
+                            // This can happen when the event is in several timelines
+                            NSLog(@"[MXMegolmDecryption] retryDecryption: %@ already decrypted on main thread", event.eventId);
                         }
                         else
                         {
-                            NSLog(@"[MXMegolmDecryption] retryDecryption: Still can't decrypt %@. Error: %@", event.eventId, event.decryptionError);
-                            allDecrypted = NO;
+                            if ([self->crypto.mxSession decryptEvent:event inTimeline:(timelineId.length ? timelineId : nil)])
+                            {
+                                NSLog(@"[MXMegolmDecryption] retryDecryption: successful re-decryption of %@", event.eventId);
+                            }
+                            else
+                            {
+                                NSLog(@"[MXMegolmDecryption] retryDecryption: Still can't decrypt %@. Error: %@", event.eventId, event.decryptionError);
+                                allDecrypted = NO;
+                            }
                         }
 
                         dispatch_group_leave(group);

--- a/MatrixSDK/Crypto/KeyBackup/MXKeyBackupPassword.h
+++ b/MatrixSDK/Crypto/KeyBackup/MXKeyBackupPassword.h
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param error the output error.
  @return a private key.
  */
-+ (nullable NSData *)generatePrivateKeyWithPassword:(NSString*)password salt:(NSString**)salt iterations:(NSUInteger*)iterations error:(NSError * _Nullable *)error;
++ (nullable NSData *)generatePrivateKeyWithPassword:(NSString*)password salt:(NSString * _Nullable *_Nonnull)salt iterations:(NSUInteger*)iterations error:(NSError * _Nullable *)error;
 
 /**
  Retrieve a private key from {password, salt, iterations}

--- a/MatrixSDKTests/MXCryptoShareTests.m
+++ b/MatrixSDKTests/MXCryptoShareTests.m
@@ -1,0 +1,281 @@
+/*
+ Copyright 2019 New Vector Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "MatrixSDKTestsData.h"
+#import "MatrixSDKTestsE2EData.h"
+
+#import "MXCrypto_Private.h"
+#import "MXCryptoStore.h"
+
+// Do not bother with retain cycles warnings in tests
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-retain-cycles"
+
+@interface MXCryptoShareTests : XCTestCase
+{
+    MatrixSDKTestsData *matrixSDKTestsData;
+    MatrixSDKTestsE2EData *matrixSDKTestsE2EData;
+}
+@end
+
+@implementation MXCryptoShareTests
+
+- (void)setUp
+{
+    [super setUp];
+
+    matrixSDKTestsData = [[MatrixSDKTestsData alloc] init];
+    matrixSDKTestsE2EData = [[MatrixSDKTestsE2EData alloc] initWithMatrixSDKTestsData:matrixSDKTestsData];
+}
+
+- (void)tearDown
+{
+    matrixSDKTestsData = nil;
+    matrixSDKTestsE2EData = nil;
+
+    [super tearDown];
+}
+
+// Import megolm session data as if they come from a response to a key share request
+- (void)mimicKeyShareResponseForSession:(MXSession*)session withSessionData:(MXMegolmSessionData*)sessionData complete:(void (^)(void))complete
+{
+    [session.crypto importMegolmSessionDatas:@[sessionData] backUp:NO success:^(NSUInteger total, NSUInteger imported) {
+        complete();
+    } failure:^(NSError *error) {
+        NSAssert(NO, @"Cannot set up intial test conditions - error: %@", error);
+    }];
+}
+
+- (void)outgoingRoomKeyRequestInSession:(MXSession*)session complete:(void (^)(MXOutgoingRoomKeyRequest*))complete
+{
+    dispatch_async(session.crypto.decryptionQueue, ^{
+        MXOutgoingRoomKeyRequest *outgoingRoomKeyRequest = [session.crypto.store outgoingRoomKeyRequestWithState:MXRoomKeyRequestStateUnsent];
+        if (!outgoingRoomKeyRequest)
+        {
+            outgoingRoomKeyRequest = [session.crypto.store outgoingRoomKeyRequestWithState:MXRoomKeyRequestStateSent];
+        }
+
+        dispatch_async(dispatch_get_main_queue(), ^{
+            complete(outgoingRoomKeyRequest);
+        });
+    });
+}
+
+
+/**
+ Common initial conditions:
+ - Alice and Bob are in a room
+ - Bob sends messages
+ - Alice gets them decrypted
+ - Export partial and full megolm session data
+ - Log Alice on a new device
+ */
+- (void)createScenario:(void (^)(MXSession *aliceSession, NSString *roomId, MXMegolmSessionData *sessionData, MXMegolmSessionData *partialSessionData, XCTestExpectation *expectation))readyToTest
+{
+    // - Alice and Bob are in a room
+    [matrixSDKTestsE2EData doE2ETestWithAliceAndBobInARoom:self cryptedBob:YES warnOnUnknowDevices:NO readyToTest:^(MXSession *aliceSession, MXSession *bobSession, NSString *roomId, XCTestExpectation *expectation) {
+
+        NSArray<NSString*> *messages = @[@"A", @"Z", @"E", @"R", @"T"];
+
+        // - Bob sends messages
+        MXRoom *roomFromBobPOV = [bobSession roomWithRoomId:roomId];
+        [roomFromBobPOV sendTextMessage:messages[0] success:^(NSString *eventId) {
+            [roomFromBobPOV sendTextMessage:messages[1] success:^(NSString *eventId) {
+                [roomFromBobPOV sendTextMessage:messages[2] success:^(NSString *eventId) {
+                    [roomFromBobPOV sendTextMessage:messages[3] success:^(NSString *eventId) {
+                        [roomFromBobPOV sendTextMessage:messages[4] success:nil failure:nil];
+                    } failure:nil];
+                } failure:nil];
+            } failure:nil];
+        } failure:^(NSError *error) {
+            NSAssert(NO, @"Cannot set up intial test conditions - error: %@", error);
+        }];
+
+
+        // - Alice gets them decrypted
+        MXRoom *roomFromAlicePOV = [aliceSession roomWithRoomId:roomId];
+        __block NSUInteger messagesCount = 0;
+        [roomFromAlicePOV liveTimeline:^(MXEventTimeline *liveTimeline) {
+            [liveTimeline listenToEventsOfTypes:@[kMXEventTypeStringRoomMessage] onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
+
+                if (++messagesCount == messages.count)
+                {
+                    NSString *sessionId, *senderKey;
+                    MXJSONModelSetString(sessionId, event.wireContent[@"session_id"]);
+                    MXJSONModelSetString(senderKey, event.wireContent[@"sender_key"]);
+
+                    MXOlmInboundGroupSession *session = [aliceSession.crypto.store inboundGroupSessionWithId:sessionId andSenderKey:senderKey];
+                    XCTAssert(session);
+
+                    // - Export partial and full megolm session data
+                    MXMegolmSessionData *sessionData = [session exportSessionDataAtMessageIndex:0];
+                    MXMegolmSessionData *partialSessionData = [session exportSessionDataAtMessageIndex:1];
+                    XCTAssert(sessionData);
+                    XCTAssert(partialSessionData);
+
+                    // - Log Alice on a new device
+                    [MXSDKOptions sharedInstance].enableCryptoWhenStartingMXSession = YES;
+                    [matrixSDKTestsData relogUserSessionWithNewDevice:aliceSession withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *aliceSession2) {
+                        [MXSDKOptions sharedInstance].enableCryptoWhenStartingMXSession = NO;
+
+                        readyToTest(aliceSession2, roomId, sessionData, partialSessionData, expectation);
+                    }];
+                }
+            }];
+        }];
+    }];
+}
+
+
+/**
+ Test that a partial shared session does not cancel key share requests.
+
+ From the scenario:
+ - Make Alice paginate back in the room
+ -> There must be pending outgoing key share request
+ - Import the partial megolm session data as if they come from key sharing
+ -> The outgoing key share request should still exist
+ - Import the full megolm session data as if they come from key sharing
+ -> There should be no more outgoing key share request
+ */
+- (void)testPartialSharedSession
+{
+    [self createScenario:^(MXSession *aliceSession, NSString *roomId, MXMegolmSessionData *sessionData, MXMegolmSessionData *partialSessionData, XCTestExpectation *expectation) {
+
+        // - Make Alice paginate back in the room
+        MXRoom *roomFromAlicePOV = [aliceSession roomWithRoomId:roomId];
+        [roomFromAlicePOV liveTimeline:^(MXEventTimeline *liveTimeline) {
+
+            [liveTimeline resetPagination];
+            [liveTimeline paginate:30 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^{
+
+                [self outgoingRoomKeyRequestInSession:aliceSession complete:^(MXOutgoingRoomKeyRequest *outgoingRoomKeyRequest) {
+
+                    // -> There must be pending outgoing key share request
+                    XCTAssert(outgoingRoomKeyRequest);
+
+                    // - Import the partial megolm session data as if they come from key sharing
+                    [self mimicKeyShareResponseForSession:aliceSession withSessionData:partialSessionData complete:^{
+
+                        // -> The outgoing key share request should still exist
+                        [self outgoingRoomKeyRequestInSession:aliceSession complete:^(MXOutgoingRoomKeyRequest *pendingOutgoingRoomKeyRequest) {
+
+                            XCTAssertEqualObjects(pendingOutgoingRoomKeyRequest.requestId, outgoingRoomKeyRequest.requestId);
+
+                            // - Import the full megolm session data as if they come from key sharing
+                            [self mimicKeyShareResponseForSession:aliceSession withSessionData:sessionData complete:^{
+
+                                [self outgoingRoomKeyRequestInSession:aliceSession complete:^(MXOutgoingRoomKeyRequest *stillPendingOutgoingRoomKeyRequest) {
+
+                                    // -> There should be no more outgoing key share request
+                                    XCTAssertNil(stillPendingOutgoingRoomKeyRequest);
+
+                                    [expectation fulfill];
+                                }];
+                            }];
+                        }];
+                    }];
+
+                }];
+            } failure:^(NSError *error) {
+                XCTFail(@"The request should not fail - NSError: %@", error);
+                [expectation fulfill];
+            }];
+        }];
+    }];
+}
+
+/**
+ Test that a shared session that is better (ie, lower index) than what we have
+ in the store is correctly imported.
+
+ From the scenario:
+ - Import the partial megolm session data
+ -> It must be successfully imported
+ - Import the full megolm session data
+ -> It must be successfully imported
+ */
+- (void)testBetterSharedSession
+{
+    [self createScenario:^(MXSession *aliceSession, NSString *roomId, MXMegolmSessionData *sessionData, MXMegolmSessionData *partialSessionData, XCTestExpectation *expectation) {
+
+        // - Import the partial megolm session data
+        [aliceSession.crypto importMegolmSessionDatas:@[partialSessionData] backUp:NO success:^(NSUInteger total, NSUInteger imported) {
+
+            // -> It must be successfully imported
+            XCTAssertEqual(imported, 1);
+
+            // - Import the full megolm session dats
+            [aliceSession.crypto importMegolmSessionDatas:@[sessionData] backUp:NO success:^(NSUInteger total, NSUInteger imported) {
+
+                // -> It must be successfully imported
+                XCTAssertEqual(imported, 1);
+                [expectation fulfill];
+
+            } failure:^(NSError *error) {
+                XCTFail(@"The request should not fail - NSError: %@", error);
+                [expectation fulfill];
+            }];
+        } failure:^(NSError *error) {
+            XCTFail(@"The request should not fail - NSError: %@", error);
+            [expectation fulfill];
+        }];
+    }];
+}
+
+/**
+ Test that a shared session that is not better (ie, higher index) than what we have
+ in the store does not overwrite what we have.
+
+ From the scenario:
+ - Import the full megolm session data
+ -> It must be successfully imported
+ - Import the partial megolm session data
+ -> It must not be imported
+ */
+- (void)testNotBetterSharedSession
+{
+    [self createScenario:^(MXSession *aliceSession, NSString *roomId, MXMegolmSessionData *sessionData, MXMegolmSessionData *partialSessionData, XCTestExpectation *expectation) {
+
+        // - Import the full megolm session data
+        [aliceSession.crypto importMegolmSessionDatas:@[sessionData] backUp:NO success:^(NSUInteger total, NSUInteger imported) {
+
+            // -> It must be successfully imported
+            XCTAssertEqual(imported, 1);
+
+            // - Import the partial megolm session data
+            [aliceSession.crypto importMegolmSessionDatas:@[partialSessionData] backUp:NO success:^(NSUInteger total, NSUInteger imported) {
+
+                // -> It must not be imported
+                XCTAssertEqual(imported, 0);
+                [expectation fulfill];
+
+            } failure:^(NSError *error) {
+                XCTFail(@"The request should not fail - NSError: %@", error);
+                [expectation fulfill];
+            }];
+        } failure:^(NSError *error) {
+            XCTFail(@"The request should not fail - NSError: %@", error);
+            [expectation fulfill];
+        }];
+    }];
+}
+
+@end
+
+#pragma clang diagnostic pop

--- a/MatrixSDKTests/MXCryptoShareTests.m
+++ b/MatrixSDKTests/MXCryptoShareTests.m
@@ -61,21 +61,6 @@
     }];
 }
 
-- (void)outgoingRoomKeyRequestInSession:(MXSession*)session complete:(void (^)(MXOutgoingRoomKeyRequest*))complete
-{
-    dispatch_async(session.crypto.decryptionQueue, ^{
-        MXOutgoingRoomKeyRequest *outgoingRoomKeyRequest = [session.crypto.store outgoingRoomKeyRequestWithState:MXRoomKeyRequestStateUnsent];
-        if (!outgoingRoomKeyRequest)
-        {
-            outgoingRoomKeyRequest = [session.crypto.store outgoingRoomKeyRequestWithState:MXRoomKeyRequestStateSent];
-        }
-
-        dispatch_async(dispatch_get_main_queue(), ^{
-            complete(outgoingRoomKeyRequest);
-        });
-    });
-}
-
 
 /**
  Common initial conditions:
@@ -164,7 +149,7 @@
             [liveTimeline resetPagination];
             [liveTimeline paginate:30 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^{
 
-                [self outgoingRoomKeyRequestInSession:aliceSession complete:^(MXOutgoingRoomKeyRequest *outgoingRoomKeyRequest) {
+                [matrixSDKTestsE2EData outgoingRoomKeyRequestInSession:aliceSession complete:^(MXOutgoingRoomKeyRequest *outgoingRoomKeyRequest) {
 
                     // -> There must be pending outgoing key share request
                     XCTAssert(outgoingRoomKeyRequest);
@@ -173,14 +158,14 @@
                     [self mimicKeyShareResponseForSession:aliceSession withSessionData:partialSessionData complete:^{
 
                         // -> The outgoing key share request should still exist
-                        [self outgoingRoomKeyRequestInSession:aliceSession complete:^(MXOutgoingRoomKeyRequest *pendingOutgoingRoomKeyRequest) {
+                        [matrixSDKTestsE2EData outgoingRoomKeyRequestInSession:aliceSession complete:^(MXOutgoingRoomKeyRequest *pendingOutgoingRoomKeyRequest) {
 
                             XCTAssertEqualObjects(pendingOutgoingRoomKeyRequest.requestId, outgoingRoomKeyRequest.requestId);
 
                             // - Import the full megolm session data as if they come from key sharing
                             [self mimicKeyShareResponseForSession:aliceSession withSessionData:sessionData complete:^{
 
-                                [self outgoingRoomKeyRequestInSession:aliceSession complete:^(MXOutgoingRoomKeyRequest *stillPendingOutgoingRoomKeyRequest) {
+                                [matrixSDKTestsE2EData outgoingRoomKeyRequestInSession:aliceSession complete:^(MXOutgoingRoomKeyRequest *stillPendingOutgoingRoomKeyRequest) {
 
                                     // -> There should be no more outgoing key share request
                                     XCTAssertNil(stillPendingOutgoingRoomKeyRequest);

--- a/MatrixSDKTests/MatrixSDKTestsE2EData.h
+++ b/MatrixSDKTests/MatrixSDKTestsE2EData.h
@@ -22,6 +22,8 @@
 
 #import "MatrixSDKTestsData.h"
 
+@class MXOutgoingRoomKeyRequest;
+
 /**
  Class helper to create reusable initial conditions for e2e.
  */
@@ -77,6 +79,10 @@
                                    cryptedSam:(BOOL)cryptedSam
                           warnOnUnknowDevices:(BOOL)warnOnUnknowDevices
                                   readyToTest:(void (^)(MXSession *aliceSession, MXSession *bobSession, MXSession *samSession, NSString *roomId, XCTestExpectation *expectation))readyToTest;
+
+#pragma mark - Tools
+
+- (void)outgoingRoomKeyRequestInSession:(MXSession*)session complete:(void (^)(MXOutgoingRoomKeyRequest*))complete;
 
 @end
 

--- a/MatrixSDKTests/MatrixSDKTestsE2EData.m
+++ b/MatrixSDKTests/MatrixSDKTestsE2EData.m
@@ -289,6 +289,25 @@
     }];
 }
 
+
+#pragma mark - Tools
+
+- (void)outgoingRoomKeyRequestInSession:(MXSession*)session complete:(void (^)(MXOutgoingRoomKeyRequest*))complete
+{
+    dispatch_async(session.crypto.decryptionQueue, ^{
+        MXOutgoingRoomKeyRequest *outgoingRoomKeyRequest = [session.crypto.store outgoingRoomKeyRequestWithState:MXRoomKeyRequestStateUnsent];
+        if (!outgoingRoomKeyRequest)
+        {
+            outgoingRoomKeyRequest = [session.crypto.store outgoingRoomKeyRequestWithState:MXRoomKeyRequestStateSent];
+        }
+
+        dispatch_async(dispatch_get_main_queue(), ^{
+            complete(outgoingRoomKeyRequest);
+        });
+    });
+}
+
+
 @end
 
 #endif // MX_CRYPTO


### PR DESCRIPTION
Fixes vector-im/riot-ios/issues/2320

- don't cancel key requests if we can't decrypt everything in the session
- overwrite the session key if we get a better version