### PR TITLE
BF Riot: Ordering of reactions is unpredictable

### DIFF
--- a/MatrixSDK/Aggregations/Data/MXReactionCount.h
+++ b/MatrixSDK/Aggregations/Data/MXReactionCount.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic) NSString *reaction;
 @property (nonatomic) NSUInteger count;
-
+@property (nonatomic) uint64_t originServerTs;
 
 // The id of the reaction event if our user has made this reaction
 @property (nonatomic, nullable) NSString *myUserReactionEventId;

--- a/MatrixSDK/Aggregations/Data/MXReactionOperation.h
+++ b/MatrixSDK/Aggregations/Data/MXReactionOperation.h
@@ -28,6 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic) NSString *eventId;
 @property (nonatomic) NSString *reaction;
+@property (nonatomic) uint64_t originServerTs;
 @property (nonatomic) BOOL isAddOperation;
 
 @property (nonatomic) void (^block)(BOOL requestAlreadyPending);

--- a/MatrixSDK/Aggregations/Data/MXReactionRelation.h
+++ b/MatrixSDK/Aggregations/Data/MXReactionRelation.h
@@ -30,6 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 // TODO: We could add sender add senderId, originServerTs
 @property (nonatomic) NSString *reactionEventId;
+@property (nonatomic) uint64_t originServerTs;
 
 @end
 

--- a/MatrixSDK/Aggregations/Data/Store/Realm/MXRealmAggregationsMapper.m
+++ b/MatrixSDK/Aggregations/Data/Store/Realm/MXRealmAggregationsMapper.m
@@ -24,6 +24,7 @@
     MXReactionCount *reactionCount = [MXReactionCount new];
     reactionCount.reaction = realmReactionCount.reaction;
     reactionCount.count = realmReactionCount.count;
+    reactionCount.originServerTs = realmReactionCount.originServerTs;
     reactionCount.myUserReactionEventId = realmReactionCount.myUserReactionEventId;
 
     return reactionCount;
@@ -36,6 +37,7 @@
     realmReactionCount.roomId = roomId;
     realmReactionCount.reaction = reactionCount.reaction;
     realmReactionCount.count = reactionCount.count;
+    realmReactionCount.originServerTs = reactionCount.originServerTs;
     realmReactionCount.myUserReactionEventId = reactionCount.myUserReactionEventId;
     realmReactionCount.primaryKey = [MXRealmReactionCount primaryKeyFromEventId:eventId
                                                                     andReaction:reactionCount.reaction];
@@ -49,6 +51,7 @@
     reactionRelation.reaction = realmReactionRelation.reaction;
     reactionRelation.eventId = realmReactionRelation.eventId;
     reactionRelation.reactionEventId = realmReactionRelation.reactionEventId;
+    reactionRelation.originServerTs = realmReactionRelation.originServerTs;
 
     return reactionRelation;
 }
@@ -59,6 +62,7 @@
     realmReactionRelation.reaction = reactionRelation.reaction;
     realmReactionRelation.eventId = reactionRelation.eventId;
     realmReactionRelation.reactionEventId = reactionRelation.reactionEventId;
+    realmReactionRelation.originServerTs = reactionRelation.originServerTs;
     realmReactionRelation.roomId = roomId;
     realmReactionRelation.primaryKey = [MXRealmReactionRelation primaryKeyFromEventId:reactionRelation.eventId
                                                                    andReactionEventId:reactionRelation.reactionEventId];

--- a/MatrixSDK/Aggregations/Data/Store/Realm/MXRealmAggregationsStore.m
+++ b/MatrixSDK/Aggregations/Data/Store/Realm/MXRealmAggregationsStore.m
@@ -118,8 +118,8 @@
 
 - (nullable NSArray<MXReactionCount *> *)reactionCountsOnEvent:(nonnull NSString *)eventId
 {
-    RLMResults<MXRealmReactionCount *> *realmReactionCounts = [MXRealmReactionCount objectsInRealm:self.realm
-                                                                              where:@"eventId = %@", eventId];
+    RLMResults<MXRealmReactionCount *> *realmReactionCounts = [[MXRealmReactionCount objectsInRealm:self.realm
+                                                                              where:@"eventId = %@", eventId] sortedResultsUsingKeyPath:@"originServerTs" ascending:YES];
 
     NSMutableArray<MXReactionCount *> *reactionCounts;
     if (realmReactionCounts.count)

--- a/MatrixSDK/Aggregations/Data/Store/Realm/MXRealmReactionCount.h
+++ b/MatrixSDK/Aggregations/Data/Store/Realm/MXRealmReactionCount.h
@@ -30,6 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property NSString *roomId;
 @property (nonatomic) NSString *reaction;
 @property (nonatomic) NSInteger count;
+@property (nonatomic) NSInteger originServerTs;
 @property (nonatomic) NSString *myUserReactionEventId;
 
 // We need a primary key to use [RLMRealm addOrUpdateObject]

--- a/MatrixSDK/Aggregations/Data/Store/Realm/MXRealmReactionRelation.h
+++ b/MatrixSDK/Aggregations/Data/Store/Realm/MXRealmReactionRelation.h
@@ -28,6 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) NSString *reaction;
 @property NSString *eventId;
 @property NSString *roomId;
+@property NSInteger originServerTs;
 @property (nonatomic) NSString *reactionEventId;
 
 // We need a primary key to use [RLMRealm addOrUpdateObject]

--- a/MatrixSDK/Aggregations/MXAggregatedReactionsUpdater.m
+++ b/MatrixSDK/Aggregations/MXAggregatedReactionsUpdater.m
@@ -296,6 +296,7 @@
     relation.reaction = reaction;
     relation.eventId = eventId;
     relation.reactionEventId = reactionEvent.eventId;
+    relation.originServerTs = reactionEvent.originServerTs;
 
     [self.store addReactionRelation:relation inRoom:reactionEvent.roomId];
 }

--- a/MatrixSDK/Aggregations/MXAggregatedReactionsUpdater.m
+++ b/MatrixSDK/Aggregations/MXAggregatedReactionsUpdater.m
@@ -319,6 +319,7 @@
         // If we still have no reaction count object, create one
         reactionCount = [MXReactionCount new];
         reactionCount.reaction = reaction;
+        reactionCount.originServerTs = reactionEvent.originServerTs;
         isANewReaction = YES;
     }
 
@@ -470,6 +471,7 @@
     MXReactionOperation *reactionOperation = [MXReactionOperation new];
     reactionOperation.eventId = eventId;
     reactionOperation.reaction = reaction;
+    reactionOperation.originServerTs = (uint64_t)([[NSDate date] timeIntervalSince1970] * 1000);;
     reactionOperation.isAddOperation = isAdd;
     reactionOperation.block = block;
 
@@ -608,17 +610,22 @@
                     {
                         updatedReactionCount.count--;
                     }
+                    
+                    if ((updatedReactionCount.originServerTs == 0 && reactionOperation.originServerTs > 0) || (updatedReactionCount.originServerTs > reactionOperation.originServerTs))
+                    {
+                        updatedReactionCount.originServerTs = reactionOperation.originServerTs;
+                    }
                 }
 
                 updatedReactionCount.localEchoesOperations = self.reactionOperations[eventId][reaction];
             }
         }
 
-        return reactionCountsByReaction.allValues;
+        return [self sortReactionCounts:reactionCountsByReaction.allValues];
     }
     else
     {
-        return reactions;
+        return [self sortReactionCounts:reactions];
     }
 }
 
@@ -691,7 +698,13 @@
         {
             reactionCount = [MXReactionCount new];
             reactionCount.reaction = relation.reaction;
+            reactionCount.originServerTs = relation.originServerTs;
             reactionCountDict[relation.reaction] = reactionCount;
+        }
+        
+        if ((reactionCount.originServerTs == 0 && relation.originServerTs > 0) || (reactionCount.originServerTs > reactionCount.originServerTs))
+        {
+            reactionCount.originServerTs = relation.originServerTs;
         }
 
         reactionCount.count++;
@@ -707,7 +720,20 @@
         }
     }
 
-    return reactionCountDict.allValues;
+    return [self sortReactionCounts:reactionCountDict.allValues];
+}
+
+- (NSArray<MXReactionCount*>*)sortReactionCounts:(NSArray<MXReactionCount*>*)reactionCounts
+{
+    if (!reactionCounts)
+    {
+        return nil;
+    }
+    
+    NSSortDescriptor *sortDescriptor;
+    sortDescriptor = [[NSSortDescriptor alloc] initWithKey:@"originServerTs" ascending:YES];
+    NSArray *sortedArray = [reactionCounts sortedArrayUsingDescriptors:@[sortDescriptor]];
+    return sortedArray;
 }
 
 // We need to store all received relations even if we do not know the event yet

--- a/MatrixSDK/Aggregations/MXAggregations.m
+++ b/MatrixSDK/Aggregations/MXAggregations.m
@@ -133,7 +133,8 @@
     MXEventRelations *relations = event.unsignedData.relations;
     if (relations.annotation)
     {
-        [self.aggregatedReactionsUpdater handleOriginalAggregatedDataOfEvent:event annotations:relations.annotation];
+        // TODO: Uncomment when reaction aggregation API will be updated.
+        // [self.aggregatedReactionsUpdater handleOriginalAggregatedDataOfEvent:event annotations:relations.annotation];
     }
 }
 


### PR DESCRIPTION
Fix vector-im/riot-ios/issues/2525