### PR TITLE
MXEventTimeline: The roomEventFilter property is now writable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Improvements:
  * MXServiceTerms: A class to support MSC2140 (Terms of Service API) (vector-im/riot-ios#2600).
  * MXRestClient: Remove Identity Server URL fallback to homeserver one's when there is no Identity Server configured.
  * MXHTTPClient: Improve M_LIMIT_EXCEEDED error handling: Do not wait to try again if the mentioned delay is too long.
+ * MXEventTimeline: The roomEventFilter property is now writable (vector-im/riot-ios#2615).
 
 Changes in Matrix iOS SDK in 0.13.1 (2019-08-08)
 ===============================================

--- a/MatrixSDK/Data/Filters/MXRoomEventFilter.h
+++ b/MatrixSDK/Data/Filters/MXRoomEventFilter.h
@@ -1,6 +1,7 @@
 /*
  Copyright 2016 OpenMarket Ltd
  Copyright 2018 New Vector Ltd
+ Copyright 2019 The Matrix.org Foundation C.I.C
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -22,7 +23,7 @@
 /**
  `MXRoomEventFilter` defines a room event filter which may be used during Matrix requests.
  */
-@interface MXRoomEventFilter : MXFilterObject;
+@interface MXRoomEventFilter : MXFilterObject <NSCopying>
 
 /**
  If YES, includes only events with a url key in their content. If NO, excludes those events.

--- a/MatrixSDK/Data/Filters/MXRoomEventFilter.m
+++ b/MatrixSDK/Data/Filters/MXRoomEventFilter.m
@@ -1,6 +1,7 @@
 /*
  Copyright 2016 OpenMarket Ltd
  Copyright 2018 New Vector Ltd
+ Copyright 2019 The Matrix.org Foundation C.I.C
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -135,6 +136,14 @@
     BOOL lazyLoadMembers = NO; // Basic default value used by homeservers
     MXJSONModelSetBoolean(lazyLoadMembers, dictionary[@"lazy_load_members"]);
     return lazyLoadMembers;
+}
+
+
+#pragma mark - NSCopying
+
+- (id)copyWithZone:(NSZone *)zone
+{
+    return [[MXRoomEventFilter alloc] initWithDictionary:self.dictionary];
 }
 
 @end

--- a/MatrixSDK/Data/MXEventTimeline.h
+++ b/MatrixSDK/Data/MXEventTimeline.h
@@ -1,5 +1,6 @@
 /*
  Copyright 2016 OpenMarket Ltd
+ Copyright 2019 The Matrix.org Foundation C.I.C
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -74,8 +75,13 @@ typedef void (^MXOnRoomEvent)(MXEvent *event, MXTimelineDirection direction, MXR
 
 /**
  The room events filter which is applied during the history pagination.
+
+ The default value can be nil. It depends if the lazy loading of room members
+ is enabled or not.
+ The filter can be modified but only before starting paginating, ie before calling one
+ the resetPagination methods.
  */
-@property (nonatomic, readonly) MXRoomEventFilter *roomEventFilter;
+@property (nonatomic, copy) MXRoomEventFilter *roomEventFilter;
 
 /**
  The state of the room at the top most recent event of the timeline.

--- a/MatrixSDK/Data/MXEventTimeline.m
+++ b/MatrixSDK/Data/MXEventTimeline.m
@@ -2,6 +2,7 @@
  Copyright 2016 OpenMarket Ltd
  Copyright 2017 Vector Creations Ltd
  Copyright 2018 New Vector Ltd
+ Copyright 2019 The Matrix.org Foundation C.I.C
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -68,34 +69,34 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
 @implementation MXEventTimeline
 
 #pragma mark - Initialisation
-- (id)initWithRoom:(MXRoom*)room2 andInitialEventId:(NSString*)initialEventId
+- (id)initWithRoom:(MXRoom*)theRoom andInitialEventId:(NSString*)initialEventId
 {
     // Is it a past or live timeline?
     if (initialEventId)
     {
         // Events for a past timeline are stored in memory
         MXMemoryStore *memoryStore = [[MXMemoryStore alloc] init];
-        [memoryStore openWithCredentials:room2.mxSession.matrixRestClient.credentials onComplete:nil failure:nil];
+        [memoryStore openWithCredentials:theRoom.mxSession.matrixRestClient.credentials onComplete:nil failure:nil];
 
-        self = [self initWithRoom:room2 initialEventId:initialEventId andStore:memoryStore];
+        self = [self initWithRoom:theRoom initialEventId:initialEventId andStore:memoryStore];
     }
     else
     {
         // Live: store events in the session store
-        self = [self initWithRoom:room2 initialEventId:initialEventId andStore:room2.mxSession.store];
+        self = [self initWithRoom:theRoom initialEventId:initialEventId andStore:theRoom.mxSession.store];
     }
     return self;
 }
 
-- (id)initWithRoom:(MXRoom*)room2 initialEventId:(NSString*)initialEventId andStore:(id<MXStore>)store2
+- (id)initWithRoom:(MXRoom*)theRoom initialEventId:(NSString*)initialEventId andStore:(id<MXStore>)theStore
 {
     self = [super init];
     if (self)
     {
         _timelineId = [[NSUUID UUID] UUIDString];
         _initialEventId = initialEventId;
-        room = room2;
-        store = store2;
+        room = theRoom;
+        store = theStore;
         eventListeners = [NSMutableArray array];
 
         if (!initialEventId)
@@ -104,8 +105,13 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
         }
 
         _state = [[MXRoomState alloc] initWithRoomId:room.roomId andMatrixSession:room.mxSession andDirection:YES];
-        
-        _roomEventFilter = [[MXRoomEventFilter alloc] init];
+
+        // If the event stream runs with lazy loading, the timeline must do the same
+        if (room.mxSession.syncWithLazyLoadOfRoomMembers)
+        {
+            _roomEventFilter = [MXRoomEventFilter new];
+            _roomEventFilter.lazyLoadMembers = YES;
+        }
     }
     return self;
 }
@@ -192,16 +198,9 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
     forwardsPaginationToken = nil;
     hasReachedHomeServerForwardsPaginationEnd = NO;
 
-    MXRoomEventFilter *filter;
-    if (room.mxSession.syncWithLazyLoadOfRoomMembers)
-    {
-        filter = [MXRoomEventFilter new];
-        filter.lazyLoadMembers = YES;
-    }
-
     // Get the context around the initial event
     MXWeakify(self);
-    return [room.mxSession.matrixRestClient contextOfEvent:_initialEventId inRoom:room.roomId limit:limit filter:filter success:^(MXEventContext *eventContext) {
+    return [room.mxSession.matrixRestClient contextOfEvent:_initialEventId inRoom:room.roomId limit:limit filter:_roomEventFilter success:^(MXEventContext *eventContext) {
         MXStrongifyAndReturnIfNil(self);
 
         // And fill the timelime with received data
@@ -311,18 +310,6 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
     else
     {
         paginationToken = forwardsPaginationToken;
-    }
-
-
-    // If the event stream runs with lazy loading, the timeline must do the same
-    if (room.mxSession.syncWithLazyLoadOfRoomMembers)
-    {
-        if (!_roomEventFilter)
-        {
-            _roomEventFilter = [MXRoomEventFilter new];
-        }
-
-        _roomEventFilter.lazyLoadMembers = YES;
     }
 
     NSLog(@"[MXEventTimeline] paginate : request %tu messages from the server", numItems);


### PR DESCRIPTION
Fix vector-im/riot-ios#2615