### PR TITLE
Less dependencies on MXCredentials

### DIFF
--- a/MatrixSDK/Contrib/Swift/MXIdentityServerRestClient.swift
+++ b/MatrixSDK/Contrib/Swift/MXIdentityServerRestClient.swift
@@ -26,26 +26,13 @@ public extension MXIdentityServerRestClient {
      
      - parameters:
      - identityServer: The identity server address.
+     - accessToken: The identity server access token if known
      - handler: the block called to handle unrecognized certificate (`nil` if unrecognized certificates are ignored).
      
      - returns: a `MXIdentityServerRestClient` instance.
      */
-    @nonobjc convenience init(identityServer: URL, unrecognizedCertificateHandler handler: MXHTTPClientOnUnrecognizedCertificate?) {
-        self.init(__identityServer: identityServer.absoluteString, andOnUnrecognizedCertificateBlock: handler)
-    }
-    
-    
-    /**
-     Create an instance based on existing user credentials.
-     
-     - parameters:
-     - credentials: A set of existing user credentials.
-     - handler: the block called to handle unrecognized certificate (`nil` if unrecognized certificates are ignored).
-     
-     - returns: a `MXIdentityServerRestClient` instance.
-     */
-    @nonobjc convenience init(credentials: MXCredentials, unrecognizedCertificateHandler handler: MXHTTPClientOnUnrecognizedCertificate?) {
-        self.init(__credentials: credentials, andOnUnrecognizedCertificateBlock: handler)
+    @nonobjc convenience init(identityServer: URL, accessToken: String?, unrecognizedCertificateHandler handler: MXHTTPClientOnUnrecognizedCertificate?) {
+        self.init(__identityServer: identityServer.absoluteString, accessToken: accessToken, andOnUnrecognizedCertificateBlock: handler)
     }
     
     
@@ -156,13 +143,14 @@ public extension MXIdentityServerRestClient {
      
      - parameters:
      - signUrl: the URL that will be called for signing.
+     - mxid: the user matrix id.
      - completion: A block object called when the operation completes.
      - response: Provides the signed data on success.
      
      - returns: a `MXHTTPOperation` instance.
      */
-    @nonobjc @discardableResult func signUrl(_ signUrl: String, completion: @escaping (_ response: MXResponse<[String: Any]>) -> Void) -> MXHTTPOperation {
-        return __signUrl(signUrl, success: currySuccess(completion), failure: curryFailure(completion))
+    @nonobjc @discardableResult func signUrl(_ signUrl: String, mxid: String, completion: @escaping (_ response: MXResponse<[String: Any]>) -> Void) -> MXHTTPOperation {
+        return __signUrl(signUrl, mxid: mxid, success: currySuccess(completion), failure: curryFailure(completion))
     }
     
 }

--- a/MatrixSDK/Contrib/Swift/MXIdentityService.swift
+++ b/MatrixSDK/Contrib/Swift/MXIdentityService.swift
@@ -25,12 +25,13 @@ public extension MXIdentityService {
      
      - parameters:
      - identityServer: The identity server address.
+     - accessToken: The identity server access token if known
      - homeserverRestClient: The homeserver REST client.
      
      - returns: a `MXIdentityService` instance.
      */
-    @nonobjc convenience init(identityServer: URL, homeserverRestClient: MXRestClient) {
-        self.init(__identityServer: identityServer.absoluteString, andHomeserverRestClient: homeserverRestClient)
+    @nonobjc convenience init(identityServer: URL, accessToken: String?, homeserverRestClient: MXRestClient) {
+        self.init(__identityServer: identityServer.absoluteString, accessToken: accessToken, andHomeserverRestClient: homeserverRestClient)
     }
     
     // MARK: -

--- a/MatrixSDK/Data/AutoDiscovery/MXAutoDiscovery.m
+++ b/MatrixSDK/Data/AutoDiscovery/MXAutoDiscovery.m
@@ -125,7 +125,7 @@
     restClient = [[MXRestClient alloc] initWithHomeServer:wellKnown.homeServer.baseUrl andOnUnrecognizedCertificateBlock:nil];
     restClient.identityServer = identityServer;
     
-    self.identityService = [[MXIdentityService alloc] initWithIdentityServer:identityServer andHomeserverRestClient:restClient];
+    self.identityService = [[MXIdentityService alloc] initWithIdentityServer:identityServer accessToken:nil andHomeserverRestClient:restClient];
 
     // Ping one CS API to check the HS
     MXHTTPOperation *operation;

--- a/MatrixSDK/IdentityServer/MXIdentityServerRestClient.h
+++ b/MatrixSDK/IdentityServer/MXIdentityServerRestClient.h
@@ -65,11 +65,6 @@ NS_ERROR_ENUM(MXIdentityServerRestClientErrorDomain)
 @property (nonatomic, readonly) NSString *identityServer;
 
 /**
- Credentials for the Matrix identity server API.
-*/
-@property (nonatomic, readonly) MXCredentials *credentials;
-
-/**
  The queue on which asynchronous response blocks are called.
  Default is dispatch_get_main_queue().
 */
@@ -96,19 +91,12 @@ NS_ERROR_ENUM(MXIdentityServerRestClientErrorDomain)
  Create an instance based on identity server URL.
 
  @param identityServer the identity server URL.
+ @param accessToken the identity server access token. Nil if not known yet.
  @param onUnrecognizedCertBlock the block called to handle unrecognized certificate (nil if unrecognized certificates are ignored).
  @return a MXIdentityServerRestClient instance.
 */
-- (instancetype)initWithIdentityServer:(NSString *)identityServer andOnUnrecognizedCertificateBlock:(nullable MXHTTPClientOnUnrecognizedCertificate)onUnrecognizedCertBlock NS_REFINED_FOR_SWIFT;
+- (instancetype)initWithIdentityServer:(NSString *)identityServer accessToken:(nullable NSString*)accessToken andOnUnrecognizedCertificateBlock:(nullable MXHTTPClientOnUnrecognizedCertificate)onUnrecognizedCertBlock NS_REFINED_FOR_SWIFT;
 
-/**
- Create an instance based on a matrix user account.
- 
- @param credentials user's credentials.
- @param onUnrecognizedCertBlock the block called to handle unrecognized certificate (nil if unrecognized certificates are ignored).
- @return a MXRestClient instance.
- */
-- (instancetype)initWithCredentials:(MXCredentials*)credentials andOnUnrecognizedCertificateBlock:(nullable MXHTTPClientOnUnrecognizedCertificate)onUnrecognizedCertBlock NS_REFINED_FOR_SWIFT;
 
 #pragma mark -
 
@@ -304,12 +292,14 @@ NS_ERROR_ENUM(MXIdentityServerRestClientErrorDomain)
  Sign a 3PID URL.
  
  @param signUrl the URL that will be called for signing.
+ @param mxid the user matrix id.
  @param success A block object called when the operation succeeds. It provides the signed data.
  @param failure A block object called when the operation fails.
  
  @return a MXHTTPOperation instance.
  */
 - (MXHTTPOperation*)signUrl:(NSString*)signUrl
+                       mxid:(NSString*)mxid
                     success:(void (^)(NSDictionary *thirdPartySigned))success
                     failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 

--- a/MatrixSDK/IdentityServer/MXIdentityService.h
+++ b/MatrixSDK/IdentityServer/MXIdentityService.h
@@ -71,11 +71,12 @@ extern NSString *const MXIdentityServiceNotificationAccessTokenKey;
  Create an instance based on identity server URL.
  
  @param identityServer The identity server URL.
+ @param accessToken the identity server access token. Nil if not known yet.
  @param homeserverRestClient The homeserver REST client.
  
  @return a MXIdentityService instance.
  */
-- (instancetype)initWithIdentityServer:(NSString *)identityServer andHomeserverRestClient:(MXRestClient*)homeserverRestClient NS_REFINED_FOR_SWIFT;
+- (instancetype)initWithIdentityServer:(NSString *)identityServer accessToken:(nullable NSString*)accessToken andHomeserverRestClient:(MXRestClient*)homeserverRestClient NS_REFINED_FOR_SWIFT;
 
 /**
  Create an instance based on identity server URL.
@@ -86,16 +87,6 @@ extern NSString *const MXIdentityServiceNotificationAccessTokenKey;
  @return a MXIdentityService instance.
  */
 - (instancetype)initWithIdentityServerRestClient:(MXIdentityServerRestClient*)identityServerRestClient andHomeserverRestClient:(MXRestClient*)homeserverRestClient;
-
-/**
- Create an instance based on identity server URL.
- 
- @param credentials user's credentials.
- @param homeserverRestClient The homeserver REST client.
- 
- @return a MXIdentityService instance.
- */
-- (instancetype)initWithCredentials:(MXCredentials *)credentials andHomeserverRestClient:(MXRestClient*)homeserverRestClient;
 
 #pragma mark -
 

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -118,10 +118,11 @@ FOUNDATION_EXPORT NSString *const kMXMembersOfRoomParametersNotMembership;
 @property (nonatomic, readonly) NSString *homeserverSuffix;
 
 /**
- The identity server URL.
- Shortcut to credentials.identityServer.
+ The identity server URL (ex: "https://vector.im").
+ 
+ TODO: Remove it when all HSes will no more require IS.
  */
-@property (nonatomic) NSString *identityServer;
+@property (nonatomic, copy) NSString *identityServer;
 
 /**
  The antivirus server URL (nil by default).

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -119,6 +119,7 @@ MXAuthAction;
         contentPathPrefix = kMXContentPrefixPath;
         
         credentials = inCredentials;
+        _identityServer = credentials.identityServer;
 
         if (credentials.homeServer)
         {
@@ -989,9 +990,9 @@ MXAuthAction;
 {
 
     NSMutableDictionary *params = [NSMutableDictionary dictionaryWithDictionary:parameters];
-    if (self.credentials.identityServer)
+    if (self.identityServer)
     {
-        NSURL *identityServerURL = [NSURL URLWithString:self.credentials.identityServer];
+        NSURL *identityServerURL = [NSURL URLWithString:self.identityServer];
         params[@"id_server"] = identityServerURL.host;
     }
 
@@ -1938,7 +1939,7 @@ MXAuthAction;
                              failure:(void (^)(NSError *error))failure
 {
     // The identity server must be defined
-    if (!self.credentials.identityServer)
+    if (!self.identityServer)
     {
         NSError *error = [NSError errorWithDomain:kMXRestClientErrorDomain code:MXRestClientErrorMissingIdentityServer userInfo:nil];
         [self dispatchFailure:error inBlock:failure];
@@ -1948,7 +1949,7 @@ MXAuthAction;
     NSString *path = [NSString stringWithFormat:@"%@/rooms/%@/invite", apiPathPrefix, roomId];
 
     // This request must not have the protocol part
-    NSString *identityServer = self.credentials.identityServer;
+    NSString *identityServer = self.identityServer;
     if ([identityServer hasPrefix:@"http://"] || [identityServer hasPrefix:@"https://"])
     {
         identityServer = [identityServer substringFromIndex:[identityServer rangeOfString:@"://"].location + 3];
@@ -2826,7 +2827,7 @@ MXAuthAction;
                     success:(void (^)(void))success
                     failure:(void (^)(NSError *error))failure
 {
-    if (!self.credentials.identityServer)
+    if (!self.identityServer)
     {
         NSLog(@"[MXRestClient] add3PID: Error: Missing identityServer");
         NSError *error = [NSError errorWithDomain:kMXRestClientErrorDomain code:MXRestClientErrorMissingIdentityServer userInfo:nil];
@@ -3327,25 +3328,6 @@ MXAuthAction;
                                      MXStrongifyAndReturnIfNil(self);
                                      [self dispatchFailure:error inBlock:failure];
                                  }];
-}
-
-#pragma mark - Identity server
-
-- (void)setIdentityServer:(NSString *)identityServer
-{
-    if (identityServer.length)
-    {
-        self.credentials.identityServer = [identityServer copy];
-    }
-    else
-    {
-        self.credentials.identityServer = nil;
-    }
-}
-
-- (NSString *)identityServer
-{
-    return self.credentials.identityServer;
 }
 
 #pragma mark - Antivirus server API

--- a/MatrixSDK/MXSession.h
+++ b/MatrixSDK/MXSession.h
@@ -361,7 +361,7 @@ FOUNDATION_EXPORT NSString *const kMXSessionNoRoomTag;
 /**
  The identity service used to handle Matrix identity server requests. Can be nil.
  */
-@property (nonatomic) MXIdentityService *identityService;
+@property (nonatomic, readonly) MXIdentityService *identityService;
 
 /**
  The media manager used to handle the media stored on the Matrix Content repository.
@@ -629,6 +629,16 @@ typedef void (^MXOnBackgroundSyncFail)(NSError *error);
  */
 - (void)setStore:(id<MXStore>)store success:(void (^)(void))onStoreDataReady
          failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
+
+/**
+ Set a new identity server.
+
+ The method updates underlaying services.
+
+ @param identityServer the new identityServer. Nil for no IS
+ @param accessToken the access token of the IS. Can be nil.
+ */
+- (void)setIdentityServer:(NSString*)identityServer andAccessToken:(NSString*)accessToken;
 
 /**
  An array of event types for which read receipts are sent.

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -200,11 +200,8 @@ typedef void (^MXOnResumeDone)(void);
         _preventPauseCount = 0;
         directRoomsOperationsQueue = [NSMutableArray array];
         publicisedGroupsByUserId = [[NSMutableDictionary alloc] init];
-        
-        if (mxRestClient.credentials.identityServer)
-        {
-            _identityService = [[MXIdentityService alloc] initWithCredentials:mxRestClient.credentials andHomeserverRestClient:mxRestClient];
-        }
+
+        [self setIdentityServer:mxRestClient.identityServer andAccessToken:mxRestClient.credentials.identityServerAccessToken];
         
         firstSyncDone = NO;
 
@@ -389,6 +386,20 @@ typedef void (^MXOnResumeDone)(void);
             failure(error);
         }
     }];
+}
+
+- (void)setIdentityServer:(NSString *)identityServer andAccessToken:(NSString *)accessToken
+{
+    matrixRestClient.identityServer = identityServer;
+
+    if (identityServer)
+    {
+        _identityService = [[MXIdentityService alloc] initWithIdentityServer:identityServer accessToken:accessToken andHomeserverRestClient:matrixRestClient];
+    }
+    else
+    {
+        _identityService = nil;
+    }
 }
 
 - (void)start:(void (^)(void))onServerSyncDone

--- a/MatrixSDK/VoIP/CallStack/MXCallStackCall.h
+++ b/MatrixSDK/VoIP/CallStack/MXCallStackCall.h
@@ -62,7 +62,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param username the username of the Matrix user on these TURN servers.
  @param password the associated password.
  */
-- (void)addTURNServerUris:(NSArray<NSString *> *)uris withUsername:(nullable NSString *)username password:(nullable NSString *)password;
+- (void)addTURNServerUris:(nullable NSArray<NSString *> *)uris withUsername:(nullable NSString *)username password:(nullable NSString *)password;
 
 /**
  Make the call stack process an incoming candidate.


### PR DESCRIPTION
MXIdentityService: Remove its dependency to MXCredentials
MXRestClient: Make it a bit less dependent on MXCredentials. Ideally, we should remove it

The contract is that services start on data initially passed in MXCredentials. Then, we can update their configs independently form MXCredentials. We just notify the MXCredentials original owner that configs as changed like identityServerAccessToken, and, very soon  identityServer.