### PR TITLE
Edits history: Expose the new original event field

### DIFF
--- a/MatrixSDK/JSONModels/Aggregations/MXAggregationPaginatedResponse.h
+++ b/MatrixSDK/JSONModels/Aggregations/MXAggregationPaginatedResponse.h
@@ -26,6 +26,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) NSArray<MXEvent*> *chunk;
 @property (nonatomic, readonly, nullable) NSString *nextBatch;
 
+// TODO: Make it non null when homeservers support it
+@property (nonatomic, readonly, nullable) MXEvent *originalEvent;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/MatrixSDK/JSONModels/Aggregations/MXAggregationPaginatedResponse.m
+++ b/MatrixSDK/JSONModels/Aggregations/MXAggregationPaginatedResponse.m
@@ -31,6 +31,8 @@
 
         paginatedResponse->_chunk = chunk;
         MXJSONModelSetString(paginatedResponse->_nextBatch, JSONDictionary[@"next_batch"])
+
+        MXJSONModelSetMXJSONModel(paginatedResponse->_originalEvent, MXEvent.class, JSONDictionary[@"original_event"])
     }
 
     return paginatedResponse;

--- a/MatrixSDKTests/MXAggregatedEditsTests.m
+++ b/MatrixSDKTests/MXAggregatedEditsTests.m
@@ -895,8 +895,10 @@ static NSString* const kEditedMarkdownMessageFormattedText = @"<strong>I meant H
 // - Edit the message 10 more times
 // - Paginate one edit
 // -> We must get an edit event and a nextBatch
+// -> We must get the original event
 // - Paginate more
 // -> We must get all other edit events and no more nextBatch
+// -> We must get the original event
 - (void)testEditsHistory
 {
     // - Run the initial condition scenario
@@ -913,6 +915,11 @@ static NSString* const kEditedMarkdownMessageFormattedText = @"<strong>I meant H
                 XCTAssertTrue(paginatedResponse.chunk.firstObject.isEditEvent);
                 XCTAssertNotNil(paginatedResponse.nextBatch);
 
+                // -> We must get the original event
+                XCTAssertNotNil(paginatedResponse.originalEvent);
+                XCTAssertEqualObjects(paginatedResponse.originalEvent.eventId, eventId);
+                XCTAssertEqualObjects(paginatedResponse.originalEvent.content[@"body"], kOriginalMessageText);
+
                 // - Paginate more
                 [mxSession.aggregations replaceEventsForEvent:eventId isEncrypted:NO inRoom:room.roomId from:paginatedResponse.nextBatch limit:20 success:^(MXAggregationPaginatedResponse *paginatedResponse) {
 
@@ -925,6 +932,11 @@ static NSString* const kEditedMarkdownMessageFormattedText = @"<strong>I meant H
                     {
                         XCTAssertTrue(event.isEditEvent);
                     }
+
+                    // -> We must get the original event
+                    XCTAssertNotNil(paginatedResponse.originalEvent);
+                    XCTAssertEqualObjects(paginatedResponse.originalEvent.eventId, eventId);
+                    XCTAssertEqualObjects(paginatedResponse.originalEvent.content[@"body"], kOriginalMessageText);
 
                     [expectation fulfill];
 


### PR DESCRIPTION
https://github.com/vector-im/riot-ios/issues/2559

Tested against https://github.com/matrix-org/synapse/pull/5654.