### PR TITLE
Reactions: Use a hack to compute count reactions based on relations ww know

### DIFF
--- a/MatrixSDK/Aggregations/Data/MXReactionCount.m
+++ b/MatrixSDK/Aggregations/Data/MXReactionCount.m
@@ -23,4 +23,16 @@
     return (_myUserReactionEventId != nil);
 }
 
+- (NSString *)description
+{
+    if (self.myUserHasReacted)
+    {
+        return [NSString stringWithFormat:@"(%@: %@)", self.reaction, @(self.count)];
+    }
+    else
+    {
+        return [NSString stringWithFormat:@"%@: %@", self.reaction, @(self.count)];
+    }
+}
+
 @end

--- a/MatrixSDK/Aggregations/Data/Store/MXAggregationsStore.h
+++ b/MatrixSDK/Aggregations/Data/Store/MXAggregationsStore.h
@@ -58,6 +58,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)deleteReactionRelation:(MXReactionRelation*)relation;
 
 #pragma mark - Batch operations
+- (nullable NSArray<MXReactionRelation*> *)reactionRelationsOnEvent:(NSString*)eventId;
 - (void)deleteAllReactionRelationsInRoom:(NSString*)roomId;
 
 

--- a/MatrixSDK/Aggregations/Data/Store/Realm/MXRealmAggregationsStore.m
+++ b/MatrixSDK/Aggregations/Data/Store/Realm/MXRealmAggregationsStore.m
@@ -183,6 +183,25 @@
 
 #pragma mark - Batch operations
 
+- (nullable NSArray<MXReactionRelation*> *)reactionRelationsOnEvent:(NSString*)eventId
+{
+    RLMResults<MXRealmReactionRelation *> *realmReactionRelations = [MXRealmReactionRelation objectsInRealm:self.realm
+                                                                                                     where:@"eventId = %@", eventId];
+
+    NSMutableArray<MXReactionRelation *> *reactionRelations;
+    if (realmReactionRelations.count)
+    {
+        reactionRelations = [NSMutableArray arrayWithCapacity:realmReactionRelations.count];
+        for (MXRealmReactionRelation *realmReactionRelation in realmReactionRelations)
+        {
+            MXReactionRelation *reactionRelation = [self.mapper reactionRelationFromRealmReactionRelation:realmReactionRelation];
+            [reactionRelations addObject:reactionRelation];
+        }
+    }
+
+    return reactionRelations;
+}
+
 - (void)deleteAllReactionRelationsInRoom:(NSString*)roomId
 {
     RLMRealm *realm = self.realm;

--- a/MatrixSDK/Aggregations/MXAggregations.m
+++ b/MatrixSDK/Aggregations/MXAggregations.m
@@ -211,6 +211,10 @@
                 [self updateReactionCountForReaction:reaction toEvent:parentEventId reactionEvent:event];
             }
         }
+        else
+        {
+            [self storeRelationForHackForReaction:reaction toEvent:parentEventId reactionEvent:event];
+        }
     }
     else
     {
@@ -363,8 +367,8 @@
     }
 
     [self notifyReactionCountChangeListenersOfRoom:roomId changes:@{
-                                                                                  eventId:reactionCountChange
-                                                                                  }];
+                                                                    eventId:reactionCountChange
+                                                                    }];
 }
 
 - (void)notifyReactionCountChangeListenersOfRoom:(NSString*)roomId event:(NSString*)eventId forDeletedReaction:(NSString*)deletedReaction
@@ -388,7 +392,7 @@
     }
 }
 
-#pragma mark - Reactions hack -
+#pragma mark - Reactions hack (TODO: Remove all methods) -
 /// TODO: To remove once the feature has landed on matrix.org homeserver
 
 // SendReactionUsingHack directly sends a `m.reaction` room message instead of using the `/send_relation` api.
@@ -455,6 +459,12 @@
           [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 
     return reactionCountDict.allValues;
+}
+
+// We need to store all received relations even if we do not know the event yet
+- (void)storeRelationForHackForReaction:(NSString*)reaction toEvent:(NSString*)eventId reactionEvent:(MXEvent *)reactionEvent
+{
+    [self storeRelationForReaction:reaction toEvent:eventId reactionEvent:reactionEvent];
 }
 
 @end

--- a/MatrixSDK/Aggregations/MXAggregations.m
+++ b/MatrixSDK/Aggregations/MXAggregations.m
@@ -113,6 +113,12 @@
         reactions = [self reactionCountsFromMatrixStoreOnEvent:eventId inRoom:roomId];
     }
 
+    if (!reactions)
+    {
+        // Check reaction data from the hack
+        reactions = [self reactionCountsUsingHackOnEvent:eventId inRoom:roomId];
+    }
+
     MXAggregatedReactions *aggregatedReactions;
     if (reactions)
     {
@@ -303,6 +309,13 @@
     if (![self.store hasReactionCountsOnEvent:eventId])
     {
         NSArray<MXReactionCount*> *reactions = [self reactionCountsFromMatrixStoreOnEvent:eventId inRoom:roomId];
+
+        if (!reactions)
+        {
+            // Check reaction data from the hack
+            reactions = [self reactionCountsUsingHackOnEvent:eventId inRoom:roomId];
+        }
+        
         if (reactions)
         {
             [self.store setReactionCounts:reactions onEvent:eventId inRoom:roomId];
@@ -375,8 +388,10 @@
     }
 }
 
-// SendReactionUsingHack directly sends a `m.reaction` room message instead of using the `/send_relation` api.
+#pragma mark - Reactions hack -
 /// TODO: To remove once the feature has landed on matrix.org homeserver
+
+// SendReactionUsingHack directly sends a `m.reaction` room message instead of using the `/send_relation` api.
 - (MXHTTPOperation*)sendReactionUsingHack:(NSString*)reaction
                          toEvent:(NSString*)eventId
                           inRoom:(NSString*)roomId
@@ -401,6 +416,45 @@
                                       };
 
     return [room sendEventOfType:kMXEventTypeStringReaction content:reactionContent localEcho:nil success:success failure:failure];
+}
+
+// Compute reactions counts from relations we know
+// Note: This is not accurate and will be removed soon
+- (nullable NSArray<MXReactionCount*> *)reactionCountsUsingHackOnEvent:(NSString*)eventId inRoom:(NSString*)roomId
+{
+    NSDate *startDate = [NSDate date];
+    
+    NSMutableDictionary<NSString*, MXReactionCount*> *reactionCountDict = [NSMutableDictionary dictionary];
+
+    NSArray<MXReactionRelation*> *relations = [self.store reactionRelationsOnEvent:eventId];
+    for (MXReactionRelation *relation in relations)
+    {
+        MXReactionCount *reactionCount = reactionCountDict[relation.reaction];
+        if (!reactionCount)
+        {
+            reactionCount = [MXReactionCount new];
+            reactionCount.reaction = relation.reaction;
+            reactionCountDict[relation.reaction] = reactionCount;
+        }
+
+        reactionCount.count++;
+
+        if (!reactionCount.myUserReactionEventId)
+        {
+            // Determine if my user has reacted
+            MXEvent *event = [self.matrixStore eventWithEventId:relation.reactionEventId inRoom:roomId];
+            if ([event.sender isEqualToString:self.mxSession.myUser.userId])
+            {
+                reactionCount.myUserReactionEventId = relation.reactionEventId;
+            }
+        }
+    }
+
+    NSLog(@"[MXAggregations] reactionCountsUsingHackOnEvent: Build %@ reactionCounts in %.0fms",
+          @(reactionCountDict.count),
+          [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+
+    return reactionCountDict.allValues;
 }
 
 @end

--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
@@ -25,7 +25,7 @@
 #import "MXSDKOptions.h"
 #import "MXTools.h"
 
-static NSUInteger const kMXFileVersion = 63;
+static NSUInteger const kMXFileVersion = 64;
 
 static NSString *const kMXFileStoreFolder = @"MXFileStore";
 static NSString *const kMXFileStoreMedaDataFile = @"MXFileStore";


### PR DESCRIPTION
closes https://github.com/vector-im/riot-ios/issues/2456.

This is a hack similar to riot-web and riot-android but it comes as a fallback. So if the homeserver has aggregation API, we will not use it.

We can have plenty of reactions now:
![Simulator Screen Shot - iPhone 7 - 2019-05-21 at 18 10 02](https://user-images.githubusercontent.com/8418515/58112395-b70f1880-7bf3-11e9-85b5-8ea19ae549fd.png)
