### PR TITLE
[WIP] MX3PidAddManager: New class to handle add 3pids to HS and to bind to IS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,10 +14,11 @@ Improvements:
  * MXHTTPClient: Add access token renewal plus request retry mechanism.
  * MXHTTPClient: Do not retry requests if the host is not valid.
  * MXAutoDiscovery: Add initWithUrl contructor.
+ * MX3PidAddManager: New class to handle add 3pids to HS and to bind to IS.
  * Privacy: Store Identity Server in Account Data ([MSC2230](https://github.com/matrix-org/matrix-doc/pull/2230))(vector-im/riot-ios#2665).
  * Privacy: Lowercase emails during IS lookup calls (vector-im/riot-ios#2696).
  * Privacy: MXRestClient: Use `id_access_token` in CS API when required (vector-im/riot-ios#2704).
- 
+
 
 API break:
  * MXRestClient: Remove identity server requests. Now MXIdentityService is used to perform identity server requests.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes in Matrix iOS SDK in 0.13.2 (2019-08-)
 Improvements:
  * MXServiceTerms: A class to support MSC2140 (Terms of Service API) (vector-im/riot-ios#2600).
  * MXRestClient: Remove identity server URL fallback to homeserver one's when there is no identity server configured.
+ * MXRestClient: Add new APIs from MSC2290 (matrix-org/matrix-doc/pull/2290).
  * MXHTTPClient: Improve M_LIMIT_EXCEEDED error handling: Do not wait to try again if the mentioned delay is too long.
  * MXEventTimeline: The roomEventFilter property is now writable (vector-im/riot-ios#2615).
  * VoIP: Make call start if there is no STUN server.

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -323,6 +323,7 @@
 		32D2CC0423422462002BD8CA /* MX3PidAddManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D2CC0023422462002BD8CA /* MX3PidAddManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		32D2CC0523422462002BD8CA /* MX3PidAddSession.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D2CC0123422462002BD8CA /* MX3PidAddSession.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		32D2CC0623422462002BD8CA /* MX3PidAddManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D2CC0223422462002BD8CA /* MX3PidAddManager.m */; };
+		32D2CC09234336D6002BD8CA /* MX3PidAddManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D2CC08234336D6002BD8CA /* MX3PidAddManager.swift */; };
 		32D7767D1A27860600FC4AA2 /* MXMemoryStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D7767B1A27860600FC4AA2 /* MXMemoryStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		32D7767E1A27860600FC4AA2 /* MXMemoryStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D7767C1A27860600FC4AA2 /* MXMemoryStore.m */; };
 		32D776811A27877300FC4AA2 /* MXMemoryRoomStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D7767F1A27877300FC4AA2 /* MXMemoryRoomStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -821,6 +822,7 @@
 		32D2CC0023422462002BD8CA /* MX3PidAddManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MX3PidAddManager.h; sourceTree = "<group>"; };
 		32D2CC0123422462002BD8CA /* MX3PidAddSession.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MX3PidAddSession.h; sourceTree = "<group>"; };
 		32D2CC0223422462002BD8CA /* MX3PidAddManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MX3PidAddManager.m; sourceTree = "<group>"; };
+		32D2CC08234336D6002BD8CA /* MX3PidAddManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MX3PidAddManager.swift; sourceTree = "<group>"; };
 		32D7767B1A27860600FC4AA2 /* MXMemoryStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXMemoryStore.h; sourceTree = "<group>"; };
 		32D7767C1A27860600FC4AA2 /* MXMemoryStore.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXMemoryStore.m; sourceTree = "<group>"; };
 		32D7767F1A27877300FC4AA2 /* MXMemoryRoomStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXMemoryRoomStore.h; sourceTree = "<group>"; };
@@ -1781,6 +1783,14 @@
 			path = ThreePidAdd;
 			sourceTree = "<group>";
 		};
+		32D2CC0723433684002BD8CA /* ThreePidAdd */ = {
+			isa = PBXGroup;
+			children = (
+				32D2CC08234336D6002BD8CA /* MX3PidAddManager.swift */,
+			);
+			path = ThreePidAdd;
+			sourceTree = "<group>";
+		};
 		32D7767A1A2785CE00FC4AA2 /* MXMemoryStore */ = {
 			isa = PBXGroup;
 			children = (
@@ -1992,6 +2002,7 @@
 		C6F9357A1E5B391B00FC34BF /* Swift */ = {
 			isa = PBXGroup;
 			children = (
+				32D2CC0723433684002BD8CA /* ThreePidAdd */,
 				C6F935821E5B3BE600FC34BF /* Data */,
 				C6F935851E5B3BE600FC34BF /* JSONModels */,
 				C6F9357E1E5B3ACA00FC34BF /* MXResponse.swift */,
@@ -2469,6 +2480,7 @@
 				327E9ABD2284521C00A98BC1 /* MXEventUnsignedData.m in Sources */,
 				32A1513A1DAD292400400192 /* MXMegolmEncryption.m in Sources */,
 				32F945F71FAB83D900622468 /* MXIncomingRoomKeyRequest.m in Sources */,
+				32D2CC09234336D6002BD8CA /* MX3PidAddManager.swift in Sources */,
 				F0173EAD1FCF0E8900B5F6A3 /* MXGroup.m in Sources */,
 				32720D9F222EAA6F0086FFF5 /* MXAutoDiscovery.m in Sources */,
 				32D2CC0623422462002BD8CA /* MX3PidAddManager.m in Sources */,

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -319,6 +319,10 @@
 		32CAB10C1A925B41008C5BB9 /* MXHTTPOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 32CAB10A1A925B41008C5BB9 /* MXHTTPOperation.m */; };
 		32CE6FB81A409B1F00317F1E /* MXFileStoreMetaData.h in Headers */ = {isa = PBXBuildFile; fileRef = 32CE6FB61A409B1F00317F1E /* MXFileStoreMetaData.h */; };
 		32CE6FB91A409B1F00317F1E /* MXFileStoreMetaData.m in Sources */ = {isa = PBXBuildFile; fileRef = 32CE6FB71A409B1F00317F1E /* MXFileStoreMetaData.m */; };
+		32D2CC0323422462002BD8CA /* MX3PidAddSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D2CBFF23422462002BD8CA /* MX3PidAddSession.m */; };
+		32D2CC0423422462002BD8CA /* MX3PidAddManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D2CC0023422462002BD8CA /* MX3PidAddManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		32D2CC0523422462002BD8CA /* MX3PidAddSession.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D2CC0123422462002BD8CA /* MX3PidAddSession.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		32D2CC0623422462002BD8CA /* MX3PidAddManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D2CC0223422462002BD8CA /* MX3PidAddManager.m */; };
 		32D7767D1A27860600FC4AA2 /* MXMemoryStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D7767B1A27860600FC4AA2 /* MXMemoryStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		32D7767E1A27860600FC4AA2 /* MXMemoryStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D7767C1A27860600FC4AA2 /* MXMemoryStore.m */; };
 		32D776811A27877300FC4AA2 /* MXMemoryRoomStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D7767F1A27877300FC4AA2 /* MXMemoryRoomStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -813,6 +817,10 @@
 		32CAB10A1A925B41008C5BB9 /* MXHTTPOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXHTTPOperation.m; sourceTree = "<group>"; };
 		32CE6FB61A409B1F00317F1E /* MXFileStoreMetaData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXFileStoreMetaData.h; sourceTree = "<group>"; };
 		32CE6FB71A409B1F00317F1E /* MXFileStoreMetaData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXFileStoreMetaData.m; sourceTree = "<group>"; };
+		32D2CBFF23422462002BD8CA /* MX3PidAddSession.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MX3PidAddSession.m; sourceTree = "<group>"; };
+		32D2CC0023422462002BD8CA /* MX3PidAddManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MX3PidAddManager.h; sourceTree = "<group>"; };
+		32D2CC0123422462002BD8CA /* MX3PidAddSession.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MX3PidAddSession.h; sourceTree = "<group>"; };
+		32D2CC0223422462002BD8CA /* MX3PidAddManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MX3PidAddManager.m; sourceTree = "<group>"; };
 		32D7767B1A27860600FC4AA2 /* MXMemoryStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXMemoryStore.h; sourceTree = "<group>"; };
 		32D7767C1A27860600FC4AA2 /* MXMemoryStore.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXMemoryStore.m; sourceTree = "<group>"; };
 		32D7767F1A27877300FC4AA2 /* MXMemoryRoomStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXMemoryRoomStore.h; sourceTree = "<group>"; };
@@ -1665,6 +1673,7 @@
 				3281E8B219E42DFE00976E1A /* JSONModels */,
 				32DC15CA1A8CF7AE006F9AD3 /* NotificationCenter */,
 				3294FD9822F321B0007F1E60 /* ServiceTerms */,
+				32D2CBFE23422462002BD8CA /* ThreePidAdd */,
 				320DFDD619DD99B60068622A /* Utils */,
 				3245A74B1AF7B2930001D8A7 /* VoIP */,
 				32A151581DB5254D00400192 /* Lib */,
@@ -1759,6 +1768,17 @@
 				32C6F93B19DD814400EA4E9C /* Info.plist */,
 			);
 			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		32D2CBFE23422462002BD8CA /* ThreePidAdd */ = {
+			isa = PBXGroup;
+			children = (
+				32D2CC0023422462002BD8CA /* MX3PidAddManager.h */,
+				32D2CC0223422462002BD8CA /* MX3PidAddManager.m */,
+				32D2CC0123422462002BD8CA /* MX3PidAddSession.h */,
+				32D2CBFF23422462002BD8CA /* MX3PidAddSession.m */,
+			);
+			path = ThreePidAdd;
 			sourceTree = "<group>";
 		};
 		32D7767A1A2785CE00FC4AA2 /* MXMemoryStore */ = {
@@ -2111,6 +2131,7 @@
 				32F9FA7D1DBA0CF0009D98A6 /* MXDecryptionResult.h in Headers */,
 				3245A7501AF7B2930001D8A7 /* MXCall.h in Headers */,
 				02CAD43B217DD12F0074700B /* MXContentScanEncryptedBody.h in Headers */,
+				32D2CC0423422462002BD8CA /* MX3PidAddManager.h in Headers */,
 				3271877D1DA7CB2F0071C818 /* MXDecrypting.h in Headers */,
 				32114A851A262CE000FF2EC4 /* MXStore.h in Headers */,
 				32BA86AF2152A79E008F277E /* MXRoomNameDefaultStringLocalizations.h in Headers */,
@@ -2227,6 +2248,7 @@
 				3275FD9C21A6B60B00B9C13D /* MXLoginPolicy.h in Headers */,
 				3250E7CA220C913900736CB5 /* MXCryptoTools.h in Headers */,
 				F0173EAC1FCF0E8900B5F6A3 /* MXGroup.h in Headers */,
+				32D2CC0523422462002BD8CA /* MX3PidAddSession.h in Headers */,
 				329FB17F1A0B665800A5E88E /* MXUser.h in Headers */,
 				320DFDE219DD99B60068622A /* MXError.h in Headers */,
 				B11BD45922CB58850064D8B0 /* MXReplyEventFormattedBodyParts.h in Headers */,
@@ -2449,6 +2471,7 @@
 				32F945F71FAB83D900622468 /* MXIncomingRoomKeyRequest.m in Sources */,
 				F0173EAD1FCF0E8900B5F6A3 /* MXGroup.m in Sources */,
 				32720D9F222EAA6F0086FFF5 /* MXAutoDiscovery.m in Sources */,
+				32D2CC0623422462002BD8CA /* MX3PidAddManager.m in Sources */,
 				92634B831EF2E3C400DB9F60 /* MXCallKitConfiguration.m in Sources */,
 				3265CB391A14C43E00E24B2F /* MXRoomState.m in Sources */,
 				3281E8B819E42DFE00976E1A /* MXJSONModel.m in Sources */,
@@ -2488,6 +2511,7 @@
 				3250E7CB220C913900736CB5 /* MXCryptoTools.m in Sources */,
 				3252DCBE224D144C0032264F /* MXKeyVerificationAccept.m in Sources */,
 				322691331E5EF77D00966A6E /* MXDeviceListOperation.m in Sources */,
+				32D2CC0323422462002BD8CA /* MX3PidAddSession.m in Sources */,
 				3283F7791EAF30F700C1688C /* MXBugReportRestClient.m in Sources */,
 				B1798304211B3649001FD722 /* MXRoomSummary.swift in Sources */,
 				9274AFE91EE580240009BEB6 /* MXCallKitAdapter.m in Sources */,

--- a/MatrixSDK/Contrib/Swift/MXRestClient.swift
+++ b/MatrixSDK/Contrib/Swift/MXRestClient.swift
@@ -1352,6 +1352,9 @@ public extension MXRestClient {
     
     /**
      Link an authenticated 3rd party id to the Matrix user.
+
+     This API is deprecated, and you should instead use `addThirdPartyIdentifierOnly`
+     for homeservers that support it.
      
      - parameters:
         - sid: the id provided during the 3PID validation session (MXRestClient.requestEmailValidation).
@@ -1364,6 +1367,27 @@ public extension MXRestClient {
      */
     @nonobjc @discardableResult func addThirdPartyIdentifier(_ sid: String, clientSecret: String, bind: Bool, completion: @escaping (_ response: MXResponse<Void>) -> Void) -> MXHTTPOperation {
         return __add3PID(sid, clientSecret: clientSecret, bind: bind, success: currySuccess(completion), failure: curryFailure(completion))
+    }
+
+    /**
+     Add a 3PID to your homeserver account.
+
+     This API does not use an identity server, as the homeserver is expected to
+     handle 3PID ownership validation.
+
+     You can check whether a homeserver supports this API via
+     `doesServerSupportSeparateAddAndBind`.
+
+     - parameters:
+     - sid: the session id provided during the 3PID validation session.
+     - clientSecret: the same secret key used in the validation session.
+     - completion: A block object called when the operation completes.
+     - response:  Indicates whether the operation was successful.
+
+     - returns: a `MXHTTPOperation` instance.
+     */
+    @nonobjc @discardableResult func addThirdPartyIdentifierOnly(withSessionId sid: String, clientSecret: String, completion: @escaping (_ response: MXResponse<Void>) -> Void) -> MXHTTPOperation {
+        return __add3PIDOnly(withSessionId: sid, clientSecret: clientSecret, success: currySuccess(completion), failure: curryFailure(completion))
     }
     
     /**
@@ -1393,7 +1417,44 @@ public extension MXRestClient {
     @nonobjc @discardableResult func thirdPartyIdentifiers(_ completion: @escaping (_ response: MXResponse<[MXThirdPartyIdentifier]?>) -> Void) -> MXHTTPOperation {
         return __threePIDs(currySuccess(completion), failure: curryFailure(completion))
     }
-    
+
+    /**
+     Bind a 3PID for discovery onto an identity server via the homeserver.
+
+     The identity server handles 3PID ownership validation and the homeserver records
+     the new binding to track where all 3PIDs for the account are bound.
+
+     You can check whether a homeserver supports this API via
+     `doesServerSupportSeparateAddAndBind`.
+
+     - parameters:
+     - sid: the session id provided during the 3PID validation session.
+     - clientSecret: the same secret key used in the validation session.
+     - completion: A block object called when the operation completes.
+     - response:  Indicates whether the operation was successful.
+
+     - returns: a `MXHTTPOperation` instance.
+     */
+    @nonobjc @discardableResult func bind3Pid(withSessionId sid: String, clientSecret: String, completion: @escaping (_ response: MXResponse<Void>) -> Void) -> MXHTTPOperation {
+        return __bind3Pid(withSessionId: sid, clientSecret: clientSecret, success: currySuccess(completion), failure: curryFailure(completion))
+    }
+
+    /**
+     Unbind a 3PID for discovery on an identity server via the homeserver.
+
+     - parameters:
+     - address: the 3rd party id.
+     - medium: medium the type of the 3rd party id.
+     - completion: A block object called when the operation completes.
+     - response:  Indicates whether the operation was successful.
+
+     - returns: a `MXHTTPOperation` instance.
+     */
+    @nonobjc @discardableResult func unbind3Pid(withAddress address: String, medium: String, completion: @escaping (_ response: MXResponse<Void>) -> Void) -> MXHTTPOperation {
+        return __unbind3Pid(withAddress: address, medium: medium, success: currySuccess(completion), failure: curryFailure(completion))
+    }
+
+
     
     // MARK: - Presence operations
     

--- a/MatrixSDK/Contrib/Swift/ThreePidAdd/MX3PidAddManager.swift
+++ b/MatrixSDK/Contrib/Swift/ThreePidAdd/MX3PidAddManager.swift
@@ -23,41 +23,45 @@ public extension MX3PidAddManager {
         self.init(__matrixSession: session)
     }
 
+    @nonobjc func cancel(session: MX3PidAddSession) {
+        __cancel3PidAddSession(session)
+    }
+
     // MARK: - Email
     @nonobjc @discardableResult func startAddEmailSession(_ email: String, nextLink: String?, completion: @escaping (_ response: MXResponse<Void>) -> Void) -> MX3PidAddSession {
-        return __startAddEmailSession(withEmail: email, nextLink: nextLink, success: currySuccess(completion), failure: curryFailure(completion));
+        return __startAddEmailSession(withEmail: email, nextLink: nextLink, success: currySuccess(completion), failure: curryFailure(completion))
     }
     
     @nonobjc func tryFinaliseAddEmailSession(_ session: MX3PidAddSession, completion: @escaping (_ response: MXResponse<Void>) -> Void) -> Void {
-        return __tryFinaliseAddEmailSession(session, success: currySuccess(completion), failure: curryFailure(completion));
+        return __tryFinaliseAddEmailSession(session, success: currySuccess(completion), failure: curryFailure(completion))
     }
 
 
     // MARK: - Add MSISDN
     @nonobjc @discardableResult func startAddPhoneNumberSession(_ phoneNumber: String, countryCode: String?, completion: @escaping (_ response: MXResponse<Void>) -> Void) -> MX3PidAddSession {
-        return __startAddPhoneNumberSession(withPhoneNumber: phoneNumber, countryCode: countryCode, success: currySuccess(completion), failure: curryFailure(completion));
+        return __startAddPhoneNumberSession(withPhoneNumber: phoneNumber, countryCode: countryCode, success: currySuccess(completion), failure: curryFailure(completion))
     }
 
     @nonobjc func finaliseAddPhoneNumberSession(_ session: MX3PidAddSession, token: String, completion: @escaping (_ response: MXResponse<Void>) -> Void) -> Void {
-        return __finaliseAddPhoneNumber(session, withToken: token, success: currySuccess(completion), failure: curryFailure(completion));
+        return __finaliseAddPhoneNumber(session, withToken: token, success: currySuccess(completion), failure: curryFailure(completion))
     }
 
 
     // MARK: - Bind Email
     @nonobjc @discardableResult func startBindEmailSession(_ email: String, completion: @escaping (_ response: MXResponse<Void>) -> Void) -> MX3PidAddSession {
-        return __startBindEmailSession(withEmail: email, success: currySuccess(completion), failure: curryFailure(completion));
+        return __startBindEmailSession(withEmail: email, success: currySuccess(completion), failure: curryFailure(completion))
     }
 
     @nonobjc func tryFinaliseBindEmailSession(_ session: MX3PidAddSession, completion: @escaping (_ response: MXResponse<Void>) -> Void) -> Void {
-        return __tryFinaliseBindEmailSession(session, success: currySuccess(completion), failure: curryFailure(completion));
+        return __tryFinaliseBindEmailSession(session, success: currySuccess(completion), failure: curryFailure(completion))
     }
 
     // MARK: - Bind phone number
     @nonobjc @discardableResult func startBindPhoneNumberSession(_ phoneNumber: String, countryCode: String?, completion: @escaping (_ response: MXResponse<Void>) -> Void) -> MX3PidAddSession {
-        return __startBindPhoneNumberSession(withPhoneNumber: phoneNumber, countryCode: countryCode, success: currySuccess(completion), failure: curryFailure(completion));
+        return __startBindPhoneNumberSession(withPhoneNumber: phoneNumber, countryCode: countryCode, success: currySuccess(completion), failure: curryFailure(completion))
     }
 
     @nonobjc func tryFinaliseBindPhoneNumberSession(_ session: MX3PidAddSession, token: String, completion: @escaping (_ response: MXResponse<Void>) -> Void) -> Void {
-        return __finaliseBindPhoneNumber(session, withToken: token, success: currySuccess(completion), failure: curryFailure(completion));
+        return __finaliseBindPhoneNumber(session, withToken: token, success: currySuccess(completion), failure: curryFailure(completion))
     }
 }

--- a/MatrixSDK/Contrib/Swift/ThreePidAdd/MX3PidAddManager.swift
+++ b/MatrixSDK/Contrib/Swift/ThreePidAdd/MX3PidAddManager.swift
@@ -1,0 +1,63 @@
+/*
+ Copyright 2019 The Matrix.org Foundation C.I.C
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import Foundation
+
+public extension MX3PidAddManager {
+
+    // MARK: - Setup
+    @nonobjc convenience init(session: MXSession) {
+        self.init(__matrixSession: session)
+    }
+
+    // MARK: - Email
+    @nonobjc @discardableResult func startAddEmailSession(_ email: String, nextLink: String?, completion: @escaping (_ response: MXResponse<Void>) -> Void) -> MX3PidAddSession {
+        return __startAddEmailSession(withEmail: email, nextLink: nextLink, success: currySuccess(completion), failure: curryFailure(completion));
+    }
+    
+    @nonobjc func tryFinaliseAddEmailSession(_ session: MX3PidAddSession, completion: @escaping (_ response: MXResponse<Void>) -> Void) -> Void {
+        return __tryFinaliseAddEmailSession(session, success: currySuccess(completion), failure: curryFailure(completion));
+    }
+
+
+    // MARK: - Add MSISDN
+    @nonobjc @discardableResult func startAddPhoneNumberSession(_ phoneNumber: String, countryCode: String?, completion: @escaping (_ response: MXResponse<Void>) -> Void) -> MX3PidAddSession {
+        return __startAddPhoneNumberSession(withPhoneNumber: phoneNumber, countryCode: countryCode, success: currySuccess(completion), failure: curryFailure(completion));
+    }
+
+    @nonobjc func finaliseAddPhoneNumberSession(_ session: MX3PidAddSession, token: String, completion: @escaping (_ response: MXResponse<Void>) -> Void) -> Void {
+        return __finaliseAddPhoneNumber(session, withToken: token, success: currySuccess(completion), failure: curryFailure(completion));
+    }
+
+
+    // MARK: - Bind Email
+    @nonobjc @discardableResult func startBindEmailSession(_ email: String, completion: @escaping (_ response: MXResponse<Void>) -> Void) -> MX3PidAddSession {
+        return __startBindEmailSession(withEmail: email, success: currySuccess(completion), failure: curryFailure(completion));
+    }
+
+    @nonobjc func tryFinaliseBindEmailSession(_ session: MX3PidAddSession, completion: @escaping (_ response: MXResponse<Void>) -> Void) -> Void {
+        return __tryFinaliseBindEmailSession(session, success: currySuccess(completion), failure: curryFailure(completion));
+    }
+
+    // MARK: - Bind phone number
+    @nonobjc @discardableResult func startBindPhoneNumberSession(_ phoneNumber: String, countryCode: String?, completion: @escaping (_ response: MXResponse<Void>) -> Void) -> MX3PidAddSession {
+        return __startBindPhoneNumberSession(withPhoneNumber: phoneNumber, countryCode: countryCode, success: currySuccess(completion), failure: curryFailure(completion));
+    }
+
+    @nonobjc func tryFinaliseBindPhoneNumberSession(_ session: MX3PidAddSession, token: String, completion: @escaping (_ response: MXResponse<Void>) -> Void) -> Void {
+        return __finaliseBindPhoneNumber(session, withToken: token, success: currySuccess(completion), failure: curryFailure(completion));
+    }
+}

--- a/MatrixSDK/Contrib/Swift/ThreePidAdd/MX3PidAddManager.swift
+++ b/MatrixSDK/Contrib/Swift/ThreePidAdd/MX3PidAddManager.swift
@@ -48,20 +48,20 @@ public extension MX3PidAddManager {
 
 
     // MARK: - Bind Email
-    @nonobjc @discardableResult func startBindEmailSession(_ email: String, completion: @escaping (_ response: MXResponse<Void>) -> Void) -> MX3PidAddSession {
-        return __startBindEmailSession(withEmail: email, success: currySuccess(completion), failure: curryFailure(completion))
+    @nonobjc @discardableResult func startIdentityServerSession(withEmail email: String, bind: Bool, completion: @escaping (_ response: MXResponse<Void>) -> Void) -> MX3PidAddSession {
+        return __startIdentityServerEmailSession(withEmail: email, bind: bind, success: currySuccess(completion), failure: curryFailure(completion))
     }
 
-    @nonobjc func tryFinaliseBindEmailSession(_ session: MX3PidAddSession, completion: @escaping (_ response: MXResponse<Void>) -> Void) -> Void {
-        return __tryFinaliseBindEmailSession(session, success: currySuccess(completion), failure: curryFailure(completion))
+    @nonobjc func tryFinaliseIdentityServerEmailSession(_ session: MX3PidAddSession, completion: @escaping (_ response: MXResponse<Void>) -> Void) -> Void {
+        return __tryFinaliseIdentityServerEmailSession(session, success: currySuccess(completion), failure: curryFailure(completion))
     }
 
     // MARK: - Bind phone number
-    @nonobjc @discardableResult func startBindPhoneNumberSession(_ phoneNumber: String, countryCode: String?, completion: @escaping (_ response: MXResponse<Void>) -> Void) -> MX3PidAddSession {
-        return __startBindPhoneNumberSession(withPhoneNumber: phoneNumber, countryCode: countryCode, success: currySuccess(completion), failure: curryFailure(completion))
+    @nonobjc @discardableResult func startIdentityServerSession(withPhoneNumber phoneNumber: String, countryCode: String?, bind: Bool, completion: @escaping (_ response: MXResponse<Void>) -> Void) -> MX3PidAddSession {
+        return __startIdentityServerPhoneNumberSession(withPhoneNumber: phoneNumber, countryCode: countryCode, bind: bind, success: currySuccess(completion), failure: curryFailure(completion))
     }
 
-    @nonobjc func tryFinaliseBindPhoneNumberSession(_ session: MX3PidAddSession, token: String, completion: @escaping (_ response: MXResponse<Void>) -> Void) -> Void {
-        return __finaliseBindPhoneNumber(session, withToken: token, success: currySuccess(completion), failure: curryFailure(completion))
+    @nonobjc func finaliseIdentityServerPhoneNumberSession(_ session: MX3PidAddSession, token: String, completion: @escaping (_ response: MXResponse<Void>) -> Void) -> Void {
+        return __finaliseIdentityServerPhoneNumber(session, withToken: token, success: currySuccess(completion), failure: curryFailure(completion))
     }
 }

--- a/MatrixSDK/Contrib/Swift/ThreePidAdd/MX3PidAddManager.swift
+++ b/MatrixSDK/Contrib/Swift/ThreePidAdd/MX3PidAddManager.swift
@@ -48,7 +48,7 @@ public extension MX3PidAddManager {
 
 
     // MARK: - Bind Email
-    @nonobjc @discardableResult func startIdentityServerSession(withEmail email: String, bind: Bool, completion: @escaping (_ response: MXResponse<Void>) -> Void) -> MX3PidAddSession {
+    @nonobjc @discardableResult func startIdentityServerSession(withEmail email: String, bind: Bool, completion: @escaping (_ response: MXResponse<Bool>) -> Void) -> MX3PidAddSession {
         return __startIdentityServerEmailSession(withEmail: email, bind: bind, success: currySuccess(completion), failure: curryFailure(completion))
     }
 
@@ -57,7 +57,7 @@ public extension MX3PidAddManager {
     }
 
     // MARK: - Bind phone number
-    @nonobjc @discardableResult func startIdentityServerSession(withPhoneNumber phoneNumber: String, countryCode: String?, bind: Bool, completion: @escaping (_ response: MXResponse<Void>) -> Void) -> MX3PidAddSession {
+    @nonobjc @discardableResult func startIdentityServerSession(withPhoneNumber phoneNumber: String, countryCode: String?, bind: Bool, completion: @escaping (_ response: MXResponse<Bool>) -> Void) -> MX3PidAddSession {
         return __startIdentityServerPhoneNumberSession(withPhoneNumber: phoneNumber, countryCode: countryCode, bind: bind, success: currySuccess(completion), failure: curryFailure(completion))
     }
 

--- a/MatrixSDK/IdentityServer/MXIdentityService.m
+++ b/MatrixSDK/IdentityServer/MXIdentityService.m
@@ -254,7 +254,17 @@ NSString *const MXIdentityServiceNotificationAccessTokenKey = @"accessToken";
                                failure:(void (^)(NSError *error))failure
 {
     return [self checkAPIVersionAvailabilityAndPerformOperationOnSuccess:^MXHTTPOperation* {
-        return [self.restClient accountWithSuccess:success failure:failure];
+        if (self.restClient.preferredAPIPathPrefix == kMXIdentityAPIPrefixPathV2)
+        {
+            return [self.restClient accountWithSuccess:success failure:failure];
+        }
+        else
+        {
+            // There is no account in v1
+            success(nil);
+            return nil;
+        }
+
     } failure:failure];
 }
 

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -1596,7 +1596,7 @@ typedef MXHTTPOperation* (^MXRestClientIdentityServerAccessTokenHandler)(void (^
                     failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
- Add a 3PID to your homeserver account
+ Add a 3PID to your homeserver account.
 
  This API does not use an identity server, as the homeserver is expected to
  handle 3PID ownership validation.

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -1576,6 +1576,9 @@ typedef MXHTTPOperation* (^MXRestClientIdentityServerAccessTokenHandler)(void (^
 /**
  Link an authenticated 3rd party id to the Matrix user.
 
+ This API is deprecated, and you should instead use `addThreePidOnly`
+ for homeservers that support it.
+
  @param sid the id provided during the 3PID validation session (see [MXRestClient requestTokenForEmail:], or [MXRestClient requestEmailValidation:]).
  @param clientSecret the same secret key used in the validation session.
  @param bind whether the homeserver should also bind this third party identifier
@@ -1591,6 +1594,28 @@ typedef MXHTTPOperation* (^MXRestClientIdentityServerAccessTokenHandler)(void (^
                        bind:(BOOL)bind
                     success:(void (^)(void))success
                     failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
+
+/**
+ Add a 3PID to your homeserver account
+
+ This API does not use an identity server, as the homeserver is expected to
+ handle 3PID ownership validation.
+
+ You can check whether a homeserver supports this API via
+ `doesServerSupportSeparateAddAndBind`.
+
+ @param sid the session id provided during the 3PID validation session.
+ @param clientSecret the same secret key used in the validation session.
+
+ @param success A block object called when the operation succeeds.
+ @param failure A block object called when the operation fails.
+
+ @return a MXHTTPOperation instance.
+ */
+- (MXHTTPOperation*)add3PIDOnlyWithSessionId:(NSString*)sid
+                                clientSecret:(NSString*)clientSecret
+                                     success:(void (^)(void))success
+                                     failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
  Remove a 3rd party id from the Matrix user information.

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -1618,6 +1618,45 @@ typedef MXHTTPOperation* (^MXRestClientIdentityServerAccessTokenHandler)(void (^
 - (MXHTTPOperation*)threePIDs:(void (^)(NSArray<MXThirdPartyIdentifier*> *threePIDs))success
                       failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
+/**
+ Bind a 3PID for discovery onto an identity server via the homeserver.
+
+ The identity server handles 3PID ownership validation and the homeserver records
+ the new binding to track where all 3PIDs for the account are bound.
+
+ You can check whether a homeserver supports this API via
+ `doesServerSupportSeparateAddAndBind`.
+
+ @param sid the session id provided during the 3PID validation session.
+ @param clientSecret the same secret key used in the validation session.
+
+ @param success A block object called when the operation succeeds.
+ @param failure A block object called when the operation fails.
+ */
+- (MXHTTPOperation*)bind3PidWithSessionId:(NSString*)sid
+                             clientSecret:(NSString*)clientSecret
+                                  success:(void (^)(void))success
+                                  failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
+
+/**
+ Unbind a 3PID for discovery on an identity server via the homeserver.
+
+ The homeserver removes its record of the binding to keep an updated record of
+ where all 3PIDs for the account are bound.
+
+ @param address the 3rd party id.
+ @param medium the type of the 3rd party id.
+
+ @param success A block object called when the operation succeeds.
+ @param failure A block object called when the operation fails.
+
+ @return a MXHTTPOperation instance.
+ */
+- (MXHTTPOperation*)unbind3PidWithAddress:(NSString*)address
+                                   medium:(NSString*)medium
+                                  success:(void (^)(void))success
+                                  failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
+
 
 #pragma mark - Presence operations
 /**

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -2988,6 +2988,32 @@ MXAuthAction;
                                  }];
 }
 
+- (MXHTTPOperation*)add3PIDOnlyWithSessionId:(NSString*)sid
+                                clientSecret:(NSString*)clientSecret
+                                     success:(void (^)(void))success
+                                     failure:(void (^)(NSError *error))failure
+{
+    NSString *path = [NSString stringWithFormat:@"%@/account/3pid/add", kMXAPIPrefixPathUnstable];
+
+    NSDictionary *parameters = @{
+                                 @"sid": sid,
+                                 @"client_secret": clientSecret
+                                 };
+
+    MXWeakify(self);
+    return [httpClient requestWithMethod:@"POST"
+                                    path:path
+                              parameters:parameters
+                                 success:^(NSDictionary *JSONResponse) {
+                                     MXStrongifyAndReturnIfNil(self);
+                                     [self dispatchSuccess:success];
+                                 }
+                                 failure:^(NSError *error) {
+                                     MXStrongifyAndReturnIfNil(self);
+                                     [self dispatchFailure:error inBlock:failure];
+                                 }];
+}
+
 - (MXHTTPOperation*)remove3PID:(NSString*)address
                         medium:(NSString*)medium
                        success:(void (^)(void))success

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -3040,6 +3040,103 @@ MXAuthAction;
                                  }];
 }
 
+- (MXHTTPOperation*)bind3PidWithSessionId:(NSString*)sid
+                             clientSecret:(NSString*)clientSecret
+                                  success:(void (^)(void))success
+                                  failure:(void (^)(NSError *error))failure
+{
+    NSString *path = [NSString stringWithFormat:@"%@/account/3pid/bind", kMXAPIPrefixPathUnstable];
+
+    if (!self.identityServer)
+    {
+        NSLog(@"[MXRestClient] bind3PidWithSessionId: Error: Missing identityServer");
+        NSError *error = [NSError errorWithDomain:kMXRestClientErrorDomain code:MXRestClientErrorMissingIdentityServer userInfo:nil];
+        [self dispatchFailure:error inBlock:failure];
+        return nil;
+    }
+
+    NSURL *identityServerURL = [NSURL URLWithString:self.credentials.identityServer];
+    NSDictionary *parameters = @{
+                                 @"id_server": identityServerURL.host,
+                                 @"sid": sid,
+                                 @"client_secret": clientSecret
+                                 };
+
+    MXWeakify(self);
+    __block MXHTTPOperation *operation;
+    operation = [self addIdentityAccessTokenToParameters:parameters success:^(NSDictionary *updatedParameters) {
+        MXStrongifyAndReturnIfNil(self);
+
+        MXHTTPOperation *operation2 = [self->httpClient requestWithMethod:@"POST"
+                                                               path:path
+                                                         parameters:updatedParameters
+                                                            success:^(NSDictionary *JSONResponse) {
+                                                                MXStrongifyAndReturnIfNil(self);
+
+                                                                if (success)
+                                                                {
+                                                                    [self dispatchProcessing:nil
+                                                                               andCompletion:success];
+                                                                }
+                                                            }
+                                                            failure:^(NSError *error) {
+                                                                MXStrongifyAndReturnIfNil(self);
+                                                                [self dispatchFailure:error inBlock:failure];
+                                                            }];
+        if (operation2)
+        {
+            [operation mutateTo:operation2];
+        }
+
+    } failure:^(NSError *error) {
+        MXStrongifyAndReturnIfNil(self);
+        [self dispatchFailure:error inBlock:failure];
+    }];
+
+    return operation;
+}
+
+- (MXHTTPOperation*)unbind3PidWithAddress:(NSString*)address
+                                   medium:(NSString*)medium
+                                  success:(void (^)(void))success
+                                  failure:(void (^)(NSError *error))failure
+{
+    NSString *path = [NSString stringWithFormat:@"%@/account/3pid/unbind", kMXAPIPrefixPathUnstable];
+
+    if (!self.identityServer)
+    {
+        NSLog(@"[MXRestClient] add3PID: Error: Missing identityServer");
+        NSError *error = [NSError errorWithDomain:kMXRestClientErrorDomain code:MXRestClientErrorMissingIdentityServer userInfo:nil];
+        [self dispatchFailure:error inBlock:failure];
+        return nil;
+    }
+
+    NSURL *identityServerURL = [NSURL URLWithString:self.credentials.identityServer];
+    NSDictionary *parameters = @{
+                                 @"id_server": identityServerURL.host,
+                                 @"medium": medium,
+                                 @"address": address
+                                 };
+
+    MXWeakify(self);
+    return [httpClient requestWithMethod:@"POST"
+                                    path:path
+                              parameters:parameters
+                                 success:^(NSDictionary *JSONResponse) {
+                                     MXStrongifyAndReturnIfNil(self);
+
+                                     if (success)
+                                     {
+                                         [self dispatchProcessing:nil
+                                                    andCompletion:success];
+                                     }
+                                 }
+                                 failure:^(NSError *error) {
+                                     MXStrongifyAndReturnIfNil(self);
+                                     [self dispatchFailure:error inBlock:failure];
+                                 }];
+}
+
 
 #pragma mark - Presence operations
 - (MXHTTPOperation*)setPresence:(MXPresence)presence andStatusMessage:(NSString*)statusMessage

--- a/MatrixSDK/MXSession.h
+++ b/MatrixSDK/MXSession.h
@@ -36,6 +36,7 @@
 #import "MXScanManager.h"
 #import "MXAggregations.h"
 #import "MXIdentityService.h"
+#import "MX3PidAddManager.h"
 
 /**
  `MXSessionState` represents the states in the life cycle of a MXSession instance.
@@ -369,6 +370,11 @@ FOUNDATION_EXPORT NSString *const kMXSessionNoRoomTag;
  The identity service used to handle Matrix identity server requests. Can be nil.
  */
 @property (nonatomic, readonly) MXIdentityService *identityService;
+
+/**
+ The module that manages add of third party identifiers.
+ */
+@property (nonatomic, readonly)  MX3PidAddManager *threePidAddManager;
 
 /**
  The media manager used to handle the media stored on the Matrix Content repository.

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -190,6 +190,7 @@ typedef void (^MXOnResumeDone)(void);
     if (self)
     {
         matrixRestClient = mxRestClient;
+        _threePidAddManager = [[MX3PidAddManager alloc] initWithMatrixSession:self];
         mediaManager = [[MXMediaManager alloc] initWithHomeServer:matrixRestClient.homeserver];
         rooms = [NSMutableDictionary dictionary];
         roomsSummaries = [NSMutableDictionary dictionary];

--- a/MatrixSDK/NotificationCenter/ServiceTerms/MXServiceTerms.m
+++ b/MatrixSDK/NotificationCenter/ServiceTerms/MXServiceTerms.m
@@ -83,7 +83,18 @@ NSString *const MXServiceTermsErrorDomain = @"org.matrix.sdk.MXServiceTermsError
         
         success(agreedTermsProgress);
         
-    } failure:failure];
+    } failure:^(NSError * _Nonnull error) {
+        NSHTTPURLResponse *urlResponse = [MXHTTPOperation urlResponseFromError:error];
+        if (urlResponse.statusCode == 404)
+        {
+            NSLog(@"[MXServiceTerms] areAllTermsAgreed: No terms (404).");
+            success([NSProgress new]);
+            return;
+        }
+        
+        NSLog(@"[MXServiceTerms] areAllTermsAgreed: Error");
+        failure(error);
+    }];
 }
 
 - (MXHTTPOperation *)agreeToTerms:(NSArray<NSString *> *)termsUrls

--- a/MatrixSDK/ThreePidAdd/MX3PidAddManager.h
+++ b/MatrixSDK/ThreePidAdd/MX3PidAddManager.h
@@ -51,6 +51,14 @@ NS_ERROR_ENUM(MX3PidAddManagerErrorDomain)
 - (instancetype)initWithMatrixSession:(MXSession*)session NS_REFINED_FOR_SWIFT;
 
 
+/**
+ Cancel a session and its current operation.
+
+ @param threePidAddSession the session to cancel.
+ */
+- (void)cancel3PidAddSession:(MX3PidAddSession*)threePidAddSession NS_REFINED_FOR_SWIFT;
+
+
 #pragma mark - Add Email
 
 /**

--- a/MatrixSDK/ThreePidAdd/MX3PidAddManager.h
+++ b/MatrixSDK/ThreePidAdd/MX3PidAddManager.h
@@ -137,8 +137,9 @@ NS_ERROR_ENUM(MX3PidAddManagerErrorDomain)
 /**
  Add (bind) or remove (unbind) an email to/from the user identity server.
 
- The user will receive a validation email.
+ If a validation(needValidation) is required, the user will receive a validation email.
  Use then `tryFinaliseBindOrUnBindEmailSession` to complete the session.
+ Else, no more action is required.
 
  @param email the email.
 
@@ -149,7 +150,7 @@ NS_ERROR_ENUM(MX3PidAddManagerErrorDomain)
  */
 - (MX3PidAddSession*)startIdentityServerEmailSessionWithEmail:(NSString*)email
                                                          bind:(BOOL)bind
-                                                      success:(void (^)(void))success
+                                                      success:(void (^)(BOOL needValidation))success
                                                       failure:(void (^)(NSError * _Nonnull))failure NS_REFINED_FOR_SWIFT;
 
 /**
@@ -172,8 +173,9 @@ NS_ERROR_ENUM(MX3PidAddManagerErrorDomain)
 /**
   Add (bind) or remove (unbind) a phone number to/from the user identity server.
 
- The user will receive a code by SMS.
+ If a validation(needValidation) is required, the user will receive a code by SMS.
  Use then `finaliseBindPhoneNumberSession` to complete the session.
+ Else, no more action is required.
 
  @param phoneNumber the phone number.
  @param countryCode the country code. Can be nil if `phoneNumber` is internationalised.
@@ -186,7 +188,7 @@ NS_ERROR_ENUM(MX3PidAddManagerErrorDomain)
 - (MX3PidAddSession*)startIdentityServerPhoneNumberSessionWithPhoneNumber:(NSString*)phoneNumber
                                                               countryCode:(nullable NSString*)countryCode
                                                                      bind:(BOOL)bind
-                                                                  success:(void (^)(void))success
+                                                                  success:(void (^)(BOOL needValidation))success
                                                                   failure:(void (^)(NSError * _Nonnull))failure NS_REFINED_FOR_SWIFT;
 
 /**

--- a/MatrixSDK/ThreePidAdd/MX3PidAddManager.h
+++ b/MatrixSDK/ThreePidAdd/MX3PidAddManager.h
@@ -135,10 +135,10 @@ NS_ERROR_ENUM(MX3PidAddManagerErrorDomain)
 #pragma mark - Bind Email
 
 /**
- Add (bind) an email to the user identity server.
+ Add (bind) or remove (unbind) an email to/from the user identity server.
 
  The user will receive a validation email.
- Use then `tryFinaliseBindEmailSession` to complete the session.
+ Use then `tryFinaliseBindOrUnBindEmailSession` to complete the session.
 
  @param email the email.
 
@@ -147,12 +147,13 @@ NS_ERROR_ENUM(MX3PidAddManagerErrorDomain)
 
  @return a 3pid add session.
  */
-- (MX3PidAddSession*)startBindEmailSessionWithEmail:(NSString*)email
-                                            success:(void (^)(void))success
-                                            failure:(void (^)(NSError * _Nonnull))failure NS_REFINED_FOR_SWIFT;
+- (MX3PidAddSession*)startIdentityServerEmailSessionWithEmail:(NSString*)email
+                                                         bind:(BOOL)bind
+                                                      success:(void (^)(void))success
+                                                      failure:(void (^)(NSError * _Nonnull))failure NS_REFINED_FOR_SWIFT;
 
 /**
- Try to finalise the email addition to the user identity server.
+ Try to finalise the email addition or removal.
 
  This must be called after the user has clicked the validation link.
 
@@ -161,15 +162,15 @@ NS_ERROR_ENUM(MX3PidAddManagerErrorDomain)
  @param success A block object called when the operation succeeds.
  @param failure A block object called when the operation fails.
  */
-- (void)tryFinaliseBindEmailSession:(MX3PidAddSession*)threePidAddSession
-                            success:(void (^)(void))success
-                            failure:(void (^)(NSError * _Nonnull))failure NS_REFINED_FOR_SWIFT;
+- (void)tryFinaliseIdentityServerEmailSession:(MX3PidAddSession*)threePidAddSession
+                                      success:(void (^)(void))success
+                                      failure:(void (^)(NSError * _Nonnull))failure NS_REFINED_FOR_SWIFT;
 
 
 #pragma mark - Bind Phone Number
 
 /**
- Add (bind) a phone number to the user identity server.
+  Add (bind) or remove (unbind) a phone number to/from the user identity server.
 
  The user will receive a code by SMS.
  Use then `finaliseBindPhoneNumberSession` to complete the session.
@@ -182,13 +183,14 @@ NS_ERROR_ENUM(MX3PidAddManagerErrorDomain)
 
  @return a 3pid add session.
  */
-- (MX3PidAddSession*)startBindPhoneNumberSessionWithPhoneNumber:(NSString*)phoneNumber
-                                                    countryCode:(nullable NSString*)countryCode
-                                                        success:(void (^)(void))success
-                                                        failure:(void (^)(NSError * _Nonnull))failure NS_REFINED_FOR_SWIFT;
+- (MX3PidAddSession*)startIdentityServerPhoneNumberSessionWithPhoneNumber:(NSString*)phoneNumber
+                                                              countryCode:(nullable NSString*)countryCode
+                                                                     bind:(BOOL)bind
+                                                                  success:(void (^)(void))success
+                                                                  failure:(void (^)(NSError * _Nonnull))failure NS_REFINED_FOR_SWIFT;
 
 /**
- Finalise the phone number addition.
+ Finalise the phone number addition or removal.
 
  @param threePidAddSession the session to finalise.
  @param token the code received by SMS.
@@ -196,11 +198,12 @@ NS_ERROR_ENUM(MX3PidAddManagerErrorDomain)
  @param success A block object called when the operation succeeds.
  @param failure A block object called when the operation fails.
  */
-- (void)finaliseBindPhoneNumberSession:(MX3PidAddSession*)threePidAddSession
-                             withToken:(NSString*)token
-                               success:(void (^)(void))success
-                               failure:(void (^)(NSError * _Nonnull))failure NS_REFINED_FOR_SWIFT;
+- (void)finaliseIdentityServerPhoneNumberSession:(MX3PidAddSession*)threePidAddSession
+                                       withToken:(NSString*)token
+                                         success:(void (^)(void))success
+                                         failure:(void (^)(NSError * _Nonnull))failure NS_REFINED_FOR_SWIFT;
 
 @end
 
 NS_ASSUME_NONNULL_END
+

--- a/MatrixSDK/ThreePidAdd/MX3PidAddManager.h
+++ b/MatrixSDK/ThreePidAdd/MX3PidAddManager.h
@@ -1,0 +1,128 @@
+/*
+ Copyright 2019 The Matrix.org Foundation C.I.C
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "MX3PidAddSession.h"
+
+@class MXSession;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ MX3PidAddManager error domain
+ */
+FOUNDATION_EXPORT NSString *const MX3PidAddManagerErrorDomain;
+
+/**
+ MXIdentityServerRestClient errors
+ */
+NS_ERROR_ENUM(MX3PidAddManagerErrorDomain)
+{
+    MX3PidAddManagerErrorDomainErrorInvalidParameters,
+    MX3PidAddManagerErrorDomainIdentityServerRequired
+};
+
+
+
+/**
+  The `MX3PidAddManager` instance allows a user to add a third party identifier
+  to their homeserver and, optionally, the identity servers (bind).
+
+  Diagrams of the intended API flows here are available at:
+
+  https://gist.github.com/jryans/839a09bf0c5a70e2f36ed990d50ed928
+ */
+@interface MX3PidAddManager : NSObject
+
+- (instancetype)initWithMatrixSession:(MXSession*)session;
+
+
+#pragma mark - Add Email
+
+/**
+ Add an email to the user homeserver account.
+
+ The user will receive a validation email.
+ Use then `tryFinaliseAddEmailSession` to complete the session.
+
+ @param email the email.
+ @param nextLink an optional URL where the user will be redirected to after they
+                 click on the validation link within the validation email.
+
+ @param success A block object called when the operation succeeds.
+ @param failure A block object called when the operation fails.
+
+ @return a 3pid add session.
+ */
+- (MX3PidAddSession*)startAddEmailSessionWithEmail:(NSString*)email
+                                          nextLink:(nullable NSString*)nextLink
+                                           success:(void (^)(void))success
+                                           failure:(void (^)(NSError * _Nonnull))failure;
+
+/**
+ Try to finalise the email addition.
+
+ This must be called after the user has clicked the validation link.
+
+ @param threePidAddSession the session to finalise.
+
+ @param success A block object called when the operation succeeds.
+ @param failure A block object called when the operation fails.
+ */
+- (void)tryFinaliseAddEmailSession:(MX3PidAddSession*)threePidAddSession
+                           success:(void (^)(void))success
+                           failure:(void (^)(NSError * _Nonnull))failure;
+
+
+#pragma mark - Add MSISDN
+
+/**
+ Add a phone number to the user homeserver account.
+
+ The user will receive a code by SMS.
+ Use then `finaliseAddPhoneNumberSession` to complete the session.
+
+ @param phoneNumber the phone number.
+ @param countryCode the country code. Can be nil if `phoneNumber` is internationalised.
+
+ @param success A block object called when the operation succeeds.
+ @param failure A block object called when the operation fails.
+
+ @return a 3pid add session.
+ */
+- (MX3PidAddSession*)startAddPhoneNumberSessionWithPhoneNumber:(NSString*)phoneNumber
+                                                   countryCode:(nullable NSString*)countryCode
+                                                       success:(void (^)(void))success
+                                                       failure:(void (^)(NSError * _Nonnull))failure;
+
+/**
+ Finalise the phone number addition.
+
+ @param threePidAddSession the session to finalise.
+ @param token the code received by SMS.
+
+ @param success A block object called when the operation succeeds.
+ @param failure A block object called when the operation fails.
+ */
+- (void)finaliseAddPhoneNumberSession:(MX3PidAddSession*)threePidAddSession
+                            withToken:(NSString*)token
+                              success:(void (^)(void))success
+                              failure:(void (^)(NSError * _Nonnull))failure;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixSDK/ThreePidAdd/MX3PidAddManager.h
+++ b/MatrixSDK/ThreePidAdd/MX3PidAddManager.h
@@ -48,7 +48,7 @@ NS_ERROR_ENUM(MX3PidAddManagerErrorDomain)
  */
 @interface MX3PidAddManager : NSObject
 
-- (instancetype)initWithMatrixSession:(MXSession*)session;
+- (instancetype)initWithMatrixSession:(MXSession*)session NS_REFINED_FOR_SWIFT;
 
 
 #pragma mark - Add Email
@@ -71,7 +71,7 @@ NS_ERROR_ENUM(MX3PidAddManagerErrorDomain)
 - (MX3PidAddSession*)startAddEmailSessionWithEmail:(NSString*)email
                                           nextLink:(nullable NSString*)nextLink
                                            success:(void (^)(void))success
-                                           failure:(void (^)(NSError * _Nonnull))failure;
+                                           failure:(void (^)(NSError * _Nonnull))failure NS_REFINED_FOR_SWIFT;
 
 /**
  Try to finalise the email addition.
@@ -85,7 +85,7 @@ NS_ERROR_ENUM(MX3PidAddManagerErrorDomain)
  */
 - (void)tryFinaliseAddEmailSession:(MX3PidAddSession*)threePidAddSession
                            success:(void (^)(void))success
-                           failure:(void (^)(NSError * _Nonnull))failure;
+                           failure:(void (^)(NSError * _Nonnull))failure NS_REFINED_FOR_SWIFT;
 
 
 #pragma mark - Add MSISDN
@@ -107,7 +107,7 @@ NS_ERROR_ENUM(MX3PidAddManagerErrorDomain)
 - (MX3PidAddSession*)startAddPhoneNumberSessionWithPhoneNumber:(NSString*)phoneNumber
                                                    countryCode:(nullable NSString*)countryCode
                                                        success:(void (^)(void))success
-                                                       failure:(void (^)(NSError * _Nonnull))failure;
+                                                       failure:(void (^)(NSError * _Nonnull))failure NS_REFINED_FOR_SWIFT;
 
 /**
  Finalise the phone number addition.
@@ -121,7 +121,77 @@ NS_ERROR_ENUM(MX3PidAddManagerErrorDomain)
 - (void)finaliseAddPhoneNumberSession:(MX3PidAddSession*)threePidAddSession
                             withToken:(NSString*)token
                               success:(void (^)(void))success
-                              failure:(void (^)(NSError * _Nonnull))failure;
+                              failure:(void (^)(NSError * _Nonnull))failure NS_REFINED_FOR_SWIFT;
+
+
+#pragma mark - Bind Email
+
+/**
+ Add (bind) an email to the user identity server.
+
+ The user will receive a validation email.
+ Use then `tryFinaliseBindEmailSession` to complete the session.
+
+ @param email the email.
+
+ @param success A block object called when the operation succeeds.
+ @param failure A block object called when the operation fails.
+
+ @return a 3pid add session.
+ */
+- (MX3PidAddSession*)startBindEmailSessionWithEmail:(NSString*)email
+                                            success:(void (^)(void))success
+                                            failure:(void (^)(NSError * _Nonnull))failure NS_REFINED_FOR_SWIFT;
+
+/**
+ Try to finalise the email addition to the user identity server.
+
+ This must be called after the user has clicked the validation link.
+
+ @param threePidAddSession the session to finalise.
+
+ @param success A block object called when the operation succeeds.
+ @param failure A block object called when the operation fails.
+ */
+- (void)tryFinaliseBindEmailSession:(MX3PidAddSession*)threePidAddSession
+                            success:(void (^)(void))success
+                            failure:(void (^)(NSError * _Nonnull))failure NS_REFINED_FOR_SWIFT;
+
+
+#pragma mark - Bind Phone Number
+
+/**
+ Add (bind) a phone number to the user identity server.
+
+ The user will receive a code by SMS.
+ Use then `finaliseBindPhoneNumberSession` to complete the session.
+
+ @param phoneNumber the phone number.
+ @param countryCode the country code. Can be nil if `phoneNumber` is internationalised.
+
+ @param success A block object called when the operation succeeds.
+ @param failure A block object called when the operation fails.
+
+ @return a 3pid add session.
+ */
+- (MX3PidAddSession*)startBindPhoneNumberSessionWithPhoneNumber:(NSString*)phoneNumber
+                                                    countryCode:(nullable NSString*)countryCode
+                                                        success:(void (^)(void))success
+                                                        failure:(void (^)(NSError * _Nonnull))failure NS_REFINED_FOR_SWIFT;
+
+/**
+ Finalise the phone number addition.
+
+ @param threePidAddSession the session to finalise.
+ @param token the code received by SMS.
+
+ @param success A block object called when the operation succeeds.
+ @param failure A block object called when the operation fails.
+ */
+- (void)finaliseBindPhoneNumberSession:(MX3PidAddSession*)threePidAddSession
+                             withToken:(NSString*)token
+                               success:(void (^)(void))success
+                               failure:(void (^)(NSError * _Nonnull))failure NS_REFINED_FOR_SWIFT;
 
 @end
 

--- a/MatrixSDK/ThreePidAdd/MX3PidAddManager.m
+++ b/MatrixSDK/ThreePidAdd/MX3PidAddManager.m
@@ -354,7 +354,7 @@ NSString *const MX3PidAddManagerErrorDomain = @"org.matrix.sdk.MX3PidAddManagerE
     } failure:failure];
 }
 
-- (MXHTTPOperation *)doesServerSupportSeparateAddAndBind:(void (^)(bool doesServerSupportSeparateAddAndBind))success
+- (MXHTTPOperation *)doesServerSupportSeparateAddAndBind:(void (^)(BOOL doesServerSupportSeparateAddAndBind))success
                                                  failure:(void (^)(NSError * _Nonnull))failure
 {
     __block MXHTTPOperation *operation;
@@ -466,7 +466,7 @@ NSString *const MX3PidAddManagerErrorDomain = @"org.matrix.sdk.MX3PidAddManagerE
 
                     threePidAddSession.httpOperation = nil;
 
-                    NSLog(@"[MX3PidAddManager] tryFinaliseIdentityServer3PidSessionWithNewHomeserver: DONE: threePid: %@", threePidAddSession);
+                    NSLog(@"[MX3PidAddManager] startIdentityServer3PidSession: DONE: threePid: %@", threePidAddSession);
                     success(NO);
 
                 } failure:^(NSError *error) {

--- a/MatrixSDK/ThreePidAdd/MX3PidAddManager.m
+++ b/MatrixSDK/ThreePidAdd/MX3PidAddManager.m
@@ -110,6 +110,7 @@ NSString *const MX3PidAddManagerErrorDomain = @"org.matrix.sdk.MX3PidAddManagerE
 
     if (doesServerSupportSeparateAddAndBind)
     {
+        // https://gist.github.com/jryans/839a09bf0c5a70e2f36ed990d50ed928#2b-adding-a-3pid-to-hs-account-after-registration-post-msc2290
         threePidAddSession.httpOperation = [mxSession.matrixRestClient add3PIDOnlyWithSessionId:threePidAddSession.sid clientSecret:threePidAddSession.clientSecret success:^{
 
             NSLog(@"[MX3PidAddManager] tryFinaliseAddEmailSession: DONE: threePid: %@", threePidAddSession);
@@ -124,6 +125,7 @@ NSString *const MX3PidAddManagerErrorDomain = @"org.matrix.sdk.MX3PidAddManagerE
     }
     else
     {
+        // https://gist.github.com/jryans/839a09bf0c5a70e2f36ed990d50ed928#2a-adding-a-3pid-to-hs-account-after-registration-pre-msc2290
         threePidAddSession.httpOperation = [mxSession.matrixRestClient add3PID:threePidAddSession.sid clientSecret:threePidAddSession.clientSecret bind:NO success:^{
             threePidAddSession.httpOperation = nil;
 
@@ -205,6 +207,7 @@ NSString *const MX3PidAddManagerErrorDomain = @"org.matrix.sdk.MX3PidAddManagerE
         MXHTTPOperation *operation;
         if (self->doesServerSupportSeparateAddAndBind)
         {
+            // https://gist.github.com/jryans/839a09bf0c5a70e2f36ed990d50ed928#2b-adding-a-3pid-to-hs-account-after-registration-post-msc2290
             operation = [self->mxSession.matrixRestClient add3PIDOnlyWithSessionId:threePidAddSession.sid clientSecret:threePidAddSession.clientSecret success:^{
 
                 NSLog(@"[MX3PidAddManager] finaliseAddPhoneNumberSession: DONE: threePid: %@", threePidAddSession);
@@ -219,6 +222,7 @@ NSString *const MX3PidAddManagerErrorDomain = @"org.matrix.sdk.MX3PidAddManagerE
         }
         else
         {
+            // https://gist.github.com/jryans/839a09bf0c5a70e2f36ed990d50ed928#2a-adding-a-3pid-to-hs-account-after-registration-pre-msc2290
             operation = [self->mxSession.matrixRestClient add3PID:threePidAddSession.sid clientSecret:threePidAddSession.clientSecret bind:NO success:^{
 
                 NSLog(@"[MX3PidAddManager] finaliseAddPhoneNumberSession: DONE: threePid: %@", threePidAddSession);
@@ -406,6 +410,7 @@ NSString *const MX3PidAddManagerErrorDomain = @"org.matrix.sdk.MX3PidAddManagerE
 
 #pragma mark - Bind to Identity Server -
 
+// https://gist.github.com/jryans/839a09bf0c5a70e2f36ed990d50ed928#3b-changing-the-bind-status-of-a-3pid-post-msc2290
 - (void)startIdentityServer3PidSession:(MX3PidAddSession*)threePidAddSession
                      success:(void (^)(BOOL needValidation))success
                      failure:(void (^)(NSError * _Nonnull))failure
@@ -581,6 +586,7 @@ NSString *const MX3PidAddManagerErrorDomain = @"org.matrix.sdk.MX3PidAddManagerE
 #pragma mark - Legacy implementation
 // TODO: To remove once these are abandonned
 
+// https://gist.github.com/jryans/839a09bf0c5a70e2f36ed990d50ed928#3a-changing-the-bind-status-of-a-3pid-pre-msc2290
 - (MXHTTPOperation *)startBind3PidSessionWithOldHomeserver:(MX3PidAddSession*)threePidAddSession
                                                    success:(void (^)(void))success
                                                    failure:(void (^)(NSError * _Nonnull))failure

--- a/MatrixSDK/ThreePidAdd/MX3PidAddManager.m
+++ b/MatrixSDK/ThreePidAdd/MX3PidAddManager.m
@@ -40,6 +40,14 @@ NSString *const MX3PidAddManagerErrorDomain = @"org.matrix.sdk.MX3PidAddManagerE
     return self;
 }
 
+- (void)cancel3PidAddSession:(MX3PidAddSession*)threePidAddSession
+{
+    NSLog(@"[MX3PidAddManager] cancel3PidAddSession: threePid: %@", threePidAddSession);
+
+    [threePidAddSession.httpOperation cancel];
+    threePidAddSession.httpOperation = nil;
+}
+
 
 #pragma mark - Add Email
 

--- a/MatrixSDK/ThreePidAdd/MX3PidAddManager.m
+++ b/MatrixSDK/ThreePidAdd/MX3PidAddManager.m
@@ -1,0 +1,243 @@
+/*
+ Copyright 2019 The Matrix.org Foundation C.I.C
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MX3PidAddManager.h"
+
+#import "MXSession.h"
+#import "MXTools.h"
+
+NSString *const MX3PidAddManagerErrorDomain = @"org.matrix.sdk.MX3PidAddManagerErrorDomain";
+
+@interface MX3PidAddManager()
+{
+    MXSession *mxSession;
+}
+
+@end
+
+@implementation MX3PidAddManager
+
+- (instancetype)initWithMatrixSession:(MXSession *)session
+{
+    self = [super init];
+    if (self)
+    {
+        mxSession = session;
+    }
+    return self;
+}
+
+
+#pragma mark - Add Email
+
+- (MX3PidAddSession*)startAddEmailSessionWithEmail:(NSString*)email
+                                          nextLink:(nullable NSString*)nextLink
+                                           success:(void (^)(void))success
+                                           failure:(void (^)(NSError * _Nonnull))failure
+{
+    MX3PidAddSession *threePidAddSession = [[MX3PidAddSession alloc] initWithMedium:kMX3PIDMediumEmail andAddress:email];
+
+    NSLog(@"[MX3PidAddManager] startAddEmailSessionWithEmail: threePid: %@", threePidAddSession);
+
+    threePidAddSession.httpOperation = [self checkIdentityServerRequirementWithSuccess:^{
+
+        MXHTTPOperation *operation = [self->mxSession.matrixRestClient requestTokenForEmail:email isDuringRegistration:NO clientSecret:threePidAddSession.clientSecret sendAttempt:threePidAddSession.sendAttempt++ nextLink:nextLink success:^(NSString *sid) {
+
+            NSLog(@"[MX3PidAddManager] startAddEmailSessionWithEmail: DONE: threePid: %@", threePidAddSession);
+
+            threePidAddSession.httpOperation = nil;
+
+            threePidAddSession.sid = sid;
+            success();
+
+        } failure:^(NSError *error) {
+            threePidAddSession.httpOperation = nil;
+            failure(error);
+        }];
+
+        if (operation)
+        {
+            [threePidAddSession.httpOperation mutateTo:operation];
+        }
+        
+    } failure:^(NSError * _Nonnull error) {
+        threePidAddSession.httpOperation = nil;
+        failure(error);
+    }];
+
+    return threePidAddSession;
+}
+
+- (void)tryFinaliseAddEmailSession:(MX3PidAddSession*)threePidAddSession
+                           success:(void (^)(void))success
+                           failure:(void (^)(NSError * _Nonnull))failure
+{
+    NSLog(@"[MX3PidAddManager] tryFinaliseAddEmailSession: threePid: %@", threePidAddSession);
+
+    if (!threePidAddSession.httpOperation && threePidAddSession.sid)
+    {
+        NSError *error = [NSError errorWithDomain:MX3PidAddManagerErrorDomain
+                                             code:MX3PidAddManagerErrorDomainErrorInvalidParameters
+                                         userInfo:nil];
+        failure(error);
+        return;
+    }
+
+    threePidAddSession.httpOperation = [mxSession.matrixRestClient add3PID:threePidAddSession.sid clientSecret:threePidAddSession.clientSecret bind:NO success:^{
+        threePidAddSession.httpOperation = nil;
+
+        NSLog(@"[MX3PidAddManager] tryFinaliseAddEmailSession: DONE: threePid: %@", threePidAddSession);
+
+        success();
+
+    } failure:^(NSError *error) {
+        threePidAddSession.httpOperation = nil;
+        failure(error);
+    }];
+}
+
+
+#pragma mark - Add MSISDN
+
+- (MX3PidAddSession*)startAddPhoneNumberSessionWithPhoneNumber:(NSString*)phoneNumber
+                                                   countryCode:(nullable NSString*)countryCode
+                                                       success:(void (^)(void))success
+                                                       failure:(void (^)(NSError * _Nonnull))failure
+{
+    MX3PidAddSession *threePidAddSession = [[MX3PidAddSession alloc] initWithMedium:kMX3PIDMediumMSISDN andAddress:phoneNumber];
+
+    NSLog(@"[MX3PidAddManager] startAddPhoneNumberSessionWithPhoneNumber: threePid: %@", threePidAddSession);
+
+    threePidAddSession.httpOperation = [self checkIdentityServerRequirementWithSuccess:^{
+
+        MXHTTPOperation *operation = [self->mxSession.matrixRestClient requestTokenForPhoneNumber:phoneNumber isDuringRegistration:NO countryCode:countryCode clientSecret:threePidAddSession.clientSecret sendAttempt:threePidAddSession.sendAttempt++ nextLink:nil success:^(NSString *sid, NSString *msisdn) {
+
+            NSLog(@"[MX3PidAddManager] startAddPhoneNumberSessionWithPhoneNumber: DONE: threePid: %@", threePidAddSession);
+
+            threePidAddSession.httpOperation = nil;
+
+            threePidAddSession.sid = sid;
+            success();
+
+        } failure:^(NSError *error) {
+            threePidAddSession.httpOperation = nil;
+            failure(error);
+        }];
+
+        if (operation)
+        {
+            [threePidAddSession.httpOperation mutateTo:operation];
+        }
+
+    } failure:^(NSError * _Nonnull error) {
+        threePidAddSession.httpOperation = nil;
+        failure(error);
+    }];
+
+    return threePidAddSession;
+}
+
+- (void)finaliseAddPhoneNumberSession:(MX3PidAddSession*)threePidAddSession
+                            withToken:(NSString*)token
+                              success:(void (^)(void))success
+                              failure:(void (^)(NSError * _Nonnull))failure
+{
+    NSLog(@"[MX3PidAddManager] finaliseAddPhoneNumberSession: threePid: %@", threePidAddSession);
+
+    MXWeakify(self);
+    threePidAddSession.httpOperation = [self submitValidationToken:token for3PidAddSession:threePidAddSession success:^{
+        MXStrongifyAndReturnIfNil(self);
+
+        MXHTTPOperation *operation = [self->mxSession.matrixRestClient add3PID:threePidAddSession.sid clientSecret:threePidAddSession.clientSecret bind:NO success:^{
+
+            NSLog(@"[MX3PidAddManager] finaliseAddPhoneNumberSession: DONE: threePid: %@", threePidAddSession);
+
+            threePidAddSession.httpOperation = nil;
+            success();
+
+        } failure:^(NSError *error) {
+            threePidAddSession.httpOperation = nil;
+            failure(error);
+        }];
+
+        if (operation)
+        {
+            [threePidAddSession.httpOperation mutateTo:operation];
+        }
+
+    } failure:^(NSError *error) {
+        threePidAddSession.httpOperation = nil;
+        failure(error);
+    }];
+}
+
+
+#pragma mark - Private methods
+
+- (MXHTTPOperation *)checkIdentityServerRequirementWithSuccess:(void (^)(void))success
+                                                       failure:(void (^)(NSError * _Nonnull))failure
+{
+    MXWeakify(self);
+    return [mxSession.matrixRestClient supportedMatrixVersions:^(MXMatrixVersions *matrixVersions) {
+        MXStrongifyAndReturnIfNil(self);
+
+        NSLog(@"[MX3PidAddManager] checkIdentityServerRequirement: %@", matrixVersions.doesServerRequireIdentityServerParam ? @"YES": @"NO");
+
+        if (matrixVersions.doesServerRequireIdentityServerParam
+            && !self->mxSession.matrixRestClient.identityServer)
+        {
+            NSError *error = [NSError errorWithDomain:MX3PidAddManagerErrorDomain
+                                                 code:MX3PidAddManagerErrorDomainIdentityServerRequired
+                                             userInfo:nil];
+            failure(error);
+        }
+        else
+        {
+            success();
+        }
+
+    } failure:failure];
+}
+
+- (nullable MXHTTPOperation *)submitValidationToken:(NSString *)token
+            for3PidAddSession:(MX3PidAddSession*)threePidAddSession
+                      success:(void (^)(void))success
+                      failure:(void (^)(NSError * _Nonnull))failure
+{
+    MXHTTPOperation *operation;
+    if (mxSession.identityService)
+    {
+        operation = [mxSession.identityService submit3PIDValidationToken:token
+                                                                  medium:threePidAddSession.medium
+                                                            clientSecret:threePidAddSession.clientSecret
+                                                                     sid:threePidAddSession.sid
+                                                                 success:success
+                                                                 failure:failure];
+    }
+    else
+    {
+        NSLog(@"[MX3PidAddManager] submitValidationToken: ERROR: Failed to submit validation token for 3PID: %@, identity service is not set", threePidAddSession);
+
+        NSError *error = [NSError errorWithDomain:MX3PidAddManagerErrorDomain
+                                             code:MX3PidAddManagerErrorDomainIdentityServerRequired
+                                         userInfo:nil];
+        failure(error);
+    }
+
+    return operation;
+}
+
+@end

--- a/MatrixSDK/ThreePidAdd/MX3PidAddManager.m
+++ b/MatrixSDK/ThreePidAdd/MX3PidAddManager.m
@@ -311,7 +311,7 @@ NSString *const MX3PidAddManagerErrorDomain = @"org.matrix.sdk.MX3PidAddManagerE
 
     if (doesServerSupportSeparateAddAndBind)
     {
-        [self tryFinaliseIdentityServer3PidSessionWithNewHomeserver:threePidAddSession withToken:nil success:success failure:failure];
+        [self tryFinaliseIdentityServer3PidSessionWithNewHomeserver:threePidAddSession withToken:token success:success failure:failure];
     }
     else
     {

--- a/MatrixSDK/ThreePidAdd/MX3PidAddSession.h
+++ b/MatrixSDK/ThreePidAdd/MX3PidAddSession.h
@@ -1,0 +1,66 @@
+/*
+ Copyright 2019 The Matrix.org Foundation C.I.C
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import "MXJSONModels.h"
+#import "MXHTTPOperation.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MX3PidAddSession : NSObject
+
+/**
+ Initialise the instance with a 3PID.
+
+ @param medium the medium.
+ @param address the id of the contact on this medium.
+ @return the new instance.
+ */
+- (instancetype)initWithMedium:(NSString*)medium andAddress:(NSString*)address;
+
+/**
+ The type of the third party media.
+ */
+@property (nonatomic, readonly) MX3PIDMedium medium;
+
+/**
+ The third party media (email address, msisdn,...).
+ */
+@property (nonatomic, readonly) NSString *address;
+
+/**
+ The client secret key used during third party validation.
+ */
+@property (nonatomic, readonly) NSString *clientSecret;
+
+/**
+ The session identifier during third party validation.
+ */
+@property (nonatomic) NSString *sid;
+
+/**
+ The ongoing HTTP request.
+ */
+@property (nonatomic, nullable) MXHTTPOperation *httpOperation;
+
+/**
+ Number of request send attempts.
+ */
+@property (nonatomic) NSUInteger sendAttempt;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixSDK/ThreePidAdd/MX3PidAddSession.h
+++ b/MatrixSDK/ThreePidAdd/MX3PidAddSession.h
@@ -61,6 +61,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic) NSUInteger sendAttempt;
 
+/**
+ Flag indicating if the 3Pid must be add to the identity server.
+ */
+@property (nonatomic) BOOL bind;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/MatrixSDK/ThreePidAdd/MX3PidAddSession.h
+++ b/MatrixSDK/ThreePidAdd/MX3PidAddSession.h
@@ -42,6 +42,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) NSString *address;
 
 /**
+ The 3PID country code when applicable.
+ */
+@property (nonatomic, nullable) NSString *countryCode;
+
+/**
  The client secret key used during third party validation.
  */
 @property (nonatomic, readonly) NSString *clientSecret;

--- a/MatrixSDK/ThreePidAdd/MX3PidAddSession.m
+++ b/MatrixSDK/ThreePidAdd/MX3PidAddSession.m
@@ -1,0 +1,35 @@
+/*
+ Copyright 2019 The Matrix.org Foundation C.I.C
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MX3PidAddSession.h"
+
+#import "MXTools.h"
+
+@implementation MX3PidAddSession
+
+- (instancetype)initWithMedium:(NSString *)medium andAddress:(NSString *)address
+{
+    self = [super init];
+    if (self)
+    {
+        _medium = [medium copy];
+        _address = [address copy];
+        _clientSecret = [MXTools generateSecret];
+    }
+    return self;
+}
+
+@end


### PR DESCRIPTION
This manager handles all HS flags. It adds, binds, unbinds 3pids, accordingly.
Apps should use it instead of MXK3Pid.

Note: All possible IS configurations are already managed by the `MXIdentityService` this manager uses.

Part of https://github.com/vector-im/riot-ios/issues/2713:
* [x] Detect whether HS supports MSC2290 (look for unstable flag `m.separate_add_and_bind`)
* [x] Add SDK support for `POST /_matrix/client/r0/account/3pid/bind`, `POST /_matrix/client/r0/account/3pid/unbind`, and `POST /_matrix/client/r0/account/3pid/add`
* [x] Implement new 3PID add flow for MSC2290 servers
* [x] Implement new 3PID bind flow for MSC2290 servers
* [x] Use `/unstable` prefix for APIs
