### PR TITLE
VoIP: Fix regression when using a TURN server

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Bug fix:
  * MX3PidAddManager: Add User-Interactive Auth to /account/3pid/add (vector-im/riot-ios#2744).
  * MXHTTPOperation: Make urlResponseFromError return the url response in case of MXError.
  * MXHTTPOperation: Fix a crash in `-mutateTo:` method when operation parameter is nil.
+ * VoIP: Fix regression when using a TURN server (vector-im/riot-ios#2796).
 
 Changes in Matrix iOS SDK in 0.14.0 (2019-10-11)
 ===============================================

--- a/MatrixSDKExtensions/VoIP/Jingle/MXJingleCallStackCall.m
+++ b/MatrixSDKExtensions/VoIP/Jingle/MXJingleCallStackCall.m
@@ -124,14 +124,13 @@
 
 - (void)addTURNServerUris:(NSArray<NSString *> *)uris withUsername:(nullable NSString *)username password:(nullable NSString *)password
 {
-    RTCConfiguration *configuration = [[RTCConfiguration alloc] init];
     RTCIceServer *ICEServer;
 
     if (uris)
     {
-        RTCIceServer *ICEServer = [[RTCIceServer alloc] initWithURLStrings:uris
-                                                                  username:username
-                                                                credential:password];
+        ICEServer = [[RTCIceServer alloc] initWithURLStrings:uris
+                                                    username:username
+                                                  credential:password];
 
         if (!ICEServer)
         {
@@ -144,6 +143,8 @@
                                           optionalConstraints:@{
                                                                 @"RtpDataChannels": @"true"
                                                                 }];
+
+    RTCConfiguration *configuration = [[RTCConfiguration alloc] init];
     if (ICEServer)
     {
         configuration.iceServers = @[ICEServer];


### PR DESCRIPTION
Closes vector-im/riot-ios#2796.