### PR TITLE
Verification by DM with users with cross-signing enabled

### DIFF
--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -386,6 +386,8 @@
 		32C474C122AF7A2D00CFBCD2 /* MXReactionOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 32C474BF22AF7A2D00CFBCD2 /* MXReactionOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		32C474C222AF7A2D00CFBCD2 /* MXReactionOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 32C474C022AF7A2D00CFBCD2 /* MXReactionOperation.m */; };
 		32C6F93319DD814400EA4E9C /* MatrixSDK.h in Headers */ = {isa = PBXBuildFile; fileRef = 32C6F93219DD814400EA4E9C /* MatrixSDK.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		32C9B71823E81A1C00C6F30A /* MXCrossSigningVerificationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 32C9B71723E81A1C00C6F30A /* MXCrossSigningVerificationTests.m */; };
+		32C9B71923E81A1C00C6F30A /* MXCrossSigningVerificationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 32C9B71723E81A1C00C6F30A /* MXCrossSigningVerificationTests.m */; };
 		32CAB1071A91EA34008C5BB9 /* MXPushRuleRoomMemberCountConditionChecker.h in Headers */ = {isa = PBXBuildFile; fileRef = 32CAB1051A91EA34008C5BB9 /* MXPushRuleRoomMemberCountConditionChecker.h */; };
 		32CAB1081A91EA34008C5BB9 /* MXPushRuleRoomMemberCountConditionChecker.m in Sources */ = {isa = PBXBuildFile; fileRef = 32CAB1061A91EA34008C5BB9 /* MXPushRuleRoomMemberCountConditionChecker.m */; };
 		32CAB10B1A925B41008C5BB9 /* MXHTTPOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 32CAB1091A925B41008C5BB9 /* MXHTTPOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1413,6 +1415,7 @@
 		32C6F93219DD814400EA4E9C /* MatrixSDK.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MatrixSDK.h; sourceTree = "<group>"; };
 		32C6F93819DD814400EA4E9C /* MatrixSDKTests-iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "MatrixSDKTests-iOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		32C6F93B19DD814400EA4E9C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		32C9B71723E81A1C00C6F30A /* MXCrossSigningVerificationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXCrossSigningVerificationTests.m; sourceTree = "<group>"; };
 		32CAB1051A91EA34008C5BB9 /* MXPushRuleRoomMemberCountConditionChecker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXPushRuleRoomMemberCountConditionChecker.h; sourceTree = "<group>"; };
 		32CAB1061A91EA34008C5BB9 /* MXPushRuleRoomMemberCountConditionChecker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXPushRuleRoomMemberCountConditionChecker.m; sourceTree = "<group>"; };
 		32CAB1091A925B41008C5BB9 /* MXHTTPOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXHTTPOperation.h; sourceTree = "<group>"; };
@@ -2433,6 +2436,7 @@
 		32C6F93919DD814400EA4E9C /* MatrixSDKTests */ = {
 			isa = PBXGroup;
 			children = (
+				32C9B71723E81A1C00C6F30A /* MXCrossSigningVerificationTests.m */,
 				32D5D16223E400A600E3E37C /* MXRoomSummaryTrustTests.m */,
 				B11BD45B22CB8ABC0064D8B0 /* MXReplyEventParserTests.m */,
 				32792BE02296C64200F4FC9D /* MXAggregatedEditsTests.m */,
@@ -3797,6 +3801,7 @@
 				32832B5D1BCC048300241108 /* MXStoreMemoryStoreTests.m in Sources */,
 				32114A7F1A24E15500FF2EC4 /* MXMyUserTests.m in Sources */,
 				32832B5E1BCC048300241108 /* MXStoreNoStoreTests.m in Sources */,
+				32C9B71823E81A1C00C6F30A /* MXCrossSigningVerificationTests.m in Sources */,
 				323C5A081A70E53500FB0549 /* MXToolsTests.m in Sources */,
 				3281E89E19E299C000976E1A /* MXErrorTests.m in Sources */,
 				3265CB3B1A151C3800E24B2F /* MXRoomStateTests.m in Sources */,
@@ -4087,6 +4092,7 @@
 				B1E09A1A2397FCE90057C069 /* MXAggregatedEditsTests.m in Sources */,
 				B1E09A1F2397FCE90057C069 /* MXAutoDiscoveryTests.m in Sources */,
 				B1E09A2E2397FD750057C069 /* MXRestClientTests.m in Sources */,
+				32C9B71923E81A1C00C6F30A /* MXCrossSigningVerificationTests.m in Sources */,
 				B1E09A1D2397FCE90057C069 /* MXCryptoDeviceVerificationTests.m in Sources */,
 				B1E09A472397FD990057C069 /* MXEventScanStoreTests.m in Sources */,
 				B1E09A3D2397FD820057C069 /* MXStoreFileStoreTests.m in Sources */,

--- a/MatrixSDK/Crypto/Verification/Transactions/SAS/MXSASTransaction.m
+++ b/MatrixSDK/Crypto/Verification/Transactions/SAS/MXSASTransaction.m
@@ -301,6 +301,11 @@ static NSArray<MXEmojiRepresentation*> *kSasEmojis;
         macContent.transactionId = self.transactionId;
         macContent.mac = mac;
         macContent.keys = keyStrings;
+        
+        // TODO: To remove
+        NSLog(@"keyListIds: %@", keyListIds);
+        NSLog(@"otherUserMasterKeys: %@", myUserCrossSigningKeys.masterKeys.keys);
+        NSLog(@"info: %@", [NSString stringWithFormat:@"%@%@", baseInfo, deviceKey.keyFullId]);
     }
 
     return macContent;
@@ -394,6 +399,10 @@ static NSArray<MXEmojiRepresentation*> *kSasEmojis;
                     else
                     {
                         NSLog(@"[MXKeyVerification][MXSASTransaction] verifyMacs: ERROR: mac for master keys do not match: %@\vs %@", self.theirMac.JSONDictionary, self.myMac.JSONDictionary);
+                        NSLog(@"keyListIds: %@", keyListIds);
+                        NSLog(@"otherUserMasterKeys: %@", otherUserMasterKeys.keys);
+                        NSLog(@"info: %@", [NSString stringWithFormat:@"%@%@", baseInfo, keyFullId]);
+                        
                         cancelCode = MXTransactionCancelCode.mismatchedKeys;
                         break;
                     }

--- a/MatrixSDK/Crypto/Verification/Transactions/SAS/MXSASTransaction.m
+++ b/MatrixSDK/Crypto/Verification/Transactions/SAS/MXSASTransaction.m
@@ -354,6 +354,7 @@ static NSArray<MXEmojiRepresentation*> *kSasEmojis;
                 }
                 else
                 {
+                    NSLog(@"[MXKeyVerification][MXSASTransaction] verifyMacs: ERROR: mac for device keys do not match: %@\vs %@", self.theirMac.JSONDictionary, self.myMac.JSONDictionary);
                     cancelCode = MXTransactionCancelCode.mismatchedKeys;
                     break;
                 }
@@ -364,7 +365,7 @@ static NSArray<MXEmojiRepresentation*> *kSasEmojis;
                 MXCrossSigningKey *otherUserMasterKeys= [self.manager.crypto crossSigningKeysForUser:self.otherDevice.userId].masterKeys;
                 if (otherUserMasterKeys)
                 {
-                    // Check MAC with  user's MSK keys
+                    // Check MAC with user's MSK keys
                     if ([key.value isEqualToString:[self macUsingAgreedMethod:otherUserMasterKeys.keys
                                                                          info:[NSString stringWithFormat:@"%@%@", baseInfo, keyFullId]]])
                     {
@@ -372,6 +373,7 @@ static NSArray<MXEmojiRepresentation*> *kSasEmojis;
                         {
                             // Mark user as verified
                             NSLog(@"[MXKeyVerification][MXSASTransaction] verifyMacs: Mark user %@ as verified", self.otherDevice.userId);
+                            dispatch_group_enter(group);
                             [self.manager.crypto.crossSigning signUserWithUserId:self.otherDevice.userId success:^{
                                 dispatch_group_leave(group);
 
@@ -391,6 +393,7 @@ static NSArray<MXEmojiRepresentation*> *kSasEmojis;
                     }
                     else
                     {
+                        NSLog(@"[MXKeyVerification][MXSASTransaction] verifyMacs: ERROR: mac for master keys do not match: %@\vs %@", self.theirMac.JSONDictionary, self.myMac.JSONDictionary);
                         cancelCode = MXTransactionCancelCode.mismatchedKeys;
                         break;
                     }
@@ -403,7 +406,7 @@ static NSArray<MXEmojiRepresentation*> *kSasEmojis;
             }
         }
 
-        dispatch_group_notify(group, dispatch_get_main_queue(), ^{
+        dispatch_group_notify(group, self.manager.crypto.cryptoQueue, ^{
             if (cancelCode)
             {
                 [self cancelWithCancelCode:cancelCode];

--- a/MatrixSDKTests/MXCrossSigningVerificationTests.m
+++ b/MatrixSDKTests/MXCrossSigningVerificationTests.m
@@ -1,0 +1,388 @@
+/*
+ Copyright 2020 The Matrix.org Foundation C.I.C
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+
+#import <XCTest/XCTest.h>
+
+#import "MatrixSDKTestsData.h"
+#import "MatrixSDKTestsE2EData.h"
+
+#import "MXCrypto_Private.h"
+#import "MXDeviceVerificationManager_Private.h"
+#import "MXFileStore.h"
+
+#import "MXKeyVerificationRequestJSONModel.h"
+
+// Do not bother with retain cycles warnings in tests
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-retain-cycles"
+
+@interface MXDeviceVerificationManager (Testing)
+
+- (MXDeviceVerificationTransaction*)transactionWithTransactionId:(NSString*)transactionId;
+
+@end
+
+@interface MXCrossSigningVerificationTests : XCTestCase <MXCrossSigningKeysStorageDelegate>
+{
+    MatrixSDKTestsData *matrixSDKTestsData;
+    MatrixSDKTestsE2EData *matrixSDKTestsE2EData;
+    
+    NSMutableArray<id> *observers;
+    
+    MXUsersDevicesMap<NSData*> *userPrivateKeys;
+}
+@end
+
+@implementation MXCrossSigningVerificationTests
+
+- (void)setUp
+{
+    [super setUp];
+    
+    matrixSDKTestsData = [[MatrixSDKTestsData alloc] init];
+    matrixSDKTestsE2EData = [[MatrixSDKTestsE2EData alloc] initWithMatrixSDKTestsData:matrixSDKTestsData];
+    
+    observers = [NSMutableArray array];
+    userPrivateKeys = [MXUsersDevicesMap new];
+}
+
+- (void)tearDown
+{
+    matrixSDKTestsData = nil;
+    matrixSDKTestsE2EData = nil;
+    
+    for (id observer in observers)
+    {
+        [[NSNotificationCenter defaultCenter] removeObserver:observer];
+    }
+    
+    [super tearDown];
+}
+
+- (void)observeSASIncomingTransactionInSession:(MXSession*)session block:(void (^)(MXIncomingSASTransaction * _Nullable transaction))block
+{
+    id observer = [[NSNotificationCenter defaultCenter] addObserverForName:MXDeviceVerificationManagerNewTransactionNotification object:session.crypto.deviceVerificationManager queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
+        
+        MXDeviceVerificationTransaction *transaction = notif.userInfo[MXDeviceVerificationManagerNotificationTransactionKey];
+        if (transaction.isIncoming && [transaction isKindOfClass:MXIncomingSASTransaction.class])
+        {
+            block((MXIncomingSASTransaction*)transaction);
+        }
+        else
+        {
+            XCTFail(@"We support only SAS. transaction: %@", transaction);
+        }
+    }];
+    
+    [observers addObject:observer];
+}
+
+- (void)observeTransactionUpdate:(MXDeviceVerificationTransaction*)transaction block:(void (^)(void))block
+{
+    id observer = [[NSNotificationCenter defaultCenter] addObserverForName:MXDeviceVerificationTransactionDidChangeNotification object:transaction queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
+        block();
+    }];
+    
+    [observers addObject:observer];
+}
+
+- (void)observeKeyVerificationRequestInSession:(MXSession*)session block:(void (^)(MXKeyVerificationRequest * _Nullable request))block
+{
+    id observer = [[NSNotificationCenter defaultCenter] addObserverForName:MXDeviceVerificationManagerNewRequestNotification object:session.crypto.deviceVerificationManager queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
+        
+        MXKeyVerificationRequest *request = notif.userInfo[MXDeviceVerificationManagerNotificationRequestKey];
+        if ([request isKindOfClass:MXKeyVerificationRequest.class])
+        {
+            block((MXKeyVerificationRequest*)request);
+        }
+        else
+        {
+            XCTFail(@"We support only SAS. transaction: %@", request);
+        }
+    }];
+    
+    [observers addObject:observer];
+}
+
+
+#pragma mark - MXCrossSigningKeysStorageDelegate
+
+- (void)getCrossSigningKey:(nonnull MXCrossSigning *)crossSigning
+                    userId:(nonnull NSString*)userId
+                  deviceId:(nonnull NSString*)deviceId
+               withKeyType:(nonnull NSString *)keyType
+         expectedPublicKey:(nonnull NSString *)expectedPublicKey
+                   success:(nonnull void (^)(NSData * _Nonnull))success
+                   failure:(nonnull void (^)(NSError * _Nonnull))failure
+{
+    NSData *privateKey = [userPrivateKeys objectForDevice:keyType forUser:userId];
+    if (privateKey)
+    {
+        success(privateKey);
+    }
+    else
+    {
+        failure([NSError errorWithDomain:@"MXCrossSigningTests: Unknown keys" code:0 userInfo:nil]);
+    }
+}
+
+- (void)saveCrossSigningKeys:(nonnull MXCrossSigning *)crossSigning
+                      userId:(nonnull NSString*)userId
+                    deviceId:(nonnull NSString*)deviceId
+                 privateKeys:(nonnull NSDictionary<NSString *,NSData *> *)privateKeys
+                     success:(nonnull void (^)(void))success
+                     failure:(nonnull void (^)(NSError * _Nonnull))failure
+{
+    [userPrivateKeys setObjects:privateKeys forUser:userId];
+    success();
+}
+
+- (void)bootstrapCrossSigningOnSession:(MXSession*)session
+                              password:(NSString*)password
+                              completion:(void (^)(void))completionBlock
+{
+    session.crypto.crossSigning.keysStorageDelegate = self;
+    [session.crypto.crossSigning bootstrapWithPassword:password success:^{
+        completionBlock();
+    } failure:^(NSError *error) {
+        XCTAssert(NO, @"Cannot set up intial test conditions - error: %@", error);
+    }];
+}
+
+
+#pragma mark - Verification by DM -
+
+/**
+ Nomical case: The full flow
+ It reuses code from testVerificationByDMFullFlow from MXCryptoDeviceVerificationTests.
+ 
+ - Alice and Bob are in a room
+ - Alice and Bob bootstrap cross-signing (This is the single difference with original testVerificationByDMFullFlow).
+ - Bob requests a verification of Alice in this Room
+ - Alice gets the request in the timeline
+ - Alice accepts it and begins a SAS verification
+ -> 1. Transaction on Bob side must be WaitForPartnerKey (Alice is WaitForPartnerToAccept)
+ -> 2. Transaction on Alice side must then move to WaitForPartnerKey
+ -> 3. Transaction on Bob side must then move to ShowSAS
+ -> 4. Transaction on Alice side must then move to ShowSAS
+ -> 5. SASs must be the same
+ -  Alice confirms SAS
+ -> 6. Transaction on Alice side must then move to WaitForPartnerToConfirm
+ -  Bob confirms SAS
+ -> 7. Transaction on Bob side must then move to Verified
+ -> 7. Transaction on Alice side must then move to Verified
+ -> Devices must be really verified
+ -> Transaction must not be listed anymore
+ -> Both ends must get a done message
+ - Then, test MXKeyVerification
+ */
+- (void)testVerificationByDMFullFlow
+{
+    // - Alice and Bob are in a room
+    [matrixSDKTestsE2EData doE2ETestWithAliceAndBobInARoom:self cryptedBob:YES warnOnUnknowDevices:YES aliceStore:[[MXMemoryStore alloc] init] bobStore:[[MXMemoryStore alloc] init] readyToTest:^(MXSession *aliceSession, MXSession *bobSession, NSString *roomId, XCTestExpectation *expectation) {
+        
+        // - Alice and Bob bootstrap cross-signing 
+        [self bootstrapCrossSigningOnSession:aliceSession password:MXTESTS_ALICE_PWD completion:^{
+            [self bootstrapCrossSigningOnSession:bobSession password:MXTESTS_BOB_PWD completion:^{
+                
+                NSString *fallbackText = @"fallbackText";
+                __block NSString *requestId;
+                
+                MXCredentials *alice = aliceSession.matrixRestClient.credentials;
+                MXCredentials *bob = bobSession.matrixRestClient.credentials;
+                
+                // - Bob requests a verification of Alice in this Room
+                [bobSession.crypto.deviceVerificationManager requestVerificationByDMWithUserId:alice.userId
+                                                                                        roomId:roomId
+                                                                                  fallbackText:fallbackText
+                                                                                       methods:@[MXKeyVerificationMethodSAS, @"toto"]
+                                                                                       success:^(MXKeyVerificationRequest *request)
+                 {
+                     requestId = request.requestId;
+                 }
+                                                                                       failure:^(NSError * _Nonnull error)
+                 {
+                     XCTFail(@"The request should not fail - NSError: %@", error);
+                     [expectation fulfill];
+                 }];
+                
+                
+                __block MXOutgoingSASTransaction *sasTransactionFromAlicePOV;
+                
+                
+                // Alice gets the request in the timeline
+                [aliceSession listenToEventsOfTypes:@[kMXEventTypeStringRoomMessage]
+                                            onEvent:^(MXEvent *event, MXTimelineDirection direction, id customObject)
+                 {
+                     if ([event.content[@"msgtype"] isEqualToString:kMXMessageTypeKeyVerificationRequest])
+                     {
+                         XCTAssertEqualObjects(event.eventId, requestId);
+                         
+                         // Check verification by DM request format
+                         MXKeyVerificationRequestJSONModel *requestJSON;
+                         MXJSONModelSetMXJSONModel(requestJSON, MXKeyVerificationRequestJSONModel.class, event.content);
+                         XCTAssertNotNil(requestJSON);
+                         
+                         // - Alice accepts it and begins a SAS verification
+                         
+                         // Wait a bit
+                         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 1 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+                             // - Alice rejects the incoming request
+                             MXKeyVerificationRequest *requestFromAlicePOV = aliceSession.crypto.deviceVerificationManager.pendingRequests.firstObject;
+                             XCTAssertNotNil(requestFromAlicePOV);
+                             
+                             [requestFromAlicePOV acceptWithMethod:MXKeyVerificationMethodSAS success:^(MXDeviceVerificationTransaction * _Nonnull transactionFromAlicePOV) {
+                                 
+                                 XCTAssertEqualObjects(transactionFromAlicePOV.transactionId, event.eventId);
+                                 
+                                 XCTAssert(transactionFromAlicePOV);
+                                 XCTAssertTrue([transactionFromAlicePOV isKindOfClass:MXOutgoingSASTransaction.class]);
+                                 sasTransactionFromAlicePOV = (MXOutgoingSASTransaction*)transactionFromAlicePOV;
+                                 
+                             } failure:^(NSError * _Nonnull error) {
+                                 XCTFail(@"The request should not fail - NSError: %@", error);
+                                 [expectation fulfill];
+                             }];
+                         });
+                     }
+                 }];
+                
+                
+                [self observeSASIncomingTransactionInSession:bobSession block:^(MXIncomingSASTransaction * _Nullable transactionFromBobPOV) {
+                    
+                    // Final checks
+                    void (^checkBothDeviceVerified)(void) = ^ void ()
+                    {
+                        if (sasTransactionFromAlicePOV.state == MXSASTransactionStateVerified
+                            && transactionFromBobPOV.state == MXSASTransactionStateVerified)
+                        {
+                            // -> Devices must be really verified
+                            MXDeviceInfo *bobDeviceFromAlicePOV = [aliceSession.crypto.store deviceWithDeviceId:bob.deviceId forUser:bob.userId];
+                            MXDeviceInfo *aliceDeviceFromBobPOV = [bobSession.crypto.store deviceWithDeviceId:alice.deviceId forUser:alice.userId];
+                            
+                            XCTAssertEqual(bobDeviceFromAlicePOV.trustLevel.localVerificationStatus, MXDeviceVerified);
+                            XCTAssertEqual(aliceDeviceFromBobPOV.trustLevel.localVerificationStatus, MXDeviceVerified);
+                            
+                            // -> Transaction must not be listed anymore
+                            XCTAssertNil([aliceSession.crypto.deviceVerificationManager transactionWithTransactionId:sasTransactionFromAlicePOV.transactionId]);
+                            XCTAssertNil([bobSession.crypto.deviceVerificationManager transactionWithTransactionId:transactionFromBobPOV.transactionId]);
+                        }
+                    };
+                    
+                    // -> Transaction on Alice side must be WaitForPartnerKey, then ShowSAS
+                    [self observeTransactionUpdate:sasTransactionFromAlicePOV block:^{
+                        
+                        switch (sasTransactionFromAlicePOV.state)
+                        {
+                                // -> 2. Transaction on Alice side must then move to WaitForPartnerKey
+                            case MXSASTransactionStateWaitForPartnerKey:
+                                XCTAssertEqual(transactionFromBobPOV.state, MXSASTransactionStateWaitForPartnerKey);
+                                break;
+                                // -> 4. Transaction on Alice side must then move to ShowSAS
+                            case MXSASTransactionStateShowSAS:
+                                XCTAssertEqual(transactionFromBobPOV.state, MXSASTransactionStateShowSAS);
+                                
+                                // -> 5. SASs must be the same
+                                XCTAssertEqualObjects(sasTransactionFromAlicePOV.sasBytes, transactionFromBobPOV.sasBytes);
+                                XCTAssertEqualObjects(sasTransactionFromAlicePOV.sasDecimal, transactionFromBobPOV.sasDecimal);
+                                XCTAssertEqualObjects(sasTransactionFromAlicePOV.sasEmoji, transactionFromBobPOV.sasEmoji);
+                                
+                                // -  Alice confirms SAS
+                                [sasTransactionFromAlicePOV confirmSASMatch];
+                                break;
+                                // -> 6. Transaction on Alice side must then move to WaitForPartnerToConfirm
+                            case MXSASTransactionStateWaitForPartnerToConfirm:
+                                // -  Bob confirms SAS
+                                [transactionFromBobPOV confirmSASMatch];
+                                break;
+                                // -> 7. Transaction on Alice side must then move to Verified
+                            case MXSASTransactionStateVerified:
+                                checkBothDeviceVerified();
+                                break;
+                            default:
+                                XCTAssert(NO, @"Unexpected Alice transation state: %@", @(sasTransactionFromAlicePOV.state));
+                                break;
+                        }
+                    }];
+                    
+                    // -> Transaction on Bob side must be WaitForPartnerKey, then ShowSAS
+                    [self observeTransactionUpdate:transactionFromBobPOV block:^{
+                        
+                        switch (transactionFromBobPOV.state)
+                        {
+                                // -> 1. Transaction on Bob side must be WaitForPartnerKey (Alice is WaitForPartnerToAccept)
+                            case MXSASTransactionStateWaitForPartnerKey:
+                                XCTAssertEqual(sasTransactionFromAlicePOV.state, MXSASTransactionStateOutgoingWaitForPartnerToAccept);
+                                break;
+                                // -> 3. Transaction on Bob side must then move to ShowSAS
+                            case MXSASTransactionStateShowSAS:
+                                break;
+                            case MXSASTransactionStateWaitForPartnerToConfirm:
+                                break;
+                                // 7. Transaction on Bob side must then move to Verified
+                            case MXSASTransactionStateVerified:
+                                checkBothDeviceVerified();
+                                break;
+                            default:
+                                XCTAssert(NO, @"Unexpected Bob transation state: %@", @(sasTransactionFromAlicePOV.state));
+                                break;
+                        }
+                    }];
+                }];
+                
+                // -> Both ends must get a done message
+                NSMutableArray<MXKeyVerificationDone*> *doneDone = [NSMutableArray new];
+                void (^checkDoneDone)(MXEvent *event, MXTimelineDirection direction, id customObject) = ^ void (MXEvent *event, MXTimelineDirection direction, id customObject)
+                {
+                    XCTAssertEqual(event.eventType, MXEventTypeKeyVerificationDone);
+                    
+                    // Check done format
+                    MXKeyVerificationDone *done;
+                    MXJSONModelSetMXJSONModel(done, MXKeyVerificationDone.class, event.content);
+                    XCTAssertNotNil(done);
+                    
+                    [doneDone addObject:done];
+                    if (doneDone.count == 2)
+                    {
+                        // Then, test MXKeyVerification
+                        MXEvent *event = [aliceSession.store eventWithEventId:requestId inRoom:roomId];
+                        [aliceSession.crypto.deviceVerificationManager keyVerificationFromKeyVerificationEvent:event success:^(MXKeyVerification * _Nonnull verificationFromAlicePOV) {
+                            
+                            XCTAssertEqual(verificationFromAlicePOV.state, MXKeyVerificationStateVerified);
+                            
+                            [expectation fulfill];
+                        } failure:^(NSError * _Nonnull error) {
+                            XCTFail(@"The request should not fail - NSError: %@", error);
+                            [expectation fulfill];
+                        }];
+                    }
+                };
+                
+                [aliceSession listenToEventsOfTypes:@[kMXEventTypeStringKeyVerificationDone]
+                                            onEvent:checkDoneDone];
+                [bobSession listenToEventsOfTypes:@[kMXEventTypeStringKeyVerificationDone]
+                                          onEvent:checkDoneDone];
+                
+                
+            }];
+        }];
+    }];
+}
+
+@end
+
+#pragma clang diagnostic pop


### PR DESCRIPTION
This PR adds a test for the full flow of verification by DM with users with cross-signing enabled.
The goal was to find the issue Amandine has when self-signing ios from web but I have detected only minor issues.
I added logs to debug A's case. 