### PR TITLE
Storage: Isolate our realm DBs to avoid migration due to change in another realm

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Improvements:
  * MXHTTPClient: Add a new notification name `kMXHTTPClientMatrixErrorNotification` posted on each Matrix error.
  * SwiftMatrixSDK: Migrate to Swift 5.0.
  * VoIP: Stop falling back to Google for STUN (vector-im/riot-ios/issues/2532).
+ * Storage: Isolate our realm DBs to avoid migration due to change in another realm.
 
 Bug Fix:
  * MXMediaLoader: Disable trusting the built-in anchors certificates when the certificate pinning is enabled.

--- a/MatrixSDK/Aggregations/Data/Store/Realm/MXRealmAggregationsStore.m
+++ b/MatrixSDK/Aggregations/Data/Store/Realm/MXRealmAggregationsStore.m
@@ -270,6 +270,12 @@
     realmConfiguration.fileURL = realmFileURL;
     realmConfiguration.deleteRealmIfMigrationNeeded = YES;
 
+    // Manage only our objects in this realm 
+    realmConfiguration.objectClasses = @[
+                                         MXRealmReactionCount.class,
+                                         MXRealmReactionRelation.class
+                                         ];
+
     return realmConfiguration;
 }
 

--- a/MatrixSDK/ContentScan/Data/Store/Realm/RealmProvider/MXScanRealmFileProvider.m
+++ b/MatrixSDK/ContentScan/Data/Store/Realm/RealmProvider/MXScanRealmFileProvider.m
@@ -18,6 +18,9 @@
 
 #import "MXRealmHelper.h"
 
+#import "MXRealmEventScan.h"
+#import "MXRealmMediaScan.h"
+
 @interface MXScanRealmFileProvider()
 
 @property (nonatomic, strong) RLMRealmConfiguration *realmConfiguration;
@@ -88,7 +91,13 @@
     
     realmConfiguration.fileURL = realmFileURL;
     realmConfiguration.deleteRealmIfMigrationNeeded = YES;
-    
+
+    // Manage only our objects in this realm 
+    realmConfiguration.objectClasses = @[
+                                         MXRealmEventScan.class,
+                                         MXRealmMediaScan.class
+                                         ];
+
     return realmConfiguration;
 }
 

--- a/MatrixSDK/ContentScan/Data/Store/Realm/RealmProvider/MXScanRealmInMemoryProvider.m
+++ b/MatrixSDK/ContentScan/Data/Store/Realm/RealmProvider/MXScanRealmInMemoryProvider.m
@@ -16,6 +16,9 @@
 
 #import "MXScanRealmInMemoryProvider.h"
 
+#import "MXRealmEventScan.h"
+#import "MXRealmMediaScan.h"
+
 @interface MXScanRealmInMemoryProvider()
 
 @property (nonatomic, strong) RLMRealmConfiguration *realmConfiguration;
@@ -70,7 +73,13 @@
     
     realmConfiguration.inMemoryIdentifier = antivirusServerDomain;
     realmConfiguration.deleteRealmIfMigrationNeeded = YES;
-    
+
+    // Manage only our objects in this realm 
+    realmConfiguration.objectClasses = @[
+                                         MXRealmEventScan.class,
+                                         MXRealmMediaScan.class
+                                         ];
+
     return realmConfiguration;
 }
 

--- a/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
+++ b/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
@@ -1103,6 +1103,18 @@ RLM_ARRAY_TYPE(MXRealmOlmInboundGroupSession)
         config.fileURL = defaultRealmFileURL;
     }
 
+    // Manage only our objects in this realm 
+    config.objectClasses = @[
+                             MXRealmDeviceInfo.class,
+                             MXRealmUser.class,
+                             MXRealmRoomAlgorithm.class,
+                             MXRealmOlmSession.class,
+                             MXRealmOlmInboundGroupSession.class,
+                             MXRealmOlmAccount.class,
+                             MXRealmOutgoingRoomKeyRequest.class,
+                             MXRealmIncomingRoomKeyRequest.class
+                             ];
+
     config.schemaVersion = kMXRealmCryptoStoreVersion;
 
     __block BOOL cleanDuplicatedDevices = NO;


### PR DESCRIPTION
This avoids the trap described at https://medium.com/@chron.vas/handling-multiple-realm-databases-f50f1100cae1
