### PR TITLE
Privacy: Sending Third-Party Request Tokens via the Homeserver

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,9 +19,11 @@ Improvements:
  * Privacy: Store Identity Server in Account Data ([MSC2230](https://github.com/matrix-org/matrix-doc/pull/2230))(vector-im/riot-ios#2665).
  * Privacy: Lowercase emails during IS lookup calls (vector-im/riot-ios#2696).
  * Privacy: MXRestClient: Use `id_access_token` in CS API when required (vector-im/riot-ios#2704).
+ * Privacy: Sending Third-Party Request Tokens via the Homeserver ([MSC2078](https://github.com/matrix-org/matrix-doc/pull/2078)).
 
 API break:
  * MXRestClient: Remove identity server requests. Now MXIdentityService is used to perform identity server requests.
+ * MXRestClient: requestTokenForPhoneNumber returns an additional optional parameter (`submitUrl`).
  
 Bug Fix:
  * Send kMXSessionCryptoDidCorruptDataNotification from the main thread.

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -599,7 +599,7 @@ typedef MXHTTPOperation* (^MXRestClientIdentityServerAccessTokenHandler)(void (^
                                   clientSecret:(NSString*)clientSecret
                                    sendAttempt:(NSUInteger)sendAttempt
                                       nextLink:(NSString *)nextLink
-                                       success:(void (^)(NSString *sid, NSString *msisdn))success
+                                       success:(void (^)(NSString *sid, NSString *msisdn, NSString *submitUrl))success
                                        failure:(void (^)(NSError *error))failure;
 
 #pragma mark - Push Notifications

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -943,7 +943,7 @@ MXAuthAction;
                                   clientSecret:(NSString*)clientSecret
                                    sendAttempt:(NSUInteger)sendAttempt
                                       nextLink:(NSString *)nextLink
-                                       success:(void (^)(NSString *sid, NSString *msisdn))success
+                                       success:(void (^)(NSString *sid, NSString *msisdn, NSString *submitUrl))success
                                        failure:(void (^)(NSError *error))failure
 {
     NSMutableDictionary *parameters = [NSMutableDictionary dictionaryWithDictionary:@{
@@ -973,12 +973,13 @@ MXAuthAction;
 
         if (success)
         {
-            __block NSString *sid, *msisdn;
+            __block NSString *sid, *msisdn, *submitUrl;
             [self dispatchProcessing:^{
                 MXJSONModelSetString(sid, JSONResponse[@"sid"]);
                 MXJSONModelSetString(msisdn, JSONResponse[@"msisdn"]);
+                MXJSONModelSetString(submitUrl, JSONResponse[@"submit_url"]);
             } andCompletion:^{
-                success(sid, msisdn);
+                success(sid, msisdn, submitUrl);
             }];
         }
     } failure:failure];

--- a/MatrixSDK/ThreePidAdd/MX3PidAddSession.h
+++ b/MatrixSDK/ThreePidAdd/MX3PidAddSession.h
@@ -71,6 +71,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic) BOOL bind;
 
+/**
+ The url where the validation token should be sent.
+ @see [self submitMsisdnTokenOtherUrl:] for more details.
+ */
+@property (nonatomic, nullable) NSString *submitUrl;
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
This PR implements ([MSC2078](https://github.com/matrix-org/matrix-doc/pull/2078)).

Fixes https://github.com/vector-im/riot-ios/issues/2731