### PR TITLE
MXHTTPClient: Enable the certificate pinning mode by default as soon …

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,8 @@ Changes in Matrix iOS SDK in 0.12.x (2019-xx-xx)
 ===============================================
 
 Improvements:
- * MXHTTPClient: support multiple SSL pinning modes (none/public key/certificate)
+ * MXRestClient/MXHTTPClient: support multiple SSL pinning modes (none/public key/certificate).
+ * MXHTTPClient: Enable the certificate pinning mode by default as soon as some certificates are present in the application bundle.
 
 Bug Fix:
  *

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -2,6 +2,7 @@
  Copyright 2014 OpenMarket Ltd
  Copyright 2017 Vector Creations Ltd
  Copyright 2018 New Vector Ltd
+ Copyright 2019 The Matrix.org Foundation C.I.C
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -1921,11 +1922,21 @@ FOUNDATION_EXPORT NSString *const kMXMembersOfRoomParametersNotMembership;
 
 #pragma mark - Certificates
 /**
- Set the certificates used to evaluate server trust according to the SSL pinning mode.
+ The certificates used to evaluate server trust.
+ The default SSL pinning mode is MXHTTPClientSSLPinningModeCertificate when the provided set is not empty.
+ Set an empty set or null to restore the default security policy.
 
  @param pinnedCertificates the pinned certificates.
  */
--(void)setPinnedCertificates:(NSSet <NSData *> *)pinnedCertificates;
+- (void)setPinnedCertificates:(NSSet<NSData *> *)pinnedCertificates;
+
+/**
+ Set the certificates used to evaluate server trust and the SSL pinning mode.
+ 
+ @param pinnedCertificates The certificates to pin against.
+ @param pinningMode The SSL pinning mode.
+ */
+- (void)setPinnedCertificates:(NSSet<NSData *> *)pinnedCertificates withPinningMode:(MXHTTPClientSSLPinningMode)pinningMode;
 
 
 #pragma mark - VoIP API

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -2,6 +2,7 @@
  Copyright 2014 OpenMarket Ltd
  Copyright 2017 Vector Creations Ltd
  Copyright 2018 New Vector Ltd
+ Copyright 2019 The Matrix.org Foundation C.I.C
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -3713,8 +3714,14 @@ MXAuthAction;
 
 #pragma mark - Certificates
 
--(void)setPinnedCertificates:(NSSet <NSData *> *)pinnedCertificates {
+-(void)setPinnedCertificates:(NSSet <NSData *> *)pinnedCertificates
+{
     httpClient.pinnedCertificates = pinnedCertificates;
+}
+
+- (void)setPinnedCertificates:(NSSet<NSData *> *)pinnedCertificates withPinningMode:(MXHTTPClientSSLPinningMode)pinningMode
+{
+    [httpClient setPinnedCertificates:pinnedCertificates withPinningMode:pinningMode];
 }
 
 #pragma mark - VoIP API

--- a/MatrixSDK/Utils/MXHTTPClient.h
+++ b/MatrixSDK/Utils/MXHTTPClient.h
@@ -1,6 +1,7 @@
 /*
  Copyright 2014 OpenMarket Ltd
  Copyright 2017 Vector Creations Ltd
+ Copyright 2019 The Matrix.org Foundation C.I.C
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -183,7 +184,9 @@ typedef NS_ENUM(NSUInteger, MXHTTPClientSSLPinningMode) {
 + (NSUInteger)timeForRetry:(MXHTTPOperation*)httpOperation;
 
 /**
- The certificates used to evaluate server trust according to the SSL pinning mode (MXHTTPClientSSLPinningModeCertificate by default).
+ The certificates used to evaluate server trust.
+ The default SSL pinning mode is MXHTTPClientSSLPinningModeCertificate when the provided set is not empty.
+ Set an empty set or null to restore the default security policy.
  */
 @property (nonatomic, strong) NSSet<NSData *> *pinnedCertificates;
 

--- a/MatrixSDK/Utils/MXHTTPClient.m
+++ b/MatrixSDK/Utils/MXHTTPClient.m
@@ -2,6 +2,7 @@
  Copyright 2014 OpenMarket Ltd
  Copyright 2017 Vector Creations Ltd
  Copyright 2018 New Vector Ltd
+ Copyright 2019 The Matrix.org Foundation C.I.C
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -571,6 +572,16 @@ NSString* const kMXHTTPClientUserConsentNotGivenErrorNotificationConsentURIKey =
 
 - (void)setPinnedCertificates:(NSSet<NSData *> *)pinnedCertificates
 {
+    // Restore the default security policy when the provided set is empty.
+    if (!pinnedCertificates.count)
+    {
+        _pinnedCertificates = pinnedCertificates;
+        [self setDefaultSecurityPolicy];
+        
+        return;
+    }
+    
+    // Else consider MXHTTPClientSSLPinningModeCertificate SSL pinning mode by default.
     [self setPinnedCertificates:pinnedCertificates withPinningMode:MXHTTPClientSSLPinningModeCertificate];
 }
 
@@ -591,12 +602,6 @@ NSString* const kMXHTTPClientUserConsentNotGivenErrorNotificationConsentURIKey =
     }
     
     _pinnedCertificates = pinnedCertificates;
-    
-    if (!pinnedCertificates.count)
-    {
-        [self setDefaultSecurityPolicy];
-        return;
-    }
     
     httpManager.securityPolicy = [AFSecurityPolicy policyWithPinningMode:mode withPinnedCertificates:pinnedCertificates];
 }
@@ -739,13 +744,15 @@ NSString* const kMXHTTPClientUserConsentNotGivenErrorNotificationConsentURIKey =
 - (void)setDefaultSecurityPolicy
 {
     // If some certificates are included in app bundle, we enable the AFNetworking pinning mode based on certificate 'AFSSLPinningModeCertificate'.
-    // These certificates will be handled as pinned certificates, the app allows them without prompting the user.
-    // This is an additional option for the developer to handle certificates.
-    AFSecurityPolicy *securityPolicy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeCertificate];
-    if (securityPolicy.pinnedCertificates.count)
+    // These certificates will be handled as pinned certificates (only these certificates will be trusted).
+    NSSet<NSData *> *certificates = [AFSecurityPolicy certificatesInBundle:[NSBundle mainBundle]];
+    if (certificates && certificates.count)
     {
-        securityPolicy.allowInvalidCertificates = YES;
-        httpManager.securityPolicy = securityPolicy;
+        httpManager.securityPolicy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeCertificate withPinnedCertificates:certificates];
+    }
+    else
+    {
+        httpManager.securityPolicy = [AFSecurityPolicy defaultPolicy];
     }
 }
 


### PR DESCRIPTION
…as some certificates are present in the application bundle.

In the previous code, we let AFSecurityPolicy try to retrieve certificate in the AFNetworking Bundle. But, this bundle is not equal to the app Bundle. So certificates were not retrieved.
BTW we do not allow InvalidCertificates anymore when the certificates pinning mode is enabled.

MXRestClient: support multiple SSL pinning modes (none/public key/certificate) too.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request updates [CHANGES.rst](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CHANGES.rst)
* [ ] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)
