### PR TITLE
Updates for privacy

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Improvements:
  * MXEventTimeline: The roomEventFilter property is now writable (vector-im/riot-ios#2615).
  * VoIP: Make call start if there is no STUN server.
  * MXMatrixVersions: Add doesServerRequireIdentityServerParam and doesServerAcceptIdentityAccessToken properties.
+ * MXMatrixVersions: Support r0.6.0. Add doesServerSupportSeparateAddAndBind (vector-im/riot-ios#2718).
  * Create MXIdentityServerRestClient and MXIdentityService to manage identity server requests (vector-im/riot-ios#2647).
  * MXIdentityService: Support identity server v2 API. Handle identity server v2 API authentification and use the hashed v2 lookup API for 3PIDs (vector-im/riot-ios#2603 and /vector-im/riot-ios#2652).
  * MXHTTPClient: Add access token renewal plus request retry mechanism.

--- a/MatrixSDK/JSONModels/MXMatrixVersions.h
+++ b/MatrixSDK/JSONModels/MXMatrixVersions.h
@@ -28,6 +28,7 @@ struct MXMatrixClientServerAPIVersionStruct
     __unsafe_unretained NSString * const r0_3_0;
     __unsafe_unretained NSString * const r0_4_0;
     __unsafe_unretained NSString * const r0_5_0;
+    __unsafe_unretained NSString * const r0_6_0;
 };
 extern const struct MXMatrixClientServerAPIVersionStruct MXMatrixClientServerAPIVersion;
 
@@ -40,6 +41,7 @@ struct MXMatrixVersionsFeatureStruct
     __unsafe_unretained NSString * const lazyLoadMembers;
     __unsafe_unretained NSString * const requireIdentityServer;
     __unsafe_unretained NSString * const idAccessToken;
+    __unsafe_unretained NSString * const separateAddAndBind;
 };
 extern const struct MXMatrixVersionsFeatureStruct MXMatrixVersionsFeature;
 
@@ -77,5 +79,12 @@ extern const struct MXMatrixVersionsFeatureStruct MXMatrixVersionsFeature;
  Some homeservers may trigger errors if they are not prepared for the new parameter.
  */
 @property (nonatomic, readonly) BOOL doesServerAcceptIdentityAccessToken;
+
+/**
+ Indicate if the server to see if it supports separate 3PID add and bind functions.
+ This affects the sequence of API calls clients should use for these operations,
+ so it's helpful to be able to check for support.
+ */
+@property (nonatomic, readonly) BOOL doesServerSupportSeparateAddAndBind;
 
 @end

--- a/MatrixSDK/JSONModels/MXMatrixVersions.h
+++ b/MatrixSDK/JSONModels/MXMatrixVersions.h
@@ -81,7 +81,7 @@ extern const struct MXMatrixVersionsFeatureStruct MXMatrixVersionsFeature;
 @property (nonatomic, readonly) BOOL doesServerAcceptIdentityAccessToken;
 
 /**
- Indicate if the server to see if it supports separate 3PID add and bind functions.
+ Indicate if the server supports separate 3PID add and bind functions.
  This affects the sequence of API calls clients should use for these operations,
  so it's helpful to be able to check for support.
  */

--- a/MatrixSDK/JSONModels/MXMatrixVersions.m
+++ b/MatrixSDK/JSONModels/MXMatrixVersions.m
@@ -23,12 +23,14 @@ const struct MXMatrixClientServerAPIVersionStruct MXMatrixClientServerAPIVersion
     .r0_3_0 = @"r0.3.0",
     .r0_4_0 = @"r0.4.0",
     .r0_5_0 = @"r0.5.0",
+    .r0_6_0 = @"r0.6.0",
 };
 
 const struct MXMatrixVersionsFeatureStruct MXMatrixVersionsFeature = {
     .lazyLoadMembers = @"m.lazy_load_members",
     .requireIdentityServer = @"m.require_identity_server",
-    .idAccessToken = @"m.id_access_token"
+    .idAccessToken = @"m.id_access_token",
+    .separateAddAndBind = @"m.separate_add_and_bind"
 };
 
 @implementation MXMatrixVersions
@@ -55,7 +57,11 @@ const struct MXMatrixVersionsFeatureStruct MXMatrixVersionsFeature = {
     // YES by default
     BOOL doesServerRequireIdentityServerParam = YES;
 
-    if (self.unstableFeatures[MXMatrixVersionsFeature.requireIdentityServer])
+    if ([self.versions containsObject:MXMatrixClientServerAPIVersion.r0_6_0])
+    {
+        doesServerRequireIdentityServerParam = NO;
+    }
+    else if (self.unstableFeatures[MXMatrixVersionsFeature.requireIdentityServer])
     {
         doesServerRequireIdentityServerParam = [self.unstableFeatures[MXMatrixVersionsFeature.requireIdentityServer] boolValue];
     }
@@ -65,7 +71,14 @@ const struct MXMatrixVersionsFeatureStruct MXMatrixVersionsFeature = {
 
 - (BOOL)doesServerAcceptIdentityAccessToken
 {
-    return [self.unstableFeatures[MXMatrixVersionsFeature.idAccessToken] boolValue];
+    return  [self.versions containsObject:MXMatrixClientServerAPIVersion.r0_6_0]
+        || [self.unstableFeatures[MXMatrixVersionsFeature.idAccessToken] boolValue];
+}
+
+- (BOOL)doesServerSupportSeparateAddAndBind
+{
+    return  [self.versions containsObject:MXMatrixClientServerAPIVersion.r0_6_0]
+        || [self.unstableFeatures[MXMatrixVersionsFeature.separateAddAndBind] boolValue];
 }
 
 @end


### PR DESCRIPTION
Several fixes in one PR

-  Fixes vector-im/riot-ios#2718 (MXMatrixVersions: Support r0.6.0. Add doesServerSupportSeparateAddAndBind)

New r0.6.0 matches the current unstable flags of the HS:
```
{
	"versions": ["r0.0.1", "r0.1.0", "r0.2.0", "r0.3.0", "r0.4.0", "r0.5.0"],
	"unstable_features": {
		"m.lazy_load_members": true,
		"m.id_access_token": true,
		"m.require_identity_server": false,
		"m.separate_add_and_bind": true
	}
}
```

- Fixes vector-im/riot-ios#2732 (Privacy: Do not include ID server or access token in /requestToken requests when HS supports MSC2290)

