### PR TITLE
Aggregations relations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes in Matrix iOS SDK in 0.12.6 (2019-05-)
 Improvements:
 * MXEvent: Create a MXEventUnsignedData model for `MXEvent.unsignedData`.
 * MXEvent: Add relatesTo property.
+* Aggregations: Create MXSession.MXAggregations to manage Matrix aggregations API.
 
 Changes in Matrix iOS SDK in 0.12.5 (2019-05-03)
 ===============================================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Changes in Matrix iOS SDK in 0.12.6 (2019-05-)
 
 Improvements:
 * MXEvent: Create a MXEventUnsignedData model for `MXEvent.unsignedData`.
+* MXEvent: Add relatesTo property.
 
 Changes in Matrix iOS SDK in 0.12.5 (2019-05-03)
 ===============================================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+Changes in Matrix iOS SDK in 0.12.6 (2019-05-)
+===============================================
+
+Improvements:
+* MXEvent: Create a MXEventUnsignedData model for `MXEvent.unsignedData`.
+
 Changes in Matrix iOS SDK in 0.12.5 (2019-05-03)
 ===============================================
 

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -180,6 +180,7 @@
 		327E9AE22285497100A98BC1 /* MXEventContentRelatesTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 327E9AE02285497100A98BC1 /* MXEventContentRelatesTo.m */; };
 		327E9AE72285A8C400A98BC1 /* MXAggregationPaginatedResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 327E9AE52285A8C400A98BC1 /* MXAggregationPaginatedResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		327E9AE82285A8C400A98BC1 /* MXAggregationPaginatedResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 327E9AE62285A8C400A98BC1 /* MXAggregationPaginatedResponse.m */; };
+		327E9AEA2285DFB600A98BC1 /* MXReactionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 327E9AE92285DFB600A98BC1 /* MXReactionTests.m */; };
 		327F8DB21C6112BA00581CA3 /* MXRoomThirdPartyInvite.h in Headers */ = {isa = PBXBuildFile; fileRef = 327F8DB01C6112BA00581CA3 /* MXRoomThirdPartyInvite.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		327F8DB31C6112BA00581CA3 /* MXRoomThirdPartyInvite.m in Sources */ = {isa = PBXBuildFile; fileRef = 327F8DB11C6112BA00581CA3 /* MXRoomThirdPartyInvite.m */; };
 		3281E89E19E299C000976E1A /* MXErrorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3281E89D19E299C000976E1A /* MXErrorTests.m */; };
@@ -606,6 +607,7 @@
 		327E9AE02285497100A98BC1 /* MXEventContentRelatesTo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXEventContentRelatesTo.m; sourceTree = "<group>"; };
 		327E9AE52285A8C400A98BC1 /* MXAggregationPaginatedResponse.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXAggregationPaginatedResponse.h; sourceTree = "<group>"; };
 		327E9AE62285A8C400A98BC1 /* MXAggregationPaginatedResponse.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXAggregationPaginatedResponse.m; sourceTree = "<group>"; };
+		327E9AE92285DFB600A98BC1 /* MXReactionTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXReactionTests.m; sourceTree = "<group>"; };
 		327F8DB01C6112BA00581CA3 /* MXRoomThirdPartyInvite.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXRoomThirdPartyInvite.h; sourceTree = "<group>"; };
 		327F8DB11C6112BA00581CA3 /* MXRoomThirdPartyInvite.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXRoomThirdPartyInvite.m; sourceTree = "<group>"; };
 		3281E89D19E299C000976E1A /* MXErrorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXErrorTests.m; sourceTree = "<group>"; };
@@ -1492,6 +1494,7 @@
 		32C6F93919DD814400EA4E9C /* MatrixSDKTests */ = {
 			isa = PBXGroup;
 			children = (
+				327E9AE92285DFB600A98BC1 /* MXReactionTests.m */,
 				327E9ACE2284783E00A98BC1 /* MXEventAnnotationTests.swift */,
 				329E808E22512DF500A48C3A /* MXCryptoDeviceVerificationTests.m */,
 				322D01C322492B0700150C68 /* MXCryptoShareTests.m */,
@@ -2314,6 +2317,7 @@
 				32720DA2222EB5650086FFF5 /* MXAutoDiscoveryTests.m in Sources */,
 				327E37B91A977810007F026F /* MXLoggerTests.m in Sources */,
 				329571931B0240CE00ABB3BA /* MXVoIPTests.m in Sources */,
+				327E9AEA2285DFB600A98BC1 /* MXReactionTests.m in Sources */,
 				32A27D1F19EC335300BAFADE /* MXRoomTests.m in Sources */,
 				32D8CAC219DEE6ED002AF8A0 /* MXRestClientNoAuthAPITests.m in Sources */,
 				32FCAB4D19E578860049C555 /* MXRestClientTests.m in Sources */,

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -178,6 +178,8 @@
 		327E9ADD2284804500A98BC1 /* MXEventRelations.m in Sources */ = {isa = PBXBuildFile; fileRef = 327E9ADB2284804500A98BC1 /* MXEventRelations.m */; };
 		327E9AE12285497100A98BC1 /* MXEventContentRelatesTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 327E9ADF2285497100A98BC1 /* MXEventContentRelatesTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		327E9AE22285497100A98BC1 /* MXEventContentRelatesTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 327E9AE02285497100A98BC1 /* MXEventContentRelatesTo.m */; };
+		327E9AE72285A8C400A98BC1 /* MXAggregationPaginatedResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 327E9AE52285A8C400A98BC1 /* MXAggregationPaginatedResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		327E9AE82285A8C400A98BC1 /* MXAggregationPaginatedResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 327E9AE62285A8C400A98BC1 /* MXAggregationPaginatedResponse.m */; };
 		327F8DB21C6112BA00581CA3 /* MXRoomThirdPartyInvite.h in Headers */ = {isa = PBXBuildFile; fileRef = 327F8DB01C6112BA00581CA3 /* MXRoomThirdPartyInvite.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		327F8DB31C6112BA00581CA3 /* MXRoomThirdPartyInvite.m in Sources */ = {isa = PBXBuildFile; fileRef = 327F8DB11C6112BA00581CA3 /* MXRoomThirdPartyInvite.m */; };
 		3281E89E19E299C000976E1A /* MXErrorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3281E89D19E299C000976E1A /* MXErrorTests.m */; };
@@ -602,6 +604,8 @@
 		327E9ADB2284804500A98BC1 /* MXEventRelations.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXEventRelations.m; sourceTree = "<group>"; };
 		327E9ADF2285497100A98BC1 /* MXEventContentRelatesTo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXEventContentRelatesTo.h; sourceTree = "<group>"; };
 		327E9AE02285497100A98BC1 /* MXEventContentRelatesTo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXEventContentRelatesTo.m; sourceTree = "<group>"; };
+		327E9AE52285A8C400A98BC1 /* MXAggregationPaginatedResponse.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXAggregationPaginatedResponse.h; sourceTree = "<group>"; };
+		327E9AE62285A8C400A98BC1 /* MXAggregationPaginatedResponse.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXAggregationPaginatedResponse.m; sourceTree = "<group>"; };
 		327F8DB01C6112BA00581CA3 /* MXRoomThirdPartyInvite.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXRoomThirdPartyInvite.h; sourceTree = "<group>"; };
 		327F8DB11C6112BA00581CA3 /* MXRoomThirdPartyInvite.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXRoomThirdPartyInvite.m; sourceTree = "<group>"; };
 		3281E89D19E299C000976E1A /* MXErrorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXErrorTests.m; sourceTree = "<group>"; };
@@ -1276,9 +1280,19 @@
 			path = Content;
 			sourceTree = "<group>";
 		};
+		327E9AE422859FE300A98BC1 /* Aggregations */ = {
+			isa = PBXGroup;
+			children = (
+				327E9AE52285A8C400A98BC1 /* MXAggregationPaginatedResponse.h */,
+				327E9AE62285A8C400A98BC1 /* MXAggregationPaginatedResponse.m */,
+			);
+			path = Aggregations;
+			sourceTree = "<group>";
+		};
 		3281E8B219E42DFE00976E1A /* JSONModels */ = {
 			isa = PBXGroup;
 			children = (
+				327E9AE422859FE300A98BC1 /* Aggregations */,
 				323547D12226D3F500F15F94 /* AutoDiscovery */,
 				3275FD9121A6B46600B9C13D /* Authentication */,
 				327E9AB9228451E500A98BC1 /* Event */,
@@ -1796,6 +1810,7 @@
 				B146D4AF21A5A04300D8C2C6 /* MXMediaScanStore.h in Headers */,
 				32FA10CE1FA1C9F700E54233 /* MXOutgoingRoomKeyRequest.h in Headers */,
 				32A1514A1DAF7C0C00400192 /* MXUsersDevicesMap.h in Headers */,
+				327E9AE72285A8C400A98BC1 /* MXAggregationPaginatedResponse.h in Headers */,
 				323E0C5B1A306D7A00A31D73 /* MXEvent.h in Headers */,
 				327F8DB21C6112BA00581CA3 /* MXRoomThirdPartyInvite.h in Headers */,
 				32BA86AC21529E29008F277E /* MXRoomNameStringsLocalizable.h in Headers */,
@@ -2122,6 +2137,7 @@
 				323360701A403A0D0071A488 /* MXFileStore.m in Sources */,
 				32A9770521626E5C00919CC0 /* MXServerNotices.m in Sources */,
 				32D7767E1A27860600FC4AA2 /* MXMemoryStore.m in Sources */,
+				327E9AE82285A8C400A98BC1 /* MXAggregationPaginatedResponse.m in Sources */,
 				3275FD9421A6B46600B9C13D /* MXLoginTerms.m in Sources */,
 				32A151531DAF8A7200400192 /* MXQueuedEncryption.m in Sources */,
 				C6D5D60A1E4FA74000706C0F /* MXEnumConstants.swift in Sources */,

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -176,6 +176,8 @@
 		327E9AD92284803100A98BC1 /* MXEventAnnotationChunk.m in Sources */ = {isa = PBXBuildFile; fileRef = 327E9AD52284803100A98BC1 /* MXEventAnnotationChunk.m */; };
 		327E9ADC2284804500A98BC1 /* MXEventRelations.h in Headers */ = {isa = PBXBuildFile; fileRef = 327E9ADA2284804500A98BC1 /* MXEventRelations.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		327E9ADD2284804500A98BC1 /* MXEventRelations.m in Sources */ = {isa = PBXBuildFile; fileRef = 327E9ADB2284804500A98BC1 /* MXEventRelations.m */; };
+		327E9AE12285497100A98BC1 /* MXEventContentRelatesTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 327E9ADF2285497100A98BC1 /* MXEventContentRelatesTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		327E9AE22285497100A98BC1 /* MXEventContentRelatesTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 327E9AE02285497100A98BC1 /* MXEventContentRelatesTo.m */; };
 		327F8DB21C6112BA00581CA3 /* MXRoomThirdPartyInvite.h in Headers */ = {isa = PBXBuildFile; fileRef = 327F8DB01C6112BA00581CA3 /* MXRoomThirdPartyInvite.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		327F8DB31C6112BA00581CA3 /* MXRoomThirdPartyInvite.m in Sources */ = {isa = PBXBuildFile; fileRef = 327F8DB11C6112BA00581CA3 /* MXRoomThirdPartyInvite.m */; };
 		3281E89E19E299C000976E1A /* MXErrorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3281E89D19E299C000976E1A /* MXErrorTests.m */; };
@@ -598,6 +600,8 @@
 		327E9AD52284803100A98BC1 /* MXEventAnnotationChunk.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXEventAnnotationChunk.m; sourceTree = "<group>"; };
 		327E9ADA2284804500A98BC1 /* MXEventRelations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXEventRelations.h; sourceTree = "<group>"; };
 		327E9ADB2284804500A98BC1 /* MXEventRelations.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXEventRelations.m; sourceTree = "<group>"; };
+		327E9ADF2285497100A98BC1 /* MXEventContentRelatesTo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXEventContentRelatesTo.h; sourceTree = "<group>"; };
+		327E9AE02285497100A98BC1 /* MXEventContentRelatesTo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXEventContentRelatesTo.m; sourceTree = "<group>"; };
 		327F8DB01C6112BA00581CA3 /* MXRoomThirdPartyInvite.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXRoomThirdPartyInvite.h; sourceTree = "<group>"; };
 		327F8DB11C6112BA00581CA3 /* MXRoomThirdPartyInvite.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXRoomThirdPartyInvite.m; sourceTree = "<group>"; };
 		3281E89D19E299C000976E1A /* MXErrorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXErrorTests.m; sourceTree = "<group>"; };
@@ -1250,6 +1254,7 @@
 		327E9AB9228451E500A98BC1 /* Event */ = {
 			isa = PBXGroup;
 			children = (
+				327E9ADE2285492000A98BC1 /* Content */,
 				327E9AD22284803000A98BC1 /* MXEventAnnotation.h */,
 				327E9AD42284803100A98BC1 /* MXEventAnnotation.m */,
 				327E9AD32284803000A98BC1 /* MXEventAnnotationChunk.h */,
@@ -1260,6 +1265,15 @@
 				327E9ADB2284804500A98BC1 /* MXEventRelations.m */,
 			);
 			path = Event;
+			sourceTree = "<group>";
+		};
+		327E9ADE2285492000A98BC1 /* Content */ = {
+			isa = PBXGroup;
+			children = (
+				327E9ADF2285497100A98BC1 /* MXEventContentRelatesTo.h */,
+				327E9AE02285497100A98BC1 /* MXEventContentRelatesTo.m */,
+			);
+			path = Content;
 			sourceTree = "<group>";
 		};
 		3281E8B219E42DFE00976E1A /* JSONModels */ = {
@@ -1821,6 +1835,7 @@
 				329FB1791A0A74B100A5E88E /* MXTools.h in Headers */,
 				322691321E5EF77D00966A6E /* MXDeviceListOperation.h in Headers */,
 				32481A841C03572900782AD3 /* MXRoomAccountData.h in Headers */,
+				327E9AE12285497100A98BC1 /* MXEventContentRelatesTo.h in Headers */,
 				321CFDFB2254E728004D31DF /* MXTransactionCancelCode.h in Headers */,
 				32A9770421626E5C00919CC0 /* MXServerNotices.h in Headers */,
 				021AFBA42179E91900742B2C /* MXEncryptedContentFile.h in Headers */,
@@ -2123,6 +2138,7 @@
 				92634B831EF2E3C400DB9F60 /* MXCallKitConfiguration.m in Sources */,
 				3265CB391A14C43E00E24B2F /* MXRoomState.m in Sources */,
 				3281E8B819E42DFE00976E1A /* MXJSONModel.m in Sources */,
+				327E9AE22285497100A98BC1 /* MXEventContentRelatesTo.m in Sources */,
 				32A1514B1DAF7C0C00400192 /* MXUsersDevicesMap.m in Sources */,
 				328BCB3421947BE200A976D3 /* MXKeyBackupVersionTrust.m in Sources */,
 				C6B40F521F2A35BE00C42C72 /* MXRoomState.swift in Sources */,

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -167,6 +167,8 @@
 		327E37B61A974F75007F026F /* MXLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 327E37B41A974F75007F026F /* MXLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		327E37B71A974F75007F026F /* MXLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 327E37B51A974F75007F026F /* MXLogger.m */; };
 		327E37B91A977810007F026F /* MXLoggerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 327E37B81A977810007F026F /* MXLoggerTests.m */; };
+		327E9ABC2284521C00A98BC1 /* MXEventUnsignedData.h in Headers */ = {isa = PBXBuildFile; fileRef = 327E9ABA2284521C00A98BC1 /* MXEventUnsignedData.h */; };
+		327E9ABD2284521C00A98BC1 /* MXEventUnsignedData.m in Sources */ = {isa = PBXBuildFile; fileRef = 327E9ABB2284521C00A98BC1 /* MXEventUnsignedData.m */; };
 		327F8DB21C6112BA00581CA3 /* MXRoomThirdPartyInvite.h in Headers */ = {isa = PBXBuildFile; fileRef = 327F8DB01C6112BA00581CA3 /* MXRoomThirdPartyInvite.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		327F8DB31C6112BA00581CA3 /* MXRoomThirdPartyInvite.m in Sources */ = {isa = PBXBuildFile; fileRef = 327F8DB11C6112BA00581CA3 /* MXRoomThirdPartyInvite.m */; };
 		3281E89E19E299C000976E1A /* MXErrorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3281E89D19E299C000976E1A /* MXErrorTests.m */; };
@@ -580,6 +582,8 @@
 		327E37B41A974F75007F026F /* MXLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXLogger.h; sourceTree = "<group>"; };
 		327E37B51A974F75007F026F /* MXLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXLogger.m; sourceTree = "<group>"; };
 		327E37B81A977810007F026F /* MXLoggerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXLoggerTests.m; sourceTree = "<group>"; };
+		327E9ABA2284521C00A98BC1 /* MXEventUnsignedData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXEventUnsignedData.h; sourceTree = "<group>"; };
+		327E9ABB2284521C00A98BC1 /* MXEventUnsignedData.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXEventUnsignedData.m; sourceTree = "<group>"; };
 		327F8DB01C6112BA00581CA3 /* MXRoomThirdPartyInvite.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXRoomThirdPartyInvite.h; sourceTree = "<group>"; };
 		327F8DB11C6112BA00581CA3 /* MXRoomThirdPartyInvite.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXRoomThirdPartyInvite.m; sourceTree = "<group>"; };
 		3281E89D19E299C000976E1A /* MXErrorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXErrorTests.m; sourceTree = "<group>"; };
@@ -1229,11 +1233,21 @@
 			path = Authentication;
 			sourceTree = "<group>";
 		};
+		327E9AB9228451E500A98BC1 /* Event */ = {
+			isa = PBXGroup;
+			children = (
+				327E9ABA2284521C00A98BC1 /* MXEventUnsignedData.h */,
+				327E9ABB2284521C00A98BC1 /* MXEventUnsignedData.m */,
+			);
+			path = Event;
+			sourceTree = "<group>";
+		};
 		3281E8B219E42DFE00976E1A /* JSONModels */ = {
 			isa = PBXGroup;
 			children = (
 				323547D12226D3F500F15F94 /* AutoDiscovery */,
 				3275FD9121A6B46600B9C13D /* Authentication */,
+				327E9AB9228451E500A98BC1 /* Event */,
 				3281E8B319E42DFE00976E1A /* MXJSONModel.h */,
 				3281E8B419E42DFE00976E1A /* MXJSONModel.m */,
 				3281E8B519E42DFE00976E1A /* MXJSONModels.h */,
@@ -1824,6 +1838,7 @@
 				3240969D1F9F751600DBA607 /* MXPushRuleSenderNotificationPermissionConditionChecker.h in Headers */,
 				329E808C224E2E1B00A48C3A /* MXOutgoingSASTransaction.h in Headers */,
 				B146D4D521A5A44E00D8C2C6 /* MXScanRealmProvider.h in Headers */,
+				327E9ABC2284521C00A98BC1 /* MXEventUnsignedData.h in Headers */,
 				32F634AB1FC5E3480054EF49 /* MXEventDecryptionResult.h in Headers */,
 				322A51C71D9BBD3C00C8536D /* MXOlmDevice.h in Headers */,
 				32442FB121EDD21300D2411B /* MXKeyBackupPassword.h in Headers */,
@@ -2073,6 +2088,7 @@
 				B18D18C22152B8E4003677D1 /* MXRoomMember.swift in Sources */,
 				32BBAE6F2178E99100D85F46 /* MXKeyBackupVersion.m in Sources */,
 				326056861C76FDF2009D44AD /* MXEventTimeline.m in Sources */,
+				327E9ABD2284521C00A98BC1 /* MXEventUnsignedData.m in Sources */,
 				32A1513A1DAD292400400192 /* MXMegolmEncryption.m in Sources */,
 				32F945F71FAB83D900622468 /* MXIncomingRoomKeyRequest.m in Sources */,
 				F0173EAD1FCF0E8900B5F6A3 /* MXGroup.m in Sources */,

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -167,8 +167,15 @@
 		327E37B61A974F75007F026F /* MXLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 327E37B41A974F75007F026F /* MXLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		327E37B71A974F75007F026F /* MXLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 327E37B51A974F75007F026F /* MXLogger.m */; };
 		327E37B91A977810007F026F /* MXLoggerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 327E37B81A977810007F026F /* MXLoggerTests.m */; };
-		327E9ABC2284521C00A98BC1 /* MXEventUnsignedData.h in Headers */ = {isa = PBXBuildFile; fileRef = 327E9ABA2284521C00A98BC1 /* MXEventUnsignedData.h */; };
+		327E9ABC2284521C00A98BC1 /* MXEventUnsignedData.h in Headers */ = {isa = PBXBuildFile; fileRef = 327E9ABA2284521C00A98BC1 /* MXEventUnsignedData.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		327E9ABD2284521C00A98BC1 /* MXEventUnsignedData.m in Sources */ = {isa = PBXBuildFile; fileRef = 327E9ABB2284521C00A98BC1 /* MXEventUnsignedData.m */; };
+		327E9ACF2284783E00A98BC1 /* MXEventAnnotationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 327E9ACE2284783E00A98BC1 /* MXEventAnnotationTests.swift */; };
+		327E9AD62284803100A98BC1 /* MXEventAnnotation.h in Headers */ = {isa = PBXBuildFile; fileRef = 327E9AD22284803000A98BC1 /* MXEventAnnotation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		327E9AD72284803100A98BC1 /* MXEventAnnotationChunk.h in Headers */ = {isa = PBXBuildFile; fileRef = 327E9AD32284803000A98BC1 /* MXEventAnnotationChunk.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		327E9AD82284803100A98BC1 /* MXEventAnnotation.m in Sources */ = {isa = PBXBuildFile; fileRef = 327E9AD42284803100A98BC1 /* MXEventAnnotation.m */; };
+		327E9AD92284803100A98BC1 /* MXEventAnnotationChunk.m in Sources */ = {isa = PBXBuildFile; fileRef = 327E9AD52284803100A98BC1 /* MXEventAnnotationChunk.m */; };
+		327E9ADC2284804500A98BC1 /* MXEventRelations.h in Headers */ = {isa = PBXBuildFile; fileRef = 327E9ADA2284804500A98BC1 /* MXEventRelations.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		327E9ADD2284804500A98BC1 /* MXEventRelations.m in Sources */ = {isa = PBXBuildFile; fileRef = 327E9ADB2284804500A98BC1 /* MXEventRelations.m */; };
 		327F8DB21C6112BA00581CA3 /* MXRoomThirdPartyInvite.h in Headers */ = {isa = PBXBuildFile; fileRef = 327F8DB01C6112BA00581CA3 /* MXRoomThirdPartyInvite.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		327F8DB31C6112BA00581CA3 /* MXRoomThirdPartyInvite.m in Sources */ = {isa = PBXBuildFile; fileRef = 327F8DB11C6112BA00581CA3 /* MXRoomThirdPartyInvite.m */; };
 		3281E89E19E299C000976E1A /* MXErrorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3281E89D19E299C000976E1A /* MXErrorTests.m */; };
@@ -584,6 +591,13 @@
 		327E37B81A977810007F026F /* MXLoggerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXLoggerTests.m; sourceTree = "<group>"; };
 		327E9ABA2284521C00A98BC1 /* MXEventUnsignedData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXEventUnsignedData.h; sourceTree = "<group>"; };
 		327E9ABB2284521C00A98BC1 /* MXEventUnsignedData.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXEventUnsignedData.m; sourceTree = "<group>"; };
+		327E9ACE2284783E00A98BC1 /* MXEventAnnotationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXEventAnnotationTests.swift; sourceTree = "<group>"; };
+		327E9AD22284803000A98BC1 /* MXEventAnnotation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXEventAnnotation.h; sourceTree = "<group>"; };
+		327E9AD32284803000A98BC1 /* MXEventAnnotationChunk.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXEventAnnotationChunk.h; sourceTree = "<group>"; };
+		327E9AD42284803100A98BC1 /* MXEventAnnotation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXEventAnnotation.m; sourceTree = "<group>"; };
+		327E9AD52284803100A98BC1 /* MXEventAnnotationChunk.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXEventAnnotationChunk.m; sourceTree = "<group>"; };
+		327E9ADA2284804500A98BC1 /* MXEventRelations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXEventRelations.h; sourceTree = "<group>"; };
+		327E9ADB2284804500A98BC1 /* MXEventRelations.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXEventRelations.m; sourceTree = "<group>"; };
 		327F8DB01C6112BA00581CA3 /* MXRoomThirdPartyInvite.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXRoomThirdPartyInvite.h; sourceTree = "<group>"; };
 		327F8DB11C6112BA00581CA3 /* MXRoomThirdPartyInvite.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXRoomThirdPartyInvite.m; sourceTree = "<group>"; };
 		3281E89D19E299C000976E1A /* MXErrorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXErrorTests.m; sourceTree = "<group>"; };
@@ -1236,8 +1250,14 @@
 		327E9AB9228451E500A98BC1 /* Event */ = {
 			isa = PBXGroup;
 			children = (
+				327E9AD22284803000A98BC1 /* MXEventAnnotation.h */,
+				327E9AD42284803100A98BC1 /* MXEventAnnotation.m */,
+				327E9AD32284803000A98BC1 /* MXEventAnnotationChunk.h */,
+				327E9AD52284803100A98BC1 /* MXEventAnnotationChunk.m */,
 				327E9ABA2284521C00A98BC1 /* MXEventUnsignedData.h */,
 				327E9ABB2284521C00A98BC1 /* MXEventUnsignedData.m */,
+				327E9ADA2284804500A98BC1 /* MXEventRelations.h */,
+				327E9ADB2284804500A98BC1 /* MXEventRelations.m */,
 			);
 			path = Event;
 			sourceTree = "<group>";
@@ -1444,6 +1464,7 @@
 		32C6F93919DD814400EA4E9C /* MatrixSDKTests */ = {
 			isa = PBXGroup;
 			children = (
+				327E9ACE2284783E00A98BC1 /* MXEventAnnotationTests.swift */,
 				329E808E22512DF500A48C3A /* MXCryptoDeviceVerificationTests.m */,
 				322D01C322492B0700150C68 /* MXCryptoShareTests.m */,
 				32720DA1222EB5650086FFF5 /* MXAutoDiscoveryTests.m */,
@@ -1748,6 +1769,7 @@
 				32954019216385F100E300FC /* MXServerNoticeContent.h in Headers */,
 				327187851DA7D0220071C818 /* MXOlmDecryption.h in Headers */,
 				32D7767D1A27860600FC4AA2 /* MXMemoryStore.h in Headers */,
+				327E9AD72284803100A98BC1 /* MXEventAnnotationChunk.h in Headers */,
 				3252DCBD224D144C0032264F /* MXKeyVerificationAccept.h in Headers */,
 				323547D52226D3F500F15F94 /* MXWellKnown.h in Headers */,
 				32FFB4F0217E146A00C96002 /* MXRecoveryKey.h in Headers */,
@@ -1826,6 +1848,7 @@
 				32BBAE6D2178E99100D85F46 /* MXKeyBackupVersion.h in Headers */,
 				323547D82226D5D600F15F94 /* MXWellKnownBaseConfig.h in Headers */,
 				32A151461DAF7C0C00400192 /* MXDeviceInfo.h in Headers */,
+				327E9ADC2284804500A98BC1 /* MXEventRelations.h in Headers */,
 				32CAB1071A91EA34008C5BB9 /* MXPushRuleRoomMemberCountConditionChecker.h in Headers */,
 				C61A4CC41E5F38CB00442158 /* SwiftMatrixSDK.h in Headers */,
 				321CFDFF2254E8C4004D31DF /* MXEmojiRepresentation.h in Headers */,
@@ -1886,6 +1909,7 @@
 				B146D47721A5950800D8C2C6 /* MXMediaScan.h in Headers */,
 				32C235721F827F3800E38FC5 /* MXRoomOperation.h in Headers */,
 				71DE22E11BC7C51200284153 /* MXReceiptData.h in Headers */,
+				327E9AD62284803100A98BC1 /* MXEventAnnotation.h in Headers */,
 				9274AFE81EE580240009BEB6 /* MXCallKitAdapter.h in Headers */,
 				321CFDE622525A49004D31DF /* MXSASTransaction.h in Headers */,
 				32DC15D01A8CF7AE006F9AD3 /* MXNotificationCenter.h in Headers */,
@@ -2052,6 +2076,7 @@
 			files = (
 				32A1513F1DAF768D00400192 /* MXOlmInboundGroupSession.m in Sources */,
 				32481A851C03572900782AD3 /* MXRoomAccountData.m in Sources */,
+				327E9AD92284803100A98BC1 /* MXEventAnnotationChunk.m in Sources */,
 				B146D4FB21A5BF7200D8C2C6 /* MXRealmEventScanStore.m in Sources */,
 				B146D4D921A5A44E00D8C2C6 /* MXScanRealmFileProvider.m in Sources */,
 				B146D50321A5C6D700D8C2C6 /* MXScanManager.m in Sources */,
@@ -2060,6 +2085,7 @@
 				32A31BC520D3FFB0005916C7 /* MXFilter.m in Sources */,
 				32B76EA520FDE85100B095F6 /* MXRoomMembersCount.m in Sources */,
 				B146D47121A5939100D8C2C6 /* MXRealmHelper.m in Sources */,
+				327E9AD82284803100A98BC1 /* MXEventAnnotation.m in Sources */,
 				F03EF4FF1DF014D9009DF592 /* MXMediaLoader.m in Sources */,
 				320A8841217F4E3F002EA952 /* MXMegolmBackupAuthData.m in Sources */,
 				32FFB4F1217E146A00C96002 /* MXRecoveryKey.m in Sources */,
@@ -2084,6 +2110,7 @@
 				3275FD9421A6B46600B9C13D /* MXLoginTerms.m in Sources */,
 				32A151531DAF8A7200400192 /* MXQueuedEncryption.m in Sources */,
 				C6D5D60A1E4FA74000706C0F /* MXEnumConstants.swift in Sources */,
+				327E9ADD2284804500A98BC1 /* MXEventRelations.m in Sources */,
 				3256E3821DCB91EB003C9718 /* MXCryptoConstants.m in Sources */,
 				B18D18C22152B8E4003677D1 /* MXRoomMember.swift in Sources */,
 				32BBAE6F2178E99100D85F46 /* MXKeyBackupVersion.m in Sources */,
@@ -2238,6 +2265,7 @@
 				3265CB3B1A151C3800E24B2F /* MXRoomStateTests.m in Sources */,
 				326D1EF51BFC79300030947B /* MXPushRuleTests.m in Sources */,
 				324BE45B1E3FA7A8008D99D4 /* MXMegolmExportEncryptionTest.m in Sources */,
+				327E9ACF2284783E00A98BC1 /* MXEventAnnotationTests.swift in Sources */,
 				32322A481E57264E005DD155 /* MXSelfSignedHomeserverTests.m in Sources */,
 				325653831A2E14ED00CC0423 /* MXStoreTests.m in Sources */,
 				3295719A1B024D2B00ABB3BA /* MXMockCallStackCall.m in Sources */,

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -181,6 +181,10 @@
 		327E9AE72285A8C400A98BC1 /* MXAggregationPaginatedResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 327E9AE52285A8C400A98BC1 /* MXAggregationPaginatedResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		327E9AE82285A8C400A98BC1 /* MXAggregationPaginatedResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 327E9AE62285A8C400A98BC1 /* MXAggregationPaginatedResponse.m */; };
 		327E9AEA2285DFB600A98BC1 /* MXReactionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 327E9AE92285DFB600A98BC1 /* MXReactionTests.m */; };
+		327E9AEF2289C61100A98BC1 /* MXAggregations.h in Headers */ = {isa = PBXBuildFile; fileRef = 327E9AED2289C61000A98BC1 /* MXAggregations.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		327E9AF02289C61100A98BC1 /* MXAggregations.m in Sources */ = {isa = PBXBuildFile; fileRef = 327E9AEE2289C61100A98BC1 /* MXAggregations.m */; };
+		327E9AF62289D53800A98BC1 /* MXReactionCount.h in Headers */ = {isa = PBXBuildFile; fileRef = 327E9AF42289D53800A98BC1 /* MXReactionCount.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		327E9AF72289D53800A98BC1 /* MXReactionCount.m in Sources */ = {isa = PBXBuildFile; fileRef = 327E9AF52289D53800A98BC1 /* MXReactionCount.m */; };
 		327F8DB21C6112BA00581CA3 /* MXRoomThirdPartyInvite.h in Headers */ = {isa = PBXBuildFile; fileRef = 327F8DB01C6112BA00581CA3 /* MXRoomThirdPartyInvite.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		327F8DB31C6112BA00581CA3 /* MXRoomThirdPartyInvite.m in Sources */ = {isa = PBXBuildFile; fileRef = 327F8DB11C6112BA00581CA3 /* MXRoomThirdPartyInvite.m */; };
 		3281E89E19E299C000976E1A /* MXErrorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3281E89D19E299C000976E1A /* MXErrorTests.m */; };
@@ -608,6 +612,11 @@
 		327E9AE52285A8C400A98BC1 /* MXAggregationPaginatedResponse.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXAggregationPaginatedResponse.h; sourceTree = "<group>"; };
 		327E9AE62285A8C400A98BC1 /* MXAggregationPaginatedResponse.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXAggregationPaginatedResponse.m; sourceTree = "<group>"; };
 		327E9AE92285DFB600A98BC1 /* MXReactionTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXReactionTests.m; sourceTree = "<group>"; };
+		327E9AED2289C61000A98BC1 /* MXAggregations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXAggregations.h; sourceTree = "<group>"; };
+		327E9AEE2289C61100A98BC1 /* MXAggregations.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXAggregations.m; sourceTree = "<group>"; };
+		327E9AF12289C6B300A98BC1 /* MXAggregations_Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXAggregations_Private.h; sourceTree = "<group>"; };
+		327E9AF42289D53800A98BC1 /* MXReactionCount.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXReactionCount.h; sourceTree = "<group>"; };
+		327E9AF52289D53800A98BC1 /* MXReactionCount.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXReactionCount.m; sourceTree = "<group>"; };
 		327F8DB01C6112BA00581CA3 /* MXRoomThirdPartyInvite.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXRoomThirdPartyInvite.h; sourceTree = "<group>"; };
 		327F8DB11C6112BA00581CA3 /* MXRoomThirdPartyInvite.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXRoomThirdPartyInvite.m; sourceTree = "<group>"; };
 		3281E89D19E299C000976E1A /* MXErrorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXErrorTests.m; sourceTree = "<group>"; };
@@ -1291,6 +1300,26 @@
 			path = Aggregations;
 			sourceTree = "<group>";
 		};
+		327E9AEC2289C5EC00A98BC1 /* Aggregations */ = {
+			isa = PBXGroup;
+			children = (
+				327E9AF32289D4F700A98BC1 /* Data */,
+				327E9AED2289C61000A98BC1 /* MXAggregations.h */,
+				327E9AEE2289C61100A98BC1 /* MXAggregations.m */,
+				327E9AF12289C6B300A98BC1 /* MXAggregations_Private.h */,
+			);
+			path = Aggregations;
+			sourceTree = "<group>";
+		};
+		327E9AF32289D4F700A98BC1 /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				327E9AF42289D53800A98BC1 /* MXReactionCount.h */,
+				327E9AF52289D53800A98BC1 /* MXReactionCount.m */,
+			);
+			path = Data;
+			sourceTree = "<group>";
+		};
 		3281E8B219E42DFE00976E1A /* JSONModels */ = {
 			isa = PBXGroup;
 			children = (
@@ -1457,6 +1486,7 @@
 		32C6F92F19DD814400EA4E9C /* MatrixSDK */ = {
 			isa = PBXGroup;
 			children = (
+				327E9AEC2289C5EC00A98BC1 /* Aggregations */,
 				02CAD431217DD12F0074700B /* ContentScan */,
 				322A51B31D9AB13E00C8536D /* Crypto */,
 				320DFDC719DD99B60068622A /* Data */,
@@ -1796,6 +1826,7 @@
 				329D3E621E251027002E2F1E /* MXRoomSummaryUpdater.h in Headers */,
 				321B413F1E09937E009EEEC7 /* MXRoomSummary.h in Headers */,
 				B17982F52119E4A2001FD722 /* MXRoomCreateContent.h in Headers */,
+				327E9AEF2289C61100A98BC1 /* MXAggregations.h in Headers */,
 				32DC15CF1A8CF7AE006F9AD3 /* MXPushRuleConditionChecker.h in Headers */,
 				32954019216385F100E300FC /* MXServerNoticeContent.h in Headers */,
 				327187851DA7D0220071C818 /* MXOlmDecryption.h in Headers */,
@@ -1810,6 +1841,7 @@
 				322691361E5EFF8700966A6E /* MXDeviceListOperationsPool.h in Headers */,
 				3281E8B719E42DFE00976E1A /* MXJSONModel.h in Headers */,
 				3284A5A01DB7C00600A09972 /* MXCryptoStore.h in Headers */,
+				327E9AF62289D53800A98BC1 /* MXReactionCount.h in Headers */,
 				B146D4AF21A5A04300D8C2C6 /* MXMediaScanStore.h in Headers */,
 				32FA10CE1FA1C9F700E54233 /* MXOutgoingRoomKeyRequest.h in Headers */,
 				32A1514A1DAF7C0C00400192 /* MXUsersDevicesMap.h in Headers */,
@@ -2121,6 +2153,7 @@
 				327E9AD82284803100A98BC1 /* MXEventAnnotation.m in Sources */,
 				F03EF4FF1DF014D9009DF592 /* MXMediaLoader.m in Sources */,
 				320A8841217F4E3F002EA952 /* MXMegolmBackupAuthData.m in Sources */,
+				327E9AF72289D53800A98BC1 /* MXReactionCount.m in Sources */,
 				32FFB4F1217E146A00C96002 /* MXRecoveryKey.m in Sources */,
 				32DC15D51A8CF874006F9AD3 /* MXPushRuleEventMatchConditionChecker.m in Sources */,
 				320BBF411D6C81550079890E /* MXEventsByTypesEnumeratorOnArray.m in Sources */,
@@ -2192,6 +2225,7 @@
 				B1798304211B3649001FD722 /* MXRoomSummary.swift in Sources */,
 				9274AFE91EE580240009BEB6 /* MXCallKitAdapter.m in Sources */,
 				C63E78B01F26588000AC692F /* MXRoomPowerLevels.swift in Sources */,
+				327E9AF02289C61100A98BC1 /* MXAggregations.m in Sources */,
 				3252DCAF224BE5D40032264F /* MXDeviceVericationManager.m in Sources */,
 				323E0C5C1A306D7A00A31D73 /* MXEvent.m in Sources */,
 				F03EF5011DF014D9009DF592 /* MXMediaManager.m in Sources */,

--- a/MatrixSDK/Aggregations/Data/MXReactionCount.h
+++ b/MatrixSDK/Aggregations/Data/MXReactionCount.h
@@ -1,0 +1,29 @@
+/*
+ Copyright 2019 New Vector Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MXReactionCount : NSObject
+
+@property (nonatomic) NSString *reaction;
+@property (nonatomic) NSUInteger count;
+@property (nonatomic) BOOL myUserHasReacted;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixSDK/Aggregations/Data/MXReactionCount.m
+++ b/MatrixSDK/Aggregations/Data/MXReactionCount.m
@@ -1,0 +1,21 @@
+/*
+ Copyright 2019 New Vector Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXReactionCount.h"
+
+@implementation MXReactionCount
+
+@end

--- a/MatrixSDK/Aggregations/MXAggregations.h
+++ b/MatrixSDK/Aggregations/MXAggregations.h
@@ -32,9 +32,9 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Send a reaction to an event in a room.
 
+ @param reaction the reaction.
  @param eventId the id of the event.
  @param roomId the id of the room.
- @param reaction the reaction.
 
  @param success A block object called when the operation succeeds. It returns
                 the event id of the event generated on the homeserver.
@@ -42,11 +42,11 @@ NS_ASSUME_NONNULL_BEGIN
 
  @return a MXHTTPOperation instance.
  */
-- (MXHTTPOperation*)sendReactionToEvent:(NSString*)eventId
-                                 inRoom:(NSString*)roomId
-                               reaction:(NSString*)reaction
-                                success:(void (^)(NSString *eventId))success
-                                failure:(void (^)(NSError *error))failure;
+- (MXHTTPOperation*)sendReaction:(NSString*)reaction
+                         toEvent:(NSString*)eventId
+                          inRoom:(NSString*)roomId
+                         success:(void (^)(NSString *eventId))success
+                         failure:(void (^)(NSError *error))failure;
 
 /**
  Returns the aggregated reactions counts.

--- a/MatrixSDK/Aggregations/MXAggregations.h
+++ b/MatrixSDK/Aggregations/MXAggregations.h
@@ -1,0 +1,62 @@
+/*
+ Copyright 2019 New Vector Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "MXHTTPOperation.h"
+#import "MXReactionCount.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ The `MXAggregations` class instance manages the Matrix aggregations API.
+ */
+@interface MXAggregations : NSObject
+
+
+#pragma mark - Reactions
+
+/**
+ Send a reaction to an event in a room.
+
+ @param eventId the id of the event.
+ @param roomId the id of the room.
+ @param reaction the reaction.
+
+ @param success A block object called when the operation succeeds. It returns
+                the event id of the event generated on the homeserver.
+ @param failure A block object called when the operation fails.
+
+ @return a MXHTTPOperation instance.
+ */
+- (MXHTTPOperation*)sendReactionToEvent:(NSString*)eventId
+                                 inRoom:(NSString*)roomId
+                               reaction:(NSString*)reaction
+                                success:(void (^)(NSString *eventId))success
+                                failure:(void (^)(NSError *error))failure;
+
+/**
+ Returns the aggregated reactions counts.
+
+ @param eventId the id of the event.
+ @param roomId the id of the room.
+ @return the top most reactions counts.
+ */
+- (nullable NSArray<MXReactionCount*> *)reactionsOnEvent:(NSString*)eventId inRoom:(NSString*)roomId;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixSDK/Aggregations/MXAggregations.m
+++ b/MatrixSDK/Aggregations/MXAggregations.m
@@ -1,0 +1,113 @@
+/*
+ Copyright 2019 New Vector Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXAggregations.h"
+#import "MXAggregations_Private.h"
+
+#import "MXSession.h"
+
+#import "MXEventUnsignedData.h"
+#import "MXEventRelations.h"
+#import "MXEventAnnotationChunk.h"
+#import "MXEventAnnotation.h"
+
+
+@interface MXAggregations ()
+
+@property (nonatomic, weak) MXRestClient *restClient;
+@property (nonatomic, weak) id<MXStore> store;
+
+@end
+
+
+@implementation MXAggregations
+
+#pragma mark - Public methods -
+
+#pragma mark - Reactions
+
+- (MXHTTPOperation*)sendReactionToEvent:(NSString*)eventId
+                                 inRoom:(NSString*)roomId
+                               reaction:(NSString*)reaction
+                                success:(void (^)(NSString *eventId))success
+                                failure:(void (^)(NSError *error))failure;
+{
+    return [self.restClient sendRelationToEvent:eventId
+                                         inRoom:roomId
+                                   relationType:MXEventRelationTypeAnnotation
+                                      eventType:kMXEventTypeStringReaction
+                                     parameters:@{
+                                                  @"key": reaction
+                                                  }
+                                        content:@{}
+                                        success:success failure:failure];
+}
+
+- (nullable NSArray<MXReactionCount*> *)reactionsOnEvent:(NSString *)eventId inRoom:(NSString *)roomId
+{
+    NSMutableArray *reactions;
+
+    MXEvent *event = [self.store eventWithEventId:eventId inRoom:roomId];
+    if (event)
+    {
+        reactions = [NSMutableArray array];
+
+        for (MXEventAnnotation *annotation in event.unsignedData.relations.annotation.chunk)
+        {
+            if ([annotation.type isEqualToString:MXEventAnnotationReaction])
+            {
+                MXReactionCount *reactionCount = [MXReactionCount new];
+                reactionCount.reaction = annotation.key;
+                reactionCount.count = annotation.count;
+
+                [reactions addObject:reactionCount];
+            }
+        }
+    }
+
+    return reactions;
+}
+
+
+#pragma mark - SDK-Private methods -
+
+- (instancetype)initWithMatrixSession:(MXSession *)mxSession
+{
+    self = [super init];
+    if (self)
+    {
+        self.restClient = mxSession.matrixRestClient;
+        self.store = mxSession.store;
+
+        [mxSession listenToEventsOfTypes:@[kMXEventTypeStringReaction] onEvent:^(MXEvent *event, MXTimelineDirection direction, id customObject) {
+
+            if (direction == MXTimelineDirectionForwards)
+            {
+                [self handleReaction:event];
+            }
+        }];
+    }
+
+    return self;
+}
+
+- (void)handleReaction:(MXEvent *)event
+{
+
+}
+
+
+@end

--- a/MatrixSDK/Aggregations/MXAggregations.m
+++ b/MatrixSDK/Aggregations/MXAggregations.m
@@ -60,6 +60,7 @@
 {
     NSMutableArray *reactions;
 
+    // TODO: change that to use a separate dedicated store where data is aggregated
     MXEvent *event = [self.store eventWithEventId:eventId inRoom:roomId];
     if (event)
     {
@@ -106,7 +107,7 @@
 
 - (void)handleReaction:(MXEvent *)event
 {
-
+    // TODO: but need a dedicated store
 }
 
 

--- a/MatrixSDK/Aggregations/MXAggregations.m
+++ b/MatrixSDK/Aggregations/MXAggregations.m
@@ -39,11 +39,11 @@
 
 #pragma mark - Reactions
 
-- (MXHTTPOperation*)sendReactionToEvent:(NSString*)eventId
-                                 inRoom:(NSString*)roomId
-                               reaction:(NSString*)reaction
-                                success:(void (^)(NSString *eventId))success
-                                failure:(void (^)(NSError *error))failure;
+- (MXHTTPOperation*)sendReaction:(NSString*)reaction
+                         toEvent:(NSString*)eventId
+                          inRoom:(NSString*)roomId
+                         success:(void (^)(NSString *eventId))success
+                         failure:(void (^)(NSError *error))failure
 {
     return [self.restClient sendRelationToEvent:eventId
                                          inRoom:roomId

--- a/MatrixSDK/Aggregations/MXAggregations_Private.h
+++ b/MatrixSDK/Aggregations/MXAggregations_Private.h
@@ -1,0 +1,39 @@
+/*
+ Copyright 2019 New Vector Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXAggregations.h"
+
+@class MXSession;
+
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ The `MXAggregations_Private` extension exposes internal operations.
+ */
+@interface MXAggregations ()
+
+/**
+ Constructor.
+
+ @param mxSession the related 'MXSession'.
+ */
+- (instancetype)initWithMatrixSession:(MXSession *)mxSession;
+
+@end
+
+NS_ASSUME_NONNULL_END
+

--- a/MatrixSDK/Contrib/Swift/JSONModels/MXEvent.swift
+++ b/MatrixSDK/Contrib/Swift/JSONModels/MXEvent.swift
@@ -55,6 +55,7 @@ public enum MXEventType {
     case callCandidates
     case callAnswer
     case callHangup
+    case reaction
     case receipt
     case roomTombStone
     case keyVerificationStart
@@ -93,6 +94,7 @@ public enum MXEventType {
         case .callCandidates: return kMXEventTypeStringCallCandidates
         case .callAnswer: return kMXEventTypeStringCallAnswer
         case .callHangup: return kMXEventTypeStringCallHangup
+        case .reaction: return kMXEventTypeStringReaction
         case .receipt: return kMXEventTypeStringReceipt
         case .roomTombStone: return kMXEventTypeStringRoomTombStone
         case .keyVerificationStart: return kMXEventTypeStringKeyVerificationStart

--- a/MatrixSDK/Data/MXRoom.h
+++ b/MatrixSDK/Data/MXRoom.h
@@ -833,6 +833,26 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidFlushDataNotification;
                              failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 
+
+#pragma mark - Aggregations
+/**
+ Send a reaction to an event.
+
+ @param eventId the event id.
+ @param reaction the reaction.
+
+ @param success A block object called when the operation succeeds. It returns
+                the event id of the event generated on the homeserver.
+ @param failure A block object called when the operation fails.
+
+ @return a MXHTTPOperation instance.
+ */
+- (MXHTTPOperation*)sendReactionToEvent:(NSString*)eventId
+                               reaction:(NSString*)reaction
+                                success:(void (^)(NSString *eventId))success
+                                failure:(void (^)(NSError *error))failure; // NS_REFINED_FOR_SWIFT;
+
+
 #pragma mark - Events listeners on the live timeline
 /**
  Register a listener to events of the room live timeline.

--- a/MatrixSDK/Data/MXRoom.h
+++ b/MatrixSDK/Data/MXRoom.h
@@ -833,26 +833,6 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidFlushDataNotification;
                              failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 
-
-#pragma mark - Aggregations
-/**
- Send a reaction to an event.
-
- @param eventId the event id.
- @param reaction the reaction.
-
- @param success A block object called when the operation succeeds. It returns
-                the event id of the event generated on the homeserver.
- @param failure A block object called when the operation fails.
-
- @return a MXHTTPOperation instance.
- */
-- (MXHTTPOperation*)sendReactionToEvent:(NSString*)eventId
-                               reaction:(NSString*)reaction
-                                success:(void (^)(NSString *eventId))success
-                                failure:(void (^)(NSError *error))failure; // NS_REFINED_FOR_SWIFT;
-
-
 #pragma mark - Events listeners on the live timeline
 /**
  Register a listener to events of the room live timeline.

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -2230,9 +2230,10 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
                                                     inRoom:_roomId
                                               relationType:MXEventRelationTypeAnnotation
                                                  eventType:kMXEventTypeStringReaction
-                                                   content:@{
+                                                parameters:@{
                                                              @"key": reaction
                                                              }
+                                                   content:@{}
                                                    success:success failure:failure];
 }
 

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -2220,6 +2220,23 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
 }
 
 
+#pragma mark - Aggregations
+- (MXHTTPOperation*)sendReactionToEvent:(NSString*)eventId
+                               reaction:(NSString*)reaction
+                                success:(void (^)(NSString *eventId))success
+                                failure:(void (^)(NSError *error))failure
+{
+    return [mxSession.matrixRestClient sendRelationToEvent:eventId
+                                                    inRoom:_roomId
+                                              relationType:MXEventRelationTypeAnnotation
+                                                 eventType:kMXEventTypeStringReaction
+                                                   content:@{
+                                                             @"key": reaction
+                                                             }
+                                                   success:success failure:failure];
+}
+
+
 #pragma mark - Events listeners on the live timeline
 - (id)listenToEvents:(MXOnRoomEvent)onEvent
 {

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -2220,24 +2220,6 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
 }
 
 
-#pragma mark - Aggregations
-- (MXHTTPOperation*)sendReactionToEvent:(NSString*)eventId
-                               reaction:(NSString*)reaction
-                                success:(void (^)(NSString *eventId))success
-                                failure:(void (^)(NSError *error))failure
-{
-    return [mxSession.matrixRestClient sendRelationToEvent:eventId
-                                                    inRoom:_roomId
-                                              relationType:MXEventRelationTypeAnnotation
-                                                 eventType:kMXEventTypeStringReaction
-                                                parameters:@{
-                                                             @"key": reaction
-                                                             }
-                                                   content:@{}
-                                                   success:success failure:failure];
-}
-
-
 #pragma mark - Events listeners on the live timeline
 - (id)listenToEvents:(MXOnRoomEvent)onEvent
 {

--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
@@ -25,7 +25,7 @@
 #import "MXSDKOptions.h"
 #import "MXTools.h"
 
-static NSUInteger const kMXFileVersion = 62;
+static NSUInteger const kMXFileVersion = 63;
 
 static NSString *const kMXFileStoreFolder = @"MXFileStore";
 static NSString *const kMXFileStoreMedaDataFile = @"MXFileStore";

--- a/MatrixSDK/JSONModels/Aggregations/MXAggregationPaginatedResponse.h
+++ b/MatrixSDK/JSONModels/Aggregations/MXAggregationPaginatedResponse.h
@@ -1,0 +1,31 @@
+/*
+ Copyright 2019 New Vector Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "MXJSONModel.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MXAggregationPaginatedResponse : MXJSONModel
+
+@property (nonatomic, readonly) NSArray<NSDictionary*> *chunk;
+@property (nonatomic, readonly, nullable) NSString *nextBatch;
+@property (nonatomic, readonly, nullable) NSString *prevBatch;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixSDK/JSONModels/Aggregations/MXAggregationPaginatedResponse.m
+++ b/MatrixSDK/JSONModels/Aggregations/MXAggregationPaginatedResponse.m
@@ -1,0 +1,39 @@
+/*
+ Copyright 2019 New Vector Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXAggregationPaginatedResponse.h"
+
+@implementation MXAggregationPaginatedResponse
+
++ (instancetype)modelFromJSON:(NSDictionary *)JSONDictionary
+{
+    MXAggregationPaginatedResponse *paginatedResponse;
+
+    NSArray<NSDictionary*> *chunk;
+    MXJSONModelSetArray(chunk, JSONDictionary[@"chunk"]);
+
+    if (chunk)
+    {
+        paginatedResponse = [MXAggregationPaginatedResponse new];
+
+        MXJSONModelSetString(paginatedResponse->_nextBatch, JSONDictionary[@"next_batch"])
+        MXJSONModelSetString(paginatedResponse->_prevBatch, JSONDictionary[@"prev_batch"])
+    }
+
+    return paginatedResponse;
+}
+
+@end

--- a/MatrixSDK/JSONModels/Event/Content/MXEventContentRelatesTo.h
+++ b/MatrixSDK/JSONModels/Event/Content/MXEventContentRelatesTo.h
@@ -20,32 +20,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-
-#pragma mark - Constants
-
-/**
- Annotation relation like reactions.
- */
-FOUNDATION_EXPORT NSString * _Nonnull const MXEventContentRelatesToAnnotationType;
-
-/**
- Reply relation.
- */
-
-FOUNDATION_EXPORT NSString * _Nonnull const MXEventContentRelatesToReferenceType;
-
-/**
- Edition relation.
- */
-FOUNDATION_EXPORT NSString * _Nonnull const MXEventContentRelatesToReplaceType;
-
-
 /**
  JSON model for MXEvent.content.relates_to.
  */
 @interface MXEventContentRelatesTo : MXJSONModel
 
-@property (nonatomic, readonly) NSString *relationType;
+@property (nonatomic, readonly) NSString *relationType;     // Ex: MXEventRelationTypeAnnotation
 @property (nonatomic, readonly) NSString *eventId;
 @property (nonatomic, readonly, nullable) NSString *key;
 

--- a/MatrixSDK/JSONModels/Event/Content/MXEventContentRelatesTo.h
+++ b/MatrixSDK/JSONModels/Event/Content/MXEventContentRelatesTo.h
@@ -1,0 +1,54 @@
+/*
+ Copyright 2019 New Vector Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "MXJSONModel.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+
+#pragma mark - Constants
+
+/**
+ Annotation relation like reactions.
+ */
+FOUNDATION_EXPORT NSString * _Nonnull const MXEventContentRelatesToAnnotationType;
+
+/**
+ Reply relation.
+ */
+
+FOUNDATION_EXPORT NSString * _Nonnull const MXEventContentRelatesToReferenceType;
+
+/**
+ Edition relation.
+ */
+FOUNDATION_EXPORT NSString * _Nonnull const MXEventContentRelatesToReplaceType;
+
+
+/**
+ JSON model for MXEvent.content.relates_to.
+ */
+@interface MXEventContentRelatesTo : MXJSONModel
+
+@property (nonatomic, readonly) NSString *relationType;
+@property (nonatomic, readonly) NSString *eventId;
+@property (nonatomic, readonly, nullable) NSString *key;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixSDK/JSONModels/Event/Content/MXEventContentRelatesTo.m
+++ b/MatrixSDK/JSONModels/Event/Content/MXEventContentRelatesTo.m
@@ -1,0 +1,51 @@
+/*
+ Copyright 2019 New Vector Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXEventContentRelatesTo.h"
+
+
+#pragma mark - Constants
+NSString *const MXEventContentRelatesToAnnotationType = @"m.annotation";
+NSString *const MXEventContentRelatesToReferenceType = @"m.reference";
+NSString *const MXEventContentRelatesToReplaceType = @"m.replace";
+
+
+@implementation MXEventContentRelatesTo
+
+#pragma mark - MXJSONModel
+
++ (id)modelFromJSON:(NSDictionary *)JSONDictionary
+{
+    MXEventContentRelatesTo *relatesTo;
+
+    NSString *relationType;
+    NSString *eventId;
+    MXJSONModelSetString(relationType, JSONDictionary[@"rel_type"]);
+    MXJSONModelSetString(eventId, JSONDictionary[@"event_id"]);
+
+    if (relationType && eventId)
+    {
+        relatesTo = [MXEventContentRelatesTo new];
+        relatesTo->_relationType = relationType;
+        relatesTo->_eventId = eventId;
+
+        MXJSONModelSetString(relatesTo->_key, JSONDictionary[@"key"]);
+    }
+
+    return relatesTo;
+}
+
+@end

--- a/MatrixSDK/JSONModels/Event/Content/MXEventContentRelatesTo.m
+++ b/MatrixSDK/JSONModels/Event/Content/MXEventContentRelatesTo.m
@@ -17,12 +17,6 @@
 #import "MXEventContentRelatesTo.h"
 
 
-#pragma mark - Constants
-NSString *const MXEventContentRelatesToAnnotationType = @"m.annotation";
-NSString *const MXEventContentRelatesToReferenceType = @"m.reference";
-NSString *const MXEventContentRelatesToReplaceType = @"m.replace";
-
-
 @implementation MXEventContentRelatesTo
 
 #pragma mark - MXJSONModel

--- a/MatrixSDK/JSONModels/Event/MXEventAnnotation.h
+++ b/MatrixSDK/JSONModels/Event/MXEventAnnotation.h
@@ -1,0 +1,41 @@
+/*
+ Copyright 2019 New Vector Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "MXJSONModel.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+
+#pragma mark - Constants
+
+// "m.reaction"
+FOUNDATION_EXPORT NSString * _Nonnull const MXEventAnnotationReaction;
+
+
+/**
+ JSON model for MXEvent.unsignedData.relations.annotation.chunk[].
+ */
+@interface MXEventAnnotation : MXJSONModel
+
+@property (nonatomic, readonly) NSString *type;         // "m.reaction"
+@property (nonatomic, readonly) NSString *key;          // "👍"
+@property (nonatomic, readonly) NSUInteger count;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixSDK/JSONModels/Event/MXEventAnnotation.m
+++ b/MatrixSDK/JSONModels/Event/MXEventAnnotation.m
@@ -1,0 +1,80 @@
+/*
+ Copyright 2019 New Vector Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXEventAnnotation.h"
+
+
+#pragma mark - Constants
+NSString *const MXEventAnnotationReaction = @"m.reaction";
+
+
+@implementation MXEventAnnotation
+
++ (instancetype)modelFromJSON:(NSDictionary *)JSONDictionary
+{
+    MXEventAnnotation *chunk;
+
+    NSString *type, *key;
+    MXJSONModelSetString(type, JSONDictionary[@"type"]);
+    MXJSONModelSetString(key, JSONDictionary[@"key"]);
+    if (type && key)
+    {
+        chunk = [MXEventAnnotation new];
+        chunk->_type = type;
+        chunk->_key = key;
+
+        MXJSONModelSetInteger(chunk->_count, JSONDictionary[@"count"])
+    }
+
+    return chunk;
+}
+
+- (NSDictionary *)JSONDictionary
+{
+    NSMutableDictionary *JSONDictionary = [NSMutableDictionary dictionary];
+    if (JSONDictionary)
+    {
+        JSONDictionary[@"type"] = _type;
+        JSONDictionary[@"key"] = _key;
+        JSONDictionary[@"count"] = @(_count);
+    }
+
+    return JSONDictionary;
+}
+
+
+#pragma mark - NSCoding
+
+- (id)initWithCoder:(NSCoder *)aDecoder
+{
+    self = [super init];
+    if (self)
+    {
+        _type = [aDecoder decodeObjectForKey:@"type"];
+        _key = [aDecoder decodeObjectForKey:@"key"];
+        _count = [aDecoder decodeIntegerForKey:@"count"];
+    }
+    return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder
+{
+    [aCoder encodeObject:_type forKey:@"type"];
+    [aCoder encodeObject:_key forKey:@"key"];
+    [aCoder encodeInteger:_count forKey:@"count"];
+}
+
+@end

--- a/MatrixSDK/JSONModels/Event/MXEventAnnotationChunk.h
+++ b/MatrixSDK/JSONModels/Event/MXEventAnnotationChunk.h
@@ -1,0 +1,36 @@
+/*
+ Copyright 2019 New Vector Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "MXJSONModel.h"
+
+@class MXEventAnnotation;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ JSON model for MXEvent.unsignedData.relations.annotation.
+ */
+@interface MXEventAnnotationChunk : MXJSONModel
+
+@property (nonatomic, readonly) NSArray<MXEventAnnotation*> *chunk;
+@property (nonatomic, readonly) NSUInteger count;
+@property (nonatomic, readonly) BOOL limited;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixSDK/JSONModels/Event/MXEventAnnotationChunk.m
+++ b/MatrixSDK/JSONModels/Event/MXEventAnnotationChunk.m
@@ -1,0 +1,82 @@
+/*
+ Copyright 2019 New Vector Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXEventAnnotationChunk.h"
+
+#import "MXEventAnnotation.h"
+
+@implementation MXEventAnnotationChunk
+
++ (instancetype)modelFromJSON:(NSDictionary *)JSONDictionary
+{
+    MXEventAnnotationChunk *annotationChunk;
+
+    NSArray<MXEventAnnotation*> *annotations;
+    MXJSONModelSetMXJSONModelArray(annotations, MXEventAnnotation, JSONDictionary[@"chunk"]);
+    if (annotations)
+    {
+        annotationChunk = [MXEventAnnotationChunk new];
+        annotationChunk->_chunk = annotations;
+
+        MXJSONModelSetInteger(annotationChunk->_count, JSONDictionary[@"count"])
+        MXJSONModelSetBoolean(annotationChunk->_limited, JSONDictionary[@"limited"])
+    }
+
+    return annotationChunk;
+}
+
+- (NSDictionary *)JSONDictionary
+{
+    NSMutableDictionary *JSONDictionary = [NSMutableDictionary dictionary];
+    if (JSONDictionary)
+    {
+        NSMutableArray *annotations = [NSMutableArray arrayWithCapacity:_chunk.count];
+        for (MXEventAnnotation *annotation in _chunk)
+        {
+            [annotations addObject:annotation.JSONDictionary];
+        }
+        JSONDictionary[@"chunk"] = annotations;
+
+        JSONDictionary[@"count"] = @(_count);
+        JSONDictionary[@"limited"] = @(_limited);
+    }
+
+    return JSONDictionary;
+}
+
+
+#pragma mark - NSCoding
+
+- (id)initWithCoder:(NSCoder *)aDecoder
+{
+    self = [super init];
+    if (self)
+    {
+        _chunk = [aDecoder decodeObjectForKey:@"chunk"];
+        _count = [aDecoder decodeIntegerForKey:@"count"];
+        _limited = [aDecoder decodeBoolForKey:@"limited"];
+    }
+    return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder
+{
+    [aCoder encodeObject:_chunk forKey:@"chunk"];
+    [aCoder encodeInteger:_count forKey:@"count"];
+    [aCoder encodeBool:_limited forKey:@"limited"];
+}
+
+@end

--- a/MatrixSDK/JSONModels/Event/MXEventRelations.h
+++ b/MatrixSDK/JSONModels/Event/MXEventRelations.h
@@ -1,0 +1,36 @@
+/*
+ Copyright 2019 New Vector Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "MXJSONModel.h"
+
+@class MXEventAnnotationChunk;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ JSON model for MXEvent.unsignedData.relations.
+ */
+@interface MXEventRelations : MXJSONModel
+
+@property (nonatomic, readonly, nullable) MXEventAnnotationChunk *annotation;
+//@property (nonatomic, readonly, nullable) MXEventReferenceChunk *reference;
+//@property (nonatomic, readonly, nullable) MXEventReplaceChunk *replace;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixSDK/JSONModels/Event/MXEventRelations.m
+++ b/MatrixSDK/JSONModels/Event/MXEventRelations.m
@@ -1,0 +1,74 @@
+/*
+ Copyright 2019 New Vector Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXEventRelations.h"
+
+#import "MXEventAnnotationChunk.h"
+
+
+@implementation MXEventRelations
+
+#pragma mark - MXJSONModel
+
++ (id)modelFromJSON:(NSDictionary *)JSONDictionary
+{
+    MXEventRelations *relations;
+
+    MXEventAnnotationChunk *annotation;
+    MXJSONModelSetMXJSONModel(annotation, MXEventAnnotationChunk, JSONDictionary[@"m.annotation"]);
+
+    if (annotation)
+    {
+        relations = [MXEventRelations new];
+        relations->_annotation = annotation;
+    }
+
+    return relations;
+}
+
+- (NSDictionary *)JSONDictionary
+{
+    NSMutableDictionary *JSONDictionary = [NSMutableDictionary dictionary];
+    if (JSONDictionary)
+    {
+        if (_annotation)
+        {
+            JSONDictionary[@"m.annotation"] = _annotation.JSONDictionary;
+        }
+    }
+
+    return JSONDictionary;
+}
+
+
+#pragma mark - NSCoding
+
+- (id)initWithCoder:(NSCoder *)aDecoder
+{
+    self = [super init];
+    if (self)
+    {
+        _annotation = [aDecoder decodeObjectForKey:@"annotation"];
+    }
+    return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder
+{
+    [aCoder encodeObject:_annotation forKey:@"annotation"];
+}
+
+@end

--- a/MatrixSDK/JSONModels/Event/MXEventUnsignedData.h
+++ b/MatrixSDK/JSONModels/Event/MXEventUnsignedData.h
@@ -1,0 +1,81 @@
+/*
+ Copyright 2019 New Vector Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "MXJSONModel.h"
+
+@class MXEvent;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MXEventUnsignedData : MXJSONModel
+
+/**
+ The age of the event in milliseconds.
+ As homeservers clocks may be not synchronised, this relative value may be more accurate.
+ It is computed by the user's home server each time it sends the event to a client.
+ Then, the SDK updates it each time the property is read.
+ */
+@property (nonatomic, readonly) NSUInteger age;
+
+/**
+ The `age` value transcoded in a timestamp based on the device clock when the SDK received
+ the event from the home server.
+ Unlike `age`, this value is static.
+ */
+@property (nonatomic, readonly) uint64_t ageLocalTs;
+
+/**
+ The event id of the state event this event replaces.
+ */
+@property (nonatomic, readonly, nullable) NSString *replacesState;
+
+/**
+ The sender of the replaced state event.
+ */
+@property (nonatomic, readonly, nullable) NSString *prevSender;
+
+/**
+ The content of the replaced state event.
+ */
+@property (nonatomic, readonly, nullable) NSDictionary<NSString *, id> *prevContent;
+
+/**
+ A reason for why the event was redacted.
+ */
+@property (nonatomic, readonly, nullable) NSDictionary *redactedBecause;
+
+/**
+ The client-supplied transaction ID, if the client being given the event is the same one which sent it.
+ */
+@property (nonatomic, readonly, nullable) NSString *transactionId;
+
+/**
+ A subset of the state of the room at the time of the invite, if membership is invite.
+
+ Note that this state is informational, and SHOULD NOT be trusted; once the client has joined the room,
+ it SHOULD fetch the live state from the server and discard the invite_room_state.
+ Also, clients must not rely on any particular state being present here; they SHOULD behave properly
+ (with possibly a degraded but not a broken experience) in the absence of any particular events here.
+ If they are set on the room, at least the state for m.room.avatar, m.room.canonical_alias, m.room.join_rules,
+ and m.room.name SHOULD be included.
+ */
+@property (nonatomic) NSArray<MXEvent *> *inviteRoomState;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixSDK/JSONModels/Event/MXEventUnsignedData.h
+++ b/MatrixSDK/JSONModels/Event/MXEventUnsignedData.h
@@ -18,7 +18,7 @@
 
 #import "MXJSONModel.h"
 
-@class MXEvent;
+@class MXEvent, MXEventRelations;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -75,6 +75,11 @@ NS_ASSUME_NONNULL_BEGIN
  and m.room.name SHOULD be included.
  */
 @property (nonatomic) NSArray<MXEvent *> *inviteRoomState;
+
+/**
+ Aggregated relations (reactions, edition, ...).
+ */
+@property (nonatomic, readonly, nullable) MXEventRelations *relations;
 
 @end
 

--- a/MatrixSDK/JSONModels/Event/MXEventUnsignedData.m
+++ b/MatrixSDK/JSONModels/Event/MXEventUnsignedData.m
@@ -1,0 +1,148 @@
+/*
+ Copyright 2019 New Vector Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXEventUnsignedData.h"
+
+#import "MXEvent.h"
+
+@implementation MXEventUnsignedData
+
+
+#pragma mark - MXJSONModel
+
++ (id)modelFromJSON:(NSDictionary *)JSONDictionary
+{
+    MXEventUnsignedData *unsignedData = [MXEventUnsignedData new];
+    if (unsignedData)
+    {
+        if (JSONDictionary[@"age"])
+        {
+            MXJSONModelSetUInteger(unsignedData.age, JSONDictionary[@"age"]);
+        }
+
+        MXJSONModelSetString(unsignedData->_replacesState, JSONDictionary[@"replaces_state"]);
+        MXJSONModelSetString(unsignedData->_prevSender, JSONDictionary[@"prev_sender"]);
+        MXJSONModelSetDictionary(unsignedData->_prevContent, JSONDictionary[@"prev_content"]);
+        MXJSONModelSetDictionary(unsignedData->_redactedBecause, JSONDictionary[@"redacted_because"]);
+        MXJSONModelSetDictionary(unsignedData->_transactionId, JSONDictionary[@"transaction_id"]);
+        MXJSONModelSetDictionary(unsignedData->_inviteRoomState, JSONDictionary[@"invite_room_state"]);
+    }
+
+    return unsignedData;
+}
+
+- (NSDictionary *)JSONDictionary
+{
+    NSMutableDictionary *JSONDictionary = [NSMutableDictionary dictionary];
+    if (JSONDictionary)
+    {
+        if (_ageLocalTs != -1)
+        {
+            JSONDictionary[@"age"] = @(self.age);
+        }
+        if (_replacesState)
+        {
+            JSONDictionary[@"replaces_state"] = _replacesState;
+        }
+        if (_prevSender)
+        {
+            JSONDictionary[@"prev_sender"] = _prevSender;
+        }
+        if (_prevContent)
+        {
+            JSONDictionary[@"prev_content"] = _prevContent;
+        }
+        if (_redactedBecause)
+        {
+            JSONDictionary[@"redacted_because"] = _redactedBecause;
+        }
+        if (_transactionId)
+        {
+            JSONDictionary[@"transaction_id"] = _transactionId;
+        }
+        if (_inviteRoomState)
+        {
+            JSONDictionary[@"invite_room_state"] = _inviteRoomState;
+        }
+    }
+
+    return JSONDictionary;
+}
+
+
+#pragma mark - NSCoding
+
+- (id)initWithCoder:(NSCoder *)aDecoder
+{
+    self = [super init];
+    if (self)
+    {
+        _ageLocalTs = (uint64_t)[aDecoder decodeInt64ForKey:@"ageLocalTs"];
+        _replacesState = [aDecoder decodeObjectForKey:@"replacesState"];
+        _prevSender = [aDecoder decodeObjectForKey:@"prevSender"];
+        _prevContent = [aDecoder decodeObjectForKey:@"prevContent"];
+        _redactedBecause = [aDecoder decodeObjectForKey:@"redactedBecause"];
+        _transactionId = [aDecoder decodeObjectForKey:@"transactionId"];
+        _inviteRoomState = [aDecoder decodeObjectForKey:@"inviteRoomState"];
+    }
+    return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder
+{
+    [aCoder encodeInt64:(int64_t)_ageLocalTs forKey:@"ageLocalTs"];
+    [aCoder encodeObject:_replacesState forKey:@"replacesState"];
+    [aCoder encodeObject:_prevSender forKey:@"prevSender"];
+    [aCoder encodeObject:_prevContent forKey:@"prevContent"];
+    [aCoder encodeObject:_redactedBecause forKey:@"redactedBecause"];
+    [aCoder encodeObject:_transactionId forKey:@"transactionId"];
+    [aCoder encodeObject:_inviteRoomState forKey:@"inviteRoomState"];
+ }
+
+
+#pragma mark - Private methods
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self)
+    {
+        _ageLocalTs = -1;
+    }
+
+    return self;
+}
+
+- (void)setAge:(NSUInteger)age
+{
+    // If the age has not been stored yet in local time stamp, do it now
+    if (-1 == _ageLocalTs)
+    {
+        _ageLocalTs = [[NSDate date] timeIntervalSince1970] * 1000 - age;
+    }
+}
+
+- (NSUInteger)age
+{
+    NSUInteger age = 0;
+    if (-1 != _ageLocalTs)
+    {
+        age = [[NSDate date] timeIntervalSince1970] * 1000 - _ageLocalTs;
+    }
+    return age;
+}
+
+@end

--- a/MatrixSDK/JSONModels/Event/MXEventUnsignedData.m
+++ b/MatrixSDK/JSONModels/Event/MXEventUnsignedData.m
@@ -17,6 +17,8 @@
 #import "MXEventUnsignedData.h"
 
 #import "MXEvent.h"
+#import "MXEventRelations.h"
+
 
 @implementation MXEventUnsignedData
 
@@ -39,6 +41,7 @@
         MXJSONModelSetDictionary(unsignedData->_redactedBecause, JSONDictionary[@"redacted_because"]);
         MXJSONModelSetDictionary(unsignedData->_transactionId, JSONDictionary[@"transaction_id"]);
         MXJSONModelSetDictionary(unsignedData->_inviteRoomState, JSONDictionary[@"invite_room_state"]);
+        MXJSONModelSetMXJSONModel(unsignedData->_relations, MXEventRelations, JSONDictionary[@"m.relations"]);
     }
 
     return unsignedData;
@@ -77,6 +80,10 @@
         {
             JSONDictionary[@"invite_room_state"] = _inviteRoomState;
         }
+        if (_relations)
+        {
+            JSONDictionary[@"m.relations"] = _relations.JSONDictionary;
+        }
     }
 
     return JSONDictionary;
@@ -97,6 +104,7 @@
         _redactedBecause = [aDecoder decodeObjectForKey:@"redactedBecause"];
         _transactionId = [aDecoder decodeObjectForKey:@"transactionId"];
         _inviteRoomState = [aDecoder decodeObjectForKey:@"inviteRoomState"];
+        _relations = [aDecoder decodeObjectForKey:@"relations"];
     }
     return self;
 }
@@ -110,6 +118,7 @@
     [aCoder encodeObject:_redactedBecause forKey:@"redactedBecause"];
     [aCoder encodeObject:_transactionId forKey:@"transactionId"];
     [aCoder encodeObject:_inviteRoomState forKey:@"inviteRoomState"];
+    [aCoder encodeObject:_relations forKey:@"relations"];
  }
 
 

--- a/MatrixSDK/JSONModels/MXEvent.h
+++ b/MatrixSDK/JSONModels/MXEvent.h
@@ -17,7 +17,7 @@
 
 #import "MXJSONModel.h"
 
-@class MXEventDecryptionResult, MXEncryptedContentFile;
+@class MXEventDecryptionResult, MXEncryptedContentFile, MXEventUnsignedData;
 
 /**
  Types of Matrix events
@@ -315,7 +315,7 @@ extern NSString *const kMXEventIdentifierKey;
  Information about this event which was not sent by the originating homeserver.
  HS sends this data under the 'unsigned' field but it is a reserved keyword. Hence, renaming.
  */
-@property (nonatomic) NSDictionary *unsignedData;
+@property (nonatomic) MXEventUnsignedData *unsignedData;
 
 /**
  The age of the event in milliseconds.

--- a/MatrixSDK/JSONModels/MXEvent.h
+++ b/MatrixSDK/JSONModels/MXEvent.h
@@ -17,7 +17,10 @@
 
 #import "MXJSONModel.h"
 
-@class MXEventDecryptionResult, MXEncryptedContentFile, MXEventUnsignedData;
+#import "MXEventUnsignedData.h"
+#import "MXEventContentRelatesTo.h"
+
+@class MXEventDecryptionResult, MXEncryptedContentFile;
 
 /**
  Types of Matrix events
@@ -356,6 +359,11 @@ extern NSString *const kMXEventIdentifierKey;
  In case of invite event, inviteRoomState contains a subset of the state of the room at the time of the invite.
  */
 @property (nonatomic) NSArray<MXEvent *> *inviteRoomState;
+
+/**
+ If the event relates to another one, some data about the relation.
+ */
+@property (nonatomic) MXEventContentRelatesTo *relatesTo;
 
 /**
  In case of sending failure (MXEventSentStateFailed), the error that occured.

--- a/MatrixSDK/JSONModels/MXEvent.h
+++ b/MatrixSDK/JSONModels/MXEvent.h
@@ -58,6 +58,7 @@ typedef enum : NSUInteger
     MXEventTypeRoomTag,
     MXEventTypePresence,
     MXEventTypeTypingNotification,
+    MXEventTypeReaction,
     MXEventTypeReceipt,
     MXEventTypeRead,
     MXEventTypeReadMarker,
@@ -109,6 +110,7 @@ FOUNDATION_EXPORT NSString *const kMXEventTypeStringRoomPinnedEvents;
 FOUNDATION_EXPORT NSString *const kMXEventTypeStringRoomTag;
 FOUNDATION_EXPORT NSString *const kMXEventTypeStringPresence;
 FOUNDATION_EXPORT NSString *const kMXEventTypeStringTypingNotification;
+FOUNDATION_EXPORT NSString *const kMXEventTypeStringReaction;
 FOUNDATION_EXPORT NSString *const kMXEventTypeStringReceipt;
 FOUNDATION_EXPORT NSString *const kMXEventTypeStringRead;
 FOUNDATION_EXPORT NSString *const kMXEventTypeStringReadMarker;
@@ -139,6 +141,13 @@ FOUNDATION_EXPORT NSString *const kMXMessageTypeVideo;
 FOUNDATION_EXPORT NSString *const kMXMessageTypeLocation;
 FOUNDATION_EXPORT NSString *const kMXMessageTypeFile;
 FOUNDATION_EXPORT NSString *const kMXMessageTypeServerNotice;
+
+/**
+ Event relations
+ */
+FOUNDATION_EXPORT NSString *const MXEventRelationTypeAnnotation;    // Reactions
+FOUNDATION_EXPORT NSString *const MXEventRelationTypeReference;     // Reply
+FOUNDATION_EXPORT NSString *const MXEventRelationTypeReplace;       // Edition
 
 /**
  Prefix used for id of temporary local event.

--- a/MatrixSDK/JSONModels/MXEvent.m
+++ b/MatrixSDK/JSONModels/MXEvent.m
@@ -51,6 +51,7 @@ NSString *const kMXEventTypeStringRoomPinnedEvents      = @"m.room.pinned_events
 NSString *const kMXEventTypeStringRoomTag               = @"m.tag";
 NSString *const kMXEventTypeStringPresence              = @"m.presence";
 NSString *const kMXEventTypeStringTypingNotification    = @"m.typing";
+NSString *const kMXEventTypeStringReaction              = @"m.reaction";
 NSString *const kMXEventTypeStringReceipt               = @"m.receipt";
 NSString *const kMXEventTypeStringRead                  = @"m.read";
 NSString *const kMXEventTypeStringReadMarker            = @"m.fully_read";
@@ -75,6 +76,10 @@ NSString *const kMXMessageTypeVideo         = @"m.video";
 NSString *const kMXMessageTypeLocation      = @"m.location";
 NSString *const kMXMessageTypeFile          = @"m.file";
 NSString *const kMXMessageTypeServerNotice  = @"m.server_notice";
+
+NSString *const MXEventRelationTypeAnnotation = @"m.annotation";
+NSString *const MXEventRelationTypeReference = @"m.reference";
+NSString *const MXEventRelationTypeReplace = @"m.replace";
 
 NSString *const kMXEventLocalEventIdPrefix = @"kMXEventLocalId_";
 

--- a/MatrixSDK/JSONModels/MXEvent.m
+++ b/MatrixSDK/JSONModels/MXEvent.m
@@ -20,7 +20,6 @@
 #import "MXTools.h"
 #import "MXEventDecryptionResult.h"
 #import "MXEncryptedContentFile.h"
-#import "MXEventUnsignedData.h"
 
 #pragma mark - Constants definitions
 
@@ -282,6 +281,16 @@ NSString *const kMXEventIdentifierKey = @"kMXEventIdentifierKey";
 - (NSArray<MXEvent *> *)inviteRoomState
 {
     return _inviteRoomState ? _inviteRoomState : _unsignedData.inviteRoomState;
+}
+
+- (MXEventContentRelatesTo *)relatesTo
+{
+    MXEventContentRelatesTo *relatesTo;
+    if (self.content[@"m.relates_to"])
+    {
+        MXJSONModelSetMXJSONModel(relatesTo, MXEventContentRelatesTo, self.content[@"m.relates_to"])
+    }
+    return relatesTo;
 }
 
 - (NSDictionary *)JSONDictionary

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -2530,7 +2530,8 @@ FOUNDATION_EXPORT NSString *const kMXMembersOfRoomParametersNotMembership;
  @param roomId the id of the room.
  @param relationType the type of relation (@see MXEventRelationTypeAnnotation and siblings).
  @param eventType event type of the message.
- @param content the message content.
+ @param parameters (optional) query parameters.
+ @param content (optional) the message content.
 
  @param success A block object called when the operation succeeds. It returns
                 the event id of the event generated on the homeserver.
@@ -2542,6 +2543,7 @@ FOUNDATION_EXPORT NSString *const kMXMembersOfRoomParametersNotMembership;
                                  inRoom:(NSString*)roomId
                            relationType:(NSString*)relationType
                               eventType:(NSString*)eventType
+                             parameters:(NSDictionary*)parameters
                                 content:(NSDictionary*)content
                                 success:(void (^)(NSString *eventId))success
                                 failure:(void (^)(NSError *error))failure;

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -36,6 +36,7 @@
 #import "MXContentScanResult.h"
 #import "MXEncryptedContentFile.h"
 #import "MXContentScanEncryptedBody.h"
+#import "MXAggregationPaginatedResponse.h"
 
 #pragma mark - Constants definitions
 /**
@@ -2518,5 +2519,34 @@ FOUNDATION_EXPORT NSString *const kMXMembersOfRoomParametersNotMembership;
 - (MXHTTPOperation*)getPublicisedGroupsForUsers:(NSArray<NSString*>*)userIds
                                         success:(void (^)(NSDictionary<NSString*, NSArray<NSString*>*> *publicisedGroupsByUserId))success
                                         failure:(void (^)(NSError *error))failure;
+
+
+#pragma mark - Aggregations
+
+/**
+ Get a list of aggregated relations associated to an event.
+
+ @param eventId the id of the event,
+ @param roomId the id of the room.
+ @param relationType (optional) the type of relation.
+ @param eventType (optional) event type to filter by.
+ @param from the token to start getting results from.
+ @param direction `MXTimelineDirectionForwards` or `MXTimelineDirectionBackwards`
+ @param limit (optional, use -1 to not defined this value) the maximum number of messages to return.
+
+ @param success A block object called when the operation succeeds. It provides a `MXAggregationPaginatedResponse` object.
+ @param failure A block object called when the operation fails.
+
+ @return a MXHTTPOperation instance.
+ */
+- (MXHTTPOperation*)aggregationsForEvent:(NSString*)eventId
+                                  inRoom:(NSString*)roomId
+                            relationType:(NSString*)relationType
+                               eventType:(NSString*)eventType
+                                    from:(NSString*)from
+                               direction:(MXTimelineDirection)direction
+                                   limit:(NSUInteger)limit
+                                 success:(void (^)(MXAggregationPaginatedResponse *paginatedResponse))success
+                                 failure:(void (^)(NSError *error))failure;
 
 @end

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -2524,6 +2524,29 @@ FOUNDATION_EXPORT NSString *const kMXMembersOfRoomParametersNotMembership;
 #pragma mark - Aggregations
 
 /**
+ Send a relation to an event.
+
+ @param eventId the id of the parent event.
+ @param roomId the id of the room.
+ @param relationType the type of relation (@see MXEventRelationTypeAnnotation and siblings).
+ @param eventType event type of the message.
+ @param content the message content.
+
+ @param success A block object called when the operation succeeds. It returns
+                the event id of the event generated on the homeserver.
+ @param failure A block object called when the operation fails.
+
+ @return a MXHTTPOperation instance.
+ */
+- (MXHTTPOperation*)sendRelationToEvent:(NSString*)eventId
+                                 inRoom:(NSString*)roomId
+                           relationType:(NSString*)relationType
+                              eventType:(NSString*)eventType
+                                content:(NSDictionary*)content
+                                success:(void (^)(NSString *eventId))success
+                                failure:(void (^)(NSError *error))failure;
+
+/**
  Get a list of aggregated relations associated to an event.
 
  @param eventId the id of the event,

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -4984,7 +4984,7 @@ MXAuthAction;
 
     // Prepare the path
     NSString *path = [NSString stringWithFormat:@"%@/rooms/%@/send_relation/%@/%@/%@/%@",
-                      apiPathPrefix,
+                      kMXAPIPrefixPathUnstable,    // TODO: use apiPathPrefix
                       roomId,
                       [MXTools encodeURIComponent:eventId],
                       relationType,
@@ -5025,7 +5025,7 @@ MXAuthAction;
                                  failure:(void (^)(NSError *error))failure
 {
     NSMutableString *path = [NSMutableString stringWithFormat:@"%@/rooms/%@/aggregations/%@",
-                             apiPathPrefix,
+                             kMXAPIPrefixPathUnstable,    // TODO: use apiPathPrefix
                              roomId,
                              [MXTools encodeURIComponent:eventId]];
 

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -4971,6 +4971,49 @@ MXAuthAction;
 
 #pragma mark - Aggregations
 
+- (MXHTTPOperation*)sendRelationToEvent:(NSString*)eventId
+                                 inRoom:(NSString*)roomId
+                           relationType:(NSString*)relationType
+                              eventType:(NSString*)eventType
+                                content:(NSDictionary*)content
+                                success:(void (^)(NSString *eventId))success
+                                failure:(void (^)(NSError *error))failure
+{
+    // Create a random transaction id to prevent duplicated events
+    NSString *txnId = [MXTools generateTransactionId];
+
+    // Prepare the path
+    NSString *path = [NSString stringWithFormat:@"%@/rooms/%@/send_relation/%@/%@/%@/%@",
+                      apiPathPrefix,
+                      roomId,
+                      [MXTools encodeURIComponent:eventId],
+                      relationType,
+                      eventType,
+                      [MXTools encodeURIComponent:txnId]];
+
+    MXWeakify(self);
+    return [httpClient requestWithMethod:@"PUT"
+                                    path:path
+                              parameters:content
+                                 success:^(NSDictionary *JSONResponse) {
+                                     MXStrongifyAndReturnIfNil(self);
+
+                                     if (success)
+                                     {
+                                         __block NSString *eventId;
+                                         [self dispatchProcessing:^{
+                                             MXJSONModelSetString(eventId, JSONResponse[@"event_id"]);
+                                         } andCompletion:^{
+                                             success(eventId);
+                                         }];
+                                     }
+                                 }
+                                 failure:^(NSError *error) {
+                                     MXStrongifyAndReturnIfNil(self);
+                                     [self dispatchFailure:error inBlock:failure];
+                                 }];
+}
+
 - (MXHTTPOperation*)aggregationsForEvent:(NSString*)eventId
                                   inRoom:(NSString*)roomId
                             relationType:(NSString*)relationType
@@ -4981,7 +5024,10 @@ MXAuthAction;
                                  success:(void (^)(MXAggregationPaginatedResponse *paginatedResponse))success
                                  failure:(void (^)(NSError *error))failure
 {
-    NSMutableString *path = [NSMutableString stringWithFormat:@"%@/rooms/%@/aggregations/%@", apiPathPrefix, roomId, eventId];
+    NSMutableString *path = [NSMutableString stringWithFormat:@"%@/rooms/%@/aggregations/%@",
+                             apiPathPrefix,
+                             roomId,
+                             [MXTools encodeURIComponent:eventId]];
 
     if (relationType)
     {

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -4975,6 +4975,7 @@ MXAuthAction;
                                  inRoom:(NSString*)roomId
                            relationType:(NSString*)relationType
                               eventType:(NSString*)eventType
+                             parameters:(NSDictionary*)parameters
                                 content:(NSDictionary*)content
                                 success:(void (^)(NSString *eventId))success
                                 failure:(void (^)(NSError *error))failure
@@ -4983,13 +4984,37 @@ MXAuthAction;
     NSString *txnId = [MXTools generateTransactionId];
 
     // Prepare the path
-    NSString *path = [NSString stringWithFormat:@"%@/rooms/%@/send_relation/%@/%@/%@/%@",
-                      kMXAPIPrefixPathUnstable,    // TODO: use apiPathPrefix
-                      roomId,
-                      [MXTools encodeURIComponent:eventId],
-                      relationType,
-                      eventType,
-                      [MXTools encodeURIComponent:txnId]];
+    NSMutableString *path = [NSMutableString stringWithFormat:@"%@/rooms/%@/send_relation/%@/%@/%@/%@",
+                             kMXAPIPrefixPathUnstable,    // TODO: use apiPathPrefix
+                             roomId,
+                             [MXTools encodeURIComponent:eventId],
+                             relationType,
+                             eventType,
+                             [MXTools encodeURIComponent:txnId]];
+
+    // Serialise query parameters
+    if (parameters)
+    {
+        NSMutableString *queryParameters;
+        for (NSString *key in parameters)
+        {
+            NSString *value = [MXTools encodeURIComponent:parameters[key]];
+
+            if (!queryParameters)
+            {
+                queryParameters = [NSMutableString stringWithFormat:@"?%@=%@", key, value];
+            }
+            else
+            {
+                [queryParameters appendFormat:@"&%@=%@", key, value];
+            }
+        }
+
+        if (queryParameters)
+        {
+            [path appendString:queryParameters];
+        }
+    }
 
     MXWeakify(self);
     return [httpClient requestWithMethod:@"PUT"

--- a/MatrixSDK/MXSession.h
+++ b/MatrixSDK/MXSession.h
@@ -33,6 +33,7 @@
 #import "MXGroup.h"
 #import "MXError.h"
 #import "MXScanManager.h"
+#import "MXAggregations.h"
 
 /**
  `MXSessionState` represents the states in the life cycle of a MXSession instance.
@@ -424,6 +425,11 @@ FOUNDATION_EXPORT NSString *const kMXSessionNoRoomTag;
  Nil if `antivirusServerURL` is nil.
  */
 @property (nonatomic, readonly) MXScanManager *scanManager;
+
+/**
+ The module that manages aggregations (reactions, edition, ...).
+ */
+@property (nonatomic, readonly) MXAggregations *aggregations;
 
 #pragma mark - Class methods
 

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -42,6 +42,8 @@
 
 #import "MXScanManager.h"
 
+#import "MXAggregations_Private.h"
+
 #pragma mark - Constants definitions
 
 const NSString *MatrixSDKVersion = @"0.12.5";
@@ -292,6 +294,8 @@ typedef void (^MXOnResumeDone)(void);
         {
             return;
         }
+
+        self->_aggregations = [[MXAggregations alloc] initWithMatrixSession:self];
 
         // Check if the user has enabled crypto
         MXWeakify(self);

--- a/MatrixSDK/MatrixSDK.h
+++ b/MatrixSDK/MatrixSDK.h
@@ -63,3 +63,8 @@ FOUNDATION_EXPORT NSString *MatrixSDKVersion;
 #import "MXServerNotices.h"
 
 #import "MXAutoDiscovery.h"
+
+#import "MXEventUnsignedData.h"
+#import "MXEventRelations.h"
+#import "MXEventAnnotationChunk.h"
+#import "MXEventAnnotation.h"

--- a/MatrixSDK/Utils/MXTools.m
+++ b/MatrixSDK/Utils/MXTools.m
@@ -94,6 +94,7 @@ NSCharacterSet *uriComponentCharset;
                                 kMXEventTypeStringRoomTag,
                                 kMXEventTypeStringPresence,
                                 kMXEventTypeStringTypingNotification,
+                                kMXEventTypeStringReaction,
                                 kMXEventTypeStringReceipt,
                                 kMXEventTypeStringRead,
                                 kMXEventTypeStringReadMarker,

--- a/MatrixSDKTests/MXEventAnnotationTests.swift
+++ b/MatrixSDKTests/MXEventAnnotationTests.swift
@@ -1,0 +1,84 @@
+/*
+ Copyright 2019 New Vector Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+import XCTest
+
+import MatrixSDK
+
+class MXEventAnnotationTests: XCTestCase {
+
+    let eventJSON = [
+        "event_id": "$eventId",
+        "type": "m.room.message",
+        "origin_server_ts": 0,
+        "unsigned": [
+            "m.relations": [
+                "m.annotation": [
+                    "chunk": [
+                        [
+                            "type": "m.reaction",
+                            "key": "👍",
+                            "count": 3
+                        ]
+                    ],
+                    "limited": false,
+                    "count": 1
+                ],
+            ]
+        ]
+        ] as [String : AnyObject]
+
+    override func setUp() {
+    }
+
+    override func tearDown() {
+    }
+
+    func testModelFromJSON() {
+        let event = MXEvent(fromJSON: eventJSON)
+
+        XCTAssertEqual(event?.unsignedData.relations?.annotation?.chunk.count, 1)
+        XCTAssertEqual(event?.unsignedData.relations?.annotation?.limited, false)
+        XCTAssertEqual(event?.unsignedData.relations?.annotation?.count, 1)
+
+        if let annotation = event?.unsignedData.relations?.annotation?.chunk[0] {
+            XCTAssertEqual(annotation.type, MXEventAnnotationReaction)
+            XCTAssertEqual(annotation.key, "👍")
+            XCTAssertEqual(annotation.count, 3)
+        }
+    }
+
+    func testJSONDictionary() {
+        let event = MXEvent(fromJSON: eventJSON)
+
+        let jsonDictionary = event?.jsonDictionary() as! [String : AnyObject]
+        XCTAssertNotNil(jsonDictionary)
+
+        XCTAssertTrue(NSDictionary(dictionary: jsonDictionary).isEqual(to: eventJSON), "JSON are different:\n\(jsonDictionary)\nvs\n\(eventJSON)")
+    }
+
+    @available(iOS 9.0, *)
+    func testNSCoding() {
+        let event = MXEvent(fromJSON: eventJSON)
+
+        let data = NSKeyedArchiver.archivedData(withRootObject: event!)
+        let event2 = try! NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(data) as? MXEvent
+
+        let jsonDictionary2 = event2?.jsonDictionary() as! [String : AnyObject]
+
+        XCTAssertTrue(NSDictionary(dictionary: jsonDictionary2).isEqual(to: eventJSON), "JSON are different:\n\(jsonDictionary2)\nvs\n\(eventJSON)")
+    }
+}
+

--- a/MatrixSDKTests/MXEventAnnotationTests.swift
+++ b/MatrixSDKTests/MXEventAnnotationTests.swift
@@ -19,7 +19,7 @@ import MatrixSDK
 
 class MXEventAnnotationTests: XCTestCase {
 
-    let eventJSON = [
+    let eventJSON: [String : Any] = [
         "event_id": "$eventId",
         "type": "m.room.message",
         "origin_server_ts": 0,
@@ -38,7 +38,7 @@ class MXEventAnnotationTests: XCTestCase {
                 ],
             ]
         ]
-        ] as [String : AnyObject]
+        ]
 
     override func setUp() {
     }
@@ -63,10 +63,13 @@ class MXEventAnnotationTests: XCTestCase {
     func testJSONDictionary() {
         let event = MXEvent(fromJSON: eventJSON)
 
-        let jsonDictionary = event?.jsonDictionary() as! [String : AnyObject]
+        let jsonDictionary = event?.jsonDictionary() as? [String : AnyObject]
         XCTAssertNotNil(jsonDictionary)
 
-        XCTAssertTrue(NSDictionary(dictionary: jsonDictionary).isEqual(to: eventJSON), "JSON are different:\n\(jsonDictionary)\nvs\n\(eventJSON)")
+        if let jsonDictionary = jsonDictionary {
+            XCTAssertTrue(NSDictionary(dictionary: jsonDictionary).isEqual(to: eventJSON), "JSON are different:\n\(jsonDictionary)\nvs\n\(eventJSON)")
+
+        }
     }
 
     @available(iOS 9.0, *)

--- a/MatrixSDKTests/MXReactionTests.m
+++ b/MatrixSDKTests/MXReactionTests.m
@@ -19,6 +19,10 @@
 #import "MatrixSDKTestsData.h"
 
 #import "MXFileStore.h"
+#import "MXEventUnsignedData.h"
+#import "MXEventRelations.h"
+#import "MXEventAnnotationChunk.h"
+#import "MXEventAnnotation.h"
 
 @interface MXReactionTests : XCTestCase
 {
@@ -41,31 +45,97 @@
     matrixSDKTestsData = nil;
 }
 
-- (void)testReactionSendAndReceive
+// Create a room with an event with a reaction on it
+- (void)createScenario:(void(^)(MXSession *mxSession, MXRoom *room, XCTestExpectation *expectation, NSString *eventId, NSString *reactionEventId))readyToTest
 {
     [matrixSDKTestsData doMXSessionTestWithBobAndARoom:self andStore:[[MXMemoryStore alloc] init] readyToTest:^(MXSession *mxSession, MXRoom *room, XCTestExpectation *expectation) {
 
         [room sendTextMessage:@"Hello" success:^(NSString *eventId) {
 
-            [room sendReactionToEvent:eventId reaction:@"👍" success:^(NSString *eventId) {
-                XCTAssertNotNil(eventId);
+            [room sendReactionToEvent:eventId reaction:@"👍" success:^(NSString *reactionEventId) {
+
+                readyToTest(mxSession, room, expectation, eventId, reactionEventId);
 
             } failure:^(NSError *error) {
-                XCTFail(@"The operation should not fail - NSError: %@", error);
+                XCTFail(@"Cannot set up intial test conditions - error: %@", error);
                 [expectation fulfill];
             }];
-
         } failure:^(NSError *error) {
             XCTFail(@"Cannot set up intial test conditions - error: %@", error);
-            [expectation fulfill];
-        }];
-
-        [room listenToEventsOfTypes:@[kMXEventTypeStringReaction] onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
-
             [expectation fulfill];
         }];
     }];
 }
 
+// - Send a message
+// - React on it
+// -> a m.reaction message must appear in the timeline
+- (void)testReactionSendAndReceive
+{
+    [matrixSDKTestsData doMXSessionTestWithBobAndARoom:self andStore:[[MXMemoryStore alloc] init] readyToTest:^(MXSession *mxSession, MXRoom *room, XCTestExpectation *expectation) {
+
+        // - Send a message
+        [room sendTextMessage:@"Hello" success:^(NSString *eventId) {
+
+            // - React on it
+            [room sendReactionToEvent:eventId reaction:@"👍" success:^(NSString *eventId) {
+                XCTAssertNotNil(eventId);
+            } failure:^(NSError *error) {
+                XCTFail(@"The operation should not fail - NSError: %@", error);
+                [expectation fulfill];
+            }];
+
+            [room listenToEventsOfTypes:@[kMXEventTypeStringReaction] onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
+
+                // -> a m.reaction message must appear in the timeline
+                XCTAssertEqual(event.eventType, MXEventTypeReaction);
+                XCTAssertEqualObjects(event.type, kMXEventTypeStringReaction);
+
+                XCTAssertNotNil(event.relatesTo);
+                XCTAssertEqualObjects(event.relatesTo.relationType, MXEventRelationTypeAnnotation);
+                XCTAssertEqualObjects(event.relatesTo.eventId, eventId);
+                XCTAssertEqualObjects(event.relatesTo.key, @"👍");
+
+                [expectation fulfill];
+            }];
+        } failure:^(NSError *error) {
+            XCTFail(@"Cannot set up intial test conditions - error: %@", error);
+            [expectation fulfill];
+        }];
+    }];
+}
+
+// - Run the scenario
+// - Do an initial sync
+// -> The aggregated reactions count must be right
+- (void)testAggregationFromInitialSync
+{
+    // - Run the scenario
+    [self createScenario:^(MXSession *mxSession, MXRoom *room, XCTestExpectation *expectation, NSString *eventId, NSString *reactionEventId) {
+
+        // - Do an initial sync
+        [matrixSDKTestsData relogUserSession:mxSession withPassword:MXTESTS_BOB_PWD onComplete:^(MXSession *newSession) {
+
+            [newSession eventWithEventId:eventId inRoom:room.roomId success:^(MXEvent *event) {
+
+                // -> The aggregated reactions count must be right
+                XCTAssertNotNil(event.unsignedData.relations.annotation);
+
+                XCTAssertEqual(event.unsignedData.relations.annotation.chunk.count, 1);
+
+                MXEventAnnotation *annotation = event.unsignedData.relations.annotation.chunk.firstObject;
+                XCTAssertEqualObjects(annotation.type, MXEventAnnotationReaction);
+                XCTAssertEqualObjects(annotation.key, @"👍");
+                XCTAssertEqual(annotation.count, 1);
+
+                [expectation fulfill];
+
+            } failure:^(NSError *error) {
+                XCTFail(@"Cannot set up intial test conditions - error: %@", error);
+                [expectation fulfill];
+            }];
+        }];
+    }];
+}
 
 @end

--- a/MatrixSDKTests/MXReactionTests.m
+++ b/MatrixSDKTests/MXReactionTests.m
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2019 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "MatrixSDKTestsData.h"
+
+#import "MXFileStore.h"
+
+@interface MXReactionTests : XCTestCase
+{
+    MatrixSDKTestsData *matrixSDKTestsData;
+}
+
+@end
+
+@implementation MXReactionTests
+
+- (void)setUp
+{
+    [super setUp];
+
+    matrixSDKTestsData = [[MatrixSDKTestsData alloc] init];
+}
+
+- (void)tearDown
+{
+    matrixSDKTestsData = nil;
+}
+
+- (void)testReactionSendAndReceive
+{
+    [matrixSDKTestsData doMXSessionTestWithBobAndARoom:self andStore:[[MXMemoryStore alloc] init] readyToTest:^(MXSession *mxSession, MXRoom *room, XCTestExpectation *expectation) {
+
+        [room sendTextMessage:@"Hello" success:^(NSString *eventId) {
+
+            [room sendReactionToEvent:eventId reaction:@"👍" success:^(NSString *eventId) {
+                XCTAssertNotNil(eventId);
+
+            } failure:^(NSError *error) {
+                XCTFail(@"The operation should not fail - NSError: %@", error);
+                [expectation fulfill];
+            }];
+
+        } failure:^(NSError *error) {
+            XCTFail(@"Cannot set up intial test conditions - error: %@", error);
+            [expectation fulfill];
+        }];
+
+        [room listenToEventsOfTypes:@[kMXEventTypeStringReaction] onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
+
+            [expectation fulfill];
+        }];
+    }];
+}
+
+
+@end

--- a/MatrixSDKTests/MXReactionTests.m
+++ b/MatrixSDKTests/MXReactionTests.m
@@ -153,6 +153,28 @@
     }];
 }
 
+// - Run the initial condition scenario
+// -> Data from aggregations must be right
+- (void)testAggregationsLive
+{
+    // - Run the initial condition scenario
+    [self createScenario:^(MXSession *mxSession, MXRoom *room, XCTestExpectation *expectation, NSString *eventId, NSString *reactionEventId) {
+
+        // -> Data from aggregations must be right
+        NSArray<MXReactionCount*> *reactions = [mxSession.aggregations reactionsOnEvent:eventId inRoom:room.roomId];
+
+        XCTAssertNotNil(reactions);
+        XCTAssertEqual(reactions.count, 1);
+
+        MXReactionCount *reactionCount = reactions.firstObject;
+        XCTAssertEqualObjects(reactionCount.reaction, @"👍");
+        XCTAssertEqual(reactionCount.count, 1);
+        XCTAssertTrue(reactionCount.myUserHasReacted);
+
+        [expectation fulfill];
+    }];
+}
+
 @end
 
 #pragma clang diagnostic pop

--- a/MatrixSDKTests/MXReactionTests.m
+++ b/MatrixSDKTests/MXReactionTests.m
@@ -56,7 +56,7 @@
 
         [room sendTextMessage:@"Hello" success:^(NSString *eventId) {
 
-            [mxSession.aggregations sendReactionToEvent:eventId inRoom:room.roomId reaction:@"👍" success:^(NSString *reactionEventId) {
+            [mxSession.aggregations sendReaction:@"👍" toEvent:eventId inRoom:room.roomId success:^(NSString *reactionEventId) {
 
                 readyToTest(mxSession, room, expectation, eventId, reactionEventId);
 
@@ -82,7 +82,7 @@
         [room sendTextMessage:@"Hello" success:^(NSString *eventId) {
 
             // - React on it
-            [mxSession.aggregations sendReactionToEvent:eventId inRoom:room.roomId reaction:@"👍" success:^(NSString *eventId) {
+            [mxSession.aggregations sendReaction:@"👍" toEvent:eventId inRoom:room.roomId success:^(NSString *eventId) {
                 XCTAssertNotNil(eventId);
             } failure:^(NSError *error) {
                 XCTFail(@"The operation should not fail - NSError: %@", error);


### PR DESCRIPTION
Part of https://github.com/vector-im/riot-ios/issues/2392

This PR:
- parses and stores aggregated data
- parses relates_to events 
- sends reactions
- provides reactions (but after an initial /sync)

Next PR will:
- provide updated reactions
- have a mechanism to notify updated reactions
- implement MXReactionCount.myUserHasReacted