### PR TITLE
MXIdentityServerRestClient: Match registration endpoint to the IS r0.3.0 spec

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,9 @@ Changes in Matrix iOS SDK in 0.15.1 (2019-xx-xx)
 Improvements:
  * Well-known: Expose "m.integrations" according to [MSC1957](https://github.com/matrix-org/matrix-doc/pull/1957) (vector-im/riot-ios#2815).
  * MXSession: Expose and store homeserverWellknown.
+ 
+Bug fix:
+ * MXIdentityServerRestClient: Match registration endpoint to the IS r0.3.0 spec (vector-im/riot-ios#2824).
 
 Changes in Matrix iOS SDK in 0.15.0 (2019-11-06)
 ===============================================

--- a/MatrixSDK/IdentityServer/MXIdentityServerRestClient.m
+++ b/MatrixSDK/IdentityServer/MXIdentityServerRestClient.m
@@ -141,7 +141,14 @@ NSString *const MXIdentityServerRestClientErrorDomain = @"org.matrix.sdk.MXIdent
                                           {
                                               __block NSString *token;
                                               [self dispatchProcessing:^{
-                                                  MXJSONModelSetString(token, JSONResponse[@"access_token"]);
+                                                  NSString *token;
+                                                  MXJSONModelSetString(token, JSONResponse[@"token"]);
+
+                                                  // The spec is `token`, but we used `access_token` for a Sydent release :/
+                                                  if (!token)
+                                                  {
+                                                      MXJSONModelSetString(token, JSONResponse[@"access_token"]);
+                                                  }
                                               } andCompletion:^{
                                                   success(token);
                                               }];


### PR DESCRIPTION
closes vector-im/riot-ios#2824