### PR TITLE
Track current user device list

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Improvements:
  * MXRoomCreationParameters: Support the initial_state parameter and allow e2e on room creation (vector-im/riot-ios/issues/2943).
  * MXCrypto: Expose devicesForUser.
  * MXRoomSummary: Add the trust property to indicate trust in other users and devices in the room (vector-im/riot-ios/issues/2906).
+ * MXCrypto: Start tracking current user devices at MXCrypto instantiation.
 
 Bug fix:
  * MXEventType: Fix Swift refinement.

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -1527,6 +1527,9 @@ NSTimeInterval kMXCryptoUploadOneTimeKeysPeriod = 60.0; // one minute
         myDevices[_myDevice.deviceId] = _myDevice;
         [_store storeDevicesForUser:userId devices:myDevices];
 
+        // Track other devices of current user
+        [_deviceList startTrackingDeviceList:userId];
+
         oneTimeKeyCount = -1;
 
         _backup = [[MXKeyBackup alloc] initWithCrypto:self];


### PR DESCRIPTION
During the implementation of a feature that implied sending events through the OLM channel, we noticed a difference of behaviour between matrix-ios-sdk and matrix-android-sdk.

While on Android, right after a login on both devices, the exange of events was possible, it was not on iOS, where the keys of the devices were not shared, and therefore they were not able to communicate.

We spotted some small differences that explain the difference of behaviour :

### On Android :
- When initializing the _MXCrypto_, a call is made to
`storeUserDevices(userId: String?, devices: MutableMap<String, MXDeviceInfo>?)`
- This call creates and stores a UserEntity using
`UserEntity.getOrCreate(realm, userId)`
- The user entity is created with a default parameter of _deviceTrackingStatus_ as stated in its declaration
`UserEntity(@PrimaryKey var userId: String? = null,
                      var devices: RealmList<DeviceInfoEntity> = RealmList(),
                      var deviceTrackingStatus: Int = 0)`
- The method `getDeviceTrackingStatuses()` of RealmCryptoStore.kt directly computes its results from the stored _UserEntity_ entities
- A call to `handleDeviceListsChanges ` is made in the initialization of _MXCrypto_. A glimpse to the implementation of this method tells us that, for the current user, the _deviceTrackingStatus_ has been updated to `PENDING_DOWNLOAD`
- Therefore the later call to `refreshOutdatedDeviceLists` will download the keys associated to recorded user devices

### On iOS :
- When initializing the _MXCrypto_, the call to `MXRealmCryptoStore:storeDevicesForUser:devices:` is made
- But the _deviceTackingStatuses_ are independently managed from the _MXRealmUser_ entity, in the _MXDeviceList_ and the _MXRealmCryptoStore_. No default option has been set for the current user in _deviceTackingStatus_
- The call to _ refreshOutdatedDeviceLists_ in the `MXCrypto:onSyncCompleted:nextSyncToken:catchingUp:` method will not consider the current user.

### The change :

By simply adding a call to `[_deviceList startTrackingDeviceList:userId];` in the initialization of _MXCrypto_, we close the behavior gap between iOS and Android.
We declare explicitely that we want the current user device list to be tracked during the first sync.

### NB :
On Android, the default value of 0 that is given to the _deviceTrackingStatus_ does not correspond to any status of the finite state machine described in _MXDeviceList_ (iOS and Android).
But the later call to `handleDeviceListsChanges` in the init of _MXCrypto_ automatically sets the value to _PENDING_DOWNLOAD_ (for the current user only).
Calling `MXDeviceList:startTrackingDeviceList:` on iOS is equivalent to those two steps on Android.

Signed-off-by: Julien Rollet julien.rollet@fabernovel.com
