### PR TITLE
Cross-signing: Add MSK to m.key.verification.mac

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -482,7 +482,7 @@ If you have already installed all dependencies, the steps are::
 
       $ git clone https://github.com/matrix-org/synapse.git
       $ cd synapse
-      $ virtualenv -p python2.7 env
+      $ virtualenv -p python3 env
       $ source env/bin/activate
       (env) $ python synapse/python_dependencies.py | xargs pip install
       (env) $ pip install lxml mock
@@ -495,7 +495,7 @@ Installation is done.
 
 Every time you want to launch these test homeservers, type::
 
-      $ virtualenv -p python2.7 env
+      $ virtualenv -p python3 env
       $ source env/bin/activate
       (env) $ demo/start.sh --no-rate-limit
 


### PR DESCRIPTION
Closes https://github.com/vector-im/riot-ios/issues/2919.

Riot-web can now cross-sign an iOS device.