### PR TITLE
MXSesssion: Send kMXSessionAccountDataDidChangeIdentityServerNotifica…

### DIFF
--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -1507,12 +1507,11 @@ typedef void (^MXOnResumeDone)(void);
 
                     // Use the IS from the account data
                     [self setIdentityServer:identityServer andAccessToken:nil];
-
-                    // And notify
-                    [[NSNotificationCenter defaultCenter] postNotificationName:kMXSessionAccountDataDidChangeIdentityServerNotification
-                                                                        object:self
-                                                                      userInfo:nil];
                 }
+
+                [[NSNotificationCenter defaultCenter] postNotificationName:kMXSessionAccountDataDidChangeIdentityServerNotification
+                                                                    object:self
+                                                                  userInfo:nil];
             }
         }
 


### PR DESCRIPTION
…tion everytime we get it from account data

So that other services depending on the current IS can get the update