### PR TITLE
Privacy: MXRestClient: Use `id_access_token` in CS API when required

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ Improvements:
  * MXAutoDiscovery: Add initWithUrl contructor.
  * Privacy: Store Identity Server in Account Data ([MSC2230](https://github.com/matrix-org/matrix-doc/pull/2230))(vector-im/riot-ios#2665).
  * Privacy: Lowercase emails during IS lookup calls (vector-im/riot-ios#2696).
+ * Privacy: MXRestClient: Use `id_access_token` in CS API when required (vector-im/riot-ios#2704).
+ 
 
 API break:
  * MXRestClient: Remove identity server requests. Now MXIdentityService is used to perform identity server requests.

--- a/MatrixSDK/Contrib/Swift/MXIdentityService.swift
+++ b/MatrixSDK/Contrib/Swift/MXIdentityService.swift
@@ -33,6 +33,26 @@ public extension MXIdentityService {
     @nonobjc convenience init(identityServer: URL, accessToken: String?, homeserverRestClient: MXRestClient) {
         self.init(__identityServer: identityServer.absoluteString, accessToken: accessToken, andHomeserverRestClient: homeserverRestClient)
     }
+
+
+    // MARK: - Access token
+
+    /**
+     Get the access token to use on the identity server.
+
+     The method triggers an /account request in order to force the setup of the
+     access token, which can lead to a "M_TERMS_NOT_SIGNED" error.
+
+     - parameters:
+     - completion: A block object called when the operation completes.
+     - response: Provides the access token
+
+     - returns: a `MXHTTPOperation` instance.
+     */
+    @nonobjc @discardableResult func accessToken(completion: @escaping (_ response: MXResponse<String>) -> Void) -> MXHTTPOperation? {
+        return __accessToken(success: currySuccess(completion), failure: curryFailure(completion))
+    }
+
     
     // MARK: -
     

--- a/MatrixSDK/IdentityServer/MXIdentityService.h
+++ b/MatrixSDK/IdentityServer/MXIdentityService.h
@@ -88,6 +88,24 @@ extern NSString *const MXIdentityServiceNotificationAccessTokenKey;
  */
 - (instancetype)initWithIdentityServerRestClient:(MXIdentityServerRestClient*)identityServerRestClient andHomeserverRestClient:(MXRestClient*)homeserverRestClient;
 
+
+#pragma mark - Access token
+
+/**
+ Get the access token to use on the identity server.
+
+ The method triggers an /account request in order to force the setup of the
+ access token, which can lead to a "M_TERMS_NOT_SIGNED" error.
+
+ @param success A block object called when the operation succeeds.
+ @param failure A block object called when the operation fails.
+
+ @return a MXHTTPOperation instance. Nil if the access token is already known
+         and no HTTP request is required.
+ */
+- (nullable MXHTTPOperation *)accessTokenWithSuccess:(void (^)(NSString * _Nullable accessToken))success
+                                             failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
+
 #pragma mark -
 
 #pragma mark Association lookup

--- a/MatrixSDK/IdentityServer/MXIdentityService.m
+++ b/MatrixSDK/IdentityServer/MXIdentityService.m
@@ -74,11 +74,14 @@ NSString *const MXIdentityServiceNotificationAccessTokenKey = @"accessToken";
 
 - (instancetype)initWithIdentityServer:(NSString *)identityServer accessToken:(nullable NSString*)accessToken andHomeserverRestClient:(MXRestClient*)homeserverRestClient
 {
-    _accessToken = accessToken;
-    
     MXIdentityServerRestClient *identityServerRestClient = [[MXIdentityServerRestClient alloc] initWithIdentityServer:identityServer accessToken:accessToken andOnUnrecognizedCertificateBlock:nil];
 
-    return [self initWithIdentityServerRestClient:identityServerRestClient andHomeserverRestClient:homeserverRestClient];
+    self = [self initWithIdentityServerRestClient:identityServerRestClient andHomeserverRestClient:homeserverRestClient];
+    if (self)
+    {
+        _accessToken = accessToken;
+    }
+    return self;
 }
 
 - (instancetype)initWithIdentityServerRestClient:(MXIdentityServerRestClient*)identityServerRestClient andHomeserverRestClient:(MXRestClient*)homeserverRestClient

--- a/MatrixSDK/IdentityServer/MXIdentityService.m
+++ b/MatrixSDK/IdentityServer/MXIdentityService.m
@@ -120,6 +120,22 @@ NSString *const MXIdentityServiceNotificationAccessTokenKey = @"accessToken";
 
 #pragma mark - Public
 
+#pragma mark Access token
+- (nullable MXHTTPOperation *)accessTokenWithSuccess:(void (^)(NSString * _Nullable accessToken))success
+                                             failure:(void (^)(NSError *error))failure
+{
+    if (self.accessToken)
+    {
+        success(self.accessToken);
+        return nil;
+    }
+
+    return [self accountWithSuccess:^(NSString * _Nonnull userId) {
+        // If we get here, we have an access token
+        success(self.accessToken);
+    } failure:failure];
+}
+
 #pragma mark Association lookup
 
 - (MXHTTPOperation*)lookup3pid:(NSString*)address

--- a/MatrixSDK/IdentityServer/MXIdentityService.m
+++ b/MatrixSDK/IdentityServer/MXIdentityService.m
@@ -74,6 +74,8 @@ NSString *const MXIdentityServiceNotificationAccessTokenKey = @"accessToken";
 
 - (instancetype)initWithIdentityServer:(NSString *)identityServer accessToken:(nullable NSString*)accessToken andHomeserverRestClient:(MXRestClient*)homeserverRestClient
 {
+    _accessToken = accessToken;
+    
     MXIdentityServerRestClient *identityServerRestClient = [[MXIdentityServerRestClient alloc] initWithIdentityServer:identityServer accessToken:accessToken andOnUnrecognizedCertificateBlock:nil];
 
     return [self initWithIdentityServerRestClient:identityServerRestClient andHomeserverRestClient:homeserverRestClient];
@@ -106,11 +108,13 @@ NSString *const MXIdentityServiceNotificationAccessTokenKey = @"accessToken";
             MXStrongifyAndReturnValueIfNil(self, nil);
             
             return [self renewAccessTokenWithSuccess:^(NSString *accessToken) {
+                self.accessToken = accessToken;
                 success(accessToken);
             } failure:failure];
         };
         
         self.restClient = identityServerRestClient;
+        _accessToken = identityServerRestClient.accessToken;
         self.homeserverRestClient = homeserverRestClient;
         
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleHTTPClientError:) name:kMXHTTPClientMatrixErrorNotification object:nil];

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -95,6 +95,18 @@ FOUNDATION_EXPORT NSString *const kMXMembersOfRoomParametersAt;
 FOUNDATION_EXPORT NSString *const kMXMembersOfRoomParametersMembership;
 FOUNDATION_EXPORT NSString *const kMXMembersOfRoomParametersNotMembership;
 
+
+/**
+ Block called when a request needs the identity server access token.
+
+ @param success A block object called when the operation succeeds. It provides the access token.
+ @param failure A block object called when the operation fails.
+
+ @return a MXHTTPOperation instance.
+ */
+typedef MXHTTPOperation* (^MXRestClientIdentityServerAccessTokenHandler)(void (^success)(NSString *accessToken), void (^failure)(NSError *error));
+
+
 /**
  `MXRestClient` makes requests to Matrix servers.
 
@@ -127,7 +139,11 @@ FOUNDATION_EXPORT NSString *const kMXMembersOfRoomParametersNotMembership;
  TODO: Remove it when all HSes will no more require IS.
  */
 @property (nonatomic, copy) NSString *identityServer;
-@property (nonatomic, copy) NSString *identityServerAccessToken;
+
+/**
+ Block called when a request needs the identity server access token.
+ */
+@property (nonatomic, copy) MXRestClientIdentityServerAccessTokenHandler identityServerAccessTokenHandler;
 
 /**
  The antivirus server URL (nil by default).

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -84,7 +84,8 @@ NS_ERROR_ENUM(kMXRestClientErrorDomain)
     MXRestClientErrorUnknown,
     MXRestClientErrorInvalidParameters,
     MXRestClientErrorInvalidContentURI,
-    MXRestClientErrorMissingIdentityServer
+    MXRestClientErrorMissingIdentityServer,
+    MXRestClientErrorMissingIdentityServerAccessToken
 };
 
 /**
@@ -126,6 +127,7 @@ FOUNDATION_EXPORT NSString *const kMXMembersOfRoomParametersNotMembership;
  TODO: Remove it when all HSes will no more require IS.
  */
 @property (nonatomic, copy) NSString *identityServer;
+@property (nonatomic, copy) NSString *identityServerAccessToken;
 
 /**
  The antivirus server URL (nil by default).

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -1044,7 +1044,7 @@ MXAuthAction;
     operation = [self supportedMatrixVersions:^(MXMatrixVersions *matrixVersions) {
 
         MXHTTPOperation *operation2;
-        if (matrixVersions.doesServerAcceptIdentityAccessToken || 1)
+        if (matrixVersions.doesServerAcceptIdentityAccessToken)
         {
             MXIdentityService *identityService = [[MXIdentityService alloc] initWithIdentityServer:self.identityServer accessToken:self.identityServerAccessToken andHomeserverRestClient:self];
 

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -1047,7 +1047,9 @@ MXAuthAction;
         {
             if (self.identityServerAccessTokenHandler)
             {
+                MXWeakify(self);
                 self.identityServerAccessTokenHandler(^(NSString *accessToken) {
+                    MXStrongifyAndReturnIfNil(self);
 
                     if (accessToken)
                     {

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -394,7 +394,6 @@ typedef void (^MXOnResumeDone)(void);
     NSLog(@"[MXSession] setIdentityServer: %@", identityServer);
     
     matrixRestClient.identityServer = identityServer;
-    matrixRestClient.identityServerAccessToken = accessToken;
 
     if (identityServer)
     {
@@ -404,6 +403,12 @@ typedef void (^MXOnResumeDone)(void);
     {
         _identityService = nil;
     }
+
+    MXWeakify(self);
+    matrixRestClient.identityServerAccessTokenHandler = ^MXHTTPOperation *(void (^success)(NSString *accessToken), void (^failure)(NSError *error)) {
+        MXStrongifyAndReturnValueIfNil(self, nil);
+        return [self.identityService accessTokenWithSuccess:success failure:failure];
+    };
 }
 
 - (void)start:(void (^)(void))onServerSyncDone

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -394,6 +394,7 @@ typedef void (^MXOnResumeDone)(void);
     NSLog(@"[MXSession] setIdentityServer: %@", identityServer);
     
     matrixRestClient.identityServer = identityServer;
+    matrixRestClient.identityServerAccessToken = accessToken;
 
     if (identityServer)
     {


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-ios/issues/2704

