### PR TITLE
BF Riot: Room Upgrades: Room appears twice in the rooms list

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changes in Matrix iOS SDK in 0.12.5 (2019-03-)
 Improvements:
  * Crypto: Handle partially-shared sessions better (vector-im/riot-ios/issues/2320).
 
+Bug Fix:
+ * MXRoomSummaryUpdater: Fix `MXRoomSummary.hiddenFromUser` property not being saved when associated room become tombstoned (vector-im/riot-ios/issues/2148).
+
 Changes in Matrix iOS SDK in 0.12.4 (2019-03-21)
 ===============================================
 

--- a/MatrixSDK/Data/MXRoomSummaryUpdater.m
+++ b/MatrixSDK/Data/MXRoomSummaryUpdater.m
@@ -205,6 +205,7 @@
         if (replacementRoomSummary)
         {
             summary.hiddenFromUser = replacementRoomSummary.membership == MXMembershipJoin;
+            updated = YES;
         }
     }
     
@@ -221,7 +222,14 @@
     if (createContent.roomPredecessorInfo)
     {
         MXRoomSummary *obsoleteRoomSummary = [session roomSummaryWithRoomId:createContent.roomPredecessorInfo.roomId];
+     
+        BOOL obsoleteRoomHiddenFromUserFormerValue = obsoleteRoomSummary.hiddenFromUser;
         obsoleteRoomSummary.hiddenFromUser = summary.membership == MXMembershipJoin; // Hide room predecessor if user joined the new one
+        
+        if (obsoleteRoomHiddenFromUserFormerValue != obsoleteRoomSummary.hiddenFromUser)
+        {
+            [obsoleteRoomSummary save:YES];
+        }
     }
 }
 

--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
@@ -25,7 +25,7 @@
 #import "MXSDKOptions.h"
 #import "MXTools.h"
 
-static NSUInteger const kMXFileVersion = 61;
+static NSUInteger const kMXFileVersion = 62;
 
 static NSString *const kMXFileStoreFolder = @"MXFileStore";
 static NSString *const kMXFileStoreMedaDataFile = @"MXFileStore";


### PR DESCRIPTION
Fix vector-im/riot-ios/issues/2148