### PR TITLE
Crypto: MXOlmSessionResult: Implement description

### DIFF
--- a/MatrixSDK/Crypto/Data/MXOlmSessionResult.m
+++ b/MatrixSDK/Crypto/Data/MXOlmSessionResult.m
@@ -30,4 +30,9 @@
     return self;
 }
 
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<MXOlmSessionResult> %@: %@", _device.deviceId, _sessionId];
+}
+
 @end


### PR DESCRIPTION
Closes https://github.com/vector-im/riot-ios/issues/2733.

Logs now look like:
```
2019-09-24 11:47:28.191237+0200 xctest[87704:1312132] [MXMegolmEncryption] shareKey: ensureOlmSessionsForDevices result (users: 1 - devices: 1): {
    "@mxbob-dffb007d-daa4-4dc4-b918-8122d740742b:localhost:8480" =     {
        NAUURJAVCD = "<MXOlmSessionResult> NAUURJAVCD: kV3ssl2JYw4JtmMFQ7Op/S8spGXB3JFURHv3PFF+TFI";
    };
}
```
