### PR TITLE
BF: Reactions appear as "New messages"

### DIFF
--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -225,6 +225,7 @@ typedef void (^MXOnResumeDone)(void);
                                       kMXEventTypeStringRoomRedaction,
                                       kMXEventTypeStringRoomThirdPartyInvite,
                                       kMXEventTypeStringRoomRelatedGroups,
+                                      kMXEventTypeStringReaction,
                                       kMXEventTypeStringCallInvite,
                                       kMXEventTypeStringCallCandidates,
                                       kMXEventTypeStringCallAnswer,


### PR DESCRIPTION
closes https://github.com/vector-im/riot-ios/issues/2516.

We must allow storing read receipts for reactions events too.
Else, the app cannot know where the last read receipt is. In this situation, it resets the receipt receipt on the last displayed message, which corrupts the unread count.