### PR TITLE
MXRoomCreationParameters: Support the initial_state parameter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Improvements:
  * Cross-Signing: Add a new module, MXCrossSigning, to handle device cross-signing (vector-im/riot-ios/issues/2890).
  * MXRoom: Add a method to retrieve trusted members count in an encrypted room.
  * MXSession: Add createRoomWithParameters with a MXRoomCreationParameters model class.
+ * MXRoomCreationParameters: Support the initial_state parameter and allow e2e on room creation (vector-im/riot-ios/issues/2943).
  * MXCrypto: Expose devicesForUser.
 
 Bug fix:

--- a/MatrixSDK/JSONModels/MXRoomCreationParameters.h
+++ b/MatrixSDK/JSONModels/MXRoomCreationParameters.h
@@ -54,6 +54,9 @@ NS_ASSUME_NONNULL_BEGIN
 // Convenience parameter for setting various default state events based on a preset.
 @property (nonatomic, nullable) MXRoomPreset preset;
 
+// A list of state events to set in the new room.
+@property (nonatomic, nullable) NSArray<NSDictionary*> *initialStateEvents;
+
 
 /**
  Return the data as a JSON dictionary.
@@ -70,6 +73,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface MXRoomCreationParameters ()
 
 + (instancetype)parametersForDirectRoomWithUser:(NSString*)userId;
+
++ (NSDictionary*)initialStateEventForEncryptionWithAlgorithm:(NSString*)algorithm;
 
 @end
 

--- a/MatrixSDK/JSONModels/MXRoomCreationParameters.m
+++ b/MatrixSDK/JSONModels/MXRoomCreationParameters.m
@@ -75,6 +75,10 @@
     {
         dictionary[@"preset"] = _preset;
     }
+    if (_initialStateEvents)
+    {
+        dictionary[@"initial_state"] = _initialStateEvents;
+    }
 
     return dictionary;
 }
@@ -90,6 +94,17 @@
     roomCreationParameters.preset = kMXRoomPresetTrustedPrivateChat;
 
     return roomCreationParameters;
+}
+
++ (NSDictionary *)initialStateEventForEncryptionWithAlgorithm:(NSString *)algorithm
+{
+    return @{
+             @"type": @"m.room.encryption",
+             @"state_key": @"",
+             @"content": @{
+                     @"algorithm": algorithm
+                     }
+             };
 }
 
 @end


### PR DESCRIPTION
and allow e2e on room creation

vector-im/riot-ios/issues/2943
