### PR TITLE
Aggregation API: Local echo for reactions

### DIFF
--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -302,6 +302,8 @@
 		32C03CBE21231C2600D92712 /* AUTHORS.rst in Resources */ = {isa = PBXBuildFile; fileRef = 32C03CBA21231C2500D92712 /* AUTHORS.rst */; };
 		32C235721F827F3800E38FC5 /* MXRoomOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 32C235701F827F3800E38FC5 /* MXRoomOperation.h */; };
 		32C235731F827F3800E38FC5 /* MXRoomOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 32C235711F827F3800E38FC5 /* MXRoomOperation.m */; };
+		32C474C122AF7A2D00CFBCD2 /* MXReactionOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 32C474BF22AF7A2D00CFBCD2 /* MXReactionOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		32C474C222AF7A2D00CFBCD2 /* MXReactionOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 32C474C022AF7A2D00CFBCD2 /* MXReactionOperation.m */; };
 		32C6F93319DD814400EA4E9C /* MatrixSDK.h in Headers */ = {isa = PBXBuildFile; fileRef = 32C6F93219DD814400EA4E9C /* MatrixSDK.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		32CAB1071A91EA34008C5BB9 /* MXPushRuleRoomMemberCountConditionChecker.h in Headers */ = {isa = PBXBuildFile; fileRef = 32CAB1051A91EA34008C5BB9 /* MXPushRuleRoomMemberCountConditionChecker.h */; };
 		32CAB1081A91EA34008C5BB9 /* MXPushRuleRoomMemberCountConditionChecker.m in Sources */ = {isa = PBXBuildFile; fileRef = 32CAB1061A91EA34008C5BB9 /* MXPushRuleRoomMemberCountConditionChecker.m */; };
@@ -765,6 +767,8 @@
 		32C03CBA21231C2500D92712 /* AUTHORS.rst */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = AUTHORS.rst; sourceTree = "<group>"; };
 		32C235701F827F3800E38FC5 /* MXRoomOperation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXRoomOperation.h; sourceTree = "<group>"; };
 		32C235711F827F3800E38FC5 /* MXRoomOperation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXRoomOperation.m; sourceTree = "<group>"; };
+		32C474BF22AF7A2D00CFBCD2 /* MXReactionOperation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXReactionOperation.h; sourceTree = "<group>"; };
+		32C474C022AF7A2D00CFBCD2 /* MXReactionOperation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXReactionOperation.m; sourceTree = "<group>"; };
 		32C6F92D19DD814400EA4E9C /* MatrixSDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MatrixSDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		32C6F93119DD814400EA4E9C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		32C6F93219DD814400EA4E9C /* MatrixSDK.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MatrixSDK.h; sourceTree = "<group>"; };
@@ -1381,6 +1385,8 @@
 				32133020228BF7BC0070BA9B /* MXReactionCountChange.m */,
 				32133023228BFA800070BA9B /* MXReactionCountChangeListener.h */,
 				32133024228BFA800070BA9B /* MXReactionCountChangeListener.m */,
+				32C474BF22AF7A2D00CFBCD2 /* MXReactionOperation.h */,
+				32C474C022AF7A2D00CFBCD2 /* MXReactionOperation.m */,
 				32B94DFF228EDEBC00716A26 /* MXReactionRelation.h */,
 				32B94E00228EDEBC00716A26 /* MXReactionRelation.m */,
 				B10AFB4522AA8A8D0092E6AF /* MXEventEditsListener.h */,
@@ -1965,6 +1971,7 @@
 				320BBF431D6C81550079890E /* MXEventsEnumeratorOnArray.h in Headers */,
 				32B76EA320FDE2BE00B095F6 /* MXRoomMembersCount.h in Headers */,
 				32C6F93319DD814400EA4E9C /* MatrixSDK.h in Headers */,
+				32C474C122AF7A2D00CFBCD2 /* MXReactionOperation.h in Headers */,
 				324BE46C1E422766008D99D4 /* MXMegolmSessionData.h in Headers */,
 				327E9AFC228AC22800A98BC1 /* MXAggregationsStore.h in Headers */,
 				323547DC2226FC5700F15F94 /* MXCredentials.h in Headers */,
@@ -2290,6 +2297,7 @@
 				32A151531DAF8A7200400192 /* MXQueuedEncryption.m in Sources */,
 				C6D5D60A1E4FA74000706C0F /* MXEnumConstants.swift in Sources */,
 				327E9ADD2284804500A98BC1 /* MXEventRelations.m in Sources */,
+				32C474C222AF7A2D00CFBCD2 /* MXReactionOperation.m in Sources */,
 				3256E3821DCB91EB003C9718 /* MXCryptoConstants.m in Sources */,
 				B18D18C22152B8E4003677D1 /* MXRoomMember.swift in Sources */,
 				32BBAE6F2178E99100D85F46 /* MXKeyBackupVersion.m in Sources */,

--- a/MatrixSDK/Aggregations/Data/MXAggregatedReactions.h
+++ b/MatrixSDK/Aggregations/Data/MXAggregatedReactions.h
@@ -27,6 +27,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic) NSArray<MXReactionCount*> *reactions;
 
+- (nullable MXAggregatedReactions *)aggregatedReactionsWithNonZeroCount;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/MatrixSDK/Aggregations/Data/MXAggregatedReactions.m
+++ b/MatrixSDK/Aggregations/Data/MXAggregatedReactions.m
@@ -18,4 +18,25 @@
 
 @implementation MXAggregatedReactions
 
+- (nullable MXAggregatedReactions *)aggregatedReactionsWithNonZeroCount
+{
+    NSMutableArray *reactions = [NSMutableArray arrayWithCapacity:self.reactions.count];
+    for (MXReactionCount *reactionCount in self.reactions)
+    {
+        if (reactionCount.count > 0)
+        {
+            [reactions addObject:reactionCount];
+        }
+    }
+
+    MXAggregatedReactions *nonZeroCountAggregatedReactions;
+    if (reactions.count)
+    {
+        nonZeroCountAggregatedReactions = [MXAggregatedReactions new];
+        nonZeroCountAggregatedReactions.reactions = reactions;
+    }
+
+    return nonZeroCountAggregatedReactions;
+}
+
 @end

--- a/MatrixSDK/Aggregations/Data/MXReactionCount.h
+++ b/MatrixSDK/Aggregations/Data/MXReactionCount.h
@@ -16,6 +16,8 @@
 
 #import <Foundation/Foundation.h>
 
+#import "MXReactionOperation.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 /**
@@ -26,11 +28,20 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) NSString *reaction;
 @property (nonatomic) NSUInteger count;
 
-// The id of the event if our user has made this reaction
+
+// The id of the reaction event if our user has made this reaction
 @property (nonatomic, nullable) NSString *myUserReactionEventId;
 
 // YES if our user has made this reaction
 @property (nonatomic, readonly) BOOL myUserHasReacted;
+
+
+// List of pending operation requests on this reaction
+// Note: self.count includes counts of them
+@property (nonatomic) NSArray<MXReactionOperation*> *localEchoesOperations;
+
+// YES if there are pending operations
+@property (nonatomic, readonly) BOOL containsLocalEcho;
 
 @end
 

--- a/MatrixSDK/Aggregations/Data/MXReactionCount.m
+++ b/MatrixSDK/Aggregations/Data/MXReactionCount.m
@@ -38,13 +38,15 @@
 
 - (NSString *)description
 {
+    NSString *echoes = self.localEchoesOperations.count ? [NSString stringWithFormat:@" - echoes: %@", @(self.localEchoesOperations.count)] : @"";
+
     if (self.myUserHasReacted)
     {
-        return [NSString stringWithFormat:@"(%@: %@)", self.reaction, @(self.count)];
+        return [NSString stringWithFormat:@"(%@: %@%@)", self.reaction, @(self.count), echoes];
     }
     else
     {
-        return [NSString stringWithFormat:@"%@: %@", self.reaction, @(self.count)];
+        return [NSString stringWithFormat:@"%@: %@%@", self.reaction, @(self.count), echoes];
     }
 }
 

--- a/MatrixSDK/Aggregations/Data/MXReactionCount.m
+++ b/MatrixSDK/Aggregations/Data/MXReactionCount.m
@@ -21,7 +21,7 @@
 - (BOOL)myUserHasReacted
 {
     // Take local echoes into consideration first
-    if (self.localEchoesOperations)
+    if (self.localEchoesOperations.count)
     {
         return self.localEchoesOperations.lastObject.isAddOperation;
     }

--- a/MatrixSDK/Aggregations/Data/MXReactionCount.m
+++ b/MatrixSDK/Aggregations/Data/MXReactionCount.m
@@ -20,7 +20,20 @@
 
 - (BOOL)myUserHasReacted
 {
-    return (_myUserReactionEventId != nil);
+    // Take local echoes into consideration first
+    if (self.localEchoesOperations)
+    {
+        return self.localEchoesOperations.lastObject.isAddOperation;
+    }
+    else
+    {
+        return (_myUserReactionEventId != nil);
+    }
+}
+
+- (BOOL)containsLocalEcho
+{
+    return (self.localEchoesOperations.count > 0);
 }
 
 - (NSString *)description

--- a/MatrixSDK/Aggregations/Data/MXReactionCountChange.h
+++ b/MatrixSDK/Aggregations/Data/MXReactionCountChange.h
@@ -26,6 +26,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, nullable) NSArray<MXReactionCount*> *modified;
 @property (nonatomic, nullable) NSArray<NSString* /*reaction string*/> *deleted;
 
+@property (nonatomic) BOOL changeDueToLocalEcho;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/MatrixSDK/Aggregations/Data/MXReactionOperation.h
+++ b/MatrixSDK/Aggregations/Data/MXReactionOperation.h
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) NSString *reaction;
 @property (nonatomic) BOOL isAddOperation;
 
-@property (nonatomic) void (^block)(void);
+@property (nonatomic) void (^block)(BOOL requestAlreadyPending);
 
 @end
 

--- a/MatrixSDK/Aggregations/Data/MXReactionOperation.h
+++ b/MatrixSDK/Aggregations/Data/MXReactionOperation.h
@@ -1,0 +1,37 @@
+/*
+ Copyright 2019 The Matrix.org Foundation C.I.C
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ A `MXReactionOperation` represents a pending operation on a reaction on a event.
+ The `MXReactionOperation` exists while the operation has not been acknowledged
+ by the homeserver, ie while we have not received the reaction event back from
+ the event stream.
+ */
+@interface MXReactionOperation : NSObject
+
+@property (nonatomic) NSString *eventId;
+@property (nonatomic) NSString *reaction;
+@property (nonatomic) BOOL isAddOperation;
+
+@property (nonatomic) void (^block)(void);
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixSDK/Aggregations/Data/MXReactionOperation.m
+++ b/MatrixSDK/Aggregations/Data/MXReactionOperation.m
@@ -1,0 +1,21 @@
+/*
+ Copyright 2019 The Matrix.org Foundation C.I.C
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXReactionOperation.h"
+
+@implementation MXReactionOperation
+
+@end

--- a/MatrixSDK/Aggregations/Data/MXReactionOperation.m
+++ b/MatrixSDK/Aggregations/Data/MXReactionOperation.m
@@ -18,4 +18,10 @@
 
 @implementation MXReactionOperation
 
+- (NSString *)description
+{
+    NSString *sign = self.isAddOperation ? @"+" : @"-";
+    return [NSString stringWithFormat:@"%@: %@", self.reaction, sign];
+}
+
 @end

--- a/MatrixSDK/Aggregations/MXAggregatedReactionsUpdater.h
+++ b/MatrixSDK/Aggregations/MXAggregatedReactionsUpdater.h
@@ -30,16 +30,16 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithMatrixSession:(MXSession *)mxSession aggregationStore:(id<MXAggregationsStore>)store;
 
 #pragma mark - Requests
-- (MXHTTPOperation*)sendReaction:(NSString*)reaction
-                         toEvent:(NSString*)eventId
-                          inRoom:(NSString*)roomId
-                         success:(void (^)(NSString *eventId))success
-                         failure:(void (^)(NSError *error))failure;
-- (MXHTTPOperation*)unReactOnReaction:(NSString*)reaction
-                              toEvent:(NSString*)eventId
-                               inRoom:(NSString*)roomId
-                              success:(void (^)(void))success
-                              failure:(void (^)(NSError *error))failure;
+- (void)addReaction:(NSString*)reaction
+           forEvent:(NSString*)eventId
+             inRoom:(NSString*)roomId
+            success:(void (^)(void))success
+            failure:(void (^)(NSError *error))failure;
+- (void)removeReaction:(NSString*)reaction
+              forEvent:(NSString*)eventId
+                inRoom:(NSString*)roomId
+               success:(void (^)(void))success
+               failure:(void (^)(NSError *error))failure;
 
 #pragma mark - Data access
 - (nullable MXAggregatedReactions *)aggregatedReactionsOnEvent:(NSString*)eventId inRoom:(NSString*)roomId;

--- a/MatrixSDK/Aggregations/MXAggregatedReactionsUpdater.h
+++ b/MatrixSDK/Aggregations/MXAggregatedReactionsUpdater.h
@@ -27,9 +27,19 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MXAggregatedReactionsUpdater : NSObject
 
-- (instancetype)initWithMyUser:(NSString*)userId
-              aggregationStore:(id<MXAggregationsStore>)store
-                   matrixStore:(id<MXStore>)matrixStore;
+- (instancetype)initWithMatrixSession:(MXSession *)mxSession aggregationStore:(id<MXAggregationsStore>)store;
+
+#pragma mark - Requests
+- (MXHTTPOperation*)sendReaction:(NSString*)reaction
+                         toEvent:(NSString*)eventId
+                          inRoom:(NSString*)roomId
+                         success:(void (^)(NSString *eventId))success
+                         failure:(void (^)(NSError *error))failure;
+- (MXHTTPOperation*)unReactOnReaction:(NSString*)reaction
+                              toEvent:(NSString*)eventId
+                               inRoom:(NSString*)roomId
+                              success:(void (^)(void))success
+                              failure:(void (^)(NSError *error))failure;
 
 #pragma mark - Data access
 - (nullable MXAggregatedReactions *)aggregatedReactionsOnEvent:(NSString*)eventId inRoom:(NSString*)roomId;

--- a/MatrixSDK/Aggregations/MXAggregatedReactionsUpdater.m
+++ b/MatrixSDK/Aggregations/MXAggregatedReactionsUpdater.m
@@ -488,26 +488,29 @@
 
         for (NSString *reaction in self.reactionOperations[eventId])
         {
-            for (MXReactionOperation *reactionOperation in self.reactionOperations[eventId][reaction])
+            if (self.reactionOperations[eventId][reaction])
             {
-                if (reactionOperation.isAddOperation)
+                MXReactionCount *updatedReactionCount = reactionCountsByReaction[reaction];
+                if (!updatedReactionCount)
                 {
-                    if (!reactionCountsByReaction[reaction])
-                    {
-                        reactionCountsByReaction[reaction] = [MXReactionCount new];
-                        reactionCountsByReaction[reaction].reaction = reaction;
-                    }
+                    updatedReactionCount = [MXReactionCount new];
+                    updatedReactionCount.reaction = reaction;
+                    reactionCountsByReaction[reaction] = updatedReactionCount;
+                }
 
-                    reactionCountsByReaction[reaction].count++;
-                }
-                else if (reactionCountsByReaction[reaction])
+                for (MXReactionOperation *reactionOperation in self.reactionOperations[eventId][reaction])
                 {
-                    reactionCountsByReaction[reaction].count--;
-                    if (reactionCountsByReaction[reaction].count == 0)
+                    if (reactionOperation.isAddOperation)
                     {
-                        [reactionCountsByReaction removeObjectForKey:reaction];
+                        updatedReactionCount.count++;
+                    }
+                    else
+                    {
+                        updatedReactionCount.count--;
                     }
                 }
+
+                updatedReactionCount.localEchoesOperations = self.reactionOperations[eventId][reaction];
             }
         }
 

--- a/MatrixSDK/Aggregations/MXAggregatedReactionsUpdater.m
+++ b/MatrixSDK/Aggregations/MXAggregatedReactionsUpdater.m
@@ -535,7 +535,6 @@
 {
     // Find the operation that corresponds to the information
     MXReactionOperation *reactionOperationToRemove;
-    BOOL isTopOperation = YES;
     for (MXReactionOperation *reactionOperation in self.reactionOperations[eventId][reaction])
     {
         if (reactionOperation.isAddOperation == isAdd)
@@ -543,8 +542,6 @@
             reactionOperationToRemove = reactionOperation;
             break;
         }
-
-        isTopOperation = NO;
     }
 
     if (reactionOperationToRemove)
@@ -562,16 +559,13 @@
         }
 
         // Run the next operation if any
-        if (isTopOperation)
-        {
-            dispatch_async(dispatch_get_main_queue(), ^{
-                MXReactionOperation *nextReactionOperation = self.reactionOperations[eventId][reaction].firstObject;
-                if (nextReactionOperation)
-                {
-                    nextReactionOperation.block(NO);
-                }
-            });
-        }
+        dispatch_async(dispatch_get_main_queue(), ^{
+            MXReactionOperation *nextReactionOperation = self.reactionOperations[eventId][reaction].firstObject;
+            if (nextReactionOperation)
+            {
+                nextReactionOperation.block(NO);
+            }
+        });
     }
 }
 

--- a/MatrixSDK/Aggregations/MXAggregatedReactionsUpdater.m
+++ b/MatrixSDK/Aggregations/MXAggregatedReactionsUpdater.m
@@ -499,7 +499,7 @@
     }
 
     // Queue the reaction or unreaction operation
-    // The queue will be used to could local echoes
+    // The queue will be used to count local echoes
     if (!self.reactionOperations[eventId])
     {
         self.reactionOperations[eventId] = [NSMutableDictionary dictionary];

--- a/MatrixSDK/Aggregations/MXAggregations.h
+++ b/MatrixSDK/Aggregations/MXAggregations.h
@@ -43,14 +43,12 @@ NS_ASSUME_NONNULL_BEGIN
  @param success A block object called when the operation succeeds. It returns
                 the event id of the event generated on the homeserver.
  @param failure A block object called when the operation fails.
-
- @return a MXHTTPOperation instance.
  */
-- (MXHTTPOperation*)sendReaction:(NSString*)reaction
-                         toEvent:(NSString*)eventId
-                          inRoom:(NSString*)roomId
-                         success:(void (^)(NSString *eventId))success
-                         failure:(void (^)(NSError *error))failure;
+- (void)addReaction:(NSString*)reaction
+        forEvent:(NSString*)eventId
+             inRoom:(NSString*)roomId
+            success:(void (^)(void))success
+            failure:(void (^)(NSError *error))failure;
 
 /**
  Unreact a reaction to an event in a room.
@@ -61,14 +59,12 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param success A block object called when the operation succeeds.
  @param failure A block object called when the operation fails.
-
- @return a MXHTTPOperation instance.
  */
-- (MXHTTPOperation*)unReactOnReaction:(NSString*)reaction
-                              toEvent:(NSString*)eventId
-                               inRoom:(NSString*)roomId
-                              success:(void (^)(void))success
-                              failure:(void (^)(NSError *error))failure;
+- (void)removeReaction:(NSString*)reaction
+              forEvent:(NSString*)eventId
+                inRoom:(NSString*)roomId
+               success:(void (^)(void))success
+               failure:(void (^)(NSError *error))failure;
 
 /**
  Returns the aggregated reactions counts.

--- a/MatrixSDK/Aggregations/MXAggregations.m
+++ b/MatrixSDK/Aggregations/MXAggregations.m
@@ -44,22 +44,22 @@
 
 #pragma mark - Reactions
 
-- (MXHTTPOperation*)sendReaction:(NSString*)reaction
-                         toEvent:(NSString*)eventId
-                          inRoom:(NSString*)roomId
-                         success:(void (^)(NSString *eventId))success
-                         failure:(void (^)(NSError *error))failure
+- (void)addReaction:(NSString*)reaction
+           forEvent:(NSString*)eventId
+             inRoom:(NSString*)roomId
+            success:(void (^)(void))success
+            failure:(void (^)(NSError *error))failure
 {
-    return [self.aggregatedReactionsUpdater sendReaction:reaction toEvent:eventId inRoom:roomId success:success failure:failure];
+    [self.aggregatedReactionsUpdater addReaction:reaction forEvent:eventId inRoom:roomId success:success failure:failure];
 }
 
-- (MXHTTPOperation*)unReactOnReaction:(NSString*)reaction
-                              toEvent:(NSString*)eventId
-                               inRoom:(NSString*)roomId
-                              success:(void (^)(void))success
-                              failure:(void (^)(NSError *error))failure
+- (void)removeReaction:(NSString*)reaction
+              forEvent:(NSString*)eventId
+                inRoom:(NSString*)roomId
+               success:(void (^)(void))success
+               failure:(void (^)(NSError *error))failure
 {
-    return [self.aggregatedReactionsUpdater unReactOnReaction:reaction toEvent:eventId inRoom:roomId success:success failure:failure];
+    [self.aggregatedReactionsUpdater removeReaction:reaction forEvent:eventId inRoom:roomId success:success failure:failure];
 }
 
 - (nullable MXAggregatedReactions *)aggregatedReactionsOnEvent:(NSString*)eventId inRoom:(NSString*)roomId

--- a/MatrixSDK/Aggregations/MXAggregations.m
+++ b/MatrixSDK/Aggregations/MXAggregations.m
@@ -50,30 +50,7 @@
                          success:(void (^)(NSString *eventId))success
                          failure:(void (^)(NSError *error))failure
 {
-    // TODO: sendReaction should return only when the actual reaction event comes back the sync
-    MXWeakify(self);
-    return [self.mxSession.matrixRestClient sendRelationToEvent:eventId
-                                                         inRoom:roomId
-                                                   relationType:MXEventRelationTypeAnnotation
-                                                      eventType:kMXEventTypeStringReaction
-                                                     parameters:@{
-                                                                  @"key": reaction
-                                                                  }
-                                                        content:@{}
-                                                        success:success failure:^(NSError *error)
-            {
-                MXStrongifyAndReturnIfNil(self);
-
-                MXError *mxError = [[MXError alloc] initWithNSError:error];
-                if ([mxError.errcode isEqualToString:kMXErrCodeStringUnrecognized])
-                {
-                    [self sendReactionUsingHack:reaction toEvent:eventId inRoom:roomId success:success failure:failure];
-                }
-                else
-                {
-                    failure(error);
-                }
-            }];
+    return [self.aggregatedReactionsUpdater sendReaction:reaction toEvent:eventId inRoom:roomId success:success failure:failure];
 }
 
 - (MXHTTPOperation*)unReactOnReaction:(NSString*)reaction
@@ -82,29 +59,7 @@
                               success:(void (^)(void))success
                               failure:(void (^)(NSError *error))failure
 {
-    MXHTTPOperation *operation;
-
-    MXReactionCount *reactionCount = [self.aggregatedReactionsUpdater reactionCountForReaction:reaction onEvent:eventId];
-    if (reactionCount && reactionCount.myUserReactionEventId)
-    {
-        MXRoom *room = [self.mxSession roomWithRoomId:roomId];
-        if (room)
-        {
-            [room redactEvent:reactionCount.myUserReactionEventId reason:nil success:success failure:failure];
-        }
-        else
-        {
-            NSLog(@"[MXAggregations] unReactOnReaction: ERROR: Unknown room %@", roomId);
-            success();
-        }
-    }
-    else
-    {
-        NSLog(@"[MXAggregations] unReactOnReaction: ERROR: Do not know reaction(%@) event on event %@", reaction, eventId);
-        success();
-    }
-    
-    return operation;
+    return [self.aggregatedReactionsUpdater unReactOnReaction:reaction toEvent:eventId inRoom:roomId success:success failure:failure];
 }
 
 - (nullable MXAggregatedReactions *)aggregatedReactionsOnEvent:(NSString*)eventId inRoom:(NSString*)roomId
@@ -213,9 +168,7 @@
         self.mxSession = mxSession;
         self.store = [[MXRealmAggregationsStore alloc] initWithCredentials:mxSession.matrixRestClient.credentials];
 
-        self.aggregatedReactionsUpdater = [[MXAggregatedReactionsUpdater alloc] initWithMyUser:mxSession.matrixRestClient.credentials.userId
-                                                                              aggregationStore:self.store
-                                                                                   matrixStore:mxSession.store];
+        self.aggregatedReactionsUpdater = [[MXAggregatedReactionsUpdater alloc] initWithMatrixSession:self.mxSession aggregationStore:self.store];
         self.aggregatedEditsUpdater = [[MXAggregatedEditsUpdater alloc] initWithMyUser:mxSession.matrixRestClient.credentials.userId
                                                                       aggregationStore:self.store
                                                                            matrixStore:mxSession.store];
@@ -268,37 +221,6 @@
                 break;
         }
     }];
-}
-
-
-#pragma mark - Reactions hack (TODO: Remove all methods) -
-/// TODO: To remove once the feature has landed on matrix.org homeserver
-
-// SendReactionUsingHack directly sends a `m.reaction` room message instead of using the `/send_relation` api.
-- (MXHTTPOperation*)sendReactionUsingHack:(NSString*)reaction
-                                  toEvent:(NSString*)eventId
-                                   inRoom:(NSString*)roomId
-                                  success:(void (^)(NSString *eventId))success
-                                  failure:(void (^)(NSError *error))failure
-{
-    NSLog(@"[MXAggregations] sendReactionUsingHack");
-
-    MXRoom *room = [self.mxSession roomWithRoomId:roomId];
-    if (!room)
-    {
-        NSLog(@"[MXAggregations] sendReactionUsingHack Error: Unknown room: %@", roomId);
-        return nil;
-    }
-
-    NSDictionary *reactionContent = @{
-                                      @"m.relates_to": @{
-                                              @"rel_type": @"m.annotation",
-                                              @"event_id": eventId,
-                                              @"key": reaction
-                                              }
-                                      };
-
-    return [room sendEventOfType:kMXEventTypeStringReaction content:reactionContent localEcho:nil success:success failure:failure];
 }
 
 @end

--- a/MatrixSDKTests/MXAggregatedReactionTests.m
+++ b/MatrixSDKTests/MXAggregatedReactionTests.m
@@ -302,7 +302,10 @@
             XCTAssertEqual(reactionCount.count, 1);
             XCTAssertTrue(reactionCount.myUserHasReacted,);
 
-            [expectation fulfill];
+            if (!change.changeDueToLocalEcho)
+            {
+                [expectation fulfill];
+            }
         }];
 
         // - Add one more reaction
@@ -338,10 +341,13 @@
             XCTAssertEqualObjects(reaction, @"👍");
 
             // -> Data from aggregations must be right
-            MXAggregatedReactions *reactions = [mxSession.aggregations aggregatedReactionsOnEvent:eventId inRoom:room.roomId];
-            XCTAssertNil(reactions);
+            if (!change.changeDueToLocalEcho)
+            {
+                MXAggregatedReactions *reactions = [mxSession.aggregations aggregatedReactionsOnEvent:eventId inRoom:room.roomId];
+                XCTAssertNil(reactions);
 
-            [expectation fulfill];
+                [expectation fulfill];
+            }
         }];
 
         // - Unreact
@@ -383,10 +389,12 @@
                     XCTAssertNotNil(change.deleted);
 
                     // -> Data from aggregations must be right
-                    MXAggregatedReactions *reactions = [mxSession.aggregations aggregatedReactionsOnEvent:eventId inRoom:room.roomId];
-                    XCTAssertNil(reactions);
-
-                    [expectation fulfill];
+                    if (!changes.allValues.firstObject.changeDueToLocalEcho)
+                    {
+                        MXAggregatedReactions *reactions = [mxSession.aggregations aggregatedReactionsOnEvent:eventId inRoom:room.roomId];
+                        XCTAssertNil(reactions);
+                        [expectation fulfill];
+                    }
                 }];
 
                 // - Unreact

--- a/MatrixSDKTests/MXAggregatedReactionTests.m
+++ b/MatrixSDKTests/MXAggregatedReactionTests.m
@@ -431,8 +431,12 @@
             MXAggregatedReactions *reactions = [mxSession.aggregations aggregatedReactionsOnEvent:eventId inRoom:room.roomId];
             XCTAssertNotNil(reactions);
             XCTAssertEqual(reactions.reactions.count, 1);
-            XCTAssertEqualObjects(reactions.reactions.firstObject.reaction, @"👍");
-            //XCTAssertTrue(reactions.reactions.firstObject.myUserHasReacted);     TODO
+
+            MXReactionCount *reactionCount = reactions.reactions.firstObject;
+            XCTAssertEqualObjects(reactionCount.reaction, @"👍");
+            XCTAssertEqual(reactionCount.count, 1);
+            XCTAssertTrue(reactionCount.myUserHasReacted);
+            XCTAssertTrue(reactionCount.containsLocalEcho);
 
             [expectation fulfill];
 
@@ -460,7 +464,15 @@
 
         // -> We must have reaction count before the request complete
         MXAggregatedReactions *reactions = [mxSession.aggregations aggregatedReactionsOnEvent:eventId inRoom:room.roomId];
-        XCTAssertNil(reactions);
+
+        XCTAssertNotNil(reactions);
+        XCTAssertEqual(reactions.reactions.count, 1);
+
+        MXReactionCount *reactionCount = reactions.reactions.firstObject;
+        XCTAssertEqualObjects(reactionCount.reaction, @"👍");
+        XCTAssertEqual(reactionCount.count, 0);
+        XCTAssertFalse(reactionCount.myUserHasReacted);
+        XCTAssertTrue(reactionCount.containsLocalEcho);
 
         [expectation fulfill];
     }];


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-ios/issues/2453.

Local echoes and debouncing are managed internally in the reaction module to avoid "noise" in the timeline messages.

![Screen Recording 2019-06-13 at 16 14 30](https://user-images.githubusercontent.com/8418515/59440137-bf273600-8df6-11e9-9296-5b85615dc9c6.gif)
