### PR TITLE
MXServiceTerms: A class to support MSC2140 (Terms of Service API)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+Changes in Matrix iOS SDK in 0.13.2 (2019-08-)
+===============================================
+
+Improvements:
+ * MXServiceTerms: A class to support MSC2140 (Terms of Service API) (vector-im/riot-ios#2600).
+
 Changes in Matrix iOS SDK in 0.13.1 (2019-08-08)
 ===============================================
 

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -227,6 +227,10 @@
 		32935F61216FA49D00A1BC24 /* MXCryptoBackupTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 32935F60216FA49D00A1BC24 /* MXCryptoBackupTests.m */; };
 		3293C700214BBA4F009B3DDB /* MXPeekingRoomSummary.h in Headers */ = {isa = PBXBuildFile; fileRef = 3293C6FE214BBA4F009B3DDB /* MXPeekingRoomSummary.h */; };
 		3293C701214BBA4F009B3DDB /* MXPeekingRoomSummary.m in Sources */ = {isa = PBXBuildFile; fileRef = 3293C6FF214BBA4F009B3DDB /* MXPeekingRoomSummary.m */; };
+		3294FD9D22F321B0007F1E60 /* MXServiceTermsRestClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 3294FD9922F321B0007F1E60 /* MXServiceTermsRestClient.m */; };
+		3294FD9E22F321B0007F1E60 /* MXServiceTerms.m in Sources */ = {isa = PBXBuildFile; fileRef = 3294FD9A22F321B0007F1E60 /* MXServiceTerms.m */; };
+		3294FD9F22F321B0007F1E60 /* MXServiceTermsRestClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 3294FD9B22F321B0007F1E60 /* MXServiceTermsRestClient.h */; };
+		3294FDA022F321B0007F1E60 /* MXServiceTerms.h in Headers */ = {isa = PBXBuildFile; fileRef = 3294FD9C22F321B0007F1E60 /* MXServiceTerms.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		32954019216385F100E300FC /* MXServerNoticeContent.h in Headers */ = {isa = PBXBuildFile; fileRef = 32954017216385F100E300FC /* MXServerNoticeContent.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3295401A216385F100E300FC /* MXServerNoticeContent.m in Sources */ = {isa = PBXBuildFile; fileRef = 32954018216385F100E300FC /* MXServerNoticeContent.m */; };
 		329571931B0240CE00ABB3BA /* MXVoIPTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 329571921B0240CE00ABB3BA /* MXVoIPTests.m */; };
@@ -702,6 +706,10 @@
 		32935F60216FA49D00A1BC24 /* MXCryptoBackupTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXCryptoBackupTests.m; sourceTree = "<group>"; };
 		3293C6FE214BBA4F009B3DDB /* MXPeekingRoomSummary.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXPeekingRoomSummary.h; sourceTree = "<group>"; };
 		3293C6FF214BBA4F009B3DDB /* MXPeekingRoomSummary.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXPeekingRoomSummary.m; sourceTree = "<group>"; };
+		3294FD9922F321B0007F1E60 /* MXServiceTermsRestClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXServiceTermsRestClient.m; sourceTree = "<group>"; };
+		3294FD9A22F321B0007F1E60 /* MXServiceTerms.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXServiceTerms.m; sourceTree = "<group>"; };
+		3294FD9B22F321B0007F1E60 /* MXServiceTermsRestClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXServiceTermsRestClient.h; sourceTree = "<group>"; };
+		3294FD9C22F321B0007F1E60 /* MXServiceTerms.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXServiceTerms.h; sourceTree = "<group>"; };
 		32954017216385F100E300FC /* MXServerNoticeContent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXServerNoticeContent.h; sourceTree = "<group>"; };
 		32954018216385F100E300FC /* MXServerNoticeContent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXServerNoticeContent.m; sourceTree = "<group>"; };
 		329571921B0240CE00ABB3BA /* MXVoIPTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXVoIPTests.m; sourceTree = "<group>"; };
@@ -1482,6 +1490,18 @@
 			path = Store;
 			sourceTree = "<group>";
 		};
+		3294FD9822F321B0007F1E60 /* ServiceTerms */ = {
+			isa = PBXGroup;
+			children = (
+				3294FD9C22F321B0007F1E60 /* MXServiceTerms.h */,
+				3294FD9A22F321B0007F1E60 /* MXServiceTerms.m */,
+				3294FD9B22F321B0007F1E60 /* MXServiceTermsRestClient.h */,
+				3294FD9922F321B0007F1E60 /* MXServiceTermsRestClient.m */,
+			);
+			name = ServiceTerms;
+			path = NotificationCenter/ServiceTerms;
+			sourceTree = "<group>";
+		};
 		329571941B024D2B00ABB3BA /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
@@ -1627,6 +1647,7 @@
 				320DFDC719DD99B60068622A /* Data */,
 				3281E8B219E42DFE00976E1A /* JSONModels */,
 				32DC15CA1A8CF7AE006F9AD3 /* NotificationCenter */,
+				3294FD9822F321B0007F1E60 /* ServiceTerms */,
 				320DFDD619DD99B60068622A /* Utils */,
 				3245A74B1AF7B2930001D8A7 /* VoIP */,
 				32A151581DB5254D00400192 /* Lib */,
@@ -1993,6 +2014,7 @@
 				32792BDC2296B90A00F4FC9D /* MXAggregatedEditsUpdater.h in Headers */,
 				327E9AEF2289C61100A98BC1 /* MXAggregations.h in Headers */,
 				32DC15CF1A8CF7AE006F9AD3 /* MXPushRuleConditionChecker.h in Headers */,
+				3294FD9F22F321B0007F1E60 /* MXServiceTermsRestClient.h in Headers */,
 				32954019216385F100E300FC /* MXServerNoticeContent.h in Headers */,
 				327187851DA7D0220071C818 /* MXOlmDecryption.h in Headers */,
 				32D7767D1A27860600FC4AA2 /* MXMemoryStore.h in Headers */,
@@ -2174,6 +2196,7 @@
 				32133021228BF7BC0070BA9B /* MXReactionCountChange.h in Headers */,
 				B146D4D721A5A44E00D8C2C6 /* MXScanRealmFileProvider.h in Headers */,
 				320DFDDB19DD99B60068622A /* MXRoom.h in Headers */,
+				3294FDA022F321B0007F1E60 /* MXServiceTerms.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2443,6 +2466,7 @@
 				F03EF5091DF071D5009DF592 /* MXEncryptedAttachments.m in Sources */,
 				B172857D2100D4F60052C51E /* MXSendReplyEventDefaultStringLocalizations.m in Sources */,
 				321CFDEF225264C4004D31DF /* NSArray+MatrixSDK.m in Sources */,
+				3294FD9D22F321B0007F1E60 /* MXServiceTermsRestClient.m in Sources */,
 				323547DD2226FC5700F15F94 /* MXCredentials.m in Sources */,
 				32FA10CF1FA1C9F700E54233 /* MXOutgoingRoomKeyRequest.m in Sources */,
 				32322A4C1E575F65005DD155 /* MXAllowedCertificates.m in Sources */,
@@ -2493,6 +2517,7 @@
 				32BBAE752179CF4000D85F46 /* MXKeyBackup.m in Sources */,
 				322A51B71D9AB15900C8536D /* MXCrypto.m in Sources */,
 				B17982FB2119E4A2001FD722 /* MXRoomPredecessorInfo.m in Sources */,
+				3294FD9E22F321B0007F1E60 /* MXServiceTerms.m in Sources */,
 				32DC15D11A8CF7AE006F9AD3 /* MXNotificationCenter.m in Sources */,
 				32637ED51E5B00400011E20D /* MXDeviceList.m in Sources */,
 				B17982FA2119E4A2001FD722 /* MXRoomCreateContent.m in Sources */,

--- a/MatrixSDK/MXError.h
+++ b/MatrixSDK/MXError.h
@@ -53,6 +53,7 @@ FOUNDATION_EXPORT NSString *const kMXErrCodeStringPasswordNoLowercase;
 FOUNDATION_EXPORT NSString *const kMXErrCodeStringPasswordNoSymbol;
 FOUNDATION_EXPORT NSString *const kMXErrCodeStringPasswordInDictionary;
 FOUNDATION_EXPORT NSString *const kMXErrCodeStringWeakPassword;
+FOUNDATION_EXPORT NSString *const kMXErrCodeStringTermsNotSigned;
 
 FOUNDATION_EXPORT NSString *const kMXErrorStringInvalidToken;
 

--- a/MatrixSDK/MXError.m
+++ b/MatrixSDK/MXError.m
@@ -50,6 +50,7 @@ NSString *const kMXErrCodeStringPasswordNoLowercase     = @"M_PASSWORD_NO_LOWERC
 NSString *const kMXErrCodeStringPasswordNoSymbol        = @"M_PASSWORD_NO_SYMBOL";
 NSString *const kMXErrCodeStringPasswordInDictionary    = @"M_PASSWORD_IN_DICTIONARY";
 NSString *const kMXErrCodeStringWeakPassword            = @"M_WEAK_PASSWORD";
+NSString *const kMXErrCodeStringTermsNotSigned          = @"M_TERMS_NOT_SIGNED";
 
 NSString *const kMXErrorStringInvalidToken      = @"Invalid token";
 

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -69,6 +69,8 @@ FOUNDATION_EXPORT NSString *const kMXAccountDataTypeDirect;
 FOUNDATION_EXPORT NSString *const kMXAccountDataTypePushRules;
 FOUNDATION_EXPORT NSString *const kMXAccountDataTypeIgnoredUserList;
 FOUNDATION_EXPORT NSString *const kMXAccountDataTypeUserWidgets;
+FOUNDATION_EXPORT NSString *const kMXAccountDataTypeAcceptedTerms;
+FOUNDATION_EXPORT NSString *const kMXAccountDataTypeAcceptedTermsKey;
 
 /**
  Account data keys

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -52,9 +52,15 @@ FOUNDATION_EXPORT NSString *const kMXAPIPrefixPathR0;
 FOUNDATION_EXPORT NSString *const kMXAPIPrefixPathUnstable;
 
 /**
- Prefix used in path of identity server API requests.
+ Prefix used in path of identity server for v1 API requests.
  */
-FOUNDATION_EXPORT NSString *const kMXIdentityAPIPrefixPath;
+FOUNDATION_EXPORT NSString *const kMXIdentityAPIPrefixPathV1;
+
+/**
+ Prefix used in path of identity server for v2 API requests.
+ */
+FOUNDATION_EXPORT NSString *const kMXIdentityAPIPrefixPathV2;
+
 
 /**
  Account data types
@@ -80,7 +86,6 @@ FOUNDATION_EXPORT NSString *const kMXRestClientErrorDomain;
 FOUNDATION_EXPORT NSString *const kMXMembersOfRoomParametersAt;
 FOUNDATION_EXPORT NSString *const kMXMembersOfRoomParametersMembership;
 FOUNDATION_EXPORT NSString *const kMXMembersOfRoomParametersNotMembership;
-
 
 /**
  `MXRestClient` makes requests to Matrix servers.

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -42,6 +42,8 @@ NSString *const kMXAccountDataTypeIgnoredUserList = @"m.ignored_user_list";
 NSString *const kMXAccountDataTypePushRules = @"m.push_rules";
 NSString *const kMXAccountDataTypeDirect = @"m.direct";
 NSString *const kMXAccountDataTypeUserWidgets = @"m.widgets";
+NSString *const kMXAccountDataTypeAcceptedTerms = @"m.accepted_terms";
+NSString *const kMXAccountDataTypeAcceptedTermsKey = @"accepted";
 
 /**
  Account data keys

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -32,10 +32,8 @@
 NSString *const kMXAPIPrefixPathR0 = @"_matrix/client/r0";
 NSString *const kMXAPIPrefixPathUnstable = @"_matrix/client/unstable";
 
-/**
- Prefix used in path of identity server API requests.
- */
-NSString *const kMXIdentityAPIPrefixPath = @"_matrix/identity/api/v1";
+NSString *const kMXIdentityAPIPrefixPathV1 = @"_matrix/identity/api/v1";
+NSString *const kMXIdentityAPIPrefixPathV2 = @"_matrix/identity/v2";
 
 /**
  Account data types
@@ -3364,7 +3362,7 @@ MXAuthAction;
 - (void)setIdentityServer:(NSString *)identityServer
 {
     self.credentials.identityServer = [identityServer copy];
-    identityHttpClient = [[MXHTTPClient alloc] initWithBaseURL:[NSString stringWithFormat:@"%@/%@", identityServer, kMXIdentityAPIPrefixPath]
+    identityHttpClient = [[MXHTTPClient alloc] initWithBaseURL:[NSString stringWithFormat:@"%@/%@", identityServer, kMXIdentityAPIPrefixPathV1]
                              andOnUnrecognizedCertificateBlock:nil];
 
     // The identity server accepts parameters in form data form not in JSON

--- a/MatrixSDK/MatrixSDK.h
+++ b/MatrixSDK/MatrixSDK.h
@@ -1,6 +1,7 @@
 /*
  Copyright 2014 OpenMarket Ltd
  Copyright 2017 Vector Creations Ltd
+ Copyright 2019 The Matrix.org Foundation C.I.C
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -65,6 +66,7 @@ FOUNDATION_EXPORT NSString *MatrixSDKVersion;
 #import "MXServerNotices.h"
 
 #import "MXAutoDiscovery.h"
+#import "MXServiceTerms.h"
 
 #import "MXEventUnsignedData.h"
 #import "MXEventRelations.h"

--- a/MatrixSDK/NotificationCenter/ServiceTerms/MXServiceTerms.h
+++ b/MatrixSDK/NotificationCenter/ServiceTerms/MXServiceTerms.h
@@ -1,0 +1,73 @@
+/*
+ Copyright 2019 The Matrix.org Foundation C.I.C
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "MXHTTPOperation.h"
+#import "MXLoginTerms.h"
+#import "MXSession.h"
+
+/**
+ Services around Matrix.
+ */
+typedef enum : NSUInteger
+{
+    // An Identity Service
+    MXServiceTypeIdentityService = 0,
+
+    // An Integration Manager
+    MXServiceTypeIntegrationManager
+} MXServiceType;
+
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MXServiceTerms : NSObject
+
+- (instancetype)initWithBaseUrl:(NSString*)baseUrl serviceType:(MXServiceType)serviceType matrixSession:(nullable MXSession *)mxSession accessToken:(nullable NSString *)accessToken;
+
+@property (nonatomic, readonly) NSString *baseUrl;
+@property (nonatomic, readonly) MXServiceType serviceType;
+
+/**
+ Get all terms of the service.
+
+ @param success A block object called when the operation succeeds.
+ @param failure A block object called when the operation fails.
+
+ @return a MXHTTPOperation instance.
+ */
+- (MXHTTPOperation*)terms:(void (^)(MXLoginTerms * _Nullable terms))success
+                  failure:(nullable void (^)(NSError * _Nonnull))failure;
+
+/**
+ Accept terms by their urls.
+
+ @param termsUrls urls of the terms documents.
+ @param mxSession the Matrix session of the user.
+
+ @param success A block object called when the operation succeeds.
+ @param failure A block object called when the operation fails.
+
+ @return a MXHTTPOperation instance.
+ */
+- (MXHTTPOperation*)agreeToTerms:(NSArray<NSString *> *)termsUrls
+                         success:(void (^)(void))success
+                         failure:(nullable void (^)(NSError * _Nonnull))failure;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixSDK/NotificationCenter/ServiceTerms/MXServiceTerms.h
+++ b/MatrixSDK/NotificationCenter/ServiceTerms/MXServiceTerms.h
@@ -50,14 +50,13 @@ NS_ASSUME_NONNULL_BEGIN
 
  @return a MXHTTPOperation instance.
  */
-- (MXHTTPOperation*)terms:(void (^)(MXLoginTerms * _Nullable terms))success
+- (MXHTTPOperation*)terms:(void (^)(MXLoginTerms * _Nullable terms, NSArray<NSString*> * _Nullable alreadyAcceptedTermsUrls))success
                   failure:(nullable void (^)(NSError * _Nonnull))failure;
 
 /**
  Accept terms by their urls.
 
  @param termsUrls urls of the terms documents.
- @param mxSession the Matrix session of the user.
 
  @param success A block object called when the operation succeeds.
  @param failure A block object called when the operation fails.

--- a/MatrixSDK/NotificationCenter/ServiceTerms/MXServiceTerms.m
+++ b/MatrixSDK/NotificationCenter/ServiceTerms/MXServiceTerms.m
@@ -1,0 +1,89 @@
+/*
+ Copyright 2019 The Matrix.org Foundation C.I.C
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXServiceTerms.h"
+#import "MXServiceTermsRestClient.h"
+
+#import "MXRestClient.h"
+
+
+NSString *const kMXIntegrationManagerAPIPrefixPathV1 = @"_matrix/integrations/v1";
+
+@interface MXServiceTerms()
+
+@property (nonatomic, strong) MXServiceTermsRestClient *restClient;
+@property (nonatomic, nullable) MXSession *mxSession;
+@property (nonatomic, nullable) NSString *accessToken;
+
+@end
+
+@implementation MXServiceTerms
+
+- (instancetype)initWithBaseUrl:(NSString*)baseUrl serviceType:(MXServiceType)serviceType matrixSession:(nullable MXSession *)mxSession accessToken:(nullable NSString *)accessToken
+{
+    self = [super init];
+    if (self)
+    {
+        _baseUrl = [baseUrl copy];
+        _serviceType = serviceType;
+        _mxSession = mxSession;
+        _accessToken = [accessToken copy];
+
+        _restClient = [[MXServiceTermsRestClient alloc] initWithBaseUrl:self.termsBaseUrl accessToken:accessToken];
+    }
+    return self;
+}
+
+- (MXHTTPOperation*)terms:(void (^)(MXLoginTerms * _Nullable terms))success
+                  failure:(nullable void (^)(NSError * _Nonnull))failure
+{
+    return [_restClient terms:success failure:failure];
+}
+
+- (MXHTTPOperation *)agreeToTerms:(NSArray<NSString *> *)termsUrls
+                          success:(void (^)(void))success
+                          failure:(void (^)(NSError * _Nonnull))failure
+{
+    NSParameterAssert(_mxSession && _accessToken);
+
+    // TODO
+    failure([[NSError alloc] initWithDomain:@"toto" code:0 userInfo:nil]);
+    return nil;
+}
+
+#pragma mark - Private methods
+
+- (NSString*)termsBaseUrl
+{
+    NSString *termsBaseUrl;
+    switch (_serviceType)
+    {
+        case MXServiceTypeIdentityService:
+            termsBaseUrl = [NSString stringWithFormat:@"%@/%@", _baseUrl, kMXIdentityAPIPrefixPathV2];
+            break;
+
+        case MXServiceTypeIntegrationManager:
+            termsBaseUrl = [NSString stringWithFormat:@"%@/%@", _baseUrl, kMXIntegrationManagerAPIPrefixPathV1];
+            break;
+
+        default:
+            break;
+    }
+
+    return termsBaseUrl;
+}
+
+@end

--- a/MatrixSDK/NotificationCenter/ServiceTerms/MXServiceTermsRestClient.h
+++ b/MatrixSDK/NotificationCenter/ServiceTerms/MXServiceTermsRestClient.h
@@ -1,0 +1,55 @@
+/*
+ Copyright 2019 The Matrix.org Foundation C.I.C
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "MXHTTPOperation.h"
+#import "MXLoginTerms.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MXServiceTermsRestClient : NSObject
+
+- (instancetype)initWithBaseUrl:(NSString*)baseUrl accessToken:(nullable NSString *)accessToken;
+
+/**
+ Get all terms of the service.
+
+ @param success A block object called when the operation succeeds.
+ @param failure A block object called when the operation fails.
+
+ @return a MXHTTPOperation instance.
+ */
+- (MXHTTPOperation*)terms:(void (^)(MXLoginTerms * _Nullable terms))success
+                  failure:(nullable void (^)(NSError * _Nonnull))failure;
+
+/**
+ Accept terms by their urls.
+
+ @param termsUrls urls of the terms documents.
+
+ @param success A block object called when the operation succeeds.
+ @param failure A block object called when the operation fails.
+
+ @return a MXHTTPOperation instance.
+ */
+- (MXHTTPOperation*)agreeToTerms:(NSArray<NSString *> *)termsUrls
+                         success:(void (^)(void))success
+                         failure:(nullable void (^)(NSError * _Nonnull))failure;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixSDK/NotificationCenter/ServiceTerms/MXServiceTermsRestClient.m
+++ b/MatrixSDK/NotificationCenter/ServiceTerms/MXServiceTermsRestClient.m
@@ -47,8 +47,6 @@
                                      MXLoginTerms *terms;
                                      MXJSONModelSetMXJSONModel(terms, MXLoginTerms.class, JSONResponse);
 
-                                     NSLog(@"#### %@", JSONResponse);
-
                                      success(terms);
                                  }
                                  failure:^(NSError *error) {

--- a/MatrixSDK/NotificationCenter/ServiceTerms/MXServiceTermsRestClient.m
+++ b/MatrixSDK/NotificationCenter/ServiceTerms/MXServiceTermsRestClient.m
@@ -1,0 +1,83 @@
+/*
+ Copyright 2019 The Matrix.org Foundation C.I.C
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXServiceTermsRestClient.h"
+
+#import "MXHTTPClient.h"
+
+@interface MXServiceTermsRestClient()
+
+@property (nonatomic, strong) MXHTTPClient *httpClient;
+
+@end
+
+@implementation MXServiceTermsRestClient
+
+- (instancetype)initWithBaseUrl:(NSString*)baseUrl accessToken:(nullable NSString *)accessToken
+{
+    self = [super init];
+    if (self)
+    {
+        _httpClient = [[MXHTTPClient alloc] initWithBaseURL:baseUrl accessToken:accessToken andOnUnrecognizedCertificateBlock:nil];
+    }
+    return self;
+}
+
+- (MXHTTPOperation*)terms:(void (^)(MXLoginTerms * _Nullable terms))success
+                  failure:(nullable void (^)(NSError * _Nonnull))failure
+{
+    return [_httpClient requestWithMethod:@"GET"
+                                    path:@"terms"
+                              parameters:nil
+                                 success:^(NSDictionary *JSONResponse) {
+
+                                     MXLoginTerms *terms;
+                                     MXJSONModelSetMXJSONModel(terms, MXLoginTerms.class, JSONResponse);
+
+                                     NSLog(@"#### %@", JSONResponse);
+
+                                     success(terms);
+                                 }
+                                 failure:^(NSError *error) {
+                                     if (failure)
+                                     {
+                                         failure(error);
+                                     }
+                                 }];
+}
+
+- (MXHTTPOperation*)agreeToTerms:(NSArray<NSString *> *)termsUrls
+                         success:(void (^)(void))success
+                         failure:(nullable void (^)(NSError * _Nonnull))failure
+{
+    return [_httpClient requestWithMethod:@"POST"
+                                     path:@"terms"
+                               parameters:@{
+                                            @"user_accepts": termsUrls
+                                            }
+                                  success:^(NSDictionary *JSONResponse) {
+                                      success();
+                                  }
+                                  failure:^(NSError *error) {
+                                      if (failure)
+                                      {
+                                          failure(error);
+                                      }
+                                  }];
+}
+
+
+@end


### PR DESCRIPTION
Part of vector-im/riot-ios#2600.
