### PR TITLE
MXSession: On resume, make the first /sync request trigger earlier

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Changes in Matrix iOS SDK in 0.xx.xx (2019-xx-xx)
 
 Improvements:
  * MX3PidAddManager: Add User-Interactive Auth to /account/3pid/add (vector-im/riot-ios#2744).
+ * MXSession: On resume, make the first /sync request trigger earlier (vector-im/riot-ios#2793).
 
 Bug fix:
  * Room members who left are listed with the actual members (vector-im/riot-ios#2737).

--- a/MatrixSDK/Utils/MXHTTPClient.m
+++ b/MatrixSDK/Utils/MXHTTPClient.m
@@ -45,6 +45,9 @@ NSString* const kMXHTTPClientMatrixErrorNotification = @"kMXHTTPClientMatrixErro
 NSString* const kMXHTTPClientMatrixErrorNotificationErrorKey = @"kMXHTTPClientMatrixErrorNotificationErrorKey";
 
 
+static NSUInteger requestCount = 0;
+
+
 @interface MXHTTPClient ()
 {
     /**
@@ -359,6 +362,11 @@ NSString* const kMXHTTPClientMatrixErrorNotificationErrorKey = @"kMXHTTPClientMa
 
     MXWeakify(self);
 
+    NSDate *startDate = [NSDate date];
+    NSUInteger requestNumber = requestCount++;
+
+    NSLog(@"[MXHTTPClient] #%@ - %@", @(requestNumber), path);
+
     mxHTTPOperation.numberOfTries++;
     mxHTTPOperation.operation = [httpManager dataTaskWithRequest:request uploadProgress:^(NSProgress * _Nonnull theUploadProgress) {
         
@@ -372,6 +380,8 @@ NSString* const kMXHTTPClientMatrixErrorNotificationErrorKey = @"kMXHTTPClientMa
         
     } downloadProgress:nil completionHandler:^(NSURLResponse * _Nonnull theResponse, NSDictionary *JSONResponse, NSError * _Nullable error) {
         NSHTTPURLResponse *response = (NSHTTPURLResponse*)theResponse;
+
+        NSLog(@"[MXHTTPClient] #%@ - %@ completed in %.0fms" ,@(requestNumber), path, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 
         if (!weakself)
         {


### PR DESCRIPTION
Fixes vector-im/riot-ios#2793

There is no need to wait that crypto makes all its requests when resuming the SDK because the SDK already made mandatory requests (ie, posting its device ids and one time keys) on a previous initial sync.
When resuming, those crypto requests are just updates and can be done in parallel.

Combine with https://github.com/matrix-org/matrix-ios-kit/pull/624, `/sync` is now the 3rd request the SDK makes. This is better than the previous [8th](https://github.com/vector-im/riot-ios/issues/2793#issuecomment-546292325) position.
Moreover, the SDK makes it once it has loaded data from the store. It does no more wait for other requests to complete.

New ranking:
```
13:00:30.290 [MXHTTPClient] #0 - _matrix/client/unstable/devices/BCJUGLYRTV
13:00:30.305 [MXHTTPClient] #1 - _matrix/client/r0/voip/turnServer
13:00:32.671 [MXHTTPClient] #2 - _matrix/client/r0/sync
```

The 2 first requests are made is parallel while the local data is loading. They do not block the `/sync` request.

