### PR TITLE
MXHTTPClient: Do not retry requests if the host is not valid.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,8 +9,9 @@ Improvements:
  * VoIP: Make call start if there is no STUN server.
  * MXMatrixVersions: Add doesServerRequireIdentityServerParam and doesServerAcceptIdentityAccessToken properties.
  * Create MXIdentityServerRestClient and MXIdentityService to manage identity server requests (vector-im/riot-ios#2647).
- * MXHTTPClient: Add access token renewal plus request retry mechanism.
  * MXIdentityService: Support identity server v2 API. Handle identity server v2 API authentification and use the hashed v2 lookup API for 3PIDs (vector-im/riot-ios#2603 and /vector-im/riot-ios#2652).
+ * MXHTTPClient: Add access token renewal plus request retry mechanism.
+ * MXHTTPClient: Do not retry requests if the host is not valid.
 
 API break:
  * MXRestClient: Remove identity server requests. Now MXIdentityService is used to perform identity server requests.

--- a/MatrixSDK/Utils/MXHTTPClient.m
+++ b/MatrixSDK/Utils/MXHTTPClient.m
@@ -480,8 +480,11 @@ NSString* const kMXHTTPClientMatrixErrorNotificationErrorKey = @"kMXHTTPClientMa
             }
             else if (mxHTTPOperation.numberOfTries < mxHTTPOperation.maxNumberOfTries
                      && mxHTTPOperation.age < mxHTTPOperation.maxRetriesTime
-                     && !([error.domain isEqualToString:NSURLErrorDomain] && error.code == kCFURLErrorCancelled)    // No need to retry a cancelation (which can also happen on SSL error)
-                     && response.statusCode != 400 && response.statusCode != 401 && response.statusCode != 403      // No amount of retrying will save you now
+                     && !([error.domain isEqualToString:NSURLErrorDomain]
+                          && (error.code == kCFURLErrorCancelled                    // No need to retry a cancelation (which can also happen on SSL error)
+                              || error.code == kCFURLErrorCannotFindHost)           // No need to retry on a non existing host
+                         )
+                     && response.statusCode != 400 && response.statusCode != 401 && response.statusCode != 403     // No amount of retrying will save you now
                      )
             {
                 // Check if it is a network connectivity issue


### PR DESCRIPTION
Useful on the auth screen of Riot.
You now instantly know when the entered custom HS is wrong.