### PR TITLE
BF: Send kMXSessionCryptoDidCorruptDataNotification from the main thread

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ Improvements:
  * MXRestClient: Remove Identity Server URL fallback to homeserver one's when there is no Identity Server configured.
  * MXHTTPClient: Improve M_LIMIT_EXCEEDED error handling: Do not wait to try again if the mentioned delay is too long.
  * MXEventTimeline: The roomEventFilter property is now writable (vector-im/riot-ios#2615).
+ 
+Bug Fix:
+ * Send kMXSessionCryptoDidCorruptDataNotification from the main thread.
 
 Changes in Matrix iOS SDK in 0.13.1 (2019-08-08)
 ===============================================

--- a/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
+++ b/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
@@ -1306,9 +1306,11 @@ RLM_ARRAY_TYPE(MXRealmOlmInboundGroupSession)
 
         // Report this db reset to higher modules
         // A user logout and in is anyway required to make crypto work reliably again
-        [[NSNotificationCenter defaultCenter] postNotificationName:kMXSessionCryptoDidCorruptDataNotification
-                                                            object:userId
-                                                          userInfo:nil];
+        dispatch_async(dispatch_get_main_queue(),^{
+            [[NSNotificationCenter defaultCenter] postNotificationName:kMXSessionCryptoDidCorruptDataNotification
+                                                                object:userId
+                                                              userInfo:nil];
+        });
     }
 
     if (cleanDuplicatedDevices)


### PR DESCRIPTION
This notification triggers a modal in the app but not called from the main thread. iOS13 does not like that and Riot crashes in loop.
