### PR TITLE
Expose [MXDeviceVerificationManager keyVerificationFromKeyVerificationEvent:]

### DIFF
--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -272,6 +272,14 @@
 		329571931B0240CE00ABB3BA /* MXVoIPTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 329571921B0240CE00ABB3BA /* MXVoIPTests.m */; };
 		329571991B024D2B00ABB3BA /* MXMockCallStack.m in Sources */ = {isa = PBXBuildFile; fileRef = 329571961B024D2B00ABB3BA /* MXMockCallStack.m */; };
 		3295719A1B024D2B00ABB3BA /* MXMockCallStackCall.m in Sources */ = {isa = PBXBuildFile; fileRef = 329571981B024D2B00ABB3BA /* MXMockCallStackCall.m */; };
+		3297912723A93D4B00F7BB9B /* MXKeyVerification.h in Headers */ = {isa = PBXBuildFile; fileRef = 3297912523A93D4B00F7BB9B /* MXKeyVerification.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3297912823A93D4B00F7BB9B /* MXKeyVerification.h in Headers */ = {isa = PBXBuildFile; fileRef = 3297912523A93D4B00F7BB9B /* MXKeyVerification.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3297912923A93D4B00F7BB9B /* MXKeyVerification.m in Sources */ = {isa = PBXBuildFile; fileRef = 3297912623A93D4B00F7BB9B /* MXKeyVerification.m */; };
+		3297912A23A93D4B00F7BB9B /* MXKeyVerification.m in Sources */ = {isa = PBXBuildFile; fileRef = 3297912623A93D4B00F7BB9B /* MXKeyVerification.m */; };
+		3297912E23AA126500F7BB9B /* MXKeyVerificationStatusResolver.h in Headers */ = {isa = PBXBuildFile; fileRef = 3297912C23AA126400F7BB9B /* MXKeyVerificationStatusResolver.h */; };
+		3297912F23AA126500F7BB9B /* MXKeyVerificationStatusResolver.h in Headers */ = {isa = PBXBuildFile; fileRef = 3297912C23AA126400F7BB9B /* MXKeyVerificationStatusResolver.h */; };
+		3297913023AA126500F7BB9B /* MXKeyVerificationStatusResolver.m in Sources */ = {isa = PBXBuildFile; fileRef = 3297912D23AA126400F7BB9B /* MXKeyVerificationStatusResolver.m */; };
+		3297913123AA126500F7BB9B /* MXKeyVerificationStatusResolver.m in Sources */ = {isa = PBXBuildFile; fileRef = 3297912D23AA126400F7BB9B /* MXKeyVerificationStatusResolver.m */; };
 		32999DDF22DCD183004FF987 /* MXPusher.h in Headers */ = {isa = PBXBuildFile; fileRef = 32999DDD22DCD183004FF987 /* MXPusher.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		32999DE022DCD183004FF987 /* MXPusher.m in Sources */ = {isa = PBXBuildFile; fileRef = 32999DDE22DCD183004FF987 /* MXPusher.m */; };
 		32999DE322DCD1AD004FF987 /* MXPusherData.h in Headers */ = {isa = PBXBuildFile; fileRef = 32999DE122DCD1AD004FF987 /* MXPusherData.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1267,6 +1275,10 @@
 		329571961B024D2B00ABB3BA /* MXMockCallStack.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXMockCallStack.m; sourceTree = "<group>"; };
 		329571971B024D2B00ABB3BA /* MXMockCallStackCall.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXMockCallStackCall.h; sourceTree = "<group>"; };
 		329571981B024D2B00ABB3BA /* MXMockCallStackCall.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXMockCallStackCall.m; sourceTree = "<group>"; };
+		3297912523A93D4B00F7BB9B /* MXKeyVerification.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXKeyVerification.h; sourceTree = "<group>"; };
+		3297912623A93D4B00F7BB9B /* MXKeyVerification.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXKeyVerification.m; sourceTree = "<group>"; };
+		3297912C23AA126400F7BB9B /* MXKeyVerificationStatusResolver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXKeyVerificationStatusResolver.h; sourceTree = "<group>"; };
+		3297912D23AA126400F7BB9B /* MXKeyVerificationStatusResolver.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXKeyVerificationStatusResolver.m; sourceTree = "<group>"; };
 		32999DDD22DCD183004FF987 /* MXPusher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXPusher.h; sourceTree = "<group>"; };
 		32999DDE22DCD183004FF987 /* MXPusher.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXPusher.m; sourceTree = "<group>"; };
 		32999DE122DCD1AD004FF987 /* MXPusherData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXPusherData.h; sourceTree = "<group>"; };
@@ -1872,6 +1884,7 @@
 		3252DCAB224BE59E0032264F /* Verification */ = {
 			isa = PBXGroup;
 			children = (
+				3297912423A93D2B00F7BB9B /* Status */,
 				320B3931239FA54300BE2C06 /* Requests */,
 				3252DCB3224BE72A0032264F /* Transactions */,
 				3252DCB1224BE6A90032264F /* JSONModels */,
@@ -2150,6 +2163,17 @@
 				329571981B024D2B00ABB3BA /* MXMockCallStackCall.m */,
 			);
 			path = Mocks;
+			sourceTree = "<group>";
+		};
+		3297912423A93D2B00F7BB9B /* Status */ = {
+			isa = PBXGroup;
+			children = (
+				3297912523A93D4B00F7BB9B /* MXKeyVerification.h */,
+				3297912623A93D4B00F7BB9B /* MXKeyVerification.m */,
+				3297912C23AA126400F7BB9B /* MXKeyVerificationStatusResolver.h */,
+				3297912D23AA126400F7BB9B /* MXKeyVerificationStatusResolver.m */,
+			);
+			path = Status;
 			sourceTree = "<group>";
 		};
 		32999DDC22DCD139004FF987 /* Push */ = {
@@ -2751,6 +2775,7 @@
 				322360521A8E610500A3CA81 /* MXPushRuleDisplayNameCondtionChecker.h in Headers */,
 				32B94E01228EDEBC00716A26 /* MXReactionRelation.h in Headers */,
 				F03EF5001DF014D9009DF592 /* MXMediaManager.h in Headers */,
+				3297912E23AA126500F7BB9B /* MXKeyVerificationStatusResolver.h in Headers */,
 				3245A7521AF7B2930001D8A7 /* MXCallManager.h in Headers */,
 				32B94E05228EE90300716A26 /* MXRealmReactionRelation.h in Headers */,
 				C6FE1EF01E65C4F7008587E4 /* MXAnalyticsDelegate.h in Headers */,
@@ -2760,6 +2785,7 @@
 				3291D4D41A68FFEB00C3BA41 /* MXFileRoomStore.h in Headers */,
 				32CF439D2371AF9500907C56 /* MXWellknownIntegrations.h in Headers */,
 				320BBF431D6C81550079890E /* MXEventsEnumeratorOnArray.h in Headers */,
+				3297912723A93D4B00F7BB9B /* MXKeyVerification.h in Headers */,
 				B11BD44C22CB56E80064D8B0 /* MXReplyEventParts.h in Headers */,
 				32B0E33F23A378320054FF1A /* MXEventReference.h in Headers */,
 				32B76EA320FDE2BE00B095F6 /* MXRoomMembersCount.h in Headers */,
@@ -2926,6 +2952,7 @@
 				B14EF2982397E90400758AF0 /* MXNoStore.h in Headers */,
 				B14EF2992397E90400758AF0 /* (null) in Headers */,
 				B14EF29A2397E90400758AF0 /* MXRealmCryptoStore.h in Headers */,
+				3297912F23AA126500F7BB9B /* MXKeyVerificationStatusResolver.h in Headers */,
 				B14EF29B2397E90400758AF0 /* MXMemoryRoomStore.h in Headers */,
 				B14EF29C2397E90400758AF0 /* MXRealmMediaScan.h in Headers */,
 				324AAC812399143400380A66 /* MXKeyVerificationKey.h in Headers */,
@@ -3129,6 +3156,7 @@
 				B14EF3562397E90400758AF0 /* MXGroup.h in Headers */,
 				B14EF3572397E90400758AF0 /* MX3PidAddSession.h in Headers */,
 				B14EF3582397E90400758AF0 /* MXUser.h in Headers */,
+				3297912823A93D4B00F7BB9B /* MXKeyVerification.h in Headers */,
 				B14EF3592397E90400758AF0 /* MXError.h in Headers */,
 				B14EF35A2397E90400758AF0 /* MXReplyEventFormattedBodyParts.h in Headers */,
 				B14EF35B2397E90400758AF0 /* MXKeyBackupData.h in Headers */,
@@ -3465,6 +3493,7 @@
 				32D2CC09234336D6002BD8CA /* MX3PidAddManager.swift in Sources */,
 				F0173EAD1FCF0E8900B5F6A3 /* MXGroup.m in Sources */,
 				32720D9F222EAA6F0086FFF5 /* MXAutoDiscovery.m in Sources */,
+				3297912923A93D4B00F7BB9B /* MXKeyVerification.m in Sources */,
 				32D2CC0623422462002BD8CA /* MX3PidAddManager.m in Sources */,
 				92634B831EF2E3C400DB9F60 /* MXCallKitConfiguration.m in Sources */,
 				3265CB391A14C43E00E24B2F /* MXRoomState.m in Sources */,
@@ -3500,6 +3529,7 @@
 				3271878A1DA7DCE50071C818 /* MXOlmEncryption.m in Sources */,
 				327187861DA7D0220071C818 /* MXOlmDecryption.m in Sources */,
 				32114A901A262ECB00FF2EC4 /* MXNoStore.m in Sources */,
+				3297913023AA126500F7BB9B /* MXKeyVerificationStatusResolver.m in Sources */,
 				B146D4F221A5AF7F00D8C2C6 /* MXRealmEventScanMapper.m in Sources */,
 				B11BD45A22CB58850064D8B0 /* MXReplyEventFormattedBodyParts.m in Sources */,
 				32CE6FB91A409B1F00317F1E /* MXFileStoreMetaData.m in Sources */,
@@ -3730,6 +3760,7 @@
 				B14EF1FE2397E90400758AF0 /* MXCryptoConstants.m in Sources */,
 				B14EF1FF2397E90400758AF0 /* MXRoomMember.swift in Sources */,
 				B14EF2002397E90400758AF0 /* MXKeyBackupVersion.m in Sources */,
+				3297912A23A93D4B00F7BB9B /* MXKeyVerification.m in Sources */,
 				B14EF2012397E90400758AF0 /* MXEventTimeline.m in Sources */,
 				B14EF2022397E90400758AF0 /* MXEventUnsignedData.m in Sources */,
 				324AAC792399140D00380A66 /* MXKeyVerificationKey.m in Sources */,
@@ -3738,6 +3769,7 @@
 				B14EF2052397E90400758AF0 /* MX3PidAddManager.swift in Sources */,
 				B14EF2062397E90400758AF0 /* MXGroup.m in Sources */,
 				B14EF2072397E90400758AF0 /* MXAutoDiscovery.m in Sources */,
+				3297913123AA126500F7BB9B /* MXKeyVerificationStatusResolver.m in Sources */,
 				B14EF2082397E90400758AF0 /* MX3PidAddManager.m in Sources */,
 				B14EF2092397E90400758AF0 /* MXCallKitConfiguration.m in Sources */,
 				B14EF20A2397E90400758AF0 /* MXRoomState.m in Sources */,

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -25,6 +25,10 @@
 		320B3935239FA56900BE2C06 /* MXKeyVerificationByDMRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 320B3932239FA56900BE2C06 /* MXKeyVerificationByDMRequest.h */; };
 		320B3936239FA56900BE2C06 /* MXKeyVerificationByDMRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 320B3933239FA56900BE2C06 /* MXKeyVerificationByDMRequest.m */; };
 		320B3937239FA56900BE2C06 /* MXKeyVerificationByDMRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 320B3933239FA56900BE2C06 /* MXKeyVerificationByDMRequest.m */; };
+		320B393A239FD15E00BE2C06 /* MXKeyVerificationRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 320B3938239FD15E00BE2C06 /* MXKeyVerificationRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		320B393B239FD15E00BE2C06 /* MXKeyVerificationRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 320B3938239FD15E00BE2C06 /* MXKeyVerificationRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		320B393C239FD15E00BE2C06 /* MXKeyVerificationRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 320B3939239FD15E00BE2C06 /* MXKeyVerificationRequest.m */; };
+		320B393D239FD15E00BE2C06 /* MXKeyVerificationRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 320B3939239FD15E00BE2C06 /* MXKeyVerificationRequest.m */; };
 		320BBF3C1D6C7D9D0079890E /* MXEventsEnumerator.h in Headers */ = {isa = PBXBuildFile; fileRef = 320BBF3B1D6C7D9D0079890E /* MXEventsEnumerator.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		320BBF411D6C81550079890E /* MXEventsByTypesEnumeratorOnArray.m in Sources */ = {isa = PBXBuildFile; fileRef = 320BBF3D1D6C81550079890E /* MXEventsByTypesEnumeratorOnArray.m */; };
 		320BBF421D6C81550079890E /* MXEventsByTypesEnumeratorOnArray.h in Headers */ = {isa = PBXBuildFile; fileRef = 320BBF3E1D6C81550079890E /* MXEventsByTypesEnumeratorOnArray.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1027,6 +1031,9 @@
 		320A883F217F4E3F002EA952 /* MXMegolmBackupAuthData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXMegolmBackupAuthData.m; sourceTree = "<group>"; };
 		320B3932239FA56900BE2C06 /* MXKeyVerificationByDMRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXKeyVerificationByDMRequest.h; sourceTree = "<group>"; };
 		320B3933239FA56900BE2C06 /* MXKeyVerificationByDMRequest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXKeyVerificationByDMRequest.m; sourceTree = "<group>"; };
+		320B3938239FD15E00BE2C06 /* MXKeyVerificationRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXKeyVerificationRequest.h; sourceTree = "<group>"; };
+		320B3939239FD15E00BE2C06 /* MXKeyVerificationRequest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXKeyVerificationRequest.m; sourceTree = "<group>"; };
+		320B393E239FD48400BE2C06 /* MXKeyVerificationRequest_Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXKeyVerificationRequest_Private.h; sourceTree = "<group>"; };
 		320BBF3B1D6C7D9D0079890E /* MXEventsEnumerator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXEventsEnumerator.h; sourceTree = "<group>"; };
 		320BBF3D1D6C81550079890E /* MXEventsByTypesEnumeratorOnArray.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXEventsByTypesEnumeratorOnArray.m; sourceTree = "<group>"; };
 		320BBF3E1D6C81550079890E /* MXEventsByTypesEnumeratorOnArray.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXEventsByTypesEnumeratorOnArray.h; sourceTree = "<group>"; };
@@ -1620,6 +1627,9 @@
 			children = (
 				320B3932239FA56900BE2C06 /* MXKeyVerificationByDMRequest.h */,
 				320B3933239FA56900BE2C06 /* MXKeyVerificationByDMRequest.m */,
+				320B3938239FD15E00BE2C06 /* MXKeyVerificationRequest.h */,
+				320B393E239FD48400BE2C06 /* MXKeyVerificationRequest_Private.h */,
+				320B3939239FD15E00BE2C06 /* MXKeyVerificationRequest.m */,
 			);
 			path = Requests;
 			sourceTree = "<group>";
@@ -2724,6 +2734,7 @@
 				3281E8B719E42DFE00976E1A /* MXJSONModel.h in Headers */,
 				3284A5A01DB7C00600A09972 /* MXCryptoStore.h in Headers */,
 				327E9AF62289D53800A98BC1 /* MXReactionCount.h in Headers */,
+				320B393A239FD15E00BE2C06 /* MXKeyVerificationRequest.h in Headers */,
 				B146D4AF21A5A04300D8C2C6 /* MXMediaScanStore.h in Headers */,
 				32FA10CE1FA1C9F700E54233 /* MXOutgoingRoomKeyRequest.h in Headers */,
 				32A1514A1DAF7C0C00400192 /* MXUsersDevicesMap.h in Headers */,
@@ -2959,6 +2970,7 @@
 				B14EF2C12397E90400758AF0 /* MXKeyBackup.h in Headers */,
 				B14EF2C22397E90400758AF0 /* MXCallKitConfiguration.h in Headers */,
 				B14EF2C32397E90400758AF0 /* MXFilterJSONModel.h in Headers */,
+				320B393B239FD15E00BE2C06 /* MXKeyVerificationRequest.h in Headers */,
 				B14EF2C42397E90400758AF0 /* MXRealmHelper.h in Headers */,
 				B14EF2C52397E90400758AF0 /* MXPushRuleDisplayNameCondtionChecker.h in Headers */,
 				B14EF2C62397E90400758AF0 /* MXReactionRelation.h in Headers */,
@@ -3512,6 +3524,7 @@
 				32E226A71D06AC9F00E6CA54 /* MXPeekingRoom.m in Sources */,
 				021AFBA72179E91900742B2C /* MXEncryptedContentFile.m in Sources */,
 				3220094619EFBF30008DE41D /* MXSessionEventListener.m in Sources */,
+				320B393C239FD15E00BE2C06 /* MXKeyVerificationRequest.m in Sources */,
 				32A31BC920D401FC005916C7 /* MXRoomFilter.m in Sources */,
 				32A151471DAF7C0C00400192 /* MXDeviceInfo.m in Sources */,
 				321CFDEB22525DEE004D31DF /* MXIncomingSASTransaction.m in Sources */,
@@ -3748,6 +3761,7 @@
 				B14EF21C2397E90400758AF0 /* MXAggregatedReactions.m in Sources */,
 				B14EF21D2397E90400758AF0 /* MXEncryptedContentKey.m in Sources */,
 				B14EF21E2397E90400758AF0 /* MXEventDecryptionResult.m in Sources */,
+				320B393D239FD15E00BE2C06 /* MXKeyVerificationRequest.m in Sources */,
 				B14EF21F2397E90400758AF0 /* MXMyUser.m in Sources */,
 				B14EF2202397E90400758AF0 /* (null) in Sources */,
 				B14EF2212397E90400758AF0 /* MX3PID.swift in Sources */,

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -21,6 +21,10 @@
 		320A883D217F4E35002EA952 /* MXMegolmBackupCreationInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 320A883B217F4E35002EA952 /* MXMegolmBackupCreationInfo.m */; };
 		320A8840217F4E3F002EA952 /* MXMegolmBackupAuthData.h in Headers */ = {isa = PBXBuildFile; fileRef = 320A883E217F4E3E002EA952 /* MXMegolmBackupAuthData.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		320A8841217F4E3F002EA952 /* MXMegolmBackupAuthData.m in Sources */ = {isa = PBXBuildFile; fileRef = 320A883F217F4E3F002EA952 /* MXMegolmBackupAuthData.m */; };
+		320B3934239FA56900BE2C06 /* MXKeyVerificationByDMRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 320B3932239FA56900BE2C06 /* MXKeyVerificationByDMRequest.h */; };
+		320B3935239FA56900BE2C06 /* MXKeyVerificationByDMRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 320B3932239FA56900BE2C06 /* MXKeyVerificationByDMRequest.h */; };
+		320B3936239FA56900BE2C06 /* MXKeyVerificationByDMRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 320B3933239FA56900BE2C06 /* MXKeyVerificationByDMRequest.m */; };
+		320B3937239FA56900BE2C06 /* MXKeyVerificationByDMRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 320B3933239FA56900BE2C06 /* MXKeyVerificationByDMRequest.m */; };
 		320BBF3C1D6C7D9D0079890E /* MXEventsEnumerator.h in Headers */ = {isa = PBXBuildFile; fileRef = 320BBF3B1D6C7D9D0079890E /* MXEventsEnumerator.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		320BBF411D6C81550079890E /* MXEventsByTypesEnumeratorOnArray.m in Sources */ = {isa = PBXBuildFile; fileRef = 320BBF3D1D6C81550079890E /* MXEventsByTypesEnumeratorOnArray.m */; };
 		320BBF421D6C81550079890E /* MXEventsByTypesEnumeratorOnArray.h in Headers */ = {isa = PBXBuildFile; fileRef = 320BBF3E1D6C81550079890E /* MXEventsByTypesEnumeratorOnArray.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -116,8 +120,8 @@
 		32481A851C03572900782AD3 /* MXRoomAccountData.m in Sources */ = {isa = PBXBuildFile; fileRef = 32481A831C03572900782AD3 /* MXRoomAccountData.m */; };
 		324AAC6F239913AD00380A66 /* MXKeyVerificationJSONModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 324AAC69239913AC00380A66 /* MXKeyVerificationJSONModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		324AAC70239913AD00380A66 /* MXKeyVerificationJSONModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 324AAC6A239913AC00380A66 /* MXKeyVerificationJSONModel.m */; };
-		324AAC71239913AD00380A66 /* MXKeyVerificationRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 324AAC6B239913AC00380A66 /* MXKeyVerificationRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		324AAC72239913AD00380A66 /* MXKeyVerificationRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 324AAC6C239913AC00380A66 /* MXKeyVerificationRequest.m */; };
+		324AAC71239913AD00380A66 /* MXKeyVerificationRequestJSONModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 324AAC6B239913AC00380A66 /* MXKeyVerificationRequestJSONModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		324AAC72239913AD00380A66 /* MXKeyVerificationRequestJSONModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 324AAC6C239913AC00380A66 /* MXKeyVerificationRequestJSONModel.m */; };
 		324AAC73239913AD00380A66 /* MXKeyVerificationDone.m in Sources */ = {isa = PBXBuildFile; fileRef = 324AAC6D239913AC00380A66 /* MXKeyVerificationDone.m */; };
 		324AAC74239913AD00380A66 /* MXKeyVerificationDone.h in Headers */ = {isa = PBXBuildFile; fileRef = 324AAC6E239913AD00380A66 /* MXKeyVerificationDone.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		324AAC752399140D00380A66 /* MXKeyVerificationAccept.m in Sources */ = {isa = PBXBuildFile; fileRef = 327A5F3F239805F600ED6329 /* MXKeyVerificationAccept.m */; };
@@ -126,7 +130,7 @@
 		324AAC782399140D00380A66 /* MXKeyVerificationJSONModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 324AAC6A239913AC00380A66 /* MXKeyVerificationJSONModel.m */; };
 		324AAC792399140D00380A66 /* MXKeyVerificationKey.m in Sources */ = {isa = PBXBuildFile; fileRef = 327A5F40239805F600ED6329 /* MXKeyVerificationKey.m */; };
 		324AAC7A2399140D00380A66 /* MXKeyVerificationMac.m in Sources */ = {isa = PBXBuildFile; fileRef = 327A5F45239805F600ED6329 /* MXKeyVerificationMac.m */; };
-		324AAC7B2399140D00380A66 /* MXKeyVerificationRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 324AAC6C239913AC00380A66 /* MXKeyVerificationRequest.m */; };
+		324AAC7B2399140D00380A66 /* MXKeyVerificationRequestJSONModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 324AAC6C239913AC00380A66 /* MXKeyVerificationRequestJSONModel.m */; };
 		324AAC7C2399140D00380A66 /* MXKeyVerificationStart.m in Sources */ = {isa = PBXBuildFile; fileRef = 327A5F42239805F600ED6329 /* MXKeyVerificationStart.m */; };
 		324AAC7D2399143400380A66 /* MXKeyVerificationAccept.h in Headers */ = {isa = PBXBuildFile; fileRef = 327A5F43239805F600ED6329 /* MXKeyVerificationAccept.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		324AAC7E2399143400380A66 /* MXKeyVerificationCancel.h in Headers */ = {isa = PBXBuildFile; fileRef = 327A5F3B239805F600ED6329 /* MXKeyVerificationCancel.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -134,7 +138,7 @@
 		324AAC802399143400380A66 /* MXKeyVerificationJSONModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 324AAC69239913AC00380A66 /* MXKeyVerificationJSONModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		324AAC812399143400380A66 /* MXKeyVerificationKey.h in Headers */ = {isa = PBXBuildFile; fileRef = 327A5F41239805F600ED6329 /* MXKeyVerificationKey.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		324AAC822399143400380A66 /* MXKeyVerificationMac.h in Headers */ = {isa = PBXBuildFile; fileRef = 327A5F38239805F500ED6329 /* MXKeyVerificationMac.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		324AAC832399143400380A66 /* MXKeyVerificationRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 324AAC6B239913AC00380A66 /* MXKeyVerificationRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		324AAC832399143400380A66 /* MXKeyVerificationRequestJSONModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 324AAC6B239913AC00380A66 /* MXKeyVerificationRequestJSONModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		324AAC842399143400380A66 /* MXKeyVerificationStart.h in Headers */ = {isa = PBXBuildFile; fileRef = 327A5F3D239805F600ED6329 /* MXKeyVerificationStart.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		324BE45B1E3FA7A8008D99D4 /* MXMegolmExportEncryptionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 324BE45A1E3FA7A8008D99D4 /* MXMegolmExportEncryptionTest.m */; };
 		324BE4681E3FADB1008D99D4 /* MXMegolmExportEncryption.h in Headers */ = {isa = PBXBuildFile; fileRef = 324BE4661E3FADB1008D99D4 /* MXMegolmExportEncryption.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1021,6 +1025,8 @@
 		320A883B217F4E35002EA952 /* MXMegolmBackupCreationInfo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXMegolmBackupCreationInfo.m; sourceTree = "<group>"; };
 		320A883E217F4E3E002EA952 /* MXMegolmBackupAuthData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXMegolmBackupAuthData.h; sourceTree = "<group>"; };
 		320A883F217F4E3F002EA952 /* MXMegolmBackupAuthData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXMegolmBackupAuthData.m; sourceTree = "<group>"; };
+		320B3932239FA56900BE2C06 /* MXKeyVerificationByDMRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXKeyVerificationByDMRequest.h; sourceTree = "<group>"; };
+		320B3933239FA56900BE2C06 /* MXKeyVerificationByDMRequest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXKeyVerificationByDMRequest.m; sourceTree = "<group>"; };
 		320BBF3B1D6C7D9D0079890E /* MXEventsEnumerator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXEventsEnumerator.h; sourceTree = "<group>"; };
 		320BBF3D1D6C81550079890E /* MXEventsByTypesEnumeratorOnArray.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXEventsByTypesEnumeratorOnArray.m; sourceTree = "<group>"; };
 		320BBF3E1D6C81550079890E /* MXEventsByTypesEnumeratorOnArray.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXEventsByTypesEnumeratorOnArray.h; sourceTree = "<group>"; };
@@ -1118,8 +1124,8 @@
 		32481A831C03572900782AD3 /* MXRoomAccountData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXRoomAccountData.m; sourceTree = "<group>"; };
 		324AAC69239913AC00380A66 /* MXKeyVerificationJSONModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXKeyVerificationJSONModel.h; sourceTree = "<group>"; };
 		324AAC6A239913AC00380A66 /* MXKeyVerificationJSONModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXKeyVerificationJSONModel.m; sourceTree = "<group>"; };
-		324AAC6B239913AC00380A66 /* MXKeyVerificationRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXKeyVerificationRequest.h; sourceTree = "<group>"; };
-		324AAC6C239913AC00380A66 /* MXKeyVerificationRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXKeyVerificationRequest.m; sourceTree = "<group>"; };
+		324AAC6B239913AC00380A66 /* MXKeyVerificationRequestJSONModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXKeyVerificationRequestJSONModel.h; sourceTree = "<group>"; };
+		324AAC6C239913AC00380A66 /* MXKeyVerificationRequestJSONModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXKeyVerificationRequestJSONModel.m; sourceTree = "<group>"; };
 		324AAC6D239913AC00380A66 /* MXKeyVerificationDone.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXKeyVerificationDone.m; sourceTree = "<group>"; };
 		324AAC6E239913AD00380A66 /* MXKeyVerificationDone.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXKeyVerificationDone.h; sourceTree = "<group>"; };
 		324BE45A1E3FA7A8008D99D4 /* MXMegolmExportEncryptionTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXMegolmExportEncryptionTest.m; sourceTree = "<group>"; };
@@ -1609,6 +1615,15 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		320B3931239FA54300BE2C06 /* Requests */ = {
+			isa = PBXGroup;
+			children = (
+				320B3932239FA56900BE2C06 /* MXKeyVerificationByDMRequest.h */,
+				320B3933239FA56900BE2C06 /* MXKeyVerificationByDMRequest.m */,
+			);
+			path = Requests;
+			sourceTree = "<group>";
+		};
 		320BBF3A1D6C7D9D0079890E /* EventsEnumerator */ = {
 			isa = PBXGroup;
 			children = (
@@ -1847,6 +1862,7 @@
 		3252DCAB224BE59E0032264F /* Verification */ = {
 			isa = PBXGroup;
 			children = (
+				320B3931239FA54300BE2C06 /* Requests */,
 				3252DCB3224BE72A0032264F /* Transactions */,
 				3252DCB1224BE6A90032264F /* JSONModels */,
 				3252DCB0224BE6670032264F /* Data */,
@@ -1883,8 +1899,8 @@
 				327A5F40239805F600ED6329 /* MXKeyVerificationKey.m */,
 				327A5F38239805F500ED6329 /* MXKeyVerificationMac.h */,
 				327A5F45239805F600ED6329 /* MXKeyVerificationMac.m */,
-				324AAC6B239913AC00380A66 /* MXKeyVerificationRequest.h */,
-				324AAC6C239913AC00380A66 /* MXKeyVerificationRequest.m */,
+				324AAC6B239913AC00380A66 /* MXKeyVerificationRequestJSONModel.h */,
+				324AAC6C239913AC00380A66 /* MXKeyVerificationRequestJSONModel.m */,
 				327A5F3D239805F600ED6329 /* MXKeyVerificationStart.h */,
 				327A5F42239805F600ED6329 /* MXKeyVerificationStart.m */,
 			);
@@ -2675,7 +2691,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				322A51B61D9AB15900C8536D /* MXCrypto.h in Headers */,
-				324AAC71239913AD00380A66 /* MXKeyVerificationRequest.h in Headers */,
+				324AAC71239913AD00380A66 /* MXKeyVerificationRequestJSONModel.h in Headers */,
 				32114A8F1A262ECB00FF2EC4 /* MXNoStore.h in Headers */,
 				3259CD531DF860C300186944 /* MXRealmCryptoStore.h in Headers */,
 				32D776811A27877300FC4AA2 /* MXMemoryRoomStore.h in Headers */,
@@ -2770,6 +2786,7 @@
 				B146D4E121A5AEF200D8C2C6 /* MXRealmMediaScanMapper.h in Headers */,
 				F08B8D5C1E014711006171A8 /* NSData+MatrixSDK.h in Headers */,
 				C60165381E3AA57900B92CFA /* MXSDKOptions.h in Headers */,
+				320B3934239FA56900BE2C06 /* MXKeyVerificationByDMRequest.h in Headers */,
 				3281E8B919E42DFE00976E1A /* MXJSONModels.h in Headers */,
 				323F3F9420D3F0C700D26D6A /* MXRoomEventFilter.h in Headers */,
 				32A9E8251EF4026E0081358A /* MXUIKitBackgroundModeHandler.h in Headers */,
@@ -2955,7 +2972,7 @@
 				B14EF2CE2397E90400758AF0 /* MXFileRoomStore.h in Headers */,
 				B14EF2CF2397E90400758AF0 /* (null) in Headers */,
 				B14EF2D02397E90400758AF0 /* MXWellknownIntegrations.h in Headers */,
-				324AAC832399143400380A66 /* MXKeyVerificationRequest.h in Headers */,
+				324AAC832399143400380A66 /* MXKeyVerificationRequestJSONModel.h in Headers */,
 				B14EF2D12397E90400758AF0 /* MXEventsEnumeratorOnArray.h in Headers */,
 				B14EF2D22397E90400758AF0 /* MXReplyEventParts.h in Headers */,
 				B14EF2D32397E90400758AF0 /* MXRoomMembersCount.h in Headers */,
@@ -3075,6 +3092,7 @@
 				B14EF33E2397E90400758AF0 /* MXOlmInboundGroupSession.h in Headers */,
 				B14EF33F2397E90400758AF0 /* (null) in Headers */,
 				B14EF3402397E90400758AF0 /* MXKeyBackupVersionTrust.h in Headers */,
+				320B3935239FA56900BE2C06 /* MXKeyVerificationByDMRequest.h in Headers */,
 				B14EF3412397E90400758AF0 /* MXOutgoingRoomKeyRequestManager.h in Headers */,
 				B14EF3422397E90400758AF0 /* MXPeekingRoomSummary.h in Headers */,
 				B14EF3432397E90400758AF0 /* MXEventTimeline.h in Headers */,
@@ -3381,6 +3399,7 @@
 				322360531A8E610500A3CA81 /* MXPushRuleDisplayNameCondtionChecker.m in Sources */,
 				32A31BC520D3FFB0005916C7 /* MXFilter.m in Sources */,
 				32B76EA520FDE85100B095F6 /* MXRoomMembersCount.m in Sources */,
+				320B3936239FA56900BE2C06 /* MXKeyVerificationByDMRequest.m in Sources */,
 				B146D47121A5939100D8C2C6 /* MXRealmHelper.m in Sources */,
 				327E9AD82284803100A98BC1 /* MXEventAnnotation.m in Sources */,
 				32999DE022DCD183004FF987 /* MXPusher.m in Sources */,
@@ -3441,7 +3460,7 @@
 				327E9AE22285497100A98BC1 /* MXEventContentRelatesTo.m in Sources */,
 				32A1514B1DAF7C0C00400192 /* MXUsersDevicesMap.m in Sources */,
 				328BCB3421947BE200A976D3 /* MXKeyBackupVersionTrust.m in Sources */,
-				324AAC72239913AD00380A66 /* MXKeyVerificationRequest.m in Sources */,
+				324AAC72239913AD00380A66 /* MXKeyVerificationRequestJSONModel.m in Sources */,
 				C6B40F521F2A35BE00C42C72 /* MXRoomState.swift in Sources */,
 				B11BD45522CB583E0064D8B0 /* MXReplyEventBodyParts.m in Sources */,
 				32F945F51FAB83D900622468 /* MXIncomingRoomKeyRequestCancellation.m in Sources */,
@@ -3693,7 +3712,7 @@
 				32B0E33C23A2989A0054FF1A /* MXEventReferenceChunk.m in Sources */,
 				B14EF1FB2397E90400758AF0 /* MXEnumConstants.swift in Sources */,
 				B14EF1FC2397E90400758AF0 /* MXEventRelations.m in Sources */,
-				324AAC7B2399140D00380A66 /* MXKeyVerificationRequest.m in Sources */,
+				324AAC7B2399140D00380A66 /* MXKeyVerificationRequestJSONModel.m in Sources */,
 				B14EF1FD2397E90400758AF0 /* MXReactionOperation.m in Sources */,
 				B14EF1FE2397E90400758AF0 /* MXCryptoConstants.m in Sources */,
 				B14EF1FF2397E90400758AF0 /* MXRoomMember.swift in Sources */,
@@ -3837,6 +3856,7 @@
 				B14EF2802397E90400758AF0 /* MXServiceTerms.m in Sources */,
 				B14EF2812397E90400758AF0 /* MXNotificationCenter.m in Sources */,
 				B14EF2822397E90400758AF0 /* MXDeviceList.m in Sources */,
+				320B3937239FA56900BE2C06 /* MXKeyVerificationByDMRequest.m in Sources */,
 				B14EF2832397E90400758AF0 /* MXRoomCreateContent.m in Sources */,
 				B14EF2842397E90400758AF0 /* MXUIKitBackgroundModeHandler.m in Sources */,
 				B14EF2852397E90400758AF0 /* (null) in Sources */,

--- a/MatrixSDK/Crypto/Verification/JSONModels/MXKeyVerificationJSONModel.m
+++ b/MatrixSDK/Crypto/Verification/JSONModels/MXKeyVerificationJSONModel.m
@@ -20,6 +20,11 @@
 
 @implementation MXKeyVerificationJSONModel
 
++ (id)modelFromJSON:(NSDictionary *)JSONDictionary
+{
+    return [[self alloc] initWithJSONDictionary:JSONDictionary];
+}
+
 - (instancetype)initWithJSONDictionary:(NSDictionary *)JSONDictionary
 {
     MXJSONModelSetString(_transactionId, JSONDictionary[@"transaction_id"]);

--- a/MatrixSDK/Crypto/Verification/JSONModels/MXKeyVerificationJSONModel.m
+++ b/MatrixSDK/Crypto/Verification/JSONModels/MXKeyVerificationJSONModel.m
@@ -16,6 +16,8 @@
 
 #import "MXKeyVerificationJSONModel.h"
 
+#import "MXEvent.h"
+
 @implementation MXKeyVerificationJSONModel
 
 - (instancetype)initWithJSONDictionary:(NSDictionary *)JSONDictionary
@@ -44,7 +46,7 @@
     {
         JSONDictionary[@"m.relates_to"] = @{
                                             @"event_id": _relatedEventId,
-                                            @"rel_type": @"m.reference"
+                                            @"rel_type": MXEventRelationTypeReference
                                             };
     }
     else

--- a/MatrixSDK/Crypto/Verification/JSONModels/MXKeyVerificationRequestJSONModel.h
+++ b/MatrixSDK/Crypto/Verification/JSONModels/MXKeyVerificationRequestJSONModel.h
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
  Model for m.key.verification.request.
  As described at https://github.com/uhoreg/matrix-doc/blob/e2e_verification_in_dms/proposals/2241-e2e-verification-in-dms.md#requesting-a-key-verification
  */
-@interface MXKeyVerificationRequest : MXJSONModel
+@interface MXKeyVerificationRequestJSONModel : MXJSONModel
 
 /**
  A fallback message to alert users that their client does not support the key verification framework.

--- a/MatrixSDK/Crypto/Verification/JSONModels/MXKeyVerificationRequestJSONModel.m
+++ b/MatrixSDK/Crypto/Verification/JSONModels/MXKeyVerificationRequestJSONModel.m
@@ -14,15 +14,15 @@
  limitations under the License.
  */
 
-#import "MXKeyVerificationRequest.h"
+#import "MXKeyVerificationRequestJSONModel.h"
 
 #import "MXEvent.h"
 
-@implementation MXKeyVerificationRequest
+@implementation MXKeyVerificationRequestJSONModel
 
 + (instancetype)modelFromJSON:(NSDictionary *)JSONDictionary
 {
-    MXKeyVerificationRequest *request = [MXKeyVerificationRequest new];
+    MXKeyVerificationRequestJSONModel *request = [MXKeyVerificationRequestJSONModel new];
     if (request)
     {
         MXJSONModelSetString(request.body, JSONDictionary[@"body"]);

--- a/MatrixSDK/Crypto/Verification/MXDeviceVericationManager.m
+++ b/MatrixSDK/Crypto/Verification/MXDeviceVericationManager.m
@@ -45,7 +45,7 @@ NSTimeInterval const MXTransactionTimeout = 10 * 60.0;
 // Request timeout in seconds
 NSTimeInterval const MXRequestDefaultTimeout = 5 * 60.0;
 
-static NSArray<MXEventTypeString> *MXDeviceVerificationManagerDMEventTypes;
+static NSArray<MXEventTypeString> *kMXDeviceVerificationManagerDMEventTypes;
 
 
 @interface MXDeviceVerificationManager ()
@@ -305,7 +305,7 @@ static NSArray<MXEventTypeString> *MXDeviceVerificationManagerDMEventTypes;
 {
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        MXDeviceVerificationManagerDMEventTypes = @[
+        kMXDeviceVerificationManagerDMEventTypes = @[
                                                     kMXEventTypeStringKeyVerificationStart,
                                                     kMXEventTypeStringKeyVerificationAccept,
                                                     kMXEventTypeStringKeyVerificationKey,
@@ -754,7 +754,7 @@ static NSArray<MXEventTypeString> *MXDeviceVerificationManagerDMEventTypes;
 
 - (void)setupIncomingDMEvents
 {
-    [_crypto.mxSession listenToEventsOfTypes:MXDeviceVerificationManagerDMEventTypes onEvent:^(MXEvent *event, MXTimelineDirection direction, id customObject) {
+    [_crypto.mxSession listenToEventsOfTypes:kMXDeviceVerificationManagerDMEventTypes onEvent:^(MXEvent *event, MXTimelineDirection direction, id customObject) {
         if (direction == MXTimelineDirectionForwards
             && ![event.sender isEqualToString:self.crypto.mxSession.myUser.userId])
         {
@@ -765,7 +765,7 @@ static NSArray<MXEventTypeString> *MXDeviceVerificationManagerDMEventTypes;
 
 - (BOOL)isVerificationByDMEventType:(MXEventTypeString)type
 {
-    return [MXDeviceVerificationManagerDMEventTypes containsObject:type];
+    return [kMXDeviceVerificationManagerDMEventTypes containsObject:type];
 }
 
 - (MXHTTPOperation*)sendMessage:(NSString*)userId

--- a/MatrixSDK/Crypto/Verification/MXDeviceVericationManager.m
+++ b/MatrixSDK/Crypto/Verification/MXDeviceVericationManager.m
@@ -24,16 +24,24 @@
 
 #import "MXTransactionCancelCode.h"
 
+#import "MXKeyVerificationRequest_Private.h"
+#import "MXKeyVerificationByDMRequest.h"
 #import "MXKeyVerificationRequestJSONModel.h"
+
 
 #pragma mark - Constants
 
 NSString *const MXDeviceVerificationErrorDomain = @"org.matrix.sdk.verification";
-NSString *const MXDeviceVerificationManagerNewTransactionNotification = @"MXDeviceVerificationManagerNewTransactionNotification";
-NSString *const MXDeviceVerificationManagerNotificationTransactionKey = @"MXDeviceVerificationManagerNotificationTransactionKey";
+NSString *const MXDeviceVerificationManagerNewRequestNotification       = @"MXDeviceVerificationManagerNewRequestNotification";
+NSString *const MXDeviceVerificationManagerNotificationRequestKey       = @"MXDeviceVerificationManagerNotificationRequestKey";
+NSString *const MXDeviceVerificationManagerNewTransactionNotification   = @"MXDeviceVerificationManagerNewTransactionNotification";
+NSString *const MXDeviceVerificationManagerNotificationTransactionKey   = @"MXDeviceVerificationManagerNotificationTransactionKey";
 
 // Transaction timeout in seconds
-NSTimeInterval const MXDeviceVerificationTimeout = 10 * 60.0;
+NSTimeInterval const MXTransactionTimeout = 10 * 60.0;
+
+// Request timeout in seconds
+NSTimeInterval const MXRequestDefaultTimeout = 5 * 60.0;
 
 
 @interface MXDeviceVerificationManager ()
@@ -43,9 +51,15 @@ NSTimeInterval const MXDeviceVerificationTimeout = 10 * 60.0;
 
     // All running transactions
     MXUsersDevicesMap<MXDeviceVerificationTransaction*> *transactions;
-
     // Timer to cancel transactions
-    NSTimer *timeoutTimer;
+    NSTimer *transactionTimeoutTimer;
+
+    // All pending requests
+    // Request id -> request
+    NSMutableDictionary<NSString*, MXKeyVerificationRequest*> *pendingRequestsMap;
+
+    // Timer to cancel requests
+    NSTimer *requestTimeoutTimer;
 }
 @end
 
@@ -59,7 +73,7 @@ NSTimeInterval const MXDeviceVerificationTimeout = 10 * 60.0;
                                    roomId:(NSString*)roomId
                              fallbackText:(NSString*)fallbackText
                                   methods:(NSArray<NSString*>*)methods
-                                  success:(void(^)(NSString *eventId))success
+                                  success:(void(^)(MXKeyVerificationRequest *request))success
                                   failure:(void(^)(NSError *error))failure
 {
     NSLog(@"[MXKeyVerification] requestVerificationByDMWithUserId: %@. RoomId: %@", userId, roomId);
@@ -82,62 +96,33 @@ NSTimeInterval const MXDeviceVerificationTimeout = 10 * 60.0;
     request.to = userId;
     request.fromDevice = _crypto.myDevice.deviceId;
 
-    [room sendMessageWithContent:request.JSONDictionary localEcho:nil success:^(NSString *eventId) {
-        NSLog(@"[MXKeyVerification] requestVerificationByDMWithUserId: -> Request event id: %@", eventId);
-        success(eventId);
+    MXEvent *event = nil;
+    [room sendMessageWithContent:request.JSONDictionary localEcho:&event success:^(NSString *eventId) {
     } failure:failure];
+
+    // Wait for the event to be sent
+    __block id observer;
+    observer = [[NSNotificationCenter defaultCenter] addObserverForName:kMXEventDidChangeSentStateNotification object:event queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification * _Nonnull note) {
+
+        if (event.sentState == MXEventSentStateSent)
+        {
+            [[NSNotificationCenter defaultCenter] removeObserver:observer];
+            observer = nil;
+
+            MXKeyVerificationRequest *request = [self verificationRequestInDMEvent:event];
+            request.state = MXKeyVerificationRequestStatePending;
+            [self addPendingRequest:request notify:NO];
+
+            success(request);
+        }
+    }];
 }
 
+#pragma mark Current requests
 
-- (void)acceptVerificationByDMFromEvent:(MXEvent*)event
-                                 method:(NSString*)method
-                                success:(void(^)(MXDeviceVerificationTransaction *transaction))success
-                                failure:(void(^)(NSError *error))failure
+- (NSArray<MXKeyVerificationRequest*> *)pendingRequests
 {
-    NSLog(@"[MXKeyVerification] acceptVerificationByDMFromEvent: %@", event.eventId);
-
-    // Sanity checks
-    NSString *fromDevice = event.content[@"from_device"];
-    if (!fromDevice)
-    {
-        NSError *error = [NSError errorWithDomain:MXDeviceVerificationErrorDomain
-                                             code:MXDeviceVerificationUnknownDeviceCode
-                                         userInfo:@{
-                                                    NSLocalizedDescriptionKey: [NSString stringWithFormat:@"from_device not found in %@", event.content]
-                                                    }];
-        failure(error);
-        return;
-    }
-
-    [self beginKeyVerificationWithUserId:event.sender andDeviceId:fromDevice dmEvent:event method:method success:success failure:failure];
-}
-
-- (void)cancelVerificationByDMFromEvent:(MXEvent*)event
-                                success:(void(^)(void))success
-                                failure:(void(^)(NSError *error))failure
-{
-    MXTransactionCancelCode *cancelCode = MXTransactionCancelCode.user;
-
-    // If there is transaction in progress, cancel it
-    MXDeviceVerificationTransaction *transaction = [self transactionWithTransactionId:event.eventId];
-    if (transaction)
-    {
-        MXDeviceVerificationTransaction *transaction = [self transactionWithTransactionId:event.eventId];
-        [self cancelTransaction:transaction code:cancelCode];
-    }
-    else
-    {
-        // Else only cancel the request
-        MXKeyVerificationCancel *cancel = [MXKeyVerificationCancel new];
-        cancel.transactionId = transaction.transactionId;
-        cancel.code = cancelCode.value;
-        cancel.reason = cancelCode.humanReadable;
-
-        [self sendMessage:event.sender roomId:event.roomId eventType:kMXEventTypeStringKeyVerificationCancel relatedTo:event.eventId content:cancel.JSONDictionary success:^{} failure:^(NSError *error) {
-
-            NSLog(@"[MXKeyVerification] cancelTransactionFromStartEvent. Error: %@", error);
-        }];
-    }
+    return pendingRequestsMap.allValues;
 }
 
 
@@ -149,17 +134,18 @@ NSTimeInterval const MXDeviceVerificationTimeout = 10 * 60.0;
                                success:(void(^)(MXDeviceVerificationTransaction *transaction))success
                                failure:(void(^)(NSError *error))failure
 {
-    [self beginKeyVerificationWithUserId:userId andDeviceId:deviceId dmEvent:nil method:method success:success failure:failure];
+    [self beginKeyVerificationWithUserId:userId andDeviceId:deviceId dmRoomId:nil dmEventId:nil method:method success:success failure:failure];
 }
 
 - (void)beginKeyVerificationWithUserId:(NSString*)userId
                            andDeviceId:(NSString*)deviceId
-                                dmEvent:(nullable MXEvent*)dmEvent
+                              dmRoomId:(nullable NSString*)dmRoomId
+                             dmEventId:(nullable NSString*)dmEventId
                                 method:(NSString*)method
                                success:(void(^)(MXDeviceVerificationTransaction *transaction))success
                                failure:(void(^)(NSError *error))failure
 {
-    NSLog(@"[MXKeyVerification] beginKeyVerification: device: %@:%@ roomId: %@ method:%@", userId, deviceId, dmEvent.roomId, method);
+    NSLog(@"[MXKeyVerification] beginKeyVerification: device: %@:%@ roomId: %@ method:%@", userId, deviceId, dmRoomId, method);
 
     // Make sure we have other device keys
     [self loadDeviceWithDeviceId:deviceId andUserId:userId success:^(MXDeviceInfo *otherDevice) {
@@ -173,9 +159,9 @@ NSTimeInterval const MXDeviceVerificationTimeout = 10 * 60.0;
             MXOutgoingSASTransaction *sasTransaction = [[MXOutgoingSASTransaction alloc] initWithOtherDevice:otherDevice andManager:self];
 
             // Detect verification by DM
-            if (dmEvent)
+            if (dmRoomId)
             {
-                [sasTransaction setDirectMessageTransportInRoom:dmEvent.roomId originalEvent:dmEvent.eventId];
+                [sasTransaction setDirectMessageTransportInRoom:dmRoomId originalEvent:dmEventId];
             }
 
             [sasTransaction start];
@@ -240,21 +226,97 @@ NSTimeInterval const MXDeviceVerificationTimeout = 10 * 60.0;
 
         // Observe incoming DM events
         [self setupIncomingDMEvents];
+
+        _requestTimeout = MXRequestDefaultTimeout;
+        pendingRequestsMap = [NSMutableDictionary dictionary];
+        [self setupVericationByDMRequests];
     }
     return self;
 }
 
 - (void)dealloc
 {
-    if (timeoutTimer)
+    if (transactionTimeoutTimer)
     {
-        [timeoutTimer invalidate];
-        timeoutTimer = nil;
+        [transactionTimeoutTimer invalidate];
+        transactionTimeoutTimer = nil;
     }
 }
 
 
-#pragma mark - Outgoing events
+#pragma mark - Requests
+
+- (void)acceptVerificationRequest:(MXKeyVerificationRequest*)request
+                           method:(NSString*)method
+                          success:(void(^)(MXDeviceVerificationTransaction *transaction))success
+                          failure:(void(^)(NSError *error))failure
+{
+    NSLog(@"[MXKeyVerification] acceptVerificationByDMRequest: event: %@", request.requestId);
+
+    // Sanity checks
+    NSString *fromDevice = request.fromDevice;
+    if (!fromDevice)
+    {
+        NSError *error = [NSError errorWithDomain:MXDeviceVerificationErrorDomain
+                                             code:MXDeviceVerificationUnknownDeviceCode
+                                         userInfo:@{
+                                                    NSLocalizedDescriptionKey: [NSString stringWithFormat:@"from_device not found"]
+                                                    }];
+        failure(error);
+        return;
+    }
+
+    if ([request isKindOfClass:MXKeyVerificationByDMRequest.class])
+    {
+        MXKeyVerificationByDMRequest *requestByDM = (MXKeyVerificationByDMRequest*)request;
+        [self beginKeyVerificationWithUserId:request.sender andDeviceId:fromDevice dmRoomId:requestByDM.roomId dmEventId:requestByDM.eventId method:method success:success failure:failure];
+    }
+    else
+    {
+        // Requests by to_device are not supported
+        NSParameterAssert(NO);
+    }
+}
+
+- (void)cancelVerificationRequest:(MXKeyVerificationRequest*)request
+                          success:(void(^)(void))success
+                          failure:(void(^)(NSError *error))failure
+{
+    MXTransactionCancelCode *cancelCode = MXTransactionCancelCode.user;
+
+    // If there is transaction in progress, cancel it
+    MXDeviceVerificationTransaction *transaction = [self transactionWithTransactionId:request.requestId];
+    if (transaction)
+    {
+        [self cancelTransaction:transaction code:cancelCode];
+    }
+    else
+    {
+        // Else only cancel the request
+        if ([request isKindOfClass:MXKeyVerificationByDMRequest.class])
+        {
+            MXKeyVerificationByDMRequest *requestByDM = (MXKeyVerificationByDMRequest*)request;
+
+            MXKeyVerificationCancel *cancel = [MXKeyVerificationCancel new];
+            cancel.transactionId = transaction.transactionId;
+            cancel.code = cancelCode.value;
+            cancel.reason = cancelCode.humanReadable;
+
+            [self sendMessage:request.sender roomId:requestByDM.roomId eventType:kMXEventTypeStringKeyVerificationCancel relatedTo:requestByDM.eventId content:cancel.JSONDictionary success:^{} failure:^(NSError *error) {
+
+                NSLog(@"[MXKeyVerification] cancelTransactionFromStartEvent. Error: %@", error);
+            }];
+        }
+        else
+        {
+            // Requests by to_device are not supported
+            NSParameterAssert(NO);
+        }
+    }
+}
+
+
+#pragma mark - Transactions
 
 - (MXHTTPOperation*)sendToOtherInTransaction:(MXDeviceVerificationTransaction*)transaction
                                    eventType:(NSString*)eventType
@@ -627,6 +689,56 @@ NSTimeInterval const MXDeviceVerificationTimeout = 10 * 60.0;
     } failure:failure];
 }
 
+- (void)setupVericationByDMRequests
+{
+    NSArray *types = @[
+                       kMXEventTypeStringRoomMessage
+                       ];
+
+    [_crypto.mxSession listenToEventsOfTypes:types onEvent:^(MXEvent *event, MXTimelineDirection direction, id customObject) {
+        if (direction == MXTimelineDirectionForwards
+            //&& ![event.sender isEqualToString:self.crypto.mxSession.myUser.userId])
+            && [event.content[@"msgtype"] isEqualToString:kMXMessageTypeKeyVerificationRequest])
+        {
+            MXKeyVerificationByDMRequest *requestByDM = [[MXKeyVerificationByDMRequest alloc] initWithEvent:event andManager:self];
+            if (requestByDM)
+            {
+                [self handleKeyVerificationRequest:requestByDM];
+            }
+        }
+    }];
+}
+
+
+- (void)handleKeyVerificationRequest:(MXKeyVerificationRequest*)request
+{
+    NSLog(@"[MXKeyVerification] handleKeyVerificationRequest: %@", request);
+
+    if (![request.to isEqualToString:self.crypto.mxSession.myUser.userId])
+    {
+        NSLog(@"[MXKeyVerification] handleKeyVerificationRequest: Request for another user: %@", request.to);
+        return;
+    }
+
+    BOOL isFromMyUser = [request.sender isEqualToString:self.crypto.mxSession.myUser.userId];
+    request.isFromMyUser = isFromMyUser;
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        // This is a live event, we should have all data
+        [self resolveStateForRequest:request success:^(MXKeyVerificationRequestState state) {
+
+            if (state == MXKeyVerificationRequestStatePending)
+            {
+                [self addPendingRequest:request notify:YES];
+            }
+
+        } failure:^(NSError *error) {
+            NSLog(@"[MXKeyVerificationRequest] handleKeyVerificationRequest: Failed to resolve state: %@", request.requestId);
+        }];
+    });
+}
+
+
 
 #pragma mark - Private methods -
 
@@ -659,6 +771,125 @@ NSTimeInterval const MXDeviceVerificationTimeout = 10 * 60.0;
     } failure:failure];
 }
 
+
+#pragma mark - Requests queue
+
+- (nullable MXKeyVerificationRequest*)verificationRequestInDMEvent:(MXEvent*)event
+{
+    MXKeyVerificationRequest *request;
+    if ([event.content[@"msgtype"] isEqualToString:kMXMessageTypeKeyVerificationRequest])
+    {
+        request = [[MXKeyVerificationByDMRequest alloc] initWithEvent:event andManager:self];
+    }
+    return request;
+}
+
+- (nullable MXKeyVerificationRequest*)pendingRequestWithRequestId:(NSString*)requestId
+{
+    return pendingRequestsMap[requestId];
+}
+
+- (void)addPendingRequest:(MXKeyVerificationRequest *)request notify:(BOOL)notify
+{
+    if (!pendingRequestsMap[request.requestId])
+    {
+        pendingRequestsMap[request.requestId] = request;
+
+        if (notify)
+        {
+            [[NSNotificationCenter defaultCenter] postNotificationName:MXDeviceVerificationManagerNewRequestNotification object:self userInfo:
+             @{
+               MXDeviceVerificationManagerNotificationRequestKey: request
+               }];
+        }
+    }
+    [self scheduleRequestTimeoutTimer];
+}
+
+- (void)removePendingRequestWithRequestId:(NSString*)requestId
+{
+    if (!pendingRequestsMap[requestId])
+    {
+        [pendingRequestsMap removeObjectForKey:requestId];
+        [self scheduleRequestTimeoutTimer];
+    }
+}
+
+
+#pragma mark - Timeout management
+
+- (nullable NSDate*)oldestRequestDate
+{
+    NSDate *oldestRequestDate;
+    for (MXKeyVerificationRequest *request in pendingRequestsMap.allValues)
+    {
+        if (!oldestRequestDate
+            || request.ageLocalTs < oldestRequestDate.timeIntervalSince1970)
+        {
+            oldestRequestDate = [NSDate dateWithTimeIntervalSince1970:(request.ageLocalTs / 1000)];
+        }
+    }
+    return oldestRequestDate;
+}
+
+- (BOOL)isRequestStillPending:(MXKeyVerificationRequest*)request
+{
+    NSDate *requestDate = [NSDate dateWithTimeIntervalSince1970:(request.ageLocalTs / 1000)];
+    return (requestDate.timeIntervalSinceNow > -_requestTimeout);
+}
+
+- (void)scheduleRequestTimeoutTimer
+{
+    if (requestTimeoutTimer)
+    {
+        if (!pendingRequestsMap.count)
+        {
+            NSLog(@"[MXKeyVerificationRequest] scheduleTimeoutTimer: Disable timer as there is no more requests");
+            [requestTimeoutTimer invalidate];
+            requestTimeoutTimer = nil;
+        }
+
+        return;
+    }
+
+    NSDate *oldestRequestDate = [self oldestRequestDate];
+    if (oldestRequestDate)
+    {
+        NSLog(@"[MXKeyVerificationRequest] scheduleTimeoutTimer: Create timer");
+
+        NSDate *timeoutDate = [oldestRequestDate dateByAddingTimeInterval:self.requestTimeout];
+        self->requestTimeoutTimer = [[NSTimer alloc] initWithFireDate:timeoutDate
+                                                      interval:0
+                                                        target:self
+                                                      selector:@selector(onRequestTimeoutTimer)
+                                                      userInfo:nil
+                                                       repeats:NO];
+        [[NSRunLoop mainRunLoop] addTimer:self->requestTimeoutTimer forMode:NSDefaultRunLoopMode];
+    }
+}
+
+- (void)onRequestTimeoutTimer
+{
+    NSLog(@"[MXKeyVerificationRequest] onTimeoutTimer");
+    requestTimeoutTimer = nil;
+
+    [self checkRequestTimeouts];
+    [self scheduleRequestTimeoutTimer];
+}
+
+- (void)checkRequestTimeouts
+{
+    for (MXKeyVerificationRequest *request in pendingRequestsMap.allValues)
+    {
+        if ([self isRequestStillPending:request])
+        {
+            NSLog(@"[MXKeyVerificationRequest] checkTimeouts: timeout %@", request);
+            [request cancelWithCancelCode:MXTransactionCancelCode.timeout];
+        }
+    }
+}
+
+
 #pragma mark - Transactions queue
 
 - (MXDeviceVerificationTransaction*)transactionWithUser:(NSString*)userId andDevice:(NSString*)deviceId
@@ -689,7 +920,7 @@ NSTimeInterval const MXDeviceVerificationTimeout = 10 * 60.0;
 - (void)addTransaction:(MXDeviceVerificationTransaction*)transaction
 {
     [transactions setObject:transaction forUser:transaction.otherUserId andDevice:transaction.otherDeviceId];
-    [self scheduleTimeoutTimer];
+    [self scheduleTransactionTimeoutTimer];
 
     dispatch_async(dispatch_get_main_queue(),^{
         [[NSNotificationCenter defaultCenter] postNotificationName:MXDeviceVerificationManagerNewTransactionNotification object:self userInfo:
@@ -705,7 +936,7 @@ NSTimeInterval const MXDeviceVerificationTimeout = 10 * 60.0;
     if (transaction)
     {
         [transactions removeObjectForUser:transaction.otherUserId andDevice:transaction.otherDeviceId];
-        [self scheduleTimeoutTimer];
+        [self scheduleTransactionTimeoutTimer];
     }
 }
 
@@ -725,20 +956,21 @@ NSTimeInterval const MXDeviceVerificationTimeout = 10 * 60.0;
 
 - (BOOL)isCreationDateValid:(MXDeviceVerificationTransaction*)transaction
 {
-    return (transaction.creationDate.timeIntervalSinceNow > -MXDeviceVerificationTimeout);
+    return (transaction.creationDate.timeIntervalSinceNow > -MXTransactionTimeout);
 }
 
-#pragma mark - Timeout management
 
-- (void)scheduleTimeoutTimer
+#pragma mark Timeout management
+
+- (void)scheduleTransactionTimeoutTimer
 {
-    if (timeoutTimer)
+    if (transactionTimeoutTimer)
     {
         if (!transactions.count)
         {
             NSLog(@"[MXKeyVerification] scheduleTimeoutTimer: Disable timer as there is no more transactions");
-            [timeoutTimer invalidate];
-            timeoutTimer = nil;
+            [transactionTimeoutTimer invalidate];
+            transactionTimeoutTimer = nil;
         }
 
         return;
@@ -751,40 +983,40 @@ NSTimeInterval const MXDeviceVerificationTimeout = 10 * 60.0;
         dispatch_async(dispatch_get_main_queue(), ^{
             MXStrongifyAndReturnIfNil(self);
 
-            if (self->timeoutTimer)
+            if (self->transactionTimeoutTimer)
             {
                 return;
             }
 
             NSLog(@"[MXKeyVerification] scheduleTimeoutTimer: Create timer");
 
-            NSDate *timeoutDate = [oldestCreationDate dateByAddingTimeInterval:MXDeviceVerificationTimeout];
-            self->timeoutTimer = [[NSTimer alloc] initWithFireDate:timeoutDate
+            NSDate *timeoutDate = [oldestCreationDate dateByAddingTimeInterval:MXTransactionTimeout];
+            self->transactionTimeoutTimer = [[NSTimer alloc] initWithFireDate:timeoutDate
                                                           interval:0
                                                             target:self
-                                                          selector:@selector(onTimeoutTimer)
+                                                          selector:@selector(onTransactionTimeoutTimer)
                                                           userInfo:nil
                                                            repeats:NO];
-            [[NSRunLoop mainRunLoop] addTimer:self->timeoutTimer forMode:NSDefaultRunLoopMode];
+            [[NSRunLoop mainRunLoop] addTimer:self->transactionTimeoutTimer forMode:NSDefaultRunLoopMode];
         });
     }
 }
 
-- (void)onTimeoutTimer
+- (void)onTransactionTimeoutTimer
 {
     NSLog(@"[MXKeyVerification] onTimeoutTimer");
-    self->timeoutTimer = nil;
+    self->transactionTimeoutTimer = nil;
 
     if (cryptoQueue)
     {
         dispatch_async(cryptoQueue, ^{
-            [self checkTimeouts];
-            [self scheduleTimeoutTimer];
+            [self checkTransactionTimeouts];
+            [self scheduleTransactionTimeoutTimer];
         });
     }
 }
 
-- (void)checkTimeouts
+- (void)checkTransactionTimeouts
 {
     for (MXDeviceVerificationTransaction *transaction in transactions.allObjects)
     {
@@ -794,6 +1026,54 @@ NSTimeInterval const MXDeviceVerificationTimeout = 10 * 60.0;
             [transaction cancelWithCancelCode:MXTransactionCancelCode.timeout];
         }
     }
+}
+
+
+#pragma mark - State resolver
+
+- (void)resolveStateForRequest:(MXKeyVerificationRequest*)request
+                       success:(void(^)(MXKeyVerificationRequestState state))success
+                       failure:(void(^)(NSError *error))failure
+{
+    if ([request isKindOfClass:MXKeyVerificationByDMRequest.class])
+    {
+        MXKeyVerificationByDMRequest *requestByDM = (MXKeyVerificationByDMRequest*)request;
+        [self resolveStateForRequestByDM:requestByDM success:success failure:failure];
+    }
+    else
+    {
+        // Requests by to_device are not supported
+        NSParameterAssert(NO);
+    }
+}
+
+- (void)resolveStateForRequestByDM:(MXKeyVerificationByDMRequest*)request
+                           success:(void(^)(MXKeyVerificationRequestState state))success
+                           failure:(void(^)(NSError *error))failure
+{
+
+    // Get all related events
+    [self.crypto.mxSession.aggregations referenceEventsForEvent:request.eventId inRoom:request.roomId from:nil limit:-1 success:^(MXAggregationPaginatedResponse * _Nonnull paginatedResponse) {
+
+        MXKeyVerificationRequestState state = MXKeyVerificationRequestStatePending;
+
+        // TODO
+        for (MXEvent *event in paginatedResponse.chunk)
+        {
+            NSLog(@"### # %@", event);
+        }
+
+        if (state == MXKeyVerificationRequestStatePending
+            && ![self isRequestStillPending:request])
+        {
+            // Check expiration
+            state = MXKeyVerificationRequestStateExpired;
+        }
+
+        request.state = state;
+        success(state);
+
+    } failure:failure];
 }
 
 @end

--- a/MatrixSDK/Crypto/Verification/MXDeviceVericationManager.m
+++ b/MatrixSDK/Crypto/Verification/MXDeviceVericationManager.m
@@ -614,7 +614,7 @@ NSTimeInterval const MXDeviceVerificationTimeout = 10 * 60.0;
     NSMutableDictionary *eventContent = [content mutableCopy];
 
     eventContent[@"m.relates_to"] = @{
-                                      @"rel_type": @"m.reference",
+                                      @"rel_type": MXEventRelationTypeReference,
                                       @"event_id": relatedTo,
                                       };
 

--- a/MatrixSDK/Crypto/Verification/MXDeviceVericationManager.m
+++ b/MatrixSDK/Crypto/Verification/MXDeviceVericationManager.m
@@ -24,6 +24,8 @@
 
 #import "MXTransactionCancelCode.h"
 
+#import "MXKeyVerificationRequestJSONModel.h"
+
 #pragma mark - Constants
 
 NSString *const MXDeviceVerificationErrorDomain = @"org.matrix.sdk.verification";
@@ -74,7 +76,7 @@ NSTimeInterval const MXDeviceVerificationTimeout = 10 * 60.0;
         return;
     }
 
-    MXKeyVerificationRequest *request = [MXKeyVerificationRequest new];
+    MXKeyVerificationRequestJSONModel *request = [MXKeyVerificationRequestJSONModel new];
     request.body = fallbackText;
     request.methods = methods;
     request.to = userId;

--- a/MatrixSDK/Crypto/Verification/MXDeviceVerificationManager.h
+++ b/MatrixSDK/Crypto/Verification/MXDeviceVerificationManager.h
@@ -19,12 +19,14 @@
 
 #import "MXKeyVerificationRequest.h"
 #import "MXDeviceVerificationTransaction.h"
+#import "MXKeyVerification.h"
 
 #import "MXSASTransaction.h"
 #import "MXIncomingSASTransaction.h"
 #import "MXOutgoingSASTransaction.h"
 
 #import "MXEvent.h"
+#import "MXHTTPOperation.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -38,6 +40,7 @@ typedef enum : NSUInteger
     MXDeviceVerificationUnknownDeviceCode,
     MXDeviceVerificationUnsupportedMethodCode,
     MXDeviceVerificationUnknownRoomCode,
+    MXDeviceVerificationUnknownIdentifier,
 } MXDeviceVerificationErrorCode;
 
 
@@ -130,6 +133,29 @@ FOUNDATION_EXPORT NSString *const MXDeviceVerificationManagerNotificationTransac
  @param complete a block called with all transactions.
  */
 - (void)transactions:(void(^)(NSArray<MXDeviceVerificationTransaction*> *transactions))complete;
+
+
+#pragma mark - Verification status
+
+/**
+ Retrieve the verification status from an event.
+
+ @param event an event in the verification process.
+ @param success a block called when the operation succeeds.
+ @param failure a block called when the operation fails.
+ @return an HTTP operation or nil if the response is synchronous.
+ */
+- (nullable MXHTTPOperation *)keyVerificationFromKeyVerificationEvent:(MXEvent*)event
+                                                              success:(void(^)(MXKeyVerification *keyVerification))success
+                                                              failure:(void(^)(NSError *error))failure;
+
+/**
+ Extract the verification identifier from an event.
+
+ @param event an event in the verification process.
+ @return the key verification id. Nil if the event is not a verification event.
+ */
+- (nullable NSString *)keyVerificationIdFromDMEvent:(MXEvent*)event;
 
 @end
 

--- a/MatrixSDK/Crypto/Verification/MXDeviceVerificationManager.h
+++ b/MatrixSDK/Crypto/Verification/MXDeviceVerificationManager.h
@@ -41,6 +41,22 @@ typedef enum : NSUInteger
 } MXDeviceVerificationErrorCode;
 
 
+#pragma mark - Requests
+
+/**
+ Posted on new device verification request.
+ */
+FOUNDATION_EXPORT NSString *const MXDeviceVerificationManagerNewRequestNotification;
+
+/**
+ The key in the notification userInfo dictionary containing the `MXKeyVerificationRequest` instance.
+ */
+FOUNDATION_EXPORT NSString *const MXDeviceVerificationManagerNotificationRequestKey;
+
+
+
+#pragma mark - Transactions
+
 /**
  Posted on new device verification transaction.
  */
@@ -63,6 +79,12 @@ FOUNDATION_EXPORT NSString *const MXDeviceVerificationManagerNotificationTransac
 #pragma mark - Requests
 
 /**
+ The timeout for requests.
+ Default is 5 min.
+ */
+@property (nonatomic) NSTimeInterval requestTimeout;
+
+/**
  Make a key verification request by Direct Message.
 
  @param userId the other user id.
@@ -76,33 +98,13 @@ FOUNDATION_EXPORT NSString *const MXDeviceVerificationManagerNotificationTransac
                                    roomId:(NSString*)roomId
                              fallbackText:(NSString*)fallbackText
                                   methods:(NSArray<NSString*>*)methods
-                                  success:(void(^)(NSString *eventId))success
+                                  success:(void(^)(MXKeyVerificationRequest *request))success
                                   failure:(void(^)(NSError *error))failure;
 
-
 /**
- Accept an incoming key verification request by Direct Message.
-
- @param event the event in the DM room.
- @param method the method to use.
- @param success a block called when the operation succeeds.
- @param failure a block called when the operation fails.
+ All pending verification requests.
  */
-- (void)acceptVerificationByDMFromEvent:(MXEvent*)event
-                                 method:(NSString*)method
-                                success:(void(^)(MXDeviceVerificationTransaction *transaction))success
-                                failure:(void(^)(NSError *error))failure;
-
-/**
- Cancel a key verification request or reject an incoming key verification request by Direct Message.
-
- @param event the original request event.
- @param success a block called when the operation succeeds.
- @param failure a block called when the operation fails.
- */
-- (void)cancelVerificationByDMFromEvent:(MXEvent*)event
-                                success:(void(^)(void))success
-                                failure:(void(^)(NSError *error))failure;
+@property (nonatomic, readonly) NSArray<MXKeyVerificationRequest*> *pendingRequests;
 
 
 #pragma mark - Transactions

--- a/MatrixSDK/Crypto/Verification/MXDeviceVerificationManager_Private.h
+++ b/MatrixSDK/Crypto/Verification/MXDeviceVerificationManager_Private.h
@@ -66,6 +66,10 @@ NS_ASSUME_NONNULL_BEGIN
                           success:(void(^)(void))success
                           failure:(void(^)(NSError *error))failure;
 
+- (BOOL)isRequestStillPending:(MXKeyVerificationRequest*)request;
+
+- (void)removePendingRequestWithRequestId:(NSString*)requestId;
+
 
 #pragma mark - Transactions
 

--- a/MatrixSDK/Crypto/Verification/MXDeviceVerificationManager_Private.h
+++ b/MatrixSDK/Crypto/Verification/MXDeviceVerificationManager_Private.h
@@ -40,7 +40,34 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithCrypto:(MXCrypto *)crypto;
 
 
-#pragma mark - Outgoing events
+#pragma mark - Requests
+
+/**
+ Accept an incoming key verification request.
+
+ @param request the request.
+ @param method the method to use.
+ @param success a block called when the operation succeeds.
+ @param failure a block called when the operation fails.
+ */
+- (void)acceptVerificationRequest:(MXKeyVerificationRequest*)request
+                           method:(NSString*)method
+                          success:(void(^)(MXDeviceVerificationTransaction *transaction))success
+                          failure:(void(^)(NSError *error))failure;
+
+/**
+ Cancel a key verification request or reject an incoming key verification request.
+
+ @param request the request.
+ @param success a block called when the operation succeeds.
+ @param failure a block called when the operation fails.
+ */
+- (void)cancelVerificationRequest:(MXKeyVerificationRequest*)request
+                          success:(void(^)(void))success
+                          failure:(void(^)(NSError *error))failure;
+
+
+#pragma mark - Transactions
 
 /**
  Send a message to the other a peer in a device verification transaction.

--- a/MatrixSDK/Crypto/Verification/Requests/MXKeyVerificationByDMRequest.h
+++ b/MatrixSDK/Crypto/Verification/Requests/MXKeyVerificationByDMRequest.h
@@ -1,0 +1,38 @@
+/*
+ Copyright 2019 The Matrix.org Foundation C.I.C
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "MXKeyVerificationRequest.h"
+
+@class MXEvent, MXDeviceVerificationManager;
+
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ An handler on an interactive request for verification by Direct Message.
+ */
+@interface MXKeyVerificationByDMRequest : MXKeyVerificationRequest
+
+@property (nonatomic, readonly) NSString *roomId;
+@property (nonatomic, readonly) NSString *eventId;
+
+- (instancetype)initWithEvent:(MXEvent*)event andManager:(MXDeviceVerificationManager*)manager;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixSDK/Crypto/Verification/Requests/MXKeyVerificationByDMRequest.m
+++ b/MatrixSDK/Crypto/Verification/Requests/MXKeyVerificationByDMRequest.m
@@ -1,0 +1,54 @@
+/*
+ Copyright 2019 The Matrix.org Foundation C.I.C
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+
+#import "MXKeyVerificationByDMRequest.h"
+
+#import "MXKeyVerificationRequest_Private.h"
+#import "MXKeyVerificationRequestJSONModel.h"
+
+#import "MXEvent.h"
+
+
+@implementation MXKeyVerificationByDMRequest
+
+- (instancetype)initWithEvent:(MXEvent*)event andManager:(MXDeviceVerificationManager*)manager
+{
+    // Check verification by DM request format
+    MXKeyVerificationRequestJSONModel *request;
+    MXJSONModelSetMXJSONModel(request, MXKeyVerificationRequestJSONModel.class, event.content);
+
+    if (!request)
+    {
+        return nil;
+    }
+
+    // Use the event id as identifier
+    self = [self initWithRequestId:event.eventId
+                                to:request.to
+                            sender:event.sender
+                        fromDevice:request.fromDevice
+                        ageLocalTs:event.ageLocalTs
+                           manager:manager];
+    if (self)
+    {
+        _roomId = event.roomId;
+        _eventId = event.eventId;
+    }
+    return self;
+}
+
+@end

--- a/MatrixSDK/Crypto/Verification/Requests/MXKeyVerificationRequest.h
+++ b/MatrixSDK/Crypto/Verification/Requests/MXKeyVerificationRequest.h
@@ -61,6 +61,11 @@ Accept an incoming key verification request.
  */
 - (void)cancelWithCancelCode:(MXTransactionCancelCode*)code;
 
+/**
+ The cancellation reason, if any.
+ */
+@property (nonatomic, nullable) MXTransactionCancelCode *reasonCancelCode;
+
 
 @property (nonatomic, readonly) NSString *requestId;
 

--- a/MatrixSDK/Crypto/Verification/Requests/MXKeyVerificationRequest.h
+++ b/MatrixSDK/Crypto/Verification/Requests/MXKeyVerificationRequest.h
@@ -1,0 +1,81 @@
+/*
+ Copyright 2019 The Matrix.org Foundation C.I.C
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "MXDeviceVerificationTransaction.h"
+
+
+#pragma mark - Constants
+
+/**
+ Notification sent when the request has been updated.
+ */
+FOUNDATION_EXPORT NSString * _Nonnull const MXKeyVerificationRequestDidChangeNotification;
+
+typedef enum : NSUInteger
+{
+    MXKeyVerificationRequestStatePending = 0,
+    MXKeyVerificationRequestStateExpired,
+    MXKeyVerificationRequestStateCancelled,
+    MXKeyVerificationRequestStateCancelledByMe,
+    MXKeyVerificationRequestStateAccepted
+} MXKeyVerificationRequestState;
+
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ An handler on an interactive verification request.
+ */
+@interface MXKeyVerificationRequest : NSObject
+
+/**
+Accept an incoming key verification request.
+
+@param method the method to use.
+@param success a block called when the operation succeeds.
+@param failure a block called when the operation fails.
+*/
+- (void)acceptWithMethod:(NSString*)method
+                 success:(void(^)(MXDeviceVerificationTransaction *transaction))success
+                 failure:(void(^)(NSError *error))failure;
+
+/**
+ Cancel this request.
+
+ @param code the cancellation reason
+ */
+- (void)cancelWithCancelCode:(MXTransactionCancelCode*)code;
+
+
+@property (nonatomic, readonly) NSString *requestId;
+
+@property (nonatomic, readonly) BOOL isFromMyUser;
+
+@property (nonatomic) NSString *to;
+
+@property (nonatomic, readonly) NSString *sender;
+@property (nonatomic, readonly) NSString *fromDevice;
+
+@property (nonatomic, readonly) NSUInteger age;
+@property (nonatomic, readonly) uint64_t ageLocalTs;
+
+@property (nonatomic, readonly) MXKeyVerificationRequestState state;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixSDK/Crypto/Verification/Requests/MXKeyVerificationRequest.m
+++ b/MatrixSDK/Crypto/Verification/Requests/MXKeyVerificationRequest.m
@@ -1,0 +1,84 @@
+/*
+ Copyright 2019 The Matrix.org Foundation C.I.C
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXKeyVerificationRequest_Private.h"
+
+#import "MXDeviceVerificationManager_Private.h"
+
+
+#pragma mark - Constants
+NSString * const MXKeyVerificationRequestDidChangeNotification = @"MXKeyVerificationRequestDidChangeNotification";
+
+
+@implementation MXKeyVerificationRequest
+
+- (NSUInteger)age
+{
+    return [[NSDate date] timeIntervalSince1970] * 1000 - _ageLocalTs;
+}
+
+
+#pragma mark - SDK-Private methods -
+
+- (instancetype)initWithRequestId:(NSString*)requestId
+                               to:(NSString*)to
+                           sender:(NSString*)sender
+                       fromDevice:(NSString*)fromDevice
+                       ageLocalTs:(uint64_t)ageLocalTs
+                          manager:(MXDeviceVerificationManager*)manager
+{
+    self = [super init];
+    if (self)
+    {
+        _state = MXKeyVerificationRequestStatePending;
+        _requestId = requestId;
+        _to = to;
+        _sender = sender;
+        _fromDevice = fromDevice;
+        _ageLocalTs = ageLocalTs;
+        _manager = manager;
+    }
+    return self;
+}
+
+- (void)acceptWithMethod:(NSString *)method success:(void (^)(MXDeviceVerificationTransaction * _Nonnull))success failure:(void (^)(NSError * _Nonnull))failure
+{
+    [self.manager acceptVerificationRequest:self method:method success:success failure:failure];
+}
+
+- (void)cancelWithCancelCode:(MXTransactionCancelCode *)code
+{
+    [self.manager cancelVerificationRequest:self success:^{
+    } failure:^(NSError * _Nonnull error) {
+    } ];
+}
+
+- (void)setState:(MXKeyVerificationRequestState)state
+{
+    NSLog(@"[MXKeyVerification][MXKeyVerificationRequest] setState: %@ -> %@", @(_state), @(state));
+
+    _state = state;
+    [self didUpdateState];
+}
+
+- (void)didUpdateState
+{
+    dispatch_async(dispatch_get_main_queue(),^{
+        [[NSNotificationCenter defaultCenter] postNotificationName:MXKeyVerificationRequestDidChangeNotification object:self userInfo:nil];
+    });
+}
+
+@end

--- a/MatrixSDK/Crypto/Verification/Requests/MXKeyVerificationRequest_Private.h
+++ b/MatrixSDK/Crypto/Verification/Requests/MXKeyVerificationRequest_Private.h
@@ -16,6 +16,9 @@
 
 #import "MXKeyVerificationRequest.h"
 
+#import "MXKeyVerificationStart.h"
+#import "MXKeyVerificationCancel.h"
+
 @class MXDeviceVerificationManager, MXHTTPOperation;
 
 
@@ -36,5 +39,8 @@
 
 @property (nonatomic) BOOL isFromMyUser;
 @property (nonatomic) MXKeyVerificationRequestState state;
+
+- (void)handleStart:(MXKeyVerificationStart*)startContent;
+- (void)handleCancel:(MXKeyVerificationCancel*)cancelContent;
 
 @end

--- a/MatrixSDK/Crypto/Verification/Requests/MXKeyVerificationRequest_Private.h
+++ b/MatrixSDK/Crypto/Verification/Requests/MXKeyVerificationRequest_Private.h
@@ -1,0 +1,40 @@
+/*
+ Copyright 2019 The Matrix.org Foundation C.I.C
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXKeyVerificationRequest.h"
+
+@class MXDeviceVerificationManager, MXHTTPOperation;
+
+
+/**
+ The `MXKeyVerificationRequest` extension exposes internal operations.
+ */
+@interface MXKeyVerificationRequest ()
+
+@property (nonatomic, readonly, weak) MXDeviceVerificationManager *manager;
+
+
+- (instancetype)initWithRequestId:(NSString*)requestId
+                               to:(NSString*)to
+                         sender:(NSString*)sender
+                     fromDevice:(NSString*)fromDevice
+                     ageLocalTs:(uint64_t)ageLocalTs
+                        manager:(MXDeviceVerificationManager*)manager;
+
+@property (nonatomic) BOOL isFromMyUser;
+@property (nonatomic) MXKeyVerificationRequestState state;
+
+@end

--- a/MatrixSDK/Crypto/Verification/Status/MXKeyVerification.h
+++ b/MatrixSDK/Crypto/Verification/Status/MXKeyVerification.h
@@ -1,0 +1,64 @@
+/*
+ Copyright 2019 The Matrix.org Foundation C.I.C
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "MXKeyVerificationRequest.h"
+#import "MXDeviceVerificationTransaction.h"
+
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ Overall verification state.
+ */
+typedef enum : NSUInteger
+{
+    // First request states
+    MXKeyVerificationStateRequestPending = 0,
+    MXKeyVerificationStateRequestExpired,
+    MXKeyVerificationStateRequestCancelled,
+    MXKeyVerificationStateRequestCancelledByMe,
+    // Once the request has been accepted, we have transaction states
+    MXKeyVerificationStateTransactionStarted,
+    MXKeyVerificationStateTransactionCancelled,
+    MXKeyVerificationStateTransactionCancelledByMe,
+    MXKeyVerificationStateTransactionFailed,
+
+    MXKeyVerificationStateVerified,
+
+} MXKeyVerificationState;
+
+/**
+ Represents the status of a key verification.
+
+ A key verification has 2 life cycles:
+ - one for the request
+ - one for the transactions
+ */
+@interface MXKeyVerification : NSObject
+
+@property (nonatomic) MXKeyVerificationState state;
+
+// Those values may be not provided if there are not in progress
+@property (nonatomic, nullable) MXKeyVerificationRequest *request;
+@property (nonatomic, nullable) MXDeviceVerificationTransaction *transaction;
+
+@property (nonatomic, readonly) BOOL isRequestAccepted;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixSDK/Crypto/Verification/Status/MXKeyVerification.m
+++ b/MatrixSDK/Crypto/Verification/Status/MXKeyVerification.m
@@ -1,0 +1,26 @@
+/*
+ Copyright 2019 The Matrix.org Foundation C.I.C
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXKeyVerification.h"
+
+@implementation MXKeyVerification
+
+- (BOOL)isRequestAccepted
+{
+    return self.state >= MXKeyVerificationStateTransactionStarted;
+}
+
+@end

--- a/MatrixSDK/Crypto/Verification/Status/MXKeyVerificationStatusResolver.h
+++ b/MatrixSDK/Crypto/Verification/Status/MXKeyVerificationStatusResolver.h
@@ -1,0 +1,41 @@
+/*
+ Copyright 2019 The Matrix.org Foundation C.I.C
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "MXKeyVerification.h"
+
+@class MXDeviceVerificationManager, MXSession, MXHTTPOperation, MXEvent;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ `MXKeyVerificationStatusResolver` computes MXKeyVerification status from an event
+ of the verification process.
+ */
+@interface MXKeyVerificationStatusResolver : NSObject
+
+- (instancetype)initWithManager:(MXDeviceVerificationManager*)manager matrixSession:(MXSession*)matrixSession;
+
+- (nullable MXHTTPOperation *)keyVerificationWithKeyVerificationId:(NSString*)keyVerificationId
+                                                             event:(MXEvent*)event
+                                                         transport:(MKeyVerificationTransport)transport
+                                                           success:(void(^)(MXKeyVerification *keyVerification))success
+                                                           failure:(void(^)(NSError *error))failure;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixSDK/Crypto/Verification/Status/MXKeyVerificationStatusResolver.m
+++ b/MatrixSDK/Crypto/Verification/Status/MXKeyVerificationStatusResolver.m
@@ -1,0 +1,242 @@
+/*
+ Copyright 2019 The Matrix.org Foundation C.I.C
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXKeyVerificationStatusResolver.h"
+
+#import "MXSession.h"
+#import "MXKeyVerificationByDMRequest.h"
+#import "MXKeyVerificationRequest_Private.h"
+#import "MXKeyVerification.h"
+#import "MXDeviceVerificationManager_Private.h"
+
+#import "MXKeyVerificationCancel.h"
+
+
+@interface MXKeyVerificationStatusResolver ()
+@property (nonatomic, weak) MXDeviceVerificationManager *manager;
+@property (nonatomic) MXSession *mxSession;
+@end
+
+
+@implementation MXKeyVerificationStatusResolver
+
+- (instancetype)initWithManager:(MXDeviceVerificationManager*)manager matrixSession:(MXSession*)matrixSession;
+
+{
+    self = [super init];
+    if (self)
+    {
+        self.manager = manager;
+        self.mxSession = matrixSession;
+    }
+    return self;
+}
+
+
+- (nullable MXHTTPOperation *)keyVerificationWithKeyVerificationId:(NSString*)keyVerificationId
+                                                             event:(MXEvent*)event
+                                                         transport:(MKeyVerificationTransport)transport
+                                                           success:(void(^)(MXKeyVerification *keyVerification))success
+                                                           failure:(void(^)(NSError *error))failure
+{
+    MXHTTPOperation *operation;
+    switch (transport)
+    {
+        case MKeyVerificationTransportDirectMessage:
+        {
+            operation = [self eventsInVerificationByDMThreadFromOriginalEventId:keyVerificationId inRoom:event.roomId success:^(MXEvent *originalEvent, NSArray<MXEvent*> *events) {
+
+                if (!originalEvent)
+                {
+                    originalEvent = event;
+                }
+
+                MXKeyVerification *keyVerification = [self makeKeyVerificationFromOriginalDMEvent:originalEvent events:events];
+                if (keyVerification)
+                {
+                    success(keyVerification);
+                }
+                else
+                {
+                    NSError *error = [NSError errorWithDomain:MXDeviceVerificationErrorDomain
+                                                         code:MXDeviceVerificationUnknownIdentifier
+                                                     userInfo:@{
+                                                                NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Unknown id"]
+                                                                }];
+                    failure(error);
+                }
+
+            } failure:failure];
+            break;
+        }
+
+        default:
+            // Requests by to_device are not supported
+            NSParameterAssert(NO);
+            break;
+    }
+
+    return operation;
+}
+
+- (nullable MXHTTPOperation *)eventsInVerificationByDMThreadFromOriginalEventId:(NSString*)originalEventId
+                                                                         inRoom:(NSString*)roomId
+                                                                        success:(void(^)(MXEvent *originalEvent, NSArray<MXEvent*> *events))success
+                                                                        failure:(void(^)(NSError *error))failure
+{
+    // Get all related events
+    return [self.mxSession.aggregations referenceEventsForEvent:originalEventId inRoom:roomId from:nil limit:-1 success:^(MXAggregationPaginatedResponse * _Nonnull paginatedResponse) {
+        success(paginatedResponse.originalEvent, paginatedResponse.chunk);
+    } failure:failure];
+}
+
+- (nullable MXKeyVerification *)makeKeyVerificationFromOriginalDMEvent:(nullable MXEvent*)originalEvent events:(NSArray<MXEvent*> *)events
+{
+    MXKeyVerification *keyVerification;
+
+    MXKeyVerificationRequest *request = [self verificationRequestInDMEvent:originalEvent events:events];
+
+    if (request)
+    {
+        keyVerification = [MXKeyVerification new];
+        keyVerification.request = request;
+
+        keyVerification.state = [self stateFromRequestState:request.state andEvents:events];
+    }
+
+    return keyVerification;
+}
+
+- (nullable MXKeyVerificationByDMRequest*)verificationRequestInDMEvent:(MXEvent*)event events:(NSArray<MXEvent*> *)events
+{
+    MXKeyVerificationByDMRequest *request;
+    if ([event.content[@"msgtype"] isEqualToString:kMXMessageTypeKeyVerificationRequest])
+    {
+        request = [[MXKeyVerificationByDMRequest alloc] initWithEvent:event andManager:self.manager];
+        if (request)
+        {
+            NSString *myUserId = self.mxSession.myUser.userId;
+            BOOL isFromMyUser = [request.sender isEqualToString:myUserId];
+            request.isFromMyUser = isFromMyUser;
+
+            MXEvent *firstEvent = events.firstObject;
+            if (firstEvent.eventType == MXEventTypeKeyVerificationCancel)
+            {
+                // If the first event is a cancel, the request has been cancelled
+                // by me or declined by the other
+                if ([firstEvent.sender isEqualToString:myUserId])
+                {
+                    request.state = MXKeyVerificationRequestStateCancelledByMe;
+                }
+                else
+                {
+                    request.state = MXKeyVerificationRequestStateCancelled;
+                }
+            }
+            else if (events.count)
+            {
+                // If there are events but no cancel event at first, the transaction
+                // has started = the request has been accepted
+                request.state = MXKeyVerificationRequestStateAccepted;
+            }
+            // There is only the request event. What is the status of it?
+            else if (![self.manager isRequestStillPending:request])
+            {
+                request.state = MXKeyVerificationRequestStateExpired;
+            }
+            else
+            {
+                request.state = MXKeyVerificationRequestStatePending;
+            }
+        }
+    }
+    return request;
+}
+
+
+- (MXKeyVerificationState)stateFromRequestState:(MXKeyVerificationRequestState)requestState andEvents:(NSArray<MXEvent*> *)events
+{
+    MXKeyVerificationState state;
+    switch (requestState)
+    {
+        case MXKeyVerificationRequestStatePending:
+            state = MXKeyVerificationStateRequestPending;
+            break;
+        case MXKeyVerificationRequestStateExpired:
+            state = MXKeyVerificationStateRequestExpired;
+            break;
+        case MXKeyVerificationRequestStateCancelled:
+            state = MXKeyVerificationStateRequestCancelled;
+            break;
+        case MXKeyVerificationRequestStateCancelledByMe:
+            state = MXKeyVerificationStateRequestCancelledByMe;
+            break;
+        case MXKeyVerificationRequestStateAccepted:
+            state = [self computeTranscationStateWithEvents:events];
+            break;
+    }
+
+    return state;
+}
+
+- (MXKeyVerificationState)computeTranscationStateWithEvents:(NSArray<MXEvent*> *)events
+{
+    for (MXEvent *event in events)
+    {
+        NSString *myUserId = self.mxSession.myUser.userId;
+
+        switch (event.eventType) {
+            case MXEventTypeKeyVerificationCancel:
+            {
+                MXKeyVerificationCancel *cancel;
+                MXJSONModelSetMXJSONModel(cancel, MXKeyVerificationCancel.class, event.content);
+
+                NSString *cancelCode = cancel.code;
+                if ([cancelCode isEqualToString:MXTransactionCancelCode.user.value]
+                    || [cancelCode isEqualToString:MXTransactionCancelCode.timeout.value])
+                {
+                    if ([event.sender isEqualToString:myUserId])
+                    {
+                        return MXKeyVerificationStateTransactionCancelledByMe;
+                    }
+                    else
+                    {
+                        return MXKeyVerificationStateTransactionCancelled;
+                    }
+                }
+                else
+                {
+                    return MXKeyVerificationStateTransactionFailed;
+                }
+                break;
+            }
+
+            case MXEventTypeKeyVerificationDone:
+                if ([event.sender isEqualToString:myUserId])
+                {
+                    return MXKeyVerificationStateVerified;
+                }
+                break;
+
+            default:
+                break;
+        }
+    }
+
+    return MXKeyVerificationStateTransactionStarted;
+}
+
+@end

--- a/MatrixSDKTests/MXCryptoDeviceVerificationTests.m
+++ b/MatrixSDKTests/MXCryptoDeviceVerificationTests.m
@@ -511,8 +511,8 @@
                  XCTAssertEqualObjects(event.eventId, requestEventId);
 
                  // Check verification by DM request format
-                 MXKeyVerificationRequest *request;
-                 MXJSONModelSetMXJSONModel(request, MXKeyVerificationRequest.class, event.content);
+                 MXKeyVerificationRequestJSONModel *request;
+                 MXJSONModelSetMXJSONModel(request, MXKeyVerificationRequestJSONModel.class, event.content);
                  XCTAssertNotNil(request);
 
                  // - Alice accepts it and begins a SAS verification
@@ -684,8 +684,8 @@
          {
              if ([event.content[@"msgtype"] isEqualToString:kMXMessageTypeKeyVerificationRequest])
              {
-                 MXKeyVerificationRequest *request;
-                 MXJSONModelSetMXJSONModel(request, MXKeyVerificationRequest.class, event.content);
+                 MXKeyVerificationRequestJSONModel *request;
+                 MXJSONModelSetMXJSONModel(request, MXKeyVerificationRequestJSONModel.class, event.content);
                  XCTAssertNotNil(request);
 
                   // - Alice rejects the incoming request


### PR DESCRIPTION
Part of https://github.com/vector-im/riot-ios/issues/2851.

to get the `MXKeyVerification` status from any event. For the moment, it works only for verification by DM events.

<img width="339" alt="Screenshot 2019-12-19 at 13 16 31" src="https://user-images.githubusercontent.com/8418515/71172942-ccb7ef80-2261-11ea-9536-135ff5902e0f.png">
