### PR TITLE
 MXMatrixVersions: Add doesServerRequireIdentityServerParam and doesServerAcceptIdentityAccessToken

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Improvements:
  * MXHTTPClient: Improve M_LIMIT_EXCEEDED error handling: Do not wait to try again if the mentioned delay is too long.
  * MXEventTimeline: The roomEventFilter property is now writable (vector-im/riot-ios#2615).
  * VoIP: Make call start if there is no STUN server.
+ * MXMatrixVersions: Add doesServerRequireIdentityServerParam and doesServerAcceptIdentityAccessToken properties.
 
 Changes in Matrix iOS SDK in 0.13.1 (2019-08-08)
 ===============================================

--- a/MatrixSDK/JSONModels/MXMatrixVersions.h
+++ b/MatrixSDK/JSONModels/MXMatrixVersions.h
@@ -18,6 +18,20 @@
 #import "MXJSONModel.h"
 
 /**
+ Matrix Client-Server API versions.
+ */
+struct MXMatrixClientServerAPIVersionStruct
+{
+    __unsafe_unretained NSString * const r0_0_1;
+    __unsafe_unretained NSString * const r0_1_0;
+    __unsafe_unretained NSString * const r0_2_0;
+    __unsafe_unretained NSString * const r0_3_0;
+    __unsafe_unretained NSString * const r0_4_0;
+    __unsafe_unretained NSString * const r0_5_0;
+};
+extern const struct MXMatrixClientServerAPIVersionStruct MXMatrixClientServerAPIVersion;
+
+/**
  Features declared in the matrix specification.
  */
 struct MXMatrixVersionsFeatureStruct

--- a/MatrixSDK/JSONModels/MXMatrixVersions.h
+++ b/MatrixSDK/JSONModels/MXMatrixVersions.h
@@ -38,6 +38,8 @@ struct MXMatrixVersionsFeatureStruct
 {
     // Room members lazy loading
     __unsafe_unretained NSString * const lazyLoadMembers;
+    __unsafe_unretained NSString * const requireIdentityServer;
+    __unsafe_unretained NSString * const idAccessToken;
 };
 extern const struct MXMatrixVersionsFeatureStruct MXMatrixVersionsFeature;
 
@@ -63,5 +65,17 @@ extern const struct MXMatrixVersionsFeatureStruct MXMatrixVersionsFeature;
  Check whether the server supports the room members lazy loading.
  */
 @property (nonatomic, readonly) BOOL supportLazyLoadMembers;
+
+/**
+ Indicate if the `id_server` parameter is required when registering with an 3pid,
+ adding a 3pid or resetting password.
+ */
+@property (nonatomic, readonly) BOOL doesServerRequireIdentityServerParam;
+
+/**
+ Indicate if the `id_access_token` parameter can be safely passed to the homeserver.
+ Some homeservers may trigger errors if they are not prepared for the new parameter.
+ */
+@property (nonatomic, readonly) BOOL doesServerAcceptIdentityAccessToken;
 
 @end

--- a/MatrixSDK/JSONModels/MXMatrixVersions.m
+++ b/MatrixSDK/JSONModels/MXMatrixVersions.m
@@ -16,6 +16,15 @@
 
 #import "MXMatrixVersions.h"
 
+const struct MXMatrixClientServerAPIVersionStruct MXMatrixClientServerAPIVersion = {
+    .r0_0_1 = @"r0.0.1",
+    .r0_1_0 = @"r0.1.0",
+    .r0_2_0 = @"r0.2.0",
+    .r0_3_0 = @"r0.3.0",
+    .r0_4_0 = @"r0.4.0",
+    .r0_5_0 = @"r0.5.0",
+};
+
 const struct MXMatrixVersionsFeatureStruct MXMatrixVersionsFeature = {
     .lazyLoadMembers = @"m.lazy_load_members"
 };
@@ -35,7 +44,8 @@ const struct MXMatrixVersionsFeatureStruct MXMatrixVersionsFeature = {
 
 - (BOOL)supportLazyLoadMembers
 {
-    return [self.unstableFeatures[MXMatrixVersionsFeature.lazyLoadMembers] boolValue];
+    return [self.versions containsObject:MXMatrixClientServerAPIVersion.r0_5_0]
+        || [self.unstableFeatures[MXMatrixVersionsFeature.lazyLoadMembers] boolValue];
 }
 
 @end

--- a/MatrixSDK/JSONModels/MXMatrixVersions.m
+++ b/MatrixSDK/JSONModels/MXMatrixVersions.m
@@ -26,7 +26,9 @@ const struct MXMatrixClientServerAPIVersionStruct MXMatrixClientServerAPIVersion
 };
 
 const struct MXMatrixVersionsFeatureStruct MXMatrixVersionsFeature = {
-    .lazyLoadMembers = @"m.lazy_load_members"
+    .lazyLoadMembers = @"m.lazy_load_members",
+    .requireIdentityServer = @"m.require_identity_server",
+    .idAccessToken = @"m.id_access_token"
 };
 
 @implementation MXMatrixVersions
@@ -46,6 +48,24 @@ const struct MXMatrixVersionsFeatureStruct MXMatrixVersionsFeature = {
 {
     return [self.versions containsObject:MXMatrixClientServerAPIVersion.r0_5_0]
         || [self.unstableFeatures[MXMatrixVersionsFeature.lazyLoadMembers] boolValue];
+}
+
+- (BOOL)doesServerRequireIdentityServerParam
+{
+    // YES by default
+    BOOL doesServerRequireIdentityServerParam = YES;
+
+    if (self.unstableFeatures[MXMatrixVersionsFeature.requireIdentityServer])
+    {
+        doesServerRequireIdentityServerParam = [self.unstableFeatures[MXMatrixVersionsFeature.requireIdentityServer] boolValue];
+    }
+
+    return doesServerRequireIdentityServerParam;
+}
+
+- (BOOL)doesServerAcceptIdentityAccessToken
+{
+    return [self.unstableFeatures[MXMatrixVersionsFeature.idAccessToken] boolValue];
 }
 
 @end


### PR DESCRIPTION
The 1st commit is an update for `supportLazyLoadMembers` implementation.
The 2nd commit will be useful for most of remaining policy features.

