### PR TITLE
Edits start -  reaction end

### DIFF
--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -82,7 +82,7 @@
 		322A51D81D9E846800C8536D /* MXCryptoTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 322A51D71D9E846800C8536D /* MXCryptoTests.m */; };
 		322D01C422492B0700150C68 /* MXCryptoShareTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 322D01C322492B0700150C68 /* MXCryptoShareTests.m */; };
 		32322A481E57264E005DD155 /* MXSelfSignedHomeserverTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 32322A471E57264E005DD155 /* MXSelfSignedHomeserverTests.m */; };
-		32322A4B1E575F65005DD155 /* MXAllowedCertificates.h in Headers */ = {isa = PBXBuildFile; fileRef = 32322A491E575F65005DD155 /* MXAllowedCertificates.h */; };
+		32322A4B1E575F65005DD155 /* MXAllowedCertificates.h in Headers */ = {isa = PBXBuildFile; fileRef = 32322A491E575F65005DD155 /* MXAllowedCertificates.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		32322A4C1E575F65005DD155 /* MXAllowedCertificates.m in Sources */ = {isa = PBXBuildFile; fileRef = 32322A4A1E575F65005DD155 /* MXAllowedCertificates.m */; };
 		3233606F1A403A0D0071A488 /* MXFileStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 3233606D1A403A0D0071A488 /* MXFileStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		323360701A403A0D0071A488 /* MXFileStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 3233606E1A403A0D0071A488 /* MXFileStore.m */; };
@@ -176,6 +176,8 @@
 		3275FD9921A6B53300B9C13D /* MXLoginPolicyData.m in Sources */ = {isa = PBXBuildFile; fileRef = 3275FD9721A6B53300B9C13D /* MXLoginPolicyData.m */; };
 		3275FD9C21A6B60B00B9C13D /* MXLoginPolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = 3275FD9A21A6B60B00B9C13D /* MXLoginPolicy.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3275FD9D21A6B60B00B9C13D /* MXLoginPolicy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3275FD9B21A6B60B00B9C13D /* MXLoginPolicy.m */; };
+		32792BD42295A86600F4FC9D /* MXAggregatedReactionsUpdater.h in Headers */ = {isa = PBXBuildFile; fileRef = 32792BD22295A86600F4FC9D /* MXAggregatedReactionsUpdater.h */; };
+		32792BD52295A86600F4FC9D /* MXAggregatedReactionsUpdater.m in Sources */ = {isa = PBXBuildFile; fileRef = 32792BD32295A86600F4FC9D /* MXAggregatedReactionsUpdater.m */; };
 		327E37B61A974F75007F026F /* MXLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 327E37B41A974F75007F026F /* MXLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		327E37B71A974F75007F026F /* MXLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 327E37B51A974F75007F026F /* MXLogger.m */; };
 		327E37B91A977810007F026F /* MXLoggerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 327E37B81A977810007F026F /* MXLoggerTests.m */; };
@@ -624,6 +626,8 @@
 		3275FD9721A6B53300B9C13D /* MXLoginPolicyData.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXLoginPolicyData.m; sourceTree = "<group>"; };
 		3275FD9A21A6B60B00B9C13D /* MXLoginPolicy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXLoginPolicy.h; sourceTree = "<group>"; };
 		3275FD9B21A6B60B00B9C13D /* MXLoginPolicy.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXLoginPolicy.m; sourceTree = "<group>"; };
+		32792BD22295A86600F4FC9D /* MXAggregatedReactionsUpdater.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXAggregatedReactionsUpdater.h; sourceTree = "<group>"; };
+		32792BD32295A86600F4FC9D /* MXAggregatedReactionsUpdater.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXAggregatedReactionsUpdater.m; sourceTree = "<group>"; };
 		327E37B41A974F75007F026F /* MXLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXLogger.h; sourceTree = "<group>"; };
 		327E37B51A974F75007F026F /* MXLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXLogger.m; sourceTree = "<group>"; };
 		327E37B81A977810007F026F /* MXLoggerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXLoggerTests.m; sourceTree = "<group>"; };
@@ -1341,6 +1345,8 @@
 				327E9AED2289C61000A98BC1 /* MXAggregations.h */,
 				327E9AEE2289C61100A98BC1 /* MXAggregations.m */,
 				327E9AF12289C6B300A98BC1 /* MXAggregations_Private.h */,
+				32792BD22295A86600F4FC9D /* MXAggregatedReactionsUpdater.h */,
+				32792BD32295A86600F4FC9D /* MXAggregatedReactionsUpdater.m */,
 			);
 			path = Aggregations;
 			sourceTree = "<group>";
@@ -1973,6 +1979,7 @@
 				32A9E8251EF4026E0081358A /* MXUIKitBackgroundModeHandler.h in Headers */,
 				325D1C261DFECE0D0070B8BF /* MXCrypto_Private.h in Headers */,
 				32E402B921C957D2004E87A6 /* MXOlmSession.h in Headers */,
+				32792BD42295A86600F4FC9D /* MXAggregatedReactionsUpdater.h in Headers */,
 				B146D4D621A5A44E00D8C2C6 /* MXScanRealmInMemoryProvider.h in Headers */,
 				B17285792100C8EA0052C51E /* MXSendReplyEventStringsLocalizable.h in Headers */,
 				32A151521DAF8A7200400192 /* MXQueuedEncryption.h in Headers */,
@@ -2321,6 +2328,7 @@
 				32A151471DAF7C0C00400192 /* MXDeviceInfo.m in Sources */,
 				321CFDEB22525DEE004D31DF /* MXIncomingSASTransaction.m in Sources */,
 				32A1515C1DB525DA00400192 /* NSObject+sortedKeys.m in Sources */,
+				32792BD52295A86600F4FC9D /* MXAggregatedReactionsUpdater.m in Sources */,
 				32618E7C20EFA45B00E1D2EA /* MXRoomMembers.m in Sources */,
 				02CAD43A217DD12F0074700B /* MXContentScanEncryptedBody.m in Sources */,
 				F03EF5091DF071D5009DF592 /* MXEncryptedAttachments.m in Sources */,

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -178,6 +178,10 @@
 		3275FD9D21A6B60B00B9C13D /* MXLoginPolicy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3275FD9B21A6B60B00B9C13D /* MXLoginPolicy.m */; };
 		32792BD42295A86600F4FC9D /* MXAggregatedReactionsUpdater.h in Headers */ = {isa = PBXBuildFile; fileRef = 32792BD22295A86600F4FC9D /* MXAggregatedReactionsUpdater.h */; };
 		32792BD52295A86600F4FC9D /* MXAggregatedReactionsUpdater.m in Sources */ = {isa = PBXBuildFile; fileRef = 32792BD32295A86600F4FC9D /* MXAggregatedReactionsUpdater.m */; };
+		32792BDC2296B90A00F4FC9D /* MXAggregatedEditsUpdater.h in Headers */ = {isa = PBXBuildFile; fileRef = 32792BDA2296B90A00F4FC9D /* MXAggregatedEditsUpdater.h */; };
+		32792BDD2296B90A00F4FC9D /* MXAggregatedEditsUpdater.m in Sources */ = {isa = PBXBuildFile; fileRef = 32792BDB2296B90A00F4FC9D /* MXAggregatedEditsUpdater.m */; };
+		32792BDF2296C59B00F4FC9D /* MXAggregatedReactionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 32792BDE2296C59B00F4FC9D /* MXAggregatedReactionTests.m */; };
+		32792BE12296C64200F4FC9D /* MXAggregatedEditsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 32792BE02296C64200F4FC9D /* MXAggregatedEditsTests.m */; };
 		327E37B61A974F75007F026F /* MXLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 327E37B41A974F75007F026F /* MXLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		327E37B71A974F75007F026F /* MXLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 327E37B51A974F75007F026F /* MXLogger.m */; };
 		327E37B91A977810007F026F /* MXLoggerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 327E37B81A977810007F026F /* MXLoggerTests.m */; };
@@ -194,7 +198,6 @@
 		327E9AE22285497100A98BC1 /* MXEventContentRelatesTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 327E9AE02285497100A98BC1 /* MXEventContentRelatesTo.m */; };
 		327E9AE72285A8C400A98BC1 /* MXAggregationPaginatedResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 327E9AE52285A8C400A98BC1 /* MXAggregationPaginatedResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		327E9AE82285A8C400A98BC1 /* MXAggregationPaginatedResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 327E9AE62285A8C400A98BC1 /* MXAggregationPaginatedResponse.m */; };
-		327E9AEA2285DFB600A98BC1 /* MXReactionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 327E9AE92285DFB600A98BC1 /* MXReactionTests.m */; };
 		327E9AEF2289C61100A98BC1 /* MXAggregations.h in Headers */ = {isa = PBXBuildFile; fileRef = 327E9AED2289C61000A98BC1 /* MXAggregations.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		327E9AF02289C61100A98BC1 /* MXAggregations.m in Sources */ = {isa = PBXBuildFile; fileRef = 327E9AEE2289C61100A98BC1 /* MXAggregations.m */; };
 		327E9AF62289D53800A98BC1 /* MXReactionCount.h in Headers */ = {isa = PBXBuildFile; fileRef = 327E9AF42289D53800A98BC1 /* MXReactionCount.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -628,6 +631,10 @@
 		3275FD9B21A6B60B00B9C13D /* MXLoginPolicy.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXLoginPolicy.m; sourceTree = "<group>"; };
 		32792BD22295A86600F4FC9D /* MXAggregatedReactionsUpdater.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXAggregatedReactionsUpdater.h; sourceTree = "<group>"; };
 		32792BD32295A86600F4FC9D /* MXAggregatedReactionsUpdater.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXAggregatedReactionsUpdater.m; sourceTree = "<group>"; };
+		32792BDA2296B90A00F4FC9D /* MXAggregatedEditsUpdater.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXAggregatedEditsUpdater.h; sourceTree = "<group>"; };
+		32792BDB2296B90A00F4FC9D /* MXAggregatedEditsUpdater.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXAggregatedEditsUpdater.m; sourceTree = "<group>"; };
+		32792BDE2296C59B00F4FC9D /* MXAggregatedReactionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXAggregatedReactionTests.m; sourceTree = "<group>"; };
+		32792BE02296C64200F4FC9D /* MXAggregatedEditsTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXAggregatedEditsTests.m; sourceTree = "<group>"; };
 		327E37B41A974F75007F026F /* MXLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXLogger.h; sourceTree = "<group>"; };
 		327E37B51A974F75007F026F /* MXLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXLogger.m; sourceTree = "<group>"; };
 		327E37B81A977810007F026F /* MXLoggerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXLoggerTests.m; sourceTree = "<group>"; };
@@ -644,7 +651,6 @@
 		327E9AE02285497100A98BC1 /* MXEventContentRelatesTo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXEventContentRelatesTo.m; sourceTree = "<group>"; };
 		327E9AE52285A8C400A98BC1 /* MXAggregationPaginatedResponse.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXAggregationPaginatedResponse.h; sourceTree = "<group>"; };
 		327E9AE62285A8C400A98BC1 /* MXAggregationPaginatedResponse.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXAggregationPaginatedResponse.m; sourceTree = "<group>"; };
-		327E9AE92285DFB600A98BC1 /* MXReactionTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXReactionTests.m; sourceTree = "<group>"; };
 		327E9AED2289C61000A98BC1 /* MXAggregations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXAggregations.h; sourceTree = "<group>"; };
 		327E9AEE2289C61100A98BC1 /* MXAggregations.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXAggregations.m; sourceTree = "<group>"; };
 		327E9AF12289C6B300A98BC1 /* MXAggregations_Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXAggregations_Private.h; sourceTree = "<group>"; };
@@ -1345,6 +1351,8 @@
 				327E9AED2289C61000A98BC1 /* MXAggregations.h */,
 				327E9AEE2289C61100A98BC1 /* MXAggregations.m */,
 				327E9AF12289C6B300A98BC1 /* MXAggregations_Private.h */,
+				32792BDA2296B90A00F4FC9D /* MXAggregatedEditsUpdater.h */,
+				32792BDB2296B90A00F4FC9D /* MXAggregatedEditsUpdater.m */,
 				32792BD22295A86600F4FC9D /* MXAggregatedReactionsUpdater.h */,
 				32792BD32295A86600F4FC9D /* MXAggregatedReactionsUpdater.m */,
 			);
@@ -1597,7 +1605,8 @@
 		32C6F93919DD814400EA4E9C /* MatrixSDKTests */ = {
 			isa = PBXGroup;
 			children = (
-				327E9AE92285DFB600A98BC1 /* MXReactionTests.m */,
+				32792BE02296C64200F4FC9D /* MXAggregatedEditsTests.m */,
+				32792BDE2296C59B00F4FC9D /* MXAggregatedReactionTests.m */,
 				327E9ACE2284783E00A98BC1 /* MXEventAnnotationTests.swift */,
 				329E808E22512DF500A48C3A /* MXCryptoDeviceVerificationTests.m */,
 				322D01C322492B0700150C68 /* MXCryptoShareTests.m */,
@@ -1900,6 +1909,7 @@
 				329D3E621E251027002E2F1E /* MXRoomSummaryUpdater.h in Headers */,
 				321B413F1E09937E009EEEC7 /* MXRoomSummary.h in Headers */,
 				B17982F52119E4A2001FD722 /* MXRoomCreateContent.h in Headers */,
+				32792BDC2296B90A00F4FC9D /* MXAggregatedEditsUpdater.h in Headers */,
 				327E9AEF2289C61100A98BC1 /* MXAggregations.h in Headers */,
 				32DC15CF1A8CF7AE006F9AD3 /* MXPushRuleConditionChecker.h in Headers */,
 				32954019216385F100E300FC /* MXServerNoticeContent.h in Headers */,
@@ -2242,6 +2252,7 @@
 				32B94E06228EE90300716A26 /* MXRealmReactionRelation.m in Sources */,
 				320BBF411D6C81550079890E /* MXEventsByTypesEnumeratorOnArray.m in Sources */,
 				3213301E228B190F0070BA9B /* MXRealmAggregationsMapper.m in Sources */,
+				32792BDD2296B90A00F4FC9D /* MXAggregatedEditsUpdater.m in Sources */,
 				3259CD541DF860C300186944 /* MXRealmCryptoStore.m in Sources */,
 				321B41401E09937E009EEEC7 /* MXRoomSummary.m in Sources */,
 				32CAB1081A91EA34008C5BB9 /* MXPushRuleRoomMemberCountConditionChecker.m in Sources */,
@@ -2442,8 +2453,8 @@
 				327137241A24BDDE00DB6757 /* MXUserTests.m in Sources */,
 				32720DA2222EB5650086FFF5 /* MXAutoDiscoveryTests.m in Sources */,
 				327E37B91A977810007F026F /* MXLoggerTests.m in Sources */,
+				32792BE12296C64200F4FC9D /* MXAggregatedEditsTests.m in Sources */,
 				329571931B0240CE00ABB3BA /* MXVoIPTests.m in Sources */,
-				327E9AEA2285DFB600A98BC1 /* MXReactionTests.m in Sources */,
 				32A27D1F19EC335300BAFADE /* MXRoomTests.m in Sources */,
 				32D8CAC219DEE6ED002AF8A0 /* MXRestClientNoAuthAPITests.m in Sources */,
 				32FCAB4D19E578860049C555 /* MXRestClientTests.m in Sources */,
@@ -2451,6 +2462,7 @@
 				329FB17C1A0A963700A5E88E /* MXRoomMemberTests.m in Sources */,
 				3246BDC51A1A0789000A7D62 /* MXRoomStateDynamicTests.m in Sources */,
 				3264DB941CECA72900B99881 /* MXAccountDataTests.m in Sources */,
+				32792BDF2296C59B00F4FC9D /* MXAggregatedReactionTests.m in Sources */,
 				322D01C422492B0700150C68 /* MXCryptoShareTests.m in Sources */,
 				323EF7471C7CB4C7000DC98C /* MXEventTimelineTests.m in Sources */,
 				32E226A91D081CE200E6CA54 /* MXPeekingRoomTests.m in Sources */,

--- a/MatrixSDK/Aggregations/Data/Store/Realm/MXRealmAggregationsStore.m
+++ b/MatrixSDK/Aggregations/Data/Store/Realm/MXRealmAggregationsStore.m
@@ -100,6 +100,12 @@
     RLMRealm *realm = self.realm;
 
     [realm transactionWithBlock:^{
+        // Flush previous data
+        RLMResults<MXRealmReactionCount *> *realmReactionCounts = [MXRealmReactionCount objectsInRealm:self.realm
+                                                                                                 where:@"eventId = %@", eventId];
+        [realm deleteObjects:realmReactionCounts];
+
+        // Set new one
         for (MXReactionCount *reactionCount in reactionCounts)
         {
             MXRealmReactionCount *realmReactionCount = [self.mapper realmReactionCountFromReactionCount:reactionCount

--- a/MatrixSDK/Aggregations/MXAggregatedEditsUpdater.h
+++ b/MatrixSDK/Aggregations/MXAggregatedEditsUpdater.h
@@ -1,0 +1,43 @@
+/*
+ Copyright 2019 The Matrix.org Foundation C.I.C
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "MXStore.h"
+#import "MXAggregationsStore.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MXAggregatedEditsUpdater : NSObject
+
+- (instancetype)initWithMyUser:(NSString*)userId
+              aggregationStore:(id<MXAggregationsStore>)store
+                   matrixStore:(id<MXStore>)matrixStore;
+
+//- (nullable MXAggregatedReactions *)aggregatedReactionsOnEvent:(NSString*)eventId inRoom:(NSString*)roomId;
+//- (nullable MXReactionCount*)reactionCountForReaction:(NSString*)reaction onEvent:(NSString*)eventId;
+
+//- (id)listenToEditsUpdateInRoom:(NSString *)roomId block:(void (^)(NSDictionary<NSString *,MXReactionCountChange *> * _Nonnull))block;
+//- (void)removeListener:(id)listener;
+
+- (void)handleReplace:(MXEvent *)event direction:(MXTimelineDirection)direction;
+- (void)handleRedaction:(MXEvent *)event;
+
+- (void)resetDataInRoom:(NSString *)roomId;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixSDK/Aggregations/MXAggregatedEditsUpdater.h
+++ b/MatrixSDK/Aggregations/MXAggregatedEditsUpdater.h
@@ -27,12 +27,16 @@ NS_ASSUME_NONNULL_BEGIN
               aggregationStore:(id<MXAggregationsStore>)store
                    matrixStore:(id<MXStore>)matrixStore;
 
+#pragma mark - Data access
 //- (nullable MXAggregatedReactions *)aggregatedReactionsOnEvent:(NSString*)eventId inRoom:(NSString*)roomId;
 //- (nullable MXReactionCount*)reactionCountForReaction:(NSString*)reaction onEvent:(NSString*)eventId;
 
+#pragma mark - Data update listener
 //- (id)listenToEditsUpdateInRoom:(NSString *)roomId block:(void (^)(NSDictionary<NSString *,MXReactionCountChange *> * _Nonnull))block;
 //- (void)removeListener:(id)listener;
 
+#pragma mark - Data update
+//- (void)handleOriginalAggregatedDataOfEvent:(MXEvent *)event replaces:(MXEventReplaceChunk*)replaces;
 - (void)handleReplace:(MXEvent *)event direction:(MXTimelineDirection)direction;
 - (void)handleRedaction:(MXEvent *)event;
 

--- a/MatrixSDK/Aggregations/MXAggregatedEditsUpdater.m
+++ b/MatrixSDK/Aggregations/MXAggregatedEditsUpdater.m
@@ -18,7 +18,7 @@
 
 @interface MXAggregatedEditsUpdater ()
 
-@property (nonatomic, weak) NSString *myUserId;
+@property (nonatomic) NSString *myUserId;
 @property (nonatomic, weak) id<MXStore> matrixStore;
 @property (nonatomic, weak) id<MXAggregationsStore> store;
 //@property (nonatomic) NSMutableArray<MXReactionCountChangeListener*> *listeners;

--- a/MatrixSDK/Aggregations/MXAggregatedEditsUpdater.m
+++ b/MatrixSDK/Aggregations/MXAggregatedEditsUpdater.m
@@ -1,0 +1,67 @@
+/*
+ Copyright 2019 The Matrix.org Foundation C.I.C
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXAggregatedEditsUpdater.h"
+
+@interface MXAggregatedEditsUpdater ()
+
+@property (nonatomic, weak) NSString *myUserId;
+@property (nonatomic, weak) id<MXStore> matrixStore;
+@property (nonatomic, weak) id<MXAggregationsStore> store;
+//@property (nonatomic) NSMutableArray<MXReactionCountChangeListener*> *listeners;
+
+@end
+
+@implementation MXAggregatedEditsUpdater
+
+- (instancetype)initWithMyUser:(NSString*)userId
+              aggregationStore:(id<MXAggregationsStore>)store
+                   matrixStore:(id<MXStore>)matrixStore
+{
+    self = [super init];
+    if (self)
+    {
+        self.myUserId = userId;
+        self.store = store;
+        self.matrixStore = matrixStore;
+
+        //self.listeners = [NSMutableArray array];
+    }
+    return self;
+}
+
+//- (nullable MXAggregatedReactions *)aggregatedReactionsOnEvent:(NSString*)eventId inRoom:(NSString*)roomId;
+//- (nullable MXReactionCount*)reactionCountForReaction:(NSString*)reaction onEvent:(NSString*)eventId;
+
+//- (id)listenToEditsUpdateInRoom:(NSString *)roomId block:(void (^)(NSDictionary<NSString *,MXReactionCountChange *> * _Nonnull))block;
+//- (void)removeListener:(id)listener;
+
+- (void)handleReplace:(MXEvent *)event direction:(MXTimelineDirection)direction
+{
+
+}
+
+- (void)handleRedaction:(MXEvent *)event
+{
+
+}
+
+- (void)resetDataInRoom:(NSString *)roomId
+{
+
+}
+
+@end

--- a/MatrixSDK/Aggregations/MXAggregatedEditsUpdater.m
+++ b/MatrixSDK/Aggregations/MXAggregatedEditsUpdater.m
@@ -43,11 +43,22 @@
     return self;
 }
 
+
+#pragma mark - Data access
+
 //- (nullable MXAggregatedReactions *)aggregatedReactionsOnEvent:(NSString*)eventId inRoom:(NSString*)roomId;
 //- (nullable MXReactionCount*)reactionCountForReaction:(NSString*)reaction onEvent:(NSString*)eventId;
 
+
+#pragma mark - Data update listener
+
 //- (id)listenToEditsUpdateInRoom:(NSString *)roomId block:(void (^)(NSDictionary<NSString *,MXReactionCountChange *> * _Nonnull))block;
 //- (void)removeListener:(id)listener;
+
+
+#pragma mark - Data update
+
+//- (void)handleOriginalAggregatedDataOfEvent:(MXEvent *)event replaces:(MXEventReplaceChunk*)replaces;
 
 - (void)handleReplace:(MXEvent *)event direction:(MXTimelineDirection)direction
 {

--- a/MatrixSDK/Aggregations/MXAggregatedReactionsUpdater.h
+++ b/MatrixSDK/Aggregations/MXAggregatedReactionsUpdater.h
@@ -31,12 +31,15 @@ NS_ASSUME_NONNULL_BEGIN
               aggregationStore:(id<MXAggregationsStore>)store
                    matrixStore:(id<MXStore>)matrixStore;
 
+#pragma mark - Data access
 - (nullable MXAggregatedReactions *)aggregatedReactionsOnEvent:(NSString*)eventId inRoom:(NSString*)roomId;
 - (nullable MXReactionCount*)reactionCountForReaction:(NSString*)reaction onEvent:(NSString*)eventId;
 
+#pragma mark - Data update listener
 - (id)listenToReactionCountUpdateInRoom:(NSString *)roomId block:(void (^)(NSDictionary<NSString *,MXReactionCountChange *> * _Nonnull))block;
 - (void)removeListener:(id)listener;
 
+#pragma mark - Data update
 - (void)handleOriginalAggregatedDataOfEvent:(MXEvent *)event annotations:(MXEventAnnotationChunk*)annotations;
 - (void)handleReaction:(MXEvent *)event direction:(MXTimelineDirection)direction;
 - (void)handleRedaction:(MXEvent *)event;

--- a/MatrixSDK/Aggregations/MXAggregatedReactionsUpdater.h
+++ b/MatrixSDK/Aggregations/MXAggregatedReactionsUpdater.h
@@ -17,6 +17,7 @@
 #import <Foundation/Foundation.h>
 
 #import "MXAggregatedReactions.h"
+#import "MXEventAnnotationChunk.h"
 
 #import "MXStore.h"
 #import "MXAggregationsStore.h"
@@ -36,6 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (id)listenToReactionCountUpdateInRoom:(NSString *)roomId block:(void (^)(NSDictionary<NSString *,MXReactionCountChange *> * _Nonnull))block;
 - (void)removeListener:(id)listener;
 
+- (void)handleOriginalAggregatedDataOfEvent:(MXEvent *)event annotations:(MXEventAnnotationChunk*)annotations;
 - (void)handleReaction:(MXEvent *)event direction:(MXTimelineDirection)direction;
 - (void)handleRedaction:(MXEvent *)event;
 

--- a/MatrixSDK/Aggregations/MXAggregatedReactionsUpdater.h
+++ b/MatrixSDK/Aggregations/MXAggregatedReactionsUpdater.h
@@ -31,12 +31,15 @@ NS_ASSUME_NONNULL_BEGIN
                    matrixStore:(id<MXStore>)matrixStore;
 
 - (nullable MXAggregatedReactions *)aggregatedReactionsOnEvent:(NSString*)eventId inRoom:(NSString*)roomId;
+- (nullable MXReactionCount*)reactionCountForReaction:(NSString*)reaction onEvent:(NSString*)eventId;
 
 - (id)listenToReactionCountUpdateInRoom:(NSString *)roomId block:(void (^)(NSDictionary<NSString *,MXReactionCountChange *> * _Nonnull))block;
 - (void)removeListener:(id)listener;
 
 - (void)handleReaction:(MXEvent *)event direction:(MXTimelineDirection)direction;
 - (void)handleRedaction:(MXEvent *)event;
+
+- (void)resetDataInRoom:(NSString *)roomId;
 
 @end
 

--- a/MatrixSDK/Aggregations/MXAggregatedReactionsUpdater.h
+++ b/MatrixSDK/Aggregations/MXAggregatedReactionsUpdater.h
@@ -1,0 +1,43 @@
+/*
+ Copyright 2019 The Matrix.org Foundation C.I.C
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "MXAggregatedReactions.h"
+
+#import "MXStore.h"
+#import "MXAggregationsStore.h"
+#import "MXReactionCountChangeListener.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MXAggregatedReactionsUpdater : NSObject
+
+- (instancetype)initWithMyUser:(NSString*)userId
+              aggregationStore:(id<MXAggregationsStore>)store
+                   matrixStore:(id<MXStore>)matrixStore;
+
+- (nullable MXAggregatedReactions *)aggregatedReactionsOnEvent:(NSString*)eventId inRoom:(NSString*)roomId;
+
+- (id)listenToReactionCountUpdateInRoom:(NSString *)roomId block:(void (^)(NSDictionary<NSString *,MXReactionCountChange *> * _Nonnull))block;
+- (void)removeListener:(id)listener;
+
+- (void)handleReaction:(MXEvent *)event direction:(MXTimelineDirection)direction;
+- (void)handleRedaction:(MXEvent *)event;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixSDK/Aggregations/MXAggregatedReactionsUpdater.m
+++ b/MatrixSDK/Aggregations/MXAggregatedReactionsUpdater.m
@@ -1,0 +1,341 @@
+/*
+ Copyright 2019 The Matrix.org Foundation C.I.C
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXAggregatedReactionsUpdater.h"
+
+#import "MXEventUnsignedData.h"
+#import "MXEventRelations.h"
+#import "MXEventAnnotationChunk.h"
+#import "MXEventAnnotation.h"
+
+@interface MXAggregatedReactionsUpdater ()
+
+@property (nonatomic, weak) NSString *myUserId;
+@property (nonatomic, weak) id<MXStore> matrixStore;
+@property (nonatomic, weak) id<MXAggregationsStore> store;
+@property (nonatomic) NSMutableArray<MXReactionCountChangeListener*> *listeners;
+
+@end
+
+@implementation MXAggregatedReactionsUpdater
+
+- (instancetype)initWithMyUser:(NSString *)userId aggregationStore:(id<MXAggregationsStore>)store matrixStore:(id<MXStore>)matrixStore
+{
+    self = [super init];
+    if (self)
+    {
+        self.myUserId = userId;
+        self.store = store;
+        self.matrixStore = matrixStore;
+
+        self.listeners = [NSMutableArray array];
+    }
+    return self;
+}
+
+- (nullable MXAggregatedReactions *)aggregatedReactionsOnEvent:(NSString*)eventId inRoom:(NSString*)roomId
+{
+    NSArray<MXReactionCount*> *reactions = [self.store reactionCountsOnEvent:eventId];
+    if (!reactions)
+    {
+        reactions = [self reactionCountsFromMatrixStoreOnEvent:eventId inRoom:roomId];
+    }
+
+    if (!reactions)
+    {
+        // Check reaction data from the hack
+        reactions = [self reactionCountsUsingHackOnEvent:eventId inRoom:roomId];
+    }
+
+    MXAggregatedReactions *aggregatedReactions;
+    if (reactions)
+    {
+        aggregatedReactions = [MXAggregatedReactions new];
+        aggregatedReactions.reactions = reactions;
+    }
+
+    return aggregatedReactions;
+}
+
+- (id)listenToReactionCountUpdateInRoom:(NSString *)roomId block:(void (^)(NSDictionary<NSString *,MXReactionCountChange *> * _Nonnull))block
+{
+    MXReactionCountChangeListener *listener = [MXReactionCountChangeListener new];
+    listener.roomId = roomId;
+    listener.notificationBlock = block;
+
+    [self.listeners addObject:listener];
+
+    return listener;
+}
+
+- (void)removeListener:(id)listener
+{
+    [self.listeners removeObject:listener];
+}
+
+
+
+- (void)handleReaction:(MXEvent *)event direction:(MXTimelineDirection)direction
+{
+    NSString *parentEventId = event.relatesTo.eventId;
+    NSString *reaction = event.relatesTo.key;
+
+    if (parentEventId && reaction)
+    {
+        // Manage aggregated reactions only for events in timelines we have
+        MXEvent *parentEvent = [self.matrixStore eventWithEventId:parentEventId inRoom:event.roomId];
+        if (parentEvent)
+        {
+            [self storeRelationForReaction:reaction toEvent:parentEventId reactionEvent:event];
+
+            if (direction == MXTimelineDirectionForwards)
+            {
+                [self updateReactionCountForReaction:reaction toEvent:parentEventId reactionEvent:event];
+            }
+        }
+        else
+        {
+            [self storeRelationForHackForReaction:reaction toEvent:parentEventId reactionEvent:event];
+        }
+    }
+    else
+    {
+        NSLog(@"[MXAggregations] handleReaction: ERROR: invalid reaction event: %@", event);
+    }
+}
+
+- (void)handleRedaction:(MXEvent *)event
+{
+    NSString *redactedEventId = event.redacts;
+    MXReactionRelation *relation = [self.store reactionRelationWithReactionEventId:redactedEventId];
+
+    if (relation)
+    {
+        [self removeReaction:relation.reaction onEvent:relation.eventId inRoomId:event.roomId];
+        [self.store deleteReactionRelation:relation];
+    }
+}
+
+#pragma mark - Private methods -
+
+- (void)storeRelationForReaction:(NSString*)reaction toEvent:(NSString*)eventId reactionEvent:(MXEvent *)reactionEvent
+{
+    MXReactionRelation *relation = [MXReactionRelation new];
+    relation.reaction = reaction;
+    relation.eventId = eventId;
+    relation.reactionEventId = reactionEvent.eventId;
+
+    [self.store addReactionRelation:relation inRoom:reactionEvent.roomId];
+}
+
+- (void)updateReactionCountForReaction:(NSString*)reaction toEvent:(NSString*)eventId reactionEvent:(MXEvent *)reactionEvent
+{
+    BOOL isANewReaction = NO;
+
+    // Migrate data from matrix store to aggregation store if needed
+    [self checkAggregationStoreForEvent:eventId inRoomId:reactionEvent.roomId];
+
+    // Create or update the current reaction count if it exists
+    MXReactionCount *reactionCount = [self.store reactionCountForReaction:reaction onEvent:eventId];
+    if (!reactionCount)
+    {
+        // If we still have no reaction count object, create one
+        reactionCount = [MXReactionCount new];
+        reactionCount.reaction = reaction;
+        isANewReaction = YES;
+    }
+
+    // Add the reaction
+    reactionCount.count++;
+
+    // Store reaction made by our user
+    if ([reactionEvent.sender isEqualToString:self.myUserId])
+    {
+        reactionCount.myUserReactionEventId = reactionEvent.eventId;
+    }
+
+    // Update store
+    [self.store addOrUpdateReactionCount:reactionCount onEvent:eventId inRoom:reactionEvent.roomId];
+
+    // Notify
+    [self notifyReactionCountChangeListenersOfRoom:reactionEvent.roomId
+                                             event:eventId
+                                     reactionCount:reactionCount
+                                     isNewReaction:isANewReaction];
+}
+
+- (void)removeReaction:(NSString*)reaction onEvent:(NSString*)eventId inRoomId:(NSString*)roomId
+{
+    // Migrate data from matrix store to aggregation store if needed
+    [self checkAggregationStoreForEvent:eventId inRoomId:roomId];
+
+    // Create or update the current reaction count if it exists
+    MXReactionCount *reactionCount = [self.store reactionCountForReaction:reaction onEvent:eventId];
+    if (reactionCount)
+    {
+        if (reactionCount.count > 1)
+        {
+            reactionCount.count--;
+
+            [self.store addOrUpdateReactionCount:reactionCount onEvent:eventId inRoom:roomId];
+            [self notifyReactionCountChangeListenersOfRoom:roomId
+                                                     event:eventId
+                                             reactionCount:reactionCount
+                                             isNewReaction:NO];
+        }
+        else
+        {
+            [self.store deleteReactionCountsForReaction:reaction onEvent:eventId];
+            [self notifyReactionCountChangeListenersOfRoom:roomId event:eventId forDeletedReaction:reaction];
+        }
+    }
+}
+
+// If not already done, copy aggregation data from matrix store to aggregation store
+- (void)checkAggregationStoreForEvent:(NSString*)eventId inRoomId:(NSString*)roomId
+{
+    if (![self.store hasReactionCountsOnEvent:eventId])
+    {
+        NSArray<MXReactionCount*> *reactions = [self reactionCountsFromMatrixStoreOnEvent:eventId inRoom:roomId];
+
+        if (!reactions)
+        {
+            // Check reaction data from the hack
+            reactions = [self reactionCountsUsingHackOnEvent:eventId inRoom:roomId];
+        }
+
+        if (reactions)
+        {
+            [self.store setReactionCounts:reactions onEvent:eventId inRoom:roomId];
+        }
+    }
+}
+
+- (nullable NSArray<MXReactionCount*> *)reactionCountsFromMatrixStoreOnEvent:(NSString*)eventId inRoom:(NSString*)roomId
+{
+    NSMutableArray *reactions;
+
+    MXEvent *event = [self.matrixStore eventWithEventId:eventId inRoom:roomId];
+    if (event)
+    {
+        for (MXEventAnnotation *annotation in event.unsignedData.relations.annotation.chunk)
+        {
+            if ([annotation.type isEqualToString:MXEventAnnotationReaction])
+            {
+                MXReactionCount *reactionCount = [MXReactionCount new];
+                reactionCount.reaction = annotation.key;
+                reactionCount.count = annotation.count;
+
+                if (!reactions)
+                {
+                    reactions = [NSMutableArray array];
+                }
+                [reactions addObject:reactionCount];
+            }
+        }
+    }
+
+    return reactions;
+}
+
+- (void)notifyReactionCountChangeListenersOfRoom:(NSString*)roomId event:(NSString*)eventId reactionCount:(MXReactionCount*)reactionCount isNewReaction:(BOOL)isNewReaction
+{
+    MXReactionCountChange *reactionCountChange = [MXReactionCountChange new];
+    if (isNewReaction)
+    {
+        reactionCountChange.inserted = @[reactionCount];
+    }
+    else
+    {
+        reactionCountChange.modified = @[reactionCount];
+    }
+
+    [self notifyReactionCountChangeListenersOfRoom:roomId changes:@{
+                                                                    eventId:reactionCountChange
+                                                                    }];
+}
+
+- (void)notifyReactionCountChangeListenersOfRoom:(NSString*)roomId event:(NSString*)eventId forDeletedReaction:(NSString*)deletedReaction
+{
+    MXReactionCountChange *reactionCountChange = [MXReactionCountChange new];
+    reactionCountChange.deleted = @[deletedReaction];
+
+    [self notifyReactionCountChangeListenersOfRoom:roomId changes:@{
+                                                                    eventId:reactionCountChange
+                                                                    }];
+}
+
+- (void)notifyReactionCountChangeListenersOfRoom:(NSString*)roomId changes:(NSDictionary<NSString*, MXReactionCountChange*>*)changes
+{
+    for (MXReactionCountChangeListener *listener in self.listeners)
+    {
+        if ([listener.roomId isEqualToString:roomId])
+        {
+            listener.notificationBlock(changes);
+        }
+    }
+}
+
+#pragma mark - Reactions hack (TODO: Remove all methods) -
+/// TODO: To remove once the feature has landed on matrix.org homeserver
+
+
+// Compute reactions counts from relations we know
+// Note: This is not accurate and will be removed soon
+- (nullable NSArray<MXReactionCount*> *)reactionCountsUsingHackOnEvent:(NSString*)eventId inRoom:(NSString*)roomId
+{
+    NSDate *startDate = [NSDate date];
+
+    NSMutableDictionary<NSString*, MXReactionCount*> *reactionCountDict = [NSMutableDictionary dictionary];
+
+    NSArray<MXReactionRelation*> *relations = [self.store reactionRelationsOnEvent:eventId];
+    for (MXReactionRelation *relation in relations)
+    {
+        MXReactionCount *reactionCount = reactionCountDict[relation.reaction];
+        if (!reactionCount)
+        {
+            reactionCount = [MXReactionCount new];
+            reactionCount.reaction = relation.reaction;
+            reactionCountDict[relation.reaction] = reactionCount;
+        }
+
+        reactionCount.count++;
+
+        if (!reactionCount.myUserReactionEventId)
+        {
+            // Determine if my user has reacted
+            MXEvent *event = [self.matrixStore eventWithEventId:relation.reactionEventId inRoom:roomId];
+            if ([event.sender isEqualToString:self.myUserId])
+            {
+                reactionCount.myUserReactionEventId = relation.reactionEventId;
+            }
+        }
+    }
+
+    NSLog(@"[MXAggregations] reactionCountsUsingHackOnEvent: Build %@ reactionCounts in %.0fms",
+          @(reactionCountDict.count),
+          [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+
+    return reactionCountDict.allValues;
+}
+
+// We need to store all received relations even if we do not know the event yet
+- (void)storeRelationForHackForReaction:(NSString*)reaction toEvent:(NSString*)eventId reactionEvent:(MXEvent *)reactionEvent
+{
+    [self storeRelationForReaction:reaction toEvent:eventId reactionEvent:reactionEvent];
+}
+
+@end

--- a/MatrixSDK/Aggregations/MXAggregatedReactionsUpdater.m
+++ b/MatrixSDK/Aggregations/MXAggregatedReactionsUpdater.m
@@ -23,7 +23,7 @@
 
 @interface MXAggregatedReactionsUpdater ()
 
-@property (nonatomic, weak) NSString *myUserId;
+@property (nonatomic) NSString *myUserId;
 @property (nonatomic, weak) id<MXStore> matrixStore;
 @property (nonatomic, weak) id<MXAggregationsStore> store;
 @property (nonatomic) NSMutableArray<MXReactionCountChangeListener*> *listeners;

--- a/MatrixSDK/Aggregations/MXAggregatedReactionsUpdater.m
+++ b/MatrixSDK/Aggregations/MXAggregatedReactionsUpdater.m
@@ -46,6 +46,9 @@
     return self;
 }
 
+
+#pragma mark - Data access
+
 - (nullable MXAggregatedReactions *)aggregatedReactionsOnEvent:(NSString*)eventId inRoom:(NSString*)roomId
 {
     NSArray<MXReactionCount*> *reactions = [self.store reactionCountsOnEvent:eventId];
@@ -65,10 +68,14 @@
 
     return aggregatedReactions;
 }
+
 - (nullable MXReactionCount*)reactionCountForReaction:(NSString*)reaction onEvent:(NSString*)eventId
 {
     return [self.store reactionCountForReaction:reaction onEvent:eventId];
 }
+
+
+#pragma mark - Data update listener
 
 - (id)listenToReactionCountUpdateInRoom:(NSString *)roomId block:(void (^)(NSDictionary<NSString *,MXReactionCountChange *> * _Nonnull))block
 {
@@ -86,6 +93,8 @@
     [self.listeners removeObject:listener];
 }
 
+
+#pragma mark - Data update
 
 - (void)handleOriginalAggregatedDataOfEvent:(MXEvent *)event annotations:(MXEventAnnotationChunk*)annotations
 {
@@ -112,7 +121,6 @@
         [self.store setReactionCounts:reactions onEvent:event.eventId inRoom:event.roomId];
     }
 }
-
 
 - (void)handleReaction:(MXEvent *)event direction:(MXTimelineDirection)direction
 {

--- a/MatrixSDK/Aggregations/MXAggregatedReactionsUpdater.m
+++ b/MatrixSDK/Aggregations/MXAggregatedReactionsUpdater.m
@@ -99,12 +99,12 @@
         MXEvent *parentEvent = [self.matrixStore eventWithEventId:parentEventId inRoom:event.roomId];
         if (parentEvent)
         {
-            [self storeRelationForReaction:reaction toEvent:parentEventId reactionEvent:event];
-
             if (direction == MXTimelineDirectionForwards)
             {
                 [self updateReactionCountForReaction:reaction toEvent:parentEventId reactionEvent:event];
             }
+
+            [self storeRelationForReaction:reaction toEvent:parentEventId reactionEvent:event];
         }
         else
         {
@@ -124,8 +124,8 @@
 
     if (relation)
     {
-        [self removeReaction:relation.reaction onEvent:relation.eventId inRoomId:event.roomId];
         [self.store deleteReactionRelation:relation];
+        [self removeReaction:relation.reaction onEvent:relation.eventId inRoomId:event.roomId];
     }
 }
 
@@ -299,11 +299,17 @@
 {
     NSDate *startDate = [NSDate date];
 
-    NSMutableDictionary<NSString*, MXReactionCount*> *reactionCountDict = [NSMutableDictionary dictionary];
+    NSMutableDictionary<NSString*, MXReactionCount*> *reactionCountDict;
 
     NSArray<MXReactionRelation*> *relations = [self.store reactionRelationsOnEvent:eventId];
     for (MXReactionRelation *relation in relations)
     {
+        if (!reactionCountDict)
+        {
+            // Have the same behavior as reactionCountsFromMatrixStoreOnEvent
+            reactionCountDict = [NSMutableDictionary dictionary];
+        }
+        
         MXReactionCount *reactionCount = reactionCountDict[relation.reaction];
         if (!reactionCount)
         {

--- a/MatrixSDK/Aggregations/MXAggregatedReactionsUpdater.m
+++ b/MatrixSDK/Aggregations/MXAggregatedReactionsUpdater.m
@@ -69,6 +69,10 @@
 
     return aggregatedReactions;
 }
+- (nullable MXReactionCount*)reactionCountForReaction:(NSString*)reaction onEvent:(NSString*)eventId
+{
+    return [self.store reactionCountForReaction:reaction onEvent:eventId];
+}
 
 - (id)listenToReactionCountUpdateInRoom:(NSString *)roomId block:(void (^)(NSDictionary<NSString *,MXReactionCountChange *> * _Nonnull))block
 {
@@ -127,6 +131,12 @@
         [self.store deleteReactionRelation:relation];
         [self removeReaction:relation.reaction onEvent:relation.eventId inRoomId:event.roomId];
     }
+}
+
+- (void)resetDataInRoom:(NSString *)roomId
+{
+    [self.store deleteAllReactionCountsInRoom:roomId];
+    [self.store deleteAllReactionRelationsInRoom:roomId];
 }
 
 #pragma mark - Private methods -

--- a/MatrixSDK/Aggregations/MXAggregations.h
+++ b/MatrixSDK/Aggregations/MXAggregations.h
@@ -21,6 +21,7 @@
 #import "MXAggregatedReactions.h"
 #import "MXReactionCount.h"
 #import "MXReactionCountChange.h"
+#import "MXEvent.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -96,6 +97,28 @@ NS_ASSUME_NONNULL_BEGIN
  @param listener the listener id.
  */
 - (void)removeListener:(id)listener;
+
+
+#pragma mark - Edits
+
+/**
+ Replace a text in a matrix event.
+
+ @param event The event to update
+ @param text The new message text
+
+ @param success A block object called when the operation succeeds. It returns
+                the event id of the event generated on the homeserver.
+ @param failure A block object called when the operation fails.
+
+ @return a MXHTTPOperation instance.
+ */
+- (MXHTTPOperation*)replaceTextMessageEvent:(MXEvent*)event
+                            withTextMessage:(nullable NSString*)text
+//                          formattedText:(nullable NSString*)formattedText     // TODO
+//                          localEcho:(MXEvent**)localEcho                      // TODO
+                                    success:(void (^)(NSString *eventId))success
+                                    failure:(void (^)(NSError *error))failure;
 
 
 /**

--- a/MatrixSDK/Aggregations/MXAggregations.m
+++ b/MatrixSDK/Aggregations/MXAggregations.m
@@ -179,6 +179,19 @@
     return self;
 }
 
+- (void)handleOriginalDataOfEvent:(MXEvent *)event
+{
+    MXEventRelations *relations = event.unsignedData.relations;
+    if (relations.annotation)
+    {
+        [self.aggregatedReactionsUpdater handleOriginalAggregatedDataOfEvent:event annotations:relations.annotation];
+    }
+    //        else if (relations.replace)
+    //        {
+    //            // TODO: Manage edits
+    //        }
+}
+
 - (void)resetDataInRoom:(NSString *)roomId
 {
     [self.aggregatedReactionsUpdater resetDataInRoom:roomId];

--- a/MatrixSDK/Aggregations/MXAggregations.m
+++ b/MatrixSDK/Aggregations/MXAggregations.m
@@ -132,7 +132,7 @@
         self.mxSession = mxSession;
         self.store = [[MXRealmAggregationsStore alloc] initWithCredentials:mxSession.matrixRestClient.credentials];
 
-        self.aggregatedReactionsUpdater = [[MXAggregatedReactionsUpdater alloc] initWithMyUser:self.mxSession.myUser.userId
+        self.aggregatedReactionsUpdater = [[MXAggregatedReactionsUpdater alloc] initWithMyUser:mxSession.matrixRestClient.credentials.userId
                                                                               aggregationStore:self.store matrixStore:mxSession.store];
 
         [mxSession listenToEventsOfTypes:@[kMXEventTypeStringReaction, kMXEventTypeStringRoomRedaction] onEvent:^(MXEvent *event, MXTimelineDirection direction, id customObject) {

--- a/MatrixSDK/Aggregations/MXAggregations.m
+++ b/MatrixSDK/Aggregations/MXAggregations.m
@@ -78,7 +78,7 @@
 {
     MXHTTPOperation *operation;
 
-    MXReactionCount *reactionCount = [self.store reactionCountForReaction:reaction onEvent:eventId];
+    MXReactionCount *reactionCount = [self.aggregatedReactionsUpdater reactionCountForReaction:reaction onEvent:eventId];
     if (reactionCount && reactionCount.myUserReactionEventId)
     {
         MXRoom *room = [self.mxSession roomWithRoomId:roomId];
@@ -158,8 +158,7 @@
 
 - (void)resetDataInRoom:(NSString *)roomId
 {
-    [self.store deleteAllReactionCountsInRoom:roomId];
-    [self.store deleteAllReactionRelationsInRoom:roomId];
+    [self.aggregatedReactionsUpdater resetDataInRoom:roomId];
 }
 
 #pragma mark - Reactions hack (TODO: Remove all methods) -

--- a/MatrixSDK/Aggregations/MXAggregations.m
+++ b/MatrixSDK/Aggregations/MXAggregations.m
@@ -21,21 +21,17 @@
 #import "MXSession.h"
 #import "MXTools.h"
 
-#import "MXEventUnsignedData.h"
 #import "MXEventRelations.h"
-#import "MXEventAnnotationChunk.h"
-#import "MXEventAnnotation.h"
 
 #import "MXRealmAggregationsStore.h"
-#import "MXReactionCountChangeListener.h"
+#import "MXAggregatedReactionsUpdater.h"
 
 
 @interface MXAggregations ()
 
 @property (nonatomic, weak) MXSession *mxSession;
-@property (nonatomic, weak) id<MXStore> matrixStore;
 @property (nonatomic) id<MXAggregationsStore> store;
-@property (nonatomic) NSMutableArray<MXReactionCountChangeListener*> *listeners;
+@property (nonatomic) MXAggregatedReactionsUpdater *aggregatedReactionsUpdater;
 
 @end
 
@@ -107,42 +103,17 @@
 
 - (nullable MXAggregatedReactions *)aggregatedReactionsOnEvent:(NSString*)eventId inRoom:(NSString*)roomId
 {
-    NSArray<MXReactionCount*> *reactions = [self.store reactionCountsOnEvent:eventId];
-    if (!reactions)
-    {
-        reactions = [self reactionCountsFromMatrixStoreOnEvent:eventId inRoom:roomId];
-    }
-
-    if (!reactions)
-    {
-        // Check reaction data from the hack
-        reactions = [self reactionCountsUsingHackOnEvent:eventId inRoom:roomId];
-    }
-
-    MXAggregatedReactions *aggregatedReactions;
-    if (reactions)
-    {
-        aggregatedReactions = [MXAggregatedReactions new];
-        aggregatedReactions.reactions = reactions;
-    }
-    
-    return aggregatedReactions;
+    return [self.aggregatedReactionsUpdater aggregatedReactionsOnEvent:eventId inRoom:roomId];
 }
 
 - (id)listenToReactionCountUpdateInRoom:(NSString *)roomId block:(void (^)(NSDictionary<NSString *,MXReactionCountChange *> * _Nonnull))block
 {
-    MXReactionCountChangeListener *listener = [MXReactionCountChangeListener new];
-    listener.roomId = roomId;
-    listener.notificationBlock = block;
-
-    [self.listeners addObject:listener];
-
-    return listener;
+    return [self.aggregatedReactionsUpdater listenToReactionCountUpdateInRoom:roomId block:block];
 }
 
 - (void)removeListener:(id)listener
 {
-    [self.listeners removeObject:listener];
+    [self.aggregatedReactionsUpdater removeListener:listener];
 }
 
 - (void)resetData
@@ -159,20 +130,21 @@
     if (self)
     {
         self.mxSession = mxSession;
-        self.matrixStore = mxSession.store;
         self.store = [[MXRealmAggregationsStore alloc] initWithCredentials:mxSession.matrixRestClient.credentials];
-        self.listeners = [NSMutableArray array];
+
+        self.aggregatedReactionsUpdater = [[MXAggregatedReactionsUpdater alloc] initWithMyUser:self.mxSession.myUser.userId
+                                                                              aggregationStore:self.store matrixStore:mxSession.store];
 
         [mxSession listenToEventsOfTypes:@[kMXEventTypeStringReaction, kMXEventTypeStringRoomRedaction] onEvent:^(MXEvent *event, MXTimelineDirection direction, id customObject) {
 
             switch (event.eventType) {
                 case MXEventTypeReaction:
-                    [self handleReaction:event direction:direction];
+                    [self.aggregatedReactionsUpdater handleReaction:event direction:direction];
                     break;
                 case MXEventTypeRoomRedaction:
                     if (direction == MXTimelineDirectionForwards)
                     {
-                        [self handleRedaction:event];
+                        [self.aggregatedReactionsUpdater handleRedaction:event];
                     }
                     break;
                 default:
@@ -190,217 +162,15 @@
     [self.store deleteAllReactionRelationsInRoom:roomId];
 }
 
-
-#pragma mark - Private methods -
-
-- (void)handleReaction:(MXEvent *)event direction:(MXTimelineDirection)direction
-{
-    NSString *parentEventId = event.relatesTo.eventId;
-    NSString *reaction = event.relatesTo.key;
-
-    if (parentEventId && reaction)
-    {
-        // Manage aggregated reactions only for events in timelines we have
-        MXEvent *parentEvent = [self.matrixStore eventWithEventId:parentEventId inRoom:event.roomId];
-        if (parentEvent)
-        {
-            [self storeRelationForReaction:reaction toEvent:parentEventId reactionEvent:event];
-
-            if (direction == MXTimelineDirectionForwards)
-            {
-                [self updateReactionCountForReaction:reaction toEvent:parentEventId reactionEvent:event];
-            }
-        }
-        else
-        {
-            [self storeRelationForHackForReaction:reaction toEvent:parentEventId reactionEvent:event];
-        }
-    }
-    else
-    {
-        NSLog(@"[MXAggregations] handleReaction: ERROR: invalid reaction event: %@", event);
-    }
-}
-
-- (void)handleRedaction:(MXEvent *)event
-{
-    NSString *redactedEventId = event.redacts;
-    MXReactionRelation *relation = [self.store reactionRelationWithReactionEventId:redactedEventId];
-
-    if (relation)
-    {
-        [self removeReaction:relation.reaction onEvent:relation.eventId inRoomId:event.roomId];
-        [self.store deleteReactionRelation:relation];
-    }
-}
-
-- (void)storeRelationForReaction:(NSString*)reaction toEvent:(NSString*)eventId reactionEvent:(MXEvent *)reactionEvent
-{
-    MXReactionRelation *relation = [MXReactionRelation new];
-    relation.reaction = reaction;
-    relation.eventId = eventId;
-    relation.reactionEventId = reactionEvent.eventId;
-    
-    [self.store addReactionRelation:relation inRoom:reactionEvent.roomId];
-}
-
-- (void)updateReactionCountForReaction:(NSString*)reaction toEvent:(NSString*)eventId reactionEvent:(MXEvent *)reactionEvent
-{
-    BOOL isANewReaction = NO;
-
-    // Migrate data from matrix store to aggregation store if needed
-    [self checkAggregationStoreForEvent:eventId inRoomId:reactionEvent.roomId];
-
-    // Create or update the current reaction count if it exists
-    MXReactionCount *reactionCount = [self.store reactionCountForReaction:reaction onEvent:eventId];
-    if (!reactionCount)
-    {
-        // If we still have no reaction count object, create one
-        reactionCount = [MXReactionCount new];
-        reactionCount.reaction = reaction;
-        isANewReaction = YES;
-    }
-
-    // Add the reaction
-    reactionCount.count++;
-
-    // Store reaction made by our user
-    if ([reactionEvent.sender isEqualToString:self.mxSession.myUser.userId])
-    {
-        reactionCount.myUserReactionEventId = reactionEvent.eventId;
-    }
-
-    // Update store
-    [self.store addOrUpdateReactionCount:reactionCount onEvent:eventId inRoom:reactionEvent.roomId];
-
-    // Notify
-    [self notifyReactionCountChangeListenersOfRoom:reactionEvent.roomId
-                                             event:eventId
-                                     reactionCount:reactionCount
-                                     isNewReaction:isANewReaction];
-}
-
-- (void)removeReaction:(NSString*)reaction onEvent:(NSString*)eventId inRoomId:(NSString*)roomId
-{
-    // Migrate data from matrix store to aggregation store if needed
-    [self checkAggregationStoreForEvent:eventId inRoomId:roomId];
-
-    // Create or update the current reaction count if it exists
-    MXReactionCount *reactionCount = [self.store reactionCountForReaction:reaction onEvent:eventId];
-    if (reactionCount)
-    {
-        if (reactionCount.count > 1)
-        {
-            reactionCount.count--;
-
-            [self.store addOrUpdateReactionCount:reactionCount onEvent:eventId inRoom:roomId];
-            [self notifyReactionCountChangeListenersOfRoom:roomId
-                                                     event:eventId
-                                             reactionCount:reactionCount
-                                             isNewReaction:NO];
-        }
-        else
-        {
-            [self.store deleteReactionCountsForReaction:reaction onEvent:eventId];
-            [self notifyReactionCountChangeListenersOfRoom:roomId event:eventId forDeletedReaction:reaction];
-        }
-    }
-}
-
-// If not already done, copy aggregation data from matrix store to aggregation store
-- (void)checkAggregationStoreForEvent:(NSString*)eventId inRoomId:(NSString*)roomId
-{
-    if (![self.store hasReactionCountsOnEvent:eventId])
-    {
-        NSArray<MXReactionCount*> *reactions = [self reactionCountsFromMatrixStoreOnEvent:eventId inRoom:roomId];
-
-        if (!reactions)
-        {
-            // Check reaction data from the hack
-            reactions = [self reactionCountsUsingHackOnEvent:eventId inRoom:roomId];
-        }
-        
-        if (reactions)
-        {
-            [self.store setReactionCounts:reactions onEvent:eventId inRoom:roomId];
-        }
-    }
-}
-
-- (nullable NSArray<MXReactionCount*> *)reactionCountsFromMatrixStoreOnEvent:(NSString*)eventId inRoom:(NSString*)roomId
-{
-    NSMutableArray *reactions;
-
-    MXEvent *event = [self.matrixStore eventWithEventId:eventId inRoom:roomId];
-    if (event)
-    {
-        for (MXEventAnnotation *annotation in event.unsignedData.relations.annotation.chunk)
-        {
-            if ([annotation.type isEqualToString:MXEventAnnotationReaction])
-            {
-                MXReactionCount *reactionCount = [MXReactionCount new];
-                reactionCount.reaction = annotation.key;
-                reactionCount.count = annotation.count;
-
-                if (!reactions)
-                {
-                    reactions = [NSMutableArray array];
-                }
-                [reactions addObject:reactionCount];
-            }
-        }
-    }
-
-    return reactions;
-}
-
-- (void)notifyReactionCountChangeListenersOfRoom:(NSString*)roomId event:(NSString*)eventId reactionCount:(MXReactionCount*)reactionCount isNewReaction:(BOOL)isNewReaction
-{
-    MXReactionCountChange *reactionCountChange = [MXReactionCountChange new];
-    if (isNewReaction)
-    {
-        reactionCountChange.inserted = @[reactionCount];
-    }
-    else
-    {
-        reactionCountChange.modified = @[reactionCount];
-    }
-
-    [self notifyReactionCountChangeListenersOfRoom:roomId changes:@{
-                                                                    eventId:reactionCountChange
-                                                                    }];
-}
-
-- (void)notifyReactionCountChangeListenersOfRoom:(NSString*)roomId event:(NSString*)eventId forDeletedReaction:(NSString*)deletedReaction
-{
-    MXReactionCountChange *reactionCountChange = [MXReactionCountChange new];
-    reactionCountChange.deleted = @[deletedReaction];
-
-    [self notifyReactionCountChangeListenersOfRoom:roomId changes:@{
-                                                                    eventId:reactionCountChange
-                                                                    }];
-}
-
-- (void)notifyReactionCountChangeListenersOfRoom:(NSString*)roomId changes:(NSDictionary<NSString*, MXReactionCountChange*>*)changes
-{
-    for (MXReactionCountChangeListener *listener in self.listeners)
-    {
-        if ([listener.roomId isEqualToString:roomId])
-        {
-            listener.notificationBlock(changes);
-        }
-    }
-}
-
 #pragma mark - Reactions hack (TODO: Remove all methods) -
 /// TODO: To remove once the feature has landed on matrix.org homeserver
 
 // SendReactionUsingHack directly sends a `m.reaction` room message instead of using the `/send_relation` api.
 - (MXHTTPOperation*)sendReactionUsingHack:(NSString*)reaction
-                         toEvent:(NSString*)eventId
-                          inRoom:(NSString*)roomId
-                         success:(void (^)(NSString *eventId))success
-                         failure:(void (^)(NSError *error))failure
+                                  toEvent:(NSString*)eventId
+                                   inRoom:(NSString*)roomId
+                                  success:(void (^)(NSString *eventId))success
+                                  failure:(void (^)(NSError *error))failure
 {
     NSLog(@"[MXAggregations] sendReactionUsingHack");
 
@@ -413,58 +183,13 @@
 
     NSDictionary *reactionContent = @{
                                       @"m.relates_to": @{
-                                                      @"rel_type": @"m.annotation",
-                                                      @"event_id": eventId,
-                                                      @"key": reaction
-                                                      }
+                                              @"rel_type": @"m.annotation",
+                                              @"event_id": eventId,
+                                              @"key": reaction
+                                              }
                                       };
 
     return [room sendEventOfType:kMXEventTypeStringReaction content:reactionContent localEcho:nil success:success failure:failure];
-}
-
-// Compute reactions counts from relations we know
-// Note: This is not accurate and will be removed soon
-- (nullable NSArray<MXReactionCount*> *)reactionCountsUsingHackOnEvent:(NSString*)eventId inRoom:(NSString*)roomId
-{
-    NSDate *startDate = [NSDate date];
-    
-    NSMutableDictionary<NSString*, MXReactionCount*> *reactionCountDict = [NSMutableDictionary dictionary];
-
-    NSArray<MXReactionRelation*> *relations = [self.store reactionRelationsOnEvent:eventId];
-    for (MXReactionRelation *relation in relations)
-    {
-        MXReactionCount *reactionCount = reactionCountDict[relation.reaction];
-        if (!reactionCount)
-        {
-            reactionCount = [MXReactionCount new];
-            reactionCount.reaction = relation.reaction;
-            reactionCountDict[relation.reaction] = reactionCount;
-        }
-
-        reactionCount.count++;
-
-        if (!reactionCount.myUserReactionEventId)
-        {
-            // Determine if my user has reacted
-            MXEvent *event = [self.matrixStore eventWithEventId:relation.reactionEventId inRoom:roomId];
-            if ([event.sender isEqualToString:self.mxSession.myUser.userId])
-            {
-                reactionCount.myUserReactionEventId = relation.reactionEventId;
-            }
-        }
-    }
-
-    NSLog(@"[MXAggregations] reactionCountsUsingHackOnEvent: Build %@ reactionCounts in %.0fms",
-          @(reactionCountDict.count),
-          [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
-
-    return reactionCountDict.allValues;
-}
-
-// We need to store all received relations even if we do not know the event yet
-- (void)storeRelationForHackForReaction:(NSString*)reaction toEvent:(NSString*)eventId reactionEvent:(MXEvent *)reactionEvent
-{
-    [self storeRelationForReaction:reaction toEvent:eventId reactionEvent:reactionEvent];
 }
 
 @end

--- a/MatrixSDK/Aggregations/MXAggregations_Private.h
+++ b/MatrixSDK/Aggregations/MXAggregations_Private.h
@@ -16,7 +16,7 @@
 
 #import "MXAggregations.h"
 
-@class MXSession;
+@class MXSession, MXEvent;
 
 
 NS_ASSUME_NONNULL_BEGIN
@@ -32,6 +32,14 @@ NS_ASSUME_NONNULL_BEGIN
  @param mxSession the related 'MXSession'.
  */
 - (instancetype)initWithMatrixSession:(MXSession *)mxSession;
+
+/**
+ Notify the aggregation manager for every events so that it can store
+ aggregated data sent by the server.
+
+ @param event the event received in a timeline.
+ */
+- (void)handleOriginalDataOfEvent:(MXEvent*)event;
 
 /**
  Clear cached data for a room.

--- a/MatrixSDK/Data/MXEventTimeline.m
+++ b/MatrixSDK/Data/MXEventTimeline.m
@@ -627,6 +627,19 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
         [store storeEventForRoom:_state.roomId event:event direction:direction];
     }
 
+    // Notify the aggregation manager for every events so that it can store
+    // aggregated data sent by the server
+
+    // TODO: remove this check once https://github.com/matrix-org/synapse/pull/5220 is merged
+    if (_isLiveTimeline && direction == MXTimelineDirectionForwards && isRoomInitialSync)
+    {
+        // Do nothing to avoid double counting
+    }
+    else
+    {
+        [room.mxSession.aggregations handleOriginalDataOfEvent:event];
+    }
+
     // Notify listeners
     [self notifyListeners:event direction:direction];
 }

--- a/MatrixSDK/Data/MXEventTimeline.m
+++ b/MatrixSDK/Data/MXEventTimeline.m
@@ -444,9 +444,6 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
         {
             // Flush the existing messages for this room by keeping state events.
             [store deleteAllMessagesInRoom:_state.roomId];
-
-            // Flush aggregated data for the events in the timeline
-            [room.mxSession.aggregations resetDataInRoom:_state.roomId];
         }
 
         for (MXEvent *event in roomSync.timeline.events)

--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
@@ -25,7 +25,7 @@
 #import "MXSDKOptions.h"
 #import "MXTools.h"
 
-static NSUInteger const kMXFileVersion = 64;
+static NSUInteger const kMXFileVersion = 65;
 
 static NSString *const kMXFileStoreFolder = @"MXFileStore";
 static NSString *const kMXFileStoreMedaDataFile = @"MXFileStore";

--- a/MatrixSDKTests/MXAggregatedEditsTests.m
+++ b/MatrixSDKTests/MXAggregatedEditsTests.m
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2019 The Matrix.org Foundation C.I.C
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "MatrixSDKTestsData.h"
+
+#import "MXFileStore.h"
+
+// Do not bother with retain cycles warnings in tests
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-retain-cycles"
+
+@interface MXAggregatedEditsTests : XCTestCase
+{
+    MatrixSDKTestsData *matrixSDKTestsData;
+}
+
+@end
+
+@implementation MXAggregatedEditsTests
+
+- (void)setUp
+{
+    [super setUp];
+
+    matrixSDKTestsData = [[MatrixSDKTestsData alloc] init];
+}
+
+- (void)tearDown
+{
+    matrixSDKTestsData = nil;
+}
+
+// Create a room with an event with an edit it on it
+- (void)createScenario:(void(^)(MXSession *mxSession, MXRoom *room, XCTestExpectation *expectation, NSString *eventId, NSString *editEventId))readyToTest
+{
+    [matrixSDKTestsData doMXSessionTestWithBobAndARoom:self andStore:[[MXMemoryStore alloc] init] readyToTest:^(MXSession *mxSession, MXRoom *room, XCTestExpectation *expectation) {
+
+        [room sendTextMessage:@"Bonjour" success:^(NSString *eventId) {
+            [mxSession eventWithEventId:eventId inRoom:room.roomId success:^(MXEvent *event) {
+                [mxSession.aggregations replaceTextMessageEvent:event withTextMessage:@"I meant Hello" success:^(NSString * _Nonnull editEventId) {
+
+                    // TODO: replaceTextMessageEvent should return only when the actual edit event comes back the sync
+                    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 1 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+                        readyToTest(mxSession, room, expectation, eventId, editEventId);
+                    });
+
+                } failure:^(NSError *error) {
+                    XCTFail(@"The operation should not fail - NSError: %@", error);
+                    [expectation fulfill];
+                }];
+
+            } failure:^(NSError *error) {
+                XCTFail(@"Cannot set up intial test conditions - error: %@", error);
+                [expectation fulfill];
+            }];
+        } failure:^(NSError *error) {
+            XCTFail(@"Cannot set up intial test conditions - error: %@", error);
+            [expectation fulfill];
+        }];
+    }];
+}
+
+
+// - Send a message
+// - Edit it
+// -> an edit m.room.message must appear in the timeline
+- (void)testEditSendAndReceive
+{
+    [matrixSDKTestsData doMXSessionTestWithBobAndARoom:self andStore:[[MXMemoryStore alloc] init] readyToTest:^(MXSession *mxSession, MXRoom *room, XCTestExpectation *expectation) {
+
+        // - Send a message
+        [room sendTextMessage:@"Bonjour" success:^(NSString *eventId) {
+
+            [mxSession eventWithEventId:eventId inRoom:room.roomId success:^(MXEvent *event) {
+
+                // Edit it
+                [mxSession.aggregations replaceTextMessageEvent:event withTextMessage:@"I meant Hello" success:^(NSString * _Nonnull eventId) {
+                     XCTAssertNotNil(eventId);
+                 } failure:^(NSError *error) {
+                     XCTFail(@"The operation should not fail - NSError: %@", error);
+                     [expectation fulfill];
+                 }];
+
+                [room listenToEventsOfTypes:@[kMXEventTypeStringRoomMessage] onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
+
+                    // -> an edit m.room.message must appear in the timeline
+                    XCTAssertEqual(event.eventType, MXEventTypeRoomMessage);
+
+                    XCTAssertNotNil(event.relatesTo);
+                    XCTAssertEqualObjects(event.relatesTo.relationType, MXEventRelationTypeReplace);
+                    XCTAssertEqualObjects(event.relatesTo.eventId, eventId);
+
+                    XCTAssertEqualObjects(event.content[@"m.new_content"][@"msgtype"], kMXMessageTypeText);
+                    XCTAssertEqualObjects(event.content[@"m.new_content"][@"body"], @"I meant Hello");
+
+                    [expectation fulfill];
+                }];
+
+            } failure:^(NSError *error) {
+                XCTFail(@"Cannot set up intial test conditions - error: %@", error);
+                [expectation fulfill];
+            }];
+        } failure:^(NSError *error) {
+            XCTFail(@"Cannot set up intial test conditions - error: %@", error);
+            [expectation fulfill];
+        }];
+    }];
+}
+
+// - Run the initial condition scenario
+// -> Check data is correctly aggregated when fetching the edited event directly from the homeserver
+- (void)testAggregatedEditServerSide
+{
+    // - Run the initial condition scenario
+    [self createScenario:^(MXSession *mxSession, MXRoom *room, XCTestExpectation *expectation, NSString *eventId, NSString *editEventId) {
+
+        // -> Check data is correctly aggregated when fetching the edited event directly from the homeserver
+        [mxSession.matrixRestClient eventWithEventId:eventId inRoom:room.roomId success:^(MXEvent *event) {
+
+            XCTAssertNotNil(event.unsignedData.relations);
+
+            XCTFail(@"TODO: Write the test once we know what we should receive");
+
+            [expectation fulfill];
+
+        } failure:^(NSError *error) {
+            XCTFail(@"Cannot set up intial test conditions - error: %@", error);
+            [expectation fulfill];
+        }];
+    }];
+}
+
+// - Run the initial condition scenario
+// - Do an initial sync
+// -> Data from aggregations must be right
+- (void)testEditsFromInitialSync
+{
+    // - Run the initial condition scenario
+    [self createScenario:^(MXSession *mxSession, MXRoom *room, XCTestExpectation *expectation, NSString *eventId, NSString *editEventId) {
+
+        MXRestClient *restClient = mxSession.matrixRestClient;
+
+        [mxSession.aggregations resetData];
+        [mxSession close];
+        mxSession = nil;
+
+        // - Do an initial sync
+        mxSession = [[MXSession alloc] initWithMatrixRestClient:restClient];
+        [mxSession setStore:[[MXMemoryStore alloc] init] success:^{
+
+            [mxSession start:^{
+
+                // -> Data from aggregations must be right
+                XCTFail(@"TODO: Write the test once we know what we should receive");
+
+                [expectation fulfill];
+
+            } failure:^(NSError *error) {
+                XCTFail(@"Cannot set up intial test conditions - error: %@", error);
+                [expectation fulfill];
+            }];
+
+        } failure:^(NSError *error) {
+            XCTFail(@"Cannot set up intial test conditions - error: %@", error);
+            [expectation fulfill];
+        }];
+    }];
+}
+
+@end
+
+#pragma clang diagnostic pop

--- a/MatrixSDKTests/MXAggregatedReactionTests.m
+++ b/MatrixSDKTests/MXAggregatedReactionTests.m
@@ -114,6 +114,36 @@
 }
 
 // - Run the initial condition scenario
+// -> Check data is correctly aggregated when fetching the reacted event directly from the homeserver
+- (void)testAggregatedReaction
+{
+    // - Run the initial condition scenario
+    [self createScenario:^(MXSession *mxSession, MXRoom *room, XCTestExpectation *expectation, NSString *eventId, NSString *editEventId) {
+
+        // -> Check data is correctly aggregated when fetching the reacted event directly from the homeserver
+        [mxSession.matrixRestClient eventWithEventId:eventId inRoom:room.roomId success:^(MXEvent *event) {
+
+            MXEventAnnotationChunk *annotations = event.unsignedData.relations.annotation;
+            XCTAssertNotNil(annotations);
+            XCTAssertEqual(annotations.count, 1);
+            XCTAssertEqual(annotations.chunk.count, 1);
+
+            MXEventAnnotation *annotation = annotations.chunk.firstObject;
+            XCTAssertNotNil(annotation);
+            XCTAssertEqualObjects(annotation.type, MXEventAnnotationReaction);
+            XCTAssertEqualObjects(annotation.key, @"👍");
+            XCTAssertEqual(annotation.count, 1);
+
+            [expectation fulfill];
+
+        } failure:^(NSError *error) {
+            XCTFail(@"Cannot set up intial test conditions - error: %@", error);
+            [expectation fulfill];
+        }];
+    }];
+}
+
+// - Run the initial condition scenario
 // - Do an initial sync
 // -> Data from aggregations must be right
 - (void)testAggregationsFromInitialSync
@@ -254,6 +284,8 @@
         }];
     }];
 }
+
+
 
 @end
 

--- a/MatrixSDKTests/MXAggregatedReactionTests.m
+++ b/MatrixSDKTests/MXAggregatedReactionTests.m
@@ -29,14 +29,14 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-retain-cycles"
 
-@interface MXReactionTests : XCTestCase
+@interface MXAggregatedReactionTests : XCTestCase
 {
     MatrixSDKTestsData *matrixSDKTestsData;
 }
 
 @end
 
-@implementation MXReactionTests
+@implementation MXAggregatedReactionTests
 
 - (void)setUp
 {

--- a/MatrixSDKTests/MatrixSDKTestsData.h
+++ b/MatrixSDKTests/MatrixSDKTestsData.h
@@ -116,6 +116,11 @@ FOUNDATION_EXPORT NSString * const kMXTestsAliceAvatarURL;
                                      andStore:(id<MXStore>)bobStore
                                   readyToTest:(void (^)(MXSession *bobSession,  MXRestClient *aliceRestClient, NSString* roomId, XCTestExpectation *expectation))readyToTest;
 
+- (void)doTestWithAliceAndBobInARoom:(XCTestCase*)testCase
+                             aliceStore:(id<MXStore>)aliceStore
+                               bobStore:(id<MXStore>)bobStore
+                         readyToTest:(void (^)(MXSession *aliceSession, MXSession *bobSession, NSString *roomId, XCTestExpectation *expectation))readyToTest;
+
 
 #pragma mark - random user
 - (void)doMXSessionTestWithAUser:(XCTestCase*)testCase

--- a/MatrixSDKTests/MatrixSDKTestsData.m
+++ b/MatrixSDKTests/MatrixSDKTestsData.m
@@ -653,6 +653,31 @@ NSString * const kMXTestsAliceAvatarURL = @"mxc://matrix.org/kciiXusgZFKuNLIfLqm
     }];
 }
 
+- (void)doTestWithAliceAndBobInARoom:(XCTestCase*)testCase
+                          aliceStore:(id<MXStore>)aliceStore
+                            bobStore:(id<MXStore>)bobStore
+                         readyToTest:(void (^)(MXSession *aliceSession, MXSession *bobSession, NSString *roomId, XCTestExpectation *expectation))readyToTest
+{
+    [self doMXSessionTestWithBobAndAliceInARoom:testCase andStore:bobStore readyToTest:^(MXSession *bobSession, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
+
+        MXSession *aliceSession = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
+        [self retain:aliceSession];
+
+        [aliceSession setStore:aliceStore success:^{
+
+            [aliceSession start:^{
+
+                readyToTest(aliceSession, bobSession, roomId, expectation);
+
+            } failure:^(NSError *error) {
+                NSAssert(NO, @"Cannot set up intial test conditions - error: %@", error);
+            }];
+        } failure:^(NSError *error) {
+            NSAssert(NO, @"Cannot set up intial test conditions - error: %@", error);
+        }];
+    }];
+}
+
 
 #pragma mark - random user
 - (void)doMXSessionTestWithAUser:(XCTestCase*)testCase


### PR DESCRIPTION
I started this branch to implement edits. I first made a refactor to let room for the edits part in MXAggregation but I got stucked in edits spec so I came back to reactions and fix some (maybe all) things.

This PR contains
- a new class `MXAggregatedReactionsUpdater` to handle storage and updates (and hack) for reaction
- the beginning of `MXAggregatedEditsUpdater`
- you can edit a message using `send_relation`
- fix for "Unreact can have no visual effect" (https://github.com/vector-im/riot-ios#2470)
- a patch while https://github.com/matrix-org/synapse/pull/5220 is not merged
- reactions on permalink (which fixes vector-im/riot-ios#2451)
- more tests on reactions (they all pass but see below)
- draft for tests for edits. I stopped writing them as I do not receive what I expect -> Need to work with the spec/synapse team.

Commits can be reviewed one by one.

# Test
They pass but with some restrictions:
- The local server must run synapse/develop with the config `experimental_msc1849_support_enabled: true`
- We must comment the 2 TODOs in `MXAggregatedReactionTests` related to server or spec issues.

<img width="404" alt="Screenshot 2019-05-24 at 08 01 55" src="https://user-images.githubusercontent.com/8418515/58311871-4aba3200-7e0a-11e9-897a-84b8f94b2772.png">


