### PR TITLE
MXRoom: sendFile: Use the original file name by default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Improvements:
  * SwiftMatrixSDK: Migrate to Swift 5.0.
  * VoIP: Stop falling back to Google for STUN (vector-im/riot-ios/issues/2532).
  * Storage: Isolate our realm DBs to avoid migration due to change in another realm.
+ * MXRoom: sendFile: Use the original file name by default.
 
 Bug Fix:
  * MXMediaLoader: Disable trusting the built-in anchors certificates when the certificate pinning is enabled.

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -1316,7 +1316,7 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
                      success:(void (^)(NSString *eventId))success
                      failure:(void (^)(NSError *error))failure
 {
-    return [self sendFile:fileLocalURL mimeType:mimeType localEcho:localEcho success:success failure:failure keepActualFilename:NO];
+    return [self sendFile:fileLocalURL mimeType:mimeType localEcho:localEcho success:success failure:failure keepActualFilename:YES];
 }
 
 - (MXHTTPOperation*)sendFile:(NSURL*)fileLocalURL


### PR DESCRIPTION
This PR fixes usage of random file names in the timeline:

![IMG_8122](https://user-images.githubusercontent.com/8418515/61116247-5afa9f00-a494-11e9-8b53-e292634d0b67.jpg)


