### PR TITLE
Mark enums as `Equatable`/`Hashable`, where applicable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@ Changes in Matrix iOS SDK in 0.15.3 (2019-xx-xx)
 ===============================================
 
 Improvements:
+ * Make enums conform to `Equatable`/`Hashable` where applicable.
  * Aggregations: Implement m.reference aggregations, aka thread ([MSC1849](https://github.com/matrix-org/matrix-doc/blob/matthew/msc1849/proposals/1849-aggregations.md)).
 
 

--- a/MatrixSDK/Contrib/Swift/Data/MX3PID.swift
+++ b/MatrixSDK/Contrib/Swift/Data/MX3PID.swift
@@ -21,7 +21,7 @@ import Foundation
 public struct MX3PID {
     
     /// Types of third-party identifiers.
-    public enum Medium {
+    public enum Medium: Equatable, Hashable {
         case email
         case msisdn
         case other(String)

--- a/MatrixSDK/Contrib/Swift/JSONModels/MXEvent.swift
+++ b/MatrixSDK/Contrib/Swift/JSONModels/MXEvent.swift
@@ -27,7 +27,7 @@ import Foundation
  Custom events types, out of the specification, may exist. In this case,
  `MXEventTypeString` must be checked.
  */
-public enum MXEventType {
+public enum MXEventType: Equatable, Hashable {
     case roomName
     case roomTopic
     case roomAvatar
@@ -122,7 +122,7 @@ public enum MXEventType {
 
 
 /// Types of messages
-public enum MXMessageType {
+public enum MXMessageType: Equatable, Hashable {
     case text, emote, notice, image, audio, video, location, file
     case custom(String)
     
@@ -148,7 +148,7 @@ public enum MXMessageType {
 
 
 /// Membership definitions
-public enum MXMembership {
+public enum MXMembership: Equatable, Hashable {
     case unknown, invite, join, leave, ban
     
     public var identifier: __MXMembership {

--- a/MatrixSDK/Contrib/Swift/JSONModels/MXJSONModels.swift
+++ b/MatrixSDK/Contrib/Swift/JSONModels/MXJSONModels.swift
@@ -18,7 +18,7 @@ import Foundation
 
 
 /// Represents a login flow
-public enum MXLoginFlowType {
+public enum MXLoginFlowType: Equatable, Hashable {
     case password
     case recaptcha
     case OAuth2
@@ -51,7 +51,7 @@ public enum MXLoginFlowType {
 
 
 /// Represents a mode for forwarding push notifications.
-public enum MXPusherKind {
+public enum MXPusherKind: Equatable, Hashable {
     case http, none, custom(String)
     
     public var objectValue: NSObject {
@@ -71,7 +71,7 @@ public enum MXPusherKind {
  have the highest priority.
  Some category may define implicit conditions.
  */
-public enum MXPushRuleKind {
+public enum MXPushRuleKind: Equatable, Hashable {
     case override, content, room, sender, underride
     
     public var identifier: __MXPushRuleKind {
@@ -97,7 +97,7 @@ public enum MXPushRuleKind {
  
  Push rules can be applied globally, or to a spefific device given a `profileTag`
  */
-public enum MXPushRuleScope {
+public enum MXPushRuleScope: Equatable, Hashable {
     case global, device(profileTag: String)
     
     public var identifier: String {

--- a/MatrixSDK/Contrib/Swift/MXEnumConstants.swift
+++ b/MatrixSDK/Contrib/Swift/MXEnumConstants.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 
-public enum MXRoomHistoryVisibility {
+public enum MXRoomHistoryVisibility: Equatable, Hashable {
     case worldReadable, shared, invited, joined
     
     public var identifier: String {
@@ -43,7 +43,7 @@ public enum MXRoomHistoryVisibility {
  
  The default homeserver value is invite.
  */
-public enum MXRoomJoinRule {
+public enum MXRoomJoinRule: Equatable, Hashable {
     
     /// Anyone can join the room without any prior action
     case `public`
@@ -73,7 +73,7 @@ public enum MXRoomJoinRule {
 
 
 /// Room guest access. The default homeserver value is forbidden.
-public enum MXRoomGuestAccess {
+public enum MXRoomGuestAccess: Equatable, Hashable {
     
     /// Guests can join the room
     case canJoin
@@ -102,7 +102,7 @@ public enum MXRoomGuestAccess {
  Room visibility in the current homeserver directory.
  The default homeserver value is private.
  */
-public enum MXRoomDirectoryVisibility {
+public enum MXRoomDirectoryVisibility: Equatable, Hashable {
     
     /// The room is not listed in the homeserver directory
     case `private`
@@ -129,7 +129,7 @@ public enum MXRoomDirectoryVisibility {
 
 /// Room presets.
 /// Define a set of state events applied during a new room creation.
-public enum MXRoomPreset {
+public enum MXRoomPreset: Equatable, Hashable {
     
     /// join_rules is set to invite. history_visibility is set to shared.
     case privateChat
@@ -161,7 +161,7 @@ public enum MXRoomPreset {
 /**
  The direction of an event in the timeline.
  */
-public enum MXTimelineDirection {
+public enum MXTimelineDirection: Equatable, Hashable {
     
     /// Forwards when the event is added to the end of the timeline.
     /// These events come from the /sync stream or from forwards pagination.

--- a/MatrixSDK/Contrib/Swift/MXRestClient.swift
+++ b/MatrixSDK/Contrib/Swift/MXRestClient.swift
@@ -21,7 +21,7 @@ import Foundation
 
 
 /// Represents account data type
-public enum MXAccountDataType {
+public enum MXAccountDataType: Equatable, Hashable {
     case direct
     case pushRules
     case ignoredUserList
@@ -41,7 +41,7 @@ public enum MXAccountDataType {
 
 
 /// Method of inviting a user to a room
-public enum MXRoomInvitee {
+public enum MXRoomInvitee: Equatable, Hashable {
     
     /// Invite a user by username
     case userId(String)


### PR DESCRIPTION
This mark the publicly exposed enums as both, `Equatable` and `Hashable`, which greatly helps in writing unit tests or scaffolding UI against the SDK.

Signed-off-by: Vincent Esche <138017+regexident@users.noreply.github.com>