### PR TITLE
Edits: support local echo

### DIFF
--- a/MatrixSDK/Aggregations/MXAggregatedEditsUpdater.h
+++ b/MatrixSDK/Aggregations/MXAggregatedEditsUpdater.h
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (MXHTTPOperation*)replaceTextMessageEvent:(MXEvent*)event
                             withTextMessage:(nullable NSString*)text
                               formattedText:(nullable NSString*)formattedText
-//                          localEcho:(MXEvent**)localEcho                      // TODO
+                                  localEcho:(MXEvent *_Nullable* _Nullable)localEcho
                                     success:(void (^)(NSString *eventId))success
                                     failure:(void (^)(NSError *error))failure;
 

--- a/MatrixSDK/Aggregations/MXAggregatedEditsUpdater.h
+++ b/MatrixSDK/Aggregations/MXAggregatedEditsUpdater.h
@@ -23,9 +23,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MXAggregatedEditsUpdater : NSObject
 
-- (instancetype)initWithMyUser:(NSString*)userId
-              aggregationStore:(id<MXAggregationsStore>)store
-                   matrixStore:(id<MXStore>)matrixStore;
+- (instancetype)initWithMatrixSession:(MXSession *)mxSession
+                     aggregationStore:(id<MXAggregationsStore>)store
+                          matrixStore:(id<MXStore>)matrixStore;
+
+#pragma mark - Requests
+- (MXHTTPOperation*)replaceTextMessageEvent:(MXEvent*)event
+                            withTextMessage:(nullable NSString*)text
+                              formattedText:(nullable NSString*)formattedText
+//                          localEcho:(MXEvent**)localEcho                      // TODO
+                                    success:(void (^)(NSString *eventId))success
+                                    failure:(void (^)(NSError *error))failure;
 
 #pragma mark - Data update listener
 - (id)listenToEditsUpdateInRoom:(NSString *)roomId block:(void (^)(MXEvent* replaceEvent))block;

--- a/MatrixSDK/Aggregations/MXAggregatedEditsUpdater.h
+++ b/MatrixSDK/Aggregations/MXAggregatedEditsUpdater.h
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (MXHTTPOperation*)replaceTextMessageEvent:(MXEvent*)event
                             withTextMessage:(nullable NSString*)text
                               formattedText:(nullable NSString*)formattedText
-                                  localEcho:(MXEvent *_Nullable* _Nullable)localEcho
+                             localEchoBlock:(nullable void (^)(MXEvent *localEcho))localEchoBlock
                                     success:(void (^)(NSString *eventId))success
                                     failure:(void (^)(NSError *error))failure;
 

--- a/MatrixSDK/Aggregations/MXAggregatedEditsUpdater.m
+++ b/MatrixSDK/Aggregations/MXAggregatedEditsUpdater.m
@@ -125,7 +125,7 @@
         operation = [MXHTTPOperation new];
 
         MXWeakify(self);
-        id observer;
+        __block id observer;
         observer = [[NSNotificationCenter defaultCenter] addObserverForName:kMXEventDidChangeSentStateNotification object:event queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification * _Nonnull note) {
             MXStrongifyAndReturnIfNil(self);
 
@@ -134,6 +134,7 @@
                 NSLog(@"[MXAggregations] replaceTextMessageEvent: Edit request can be done now");
 
                 [[NSNotificationCenter defaultCenter] removeObserver:observer];
+                observer = nil;
 
                 MXHTTPOperation *operation2 = [self replaceTextMessageEvent:event withTextMessage:text formattedText:formattedText localEchoBlock:localEchoBlock success:success failure:failure];
 

--- a/MatrixSDK/Aggregations/MXAggregatedEditsUpdater.m
+++ b/MatrixSDK/Aggregations/MXAggregatedEditsUpdater.m
@@ -55,7 +55,7 @@
 - (MXHTTPOperation*)replaceTextMessageEvent:(MXEvent*)event
                             withTextMessage:(nullable NSString*)text
                               formattedText:(nullable NSString*)formattedText
-//                          localEcho:(MXEvent**)localEcho                      // TODO
+                                  localEcho:(MXEvent *_Nullable* _Nullable)localEcho
                                     success:(void (^)(NSString *eventId))success
                                     failure:(void (^)(NSError *error))failure;
 {
@@ -80,7 +80,7 @@
     // Directly send a room message instead of using the `/send_relation` API to simplify local echo management for the moment.
     return [self replaceTextMessageEventUsingHack:event withTextMessage:text
                                     formattedText:formattedText
-                                        localEcho:nil success:success failure:failure];
+                                        localEcho:localEcho success:success failure:failure];
 }
 
 - (MXHTTPOperation*)replaceTextMessageEventUsingHack:(MXEvent*)event
@@ -148,7 +148,7 @@
                                  @"event_id": event.eventId
                                  };
 
-    return [room sendEventOfType:kMXEventTypeStringRoomMessage content:content localEcho:nil success:success failure:failure];
+    return [room sendEventOfType:kMXEventTypeStringRoomMessage content:content localEcho:localEcho success:success failure:failure];
 }
 
 

--- a/MatrixSDK/Aggregations/MXAggregatedEditsUpdater.m
+++ b/MatrixSDK/Aggregations/MXAggregatedEditsUpdater.m
@@ -59,44 +59,11 @@
                                     success:(void (^)(NSString *eventId))success
                                     failure:(void (^)(NSError *error))failure;
 {
-    //    NSDictionary *content = @{
-    //                              @"msgtype": kMXMessageTypeText,
-    //                              @"body": [NSString stringWithFormat:@"* %@", event.content[@"body"]],
-    //                              @"m.new_content": @{
-    //                                      @"msgtype": kMXMessageTypeText,
-    //                                      @"body": text
-    //                                      }
-    //                              };
-    //
-    //    // TODO: manage a sent state like when using classic /send
-    //    return [self.mxSession.matrixRestClient sendRelationToEvent:event.eventId
-    //                                                         inRoom:event.roomId
-    //                                                   relationType:MXEventRelationTypeReplace
-    //                                                      eventType:kMXEventTypeStringRoomMessage
-    //                                                     parameters:nil
-    //                                                        content:content
-    //                                                        success:success failure:failure];
-
-    // Directly send a room message instead of using the `/send_relation` API to simplify local echo management for the moment.
-    return [self replaceTextMessageEventUsingHack:event withTextMessage:text
-                                    formattedText:formattedText
-                                        localEcho:localEcho success:success failure:failure];
-}
-
-- (MXHTTPOperation*)replaceTextMessageEventUsingHack:(MXEvent*)event
-                                     withTextMessage:(nullable NSString*)text
-                                       formattedText:(nullable NSString*)formattedText
-                                           localEcho:(MXEvent**)localEcho
-                                             success:(void (^)(NSString *eventId))success
-                                             failure:(void (^)(NSError *error))failure
-{
-    NSLog(@"[MXAggregations] replaceTextMessageEvent using hack");
-
     NSString *roomId = event.roomId;
     MXRoom *room = [self.mxSession roomWithRoomId:roomId];
     if (!room)
     {
-        NSLog(@"[MXAggregations] replaceTextMessageEvent using hack Error: Unknown room: %@", roomId);
+        NSLog(@"[MXAggregations] replaceTextMessageEvent: Error: Unknown room: %@", roomId);
         failure(nil);
         return nil;
     }
@@ -105,7 +72,7 @@
 
     if (![messageType isEqualToString:kMXMessageTypeText])
     {
-        NSLog(@"[MXAggregations] replaceTextMessageEvent using hack. Error: Only message type %@ is supported", kMXMessageTypeText);
+        NSLog(@"[MXAggregations] replaceTextMessageEvent: Error: Only message type %@ is supported", kMXMessageTypeText);
         failure(nil);
         return nil;
     }

--- a/MatrixSDK/Aggregations/MXAggregatedEditsUpdater.m
+++ b/MatrixSDK/Aggregations/MXAggregatedEditsUpdater.m
@@ -16,12 +16,15 @@
 
 #import "MXAggregatedEditsUpdater.h"
 
+#import "MXSession.h"
+
 #import "MXEventRelations.h"
 #import "MXEventReplace.h"
 #import "MXEventEditsListener.h"
 
 @interface MXAggregatedEditsUpdater ()
 
+@property (nonatomic, weak) MXSession *mxSession;
 @property (nonatomic) NSString *myUserId;
 @property (nonatomic, weak) id<MXStore> matrixStore;
 @property (nonatomic) NSMutableArray<MXEventEditsListener*> *listeners;
@@ -30,19 +33,122 @@
 
 @implementation MXAggregatedEditsUpdater
 
-- (instancetype)initWithMyUser:(NSString*)userId
-              aggregationStore:(id<MXAggregationsStore>)store
-                   matrixStore:(id<MXStore>)matrixStore
+- (instancetype)initWithMatrixSession:(MXSession *)mxSession
+                     aggregationStore:(id<MXAggregationsStore>)store
+                          matrixStore:(id<MXStore>)matrixStore
 {
     self = [super init];
     if (self)
     {
-        self.myUserId = userId;
+        self.mxSession = mxSession;
+        self.myUserId = mxSession.matrixRestClient.credentials.userId;
         self.matrixStore = matrixStore;
 
         self.listeners = [NSMutableArray array];
     }
     return self;
+}
+
+
+#pragma mark - Requests
+
+- (MXHTTPOperation*)replaceTextMessageEvent:(MXEvent*)event
+                            withTextMessage:(nullable NSString*)text
+                              formattedText:(nullable NSString*)formattedText
+//                          localEcho:(MXEvent**)localEcho                      // TODO
+                                    success:(void (^)(NSString *eventId))success
+                                    failure:(void (^)(NSError *error))failure;
+{
+    //    NSDictionary *content = @{
+    //                              @"msgtype": kMXMessageTypeText,
+    //                              @"body": [NSString stringWithFormat:@"* %@", event.content[@"body"]],
+    //                              @"m.new_content": @{
+    //                                      @"msgtype": kMXMessageTypeText,
+    //                                      @"body": text
+    //                                      }
+    //                              };
+    //
+    //    // TODO: manage a sent state like when using classic /send
+    //    return [self.mxSession.matrixRestClient sendRelationToEvent:event.eventId
+    //                                                         inRoom:event.roomId
+    //                                                   relationType:MXEventRelationTypeReplace
+    //                                                      eventType:kMXEventTypeStringRoomMessage
+    //                                                     parameters:nil
+    //                                                        content:content
+    //                                                        success:success failure:failure];
+
+    // Directly send a room message instead of using the `/send_relation` API to simplify local echo management for the moment.
+    return [self replaceTextMessageEventUsingHack:event withTextMessage:text
+                                    formattedText:formattedText
+                                        localEcho:nil success:success failure:failure];
+}
+
+- (MXHTTPOperation*)replaceTextMessageEventUsingHack:(MXEvent*)event
+                                     withTextMessage:(nullable NSString*)text
+                                       formattedText:(nullable NSString*)formattedText
+                                           localEcho:(MXEvent**)localEcho
+                                             success:(void (^)(NSString *eventId))success
+                                             failure:(void (^)(NSError *error))failure
+{
+    NSLog(@"[MXAggregations] replaceTextMessageEvent using hack");
+
+    NSString *roomId = event.roomId;
+    MXRoom *room = [self.mxSession roomWithRoomId:roomId];
+    if (!room)
+    {
+        NSLog(@"[MXAggregations] replaceTextMessageEvent using hack Error: Unknown room: %@", roomId);
+        failure(nil);
+        return nil;
+    }
+
+    NSString *messageType = event.content[@"msgtype"];
+
+    if (![messageType isEqualToString:kMXMessageTypeText])
+    {
+        NSLog(@"[MXAggregations] replaceTextMessageEvent using hack. Error: Only message type %@ is supported", kMXMessageTypeText);
+        failure(nil);
+        return nil;
+    }
+
+    NSMutableDictionary *content = [NSMutableDictionary new];
+    NSMutableDictionary *compatibilityContent = [NSMutableDictionary dictionaryWithDictionary:@{
+                                                                                                @"msgtype": kMXMessageTypeText,
+                                                                                                @"body": [NSString stringWithFormat:@"* %@", text]
+                                                                                                }];
+
+    NSMutableDictionary *newContent = [NSMutableDictionary dictionaryWithDictionary:@{
+                                                                                      @"msgtype": kMXMessageTypeText,
+                                                                                      @"body": text
+                                                                                      }];
+
+
+    if (formattedText)
+    {
+        // Send the HTML formatted string
+
+        [compatibilityContent addEntriesFromDictionary:@{
+                                                         @"formatted_body": [NSString stringWithFormat:@"* %@", formattedText],
+                                                         @"format": kMXRoomMessageFormatHTML
+                                                         }];
+
+
+        [newContent addEntriesFromDictionary:@{
+                                               @"formatted_body": formattedText,
+                                               @"format": kMXRoomMessageFormatHTML
+                                               }];
+    }
+
+
+    [content addEntriesFromDictionary:compatibilityContent];
+
+    content[@"m.new_content"] = newContent;
+
+    content[@"m.relates_to"] = @{
+                                 @"rel_type" : @"m.replace",
+                                 @"event_id": event.eventId
+                                 };
+
+    return [room sendEventOfType:kMXEventTypeStringRoomMessage content:content localEcho:nil success:success failure:failure];
 }
 
 

--- a/MatrixSDK/Aggregations/MXAggregations.h
+++ b/MatrixSDK/Aggregations/MXAggregations.h
@@ -102,6 +102,9 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param event The event to update
  @param text The new message text
+ @param formattedText The new message formatted text
+ @param localEchoBlock block called to provide a local echo of the replacement event.
+                       It is called twice when the passed `event` is a local echo.
 
  @param success A block object called when the operation succeeds. It returns
                 the event id of the event generated on the homeserver.
@@ -112,7 +115,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (MXHTTPOperation*)replaceTextMessageEvent:(MXEvent*)event
                             withTextMessage:(nullable NSString*)text
                               formattedText:(nullable NSString*)formattedText
-                                  localEcho:(MXEvent *_Nullable* _Nullable)localEcho
+                             localEchoBlock:(nullable void (^)(MXEvent *localEcho))localEchoBlock
                                     success:(void (^)(NSString *eventId))success
                                     failure:(void (^)(NSError *error))failure;
 

--- a/MatrixSDK/Aggregations/MXAggregations.h
+++ b/MatrixSDK/Aggregations/MXAggregations.h
@@ -112,7 +112,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (MXHTTPOperation*)replaceTextMessageEvent:(MXEvent*)event
                             withTextMessage:(nullable NSString*)text
                               formattedText:(nullable NSString*)formattedText
-//                          localEcho:(MXEvent**)localEcho                      // TODO(@steve): in phase2
+                                  localEcho:(MXEvent *_Nullable* _Nullable)localEcho
                                     success:(void (^)(NSString *eventId))success
                                     failure:(void (^)(NSError *error))failure;
 

--- a/MatrixSDK/Aggregations/MXAggregations.m
+++ b/MatrixSDK/Aggregations/MXAggregations.m
@@ -95,11 +95,11 @@
 - (MXHTTPOperation*)replaceTextMessageEvent:(MXEvent*)event
                             withTextMessage:(nullable NSString*)text
                               formattedText:(nullable NSString*)formattedText
-                                  localEcho:(MXEvent *_Nullable* _Nullable)localEcho
+                             localEchoBlock:(nullable void (^)(MXEvent *localEcho))localEchoBlock
                                     success:(void (^)(NSString *eventId))success
                                     failure:(void (^)(NSError *error))failure
 {
-    return [self.aggregatedEditsUpdater replaceTextMessageEvent:event withTextMessage:text formattedText:formattedText localEcho:localEcho success:success failure:failure];
+    return [self.aggregatedEditsUpdater replaceTextMessageEvent:event withTextMessage:text formattedText:formattedText localEchoBlock:localEchoBlock success:success failure:failure];
 }
 
 - (id)listenToEditsUpdateInRoom:(NSString *)roomId block:(void (^)(MXEvent* replaceEvent))block

--- a/MatrixSDK/Aggregations/MXAggregations.m
+++ b/MatrixSDK/Aggregations/MXAggregations.m
@@ -95,11 +95,11 @@
 - (MXHTTPOperation*)replaceTextMessageEvent:(MXEvent*)event
                             withTextMessage:(nullable NSString*)text
                               formattedText:(nullable NSString*)formattedText
-//                          localEcho:(MXEvent**)localEcho                      // TODO
+                                  localEcho:(MXEvent *_Nullable* _Nullable)localEcho
                                     success:(void (^)(NSString *eventId))success
                                     failure:(void (^)(NSError *error))failure
 {
-    return [self.aggregatedEditsUpdater replaceTextMessageEvent:event withTextMessage:text formattedText:formattedText success:success failure:failure];
+    return [self.aggregatedEditsUpdater replaceTextMessageEvent:event withTextMessage:text formattedText:formattedText localEcho:localEcho success:success failure:failure];
 }
 
 - (id)listenToEditsUpdateInRoom:(NSString *)roomId block:(void (^)(MXEvent* replaceEvent))block

--- a/MatrixSDK/Aggregations/MXAggregations.m
+++ b/MatrixSDK/Aggregations/MXAggregations.m
@@ -97,98 +97,9 @@
                               formattedText:(nullable NSString*)formattedText
 //                          localEcho:(MXEvent**)localEcho                      // TODO
                                     success:(void (^)(NSString *eventId))success
-                                    failure:(void (^)(NSError *error))failure;
+                                    failure:(void (^)(NSError *error))failure
 {
-//    NSDictionary *content = @{
-//                              @"msgtype": kMXMessageTypeText,
-//                              @"body": [NSString stringWithFormat:@"* %@", event.content[@"body"]],
-//                              @"m.new_content": @{
-//                                      @"msgtype": kMXMessageTypeText,
-//                                      @"body": text
-//                                      }
-//                              };
-//
-//    // TODO: manage a sent state like when using classic /send
-//    return [self.mxSession.matrixRestClient sendRelationToEvent:event.eventId
-//                                                         inRoom:event.roomId
-//                                                   relationType:MXEventRelationTypeReplace
-//                                                      eventType:kMXEventTypeStringRoomMessage
-//                                                     parameters:nil
-//                                                        content:content
-//                                                        success:success failure:failure];
-    
-    // Directly send a room message instead of using the `/send_relation` API to simplify local echo management for the moment.
-    return [self replaceTextMessageEventUsingHack:event withTextMessage:text
-                                    formattedText:formattedText
-                                        localEcho:nil success:success failure:failure];
-}
-
-- (MXHTTPOperation*)replaceTextMessageEventUsingHack:(MXEvent*)event
-                                     withTextMessage:(nullable NSString*)text
-                                       formattedText:(nullable NSString*)formattedText
-                                           localEcho:(MXEvent**)localEcho
-                                             success:(void (^)(NSString *eventId))success
-                                             failure:(void (^)(NSError *error))failure
-{
-    NSLog(@"[MXAggregations] replaceTextMessageEvent using hack");
-    
-    NSString *roomId = event.roomId;
-    MXRoom *room = [self.mxSession roomWithRoomId:roomId];
-    if (!room)
-    {
-        NSLog(@"[MXAggregations] replaceTextMessageEvent using hack Error: Unknown room: %@", roomId);
-        failure(nil);
-        return nil;
-    }
-    
-    NSString *messageType = event.content[@"msgtype"];
-    
-    if (![messageType isEqualToString:kMXMessageTypeText])
-    {
-        NSLog(@"[MXAggregations] replaceTextMessageEvent using hack. Error: Only message type %@ is supported", kMXMessageTypeText);
-        failure(nil);
-        return nil;
-    }
-    
-    NSMutableDictionary *content = [NSMutableDictionary new];
-    NSMutableDictionary *compatibilityContent = [NSMutableDictionary dictionaryWithDictionary:@{
-                                                                                                @"msgtype": kMXMessageTypeText,
-                                                                                                @"body": [NSString stringWithFormat:@"* %@", text]
-                                                                                                }];
-    
-    NSMutableDictionary *newContent = [NSMutableDictionary dictionaryWithDictionary:@{
-                                                                                      @"msgtype": kMXMessageTypeText,
-                                                                                      @"body": text
-                                                                                      }];
-    
-                                       
-    if (formattedText)
-    {
-        // Send the HTML formatted string
-        
-        [compatibilityContent addEntriesFromDictionary:@{
-                                            @"formatted_body": [NSString stringWithFormat:@"* %@", formattedText],
-                                            @"format": kMXRoomMessageFormatHTML
-                                            }];
-        
-        
-        [newContent addEntriesFromDictionary:@{
-                                               @"formatted_body": formattedText,
-                                               @"format": kMXRoomMessageFormatHTML
-                                               }];
-    }
-    
-    
-    [content addEntriesFromDictionary:compatibilityContent];
-    
-    content[@"m.new_content"] = newContent;
-    
-    content[@"m.relates_to"] = @{
-                                 @"rel_type" : @"m.replace",
-                                 @"event_id": event.eventId
-                                 };
-    
-    return [room sendEventOfType:kMXEventTypeStringRoomMessage content:content localEcho:nil success:success failure:failure];
+    return [self.aggregatedEditsUpdater replaceTextMessageEvent:event withTextMessage:text formattedText:formattedText success:success failure:failure];
 }
 
 - (id)listenToEditsUpdateInRoom:(NSString *)roomId block:(void (^)(MXEvent* replaceEvent))block
@@ -207,9 +118,9 @@
         self.store = [[MXRealmAggregationsStore alloc] initWithCredentials:mxSession.matrixRestClient.credentials];
 
         self.aggregatedReactionsUpdater = [[MXAggregatedReactionsUpdater alloc] initWithMatrixSession:self.mxSession aggregationStore:self.store];
-        self.aggregatedEditsUpdater = [[MXAggregatedEditsUpdater alloc] initWithMyUser:mxSession.matrixRestClient.credentials.userId
-                                                                      aggregationStore:self.store
-                                                                           matrixStore:mxSession.store];
+        self.aggregatedEditsUpdater = [[MXAggregatedEditsUpdater alloc] initWithMatrixSession:self.mxSession
+                                                                             aggregationStore:self.store
+                                                                                  matrixStore:mxSession.store];
 
         [self registerListener];
     }

--- a/MatrixSDKTests/MXAggregatedEditsTests.m
+++ b/MatrixSDKTests/MXAggregatedEditsTests.m
@@ -62,7 +62,7 @@ static NSString* const kEditedMarkdownMessageFormattedText = @"<strong>I meant H
 
         [room sendTextMessage:kOriginalMessageText success:^(NSString *eventId) {
             [mxSession eventWithEventId:eventId inRoom:room.roomId success:^(MXEvent *event) {
-                [mxSession.aggregations replaceTextMessageEvent:event withTextMessage:kEditedMessageText formattedText:nil success:^(NSString * _Nonnull editEventId) {
+                [mxSession.aggregations replaceTextMessageEvent:event withTextMessage:kEditedMessageText formattedText:nil localEcho:nil success:^(NSString * _Nonnull editEventId) {
                     
                     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 1 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
                         readyToTest(mxSession, room, expectation, eventId, editEventId);
@@ -91,7 +91,7 @@ static NSString* const kEditedMarkdownMessageFormattedText = @"<strong>I meant H
         
         [room sendTextMessage:kOriginalMarkdownMessageText success:^(NSString *eventId) {
             [mxSession eventWithEventId:eventId inRoom:room.roomId success:^(MXEvent *event) {
-                [mxSession.aggregations replaceTextMessageEvent:event withTextMessage:kEditedMarkdownMessageText formattedText:kEditedMarkdownMessageFormattedText success:^(NSString * _Nonnull editEventId) {
+                [mxSession.aggregations replaceTextMessageEvent:event withTextMessage:kEditedMarkdownMessageText formattedText:kEditedMarkdownMessageFormattedText localEcho:nil success:^(NSString * _Nonnull editEventId) {
                     
                     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 1 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
                         readyToTest(mxSession, room, expectation, eventId, editEventId);
@@ -239,7 +239,7 @@ static NSString* const kEditedMarkdownMessageFormattedText = @"<strong>I meant H
             [mxSession eventWithEventId:eventId inRoom:room.roomId success:^(MXEvent *event) {
 
                 // Edit it
-                [mxSession.aggregations replaceTextMessageEvent:event withTextMessage:kEditedMessageText formattedText:nil  success:^(NSString * _Nonnull eventId) {
+                [mxSession.aggregations replaceTextMessageEvent:event withTextMessage:kEditedMessageText formattedText:nil localEcho:nil success:^(NSString * _Nonnull eventId) {
                      XCTAssertNotNil(eventId);
                  } failure:^(NSError *error) {
                      XCTFail(@"The operation should not fail - NSError: %@", error);
@@ -285,7 +285,7 @@ static NSString* const kEditedMarkdownMessageFormattedText = @"<strong>I meant H
             [mxSession eventWithEventId:eventId inRoom:room.roomId success:^(MXEvent *event) {
                 
                 // Edit it
-                [mxSession.aggregations replaceTextMessageEvent:event withTextMessage:kEditedMarkdownMessageText formattedText:kEditedMarkdownMessageFormattedText success:^(NSString * _Nonnull eventId) {
+                [mxSession.aggregations replaceTextMessageEvent:event withTextMessage:kEditedMarkdownMessageText formattedText:kEditedMarkdownMessageFormattedText localEcho:nil success:^(NSString * _Nonnull eventId) {
                     XCTAssertNotNil(eventId);
                 } failure:^(NSError *error) {
                     XCTFail(@"The operation should not fail - NSError: %@", error);
@@ -543,7 +543,7 @@ static NSString* const kEditedMarkdownMessageFormattedText = @"<strong>I meant H
         
         MXEvent *editedEvent = [mxSession.store eventWithEventId:eventId inRoom:room.roomId];
         
-        [mxSession.aggregations replaceTextMessageEvent:editedEvent withTextMessage:secondEditionTextMessage formattedText:nil success:^(NSString * _Nonnull eventId) {
+        [mxSession.aggregations replaceTextMessageEvent:editedEvent withTextMessage:secondEditionTextMessage formattedText:nil localEcho:nil success:^(NSString * _Nonnull eventId) {
             
         } failure:^(NSError * _Nonnull error) {
             XCTFail(@"Cannot set up intial test conditions - error: %@", error);


### PR DESCRIPTION
Main use cases for https://github.com/vector-im/riot-ios/issues/2489.

- [x] manage local echoes for edits on sent messages
- [x] support edits on local echoes
- [x] support edits on messages being sent
