### PR TITLE
Privacy: Lowercase emails during IS lookup calls

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Improvements:
  * MXHTTPClient: Do not retry requests if the host is not valid.
  * MXAutoDiscovery: Add initWithUrl contructor.
  * Privacy: Store Identity Server in Account Data ([MSC2230](https://github.com/matrix-org/matrix-doc/pull/2230))(vector-im/riot-ios#2665).
+ * Privacy: Lowercase emails during IS lookup calls (vector-im/riot-ios#2696).
 
 API break:
  * MXRestClient: Remove identity server requests. Now MXIdentityService is used to perform identity server requests.

--- a/MatrixSDK/IdentityServer/MXIdentityServerRestClient.m
+++ b/MatrixSDK/IdentityServer/MXIdentityServerRestClient.m
@@ -165,6 +165,12 @@ NSString *const MXIdentityServerRestClientErrorDomain = @"org.matrix.sdk.MXIdent
         failure(error);
         return nil;
     }
+
+    if ([medium isEqualToString:kMX3PIDMediumEmail])
+    {
+        // Email should be lower case
+        address = address.lowercaseString;
+    }
     
     return [self.httpClient requestWithMethod:@"GET"
                                          path:path
@@ -199,11 +205,37 @@ NSString *const MXIdentityServerRestClientErrorDomain = @"org.matrix.sdk.MXIdent
         failure(error);
         return nil;
     }
+
+    // Emails should be lower case
+    NSMutableArray<NSArray<NSString*>*> *lowercaseThreepids = [NSMutableArray new];
+    for (NSArray<NSString*> *threepidArray in threepids)
+    {
+        if (threepidArray.count < 2)
+        {
+            continue;
+        }
+
+        NSString *medium = threepidArray[0];
+        NSString *address = threepidArray[1];
+
+        if ([medium isEqualToString:kMX3PIDMediumEmail])
+        {
+            [lowercaseThreepids addObject:@[
+                                            medium,
+                                            address.lowercaseString
+                                            ]];
+        }
+        else
+        {
+            [lowercaseThreepids addObject:threepidArray];
+        }
+    }
+
     
     NSData *payloadData = nil;
     if (threepids)
     {
-        payloadData = [NSJSONSerialization dataWithJSONObject:@{@"threepids": threepids} options:0 error:nil];
+        payloadData = [NSJSONSerialization dataWithJSONObject:@{@"threepids": lowercaseThreepids} options:0 error:nil];
     }
     
     return [self.httpClient requestWithMethod:@"POST"
@@ -299,6 +331,12 @@ NSString *const MXIdentityServerRestClientErrorDomain = @"org.matrix.sdk.MXIdent
             
             NSString *medium = threepidArray[0];
             NSString *threepid = threepidArray[1];
+
+            if ([medium isEqualToString:kMX3PIDMediumEmail])
+            {
+                // Email should be lower case
+                threepid = threepid.lowercaseString;
+            }
             
             NSString *hashedTreePid;
             


### PR DESCRIPTION
closes vector-im/riot-ios#2696