### PR TITLE
Edits: Support edits in e2e rooms

### DIFF
--- a/MatrixSDK/Aggregations/MXAggregatedEditsUpdater.m
+++ b/MatrixSDK/Aggregations/MXAggregatedEditsUpdater.m
@@ -156,7 +156,7 @@
         {
             // Build a temporary local echo
             localEcho = [room fakeEventWithEventId:nil eventType:kMXEventTypeStringRoomMessage andContent:content];
-            localEcho.sentState = MXEventSentStateSending;
+            localEcho.sentState = event.sentState;
         }
     }
     else

--- a/MatrixSDK/Aggregations/MXAggregatedEditsUpdater.m
+++ b/MatrixSDK/Aggregations/MXAggregatedEditsUpdater.m
@@ -69,6 +69,7 @@
         return nil;
     }
 
+    // If it is not already done, decrypt the event to build the new content
     if (event.isEncrypted && !event.clearEvent)
     {
         if (![self.mxSession decryptEvent:event inTimeline:nil])

--- a/MatrixSDKTests/MXAggregatedEditsTests.m
+++ b/MatrixSDKTests/MXAggregatedEditsTests.m
@@ -773,6 +773,87 @@ static NSString* const kEditedMarkdownMessageFormattedText = @"<strong>I meant H
     }];
 }
 
+// - Send a message in an e2e room
+// - Edit its local echo
+// -> We must get notified about the replace event
+// -> The local echo block must have been called twice
+- (void)testEditOfEventBeingSentInE2ERoom
+{
+    // - Send a message in an e2e room
+    [matrixSDKTestsE2EData doE2ETestWithAliceAndBobInARoom:self cryptedBob:YES warnOnUnknowDevices:NO aliceStore:[[MXMemoryStore alloc] init] bobStore:[[MXMemoryStore alloc] init] readyToTest:^(MXSession *mxSession, MXSession *bobSession, NSString *roomId, XCTestExpectation *expectation) {
+
+        MXRoom *room = [mxSession roomWithRoomId:roomId];
+
+        __block NSString *eventId;
+        __block NSUInteger localEchoBlockCount = 0;
+
+        // - Send a message
+        MXEvent *localEcho;
+        [room sendTextMessage:kOriginalMessageText formattedText:nil localEcho:&localEcho success:^(NSString *theEventId) {
+            eventId = theEventId;
+        } failure:^(NSError *error) {
+            XCTFail(@"Cannot set up intial test conditions - error: %@", error);
+            [expectation fulfill];
+        }];
+
+        // - Edit its local echo
+        [mxSession.aggregations replaceTextMessageEvent:localEcho withTextMessage:kEditedMessageText formattedText:nil localEchoBlock:^(MXEvent * _Nonnull localEcho) {
+
+            localEchoBlockCount++;
+
+            XCTAssertEqual(localEcho.eventType, MXEventTypeRoomMessage);
+
+            XCTAssertNotNil(localEcho.relatesTo);
+            XCTAssertEqualObjects(localEcho.relatesTo.relationType, MXEventRelationTypeReplace);
+
+            XCTAssertEqualObjects(localEcho.content[@"m.new_content"][@"msgtype"], kMXMessageTypeText);
+            XCTAssertEqualObjects(localEcho.content[@"m.new_content"][@"body"], kEditedMessageText);
+
+            switch (localEchoBlockCount) {
+                    case 1:
+                    // The first local echo must point to a local echo
+                    XCTAssertEqual(localEcho.sentState, MXEventSentStateEncrypting);
+                    XCTAssertTrue([localEcho.relatesTo.eventId hasPrefix:kMXEventLocalEventIdPrefix]);
+                    break;
+                    case 2:
+                    // The second local echo must point to the final event id
+                    XCTAssertEqual(localEcho.sentState, MXEventSentStateEncrypting);
+                    XCTAssertFalse([localEcho.relatesTo.eventId hasPrefix:kMXEventLocalEventIdPrefix]);
+                    break;
+
+                default:
+                    break;
+            }
+
+        } success:^(NSString * _Nonnull eventId) {
+            XCTAssertNotNil(eventId);
+        } failure:^(NSError *error) {
+            XCTFail(@"The operation should not fail - NSError: %@", error);
+            [expectation fulfill];
+        }];
+
+        // -> We must get notified about the replace event
+        [mxSession.aggregations listenToEditsUpdateInRoom:room.roomId block:^(MXEvent * _Nonnull replaceEvent) {
+
+            XCTAssertNotNil(eventId, @"The original event must have been sent before receiving the final edit");
+
+            MXEvent *editedEvent = [mxSession.store eventWithEventId:eventId inRoom:room.roomId];
+
+            XCTAssertNotNil(editedEvent);
+            XCTAssertTrue(editedEvent.contentHasBeenEdited);
+            XCTAssertEqualObjects(editedEvent.unsignedData.relations.replace.eventId, replaceEvent.eventId);
+            XCTAssertEqualObjects(editedEvent.content[@"body"], kEditedMessageText);
+
+            XCTAssertEqualObjects(replaceEvent.relatesTo.eventId, eventId);
+
+            // -> The local echo block must have been called twice
+            XCTAssertEqual(localEchoBlockCount, 2);
+
+            [expectation fulfill];
+        }];
+    }];
+}
+
 @end
 
 #pragma clang diagnostic pop


### PR DESCRIPTION
https://github.com/vector-im/riot-ios/issues/2449

This is compatible with the current implementation in Riot-Web but this code may change with the update of MSC1849.
Note that synapse does not support aggregation in e2e rooms yet. That means the app may not display edited content when opening a permalink.