### PR TITLE
MXAggregations: Optimise `referenceEventsForEvent` method, use cache when possible

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Improvements:
  * MXRoomCreationParameters: Support the initial_state parameter and allow e2e on room creation (vector-im/riot-ios/issues/2943).
  * MXCrypto: Expose devicesForUser.
  * MXRoomSummary: Add the trust property to indicate trust in other users and devices in the room (vector-im/riot-ios/issues/2906).
+ * MXStore: Add a method to get related events for a specific event.
 
 Bug fix:
  * MXEventType: Fix Swift refinement.

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -928,6 +928,8 @@
 		B17285792100C8EA0052C51E /* MXSendReplyEventStringsLocalizable.h in Headers */ = {isa = PBXBuildFile; fileRef = B17285782100C88A0052C51E /* MXSendReplyEventStringsLocalizable.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B172857C2100D4F60052C51E /* MXSendReplyEventDefaultStringLocalizations.h in Headers */ = {isa = PBXBuildFile; fileRef = B172857A2100D4F60052C51E /* MXSendReplyEventDefaultStringLocalizations.h */; };
 		B172857D2100D4F60052C51E /* MXSendReplyEventDefaultStringLocalizations.m in Sources */ = {isa = PBXBuildFile; fileRef = B172857B2100D4F60052C51E /* MXSendReplyEventDefaultStringLocalizations.m */; };
+		B176B25123EB03E4001879C6 /* MXAggregationPaginatedResponse_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = B176B25023EB03E3001879C6 /* MXAggregationPaginatedResponse_Private.h */; };
+		B176B25223EB03E4001879C6 /* MXAggregationPaginatedResponse_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = B176B25023EB03E3001879C6 /* MXAggregationPaginatedResponse_Private.h */; };
 		B17982F52119E4A2001FD722 /* MXRoomCreateContent.h in Headers */ = {isa = PBXBuildFile; fileRef = B17982ED2119E49E001FD722 /* MXRoomCreateContent.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B17982F62119E4A2001FD722 /* MXRoomTombStoneContent.m in Sources */ = {isa = PBXBuildFile; fileRef = B17982EE2119E49F001FD722 /* MXRoomTombStoneContent.m */; };
 		B17982F72119E4A2001FD722 /* MXRoomPredecessorInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = B17982EF2119E49F001FD722 /* MXRoomPredecessorInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1548,6 +1550,7 @@
 		B17285782100C88A0052C51E /* MXSendReplyEventStringsLocalizable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MXSendReplyEventStringsLocalizable.h; path = ../MXSendReplyEventStringsLocalizable.h; sourceTree = "<group>"; };
 		B172857A2100D4F60052C51E /* MXSendReplyEventDefaultStringLocalizations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MXSendReplyEventDefaultStringLocalizations.h; path = ../MXSendReplyEventDefaultStringLocalizations.h; sourceTree = "<group>"; };
 		B172857B2100D4F60052C51E /* MXSendReplyEventDefaultStringLocalizations.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = MXSendReplyEventDefaultStringLocalizations.m; path = ../MXSendReplyEventDefaultStringLocalizations.m; sourceTree = "<group>"; };
+		B176B25023EB03E3001879C6 /* MXAggregationPaginatedResponse_Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXAggregationPaginatedResponse_Private.h; sourceTree = "<group>"; };
 		B17982ED2119E49E001FD722 /* MXRoomCreateContent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXRoomCreateContent.h; sourceTree = "<group>"; };
 		B17982EE2119E49F001FD722 /* MXRoomTombStoneContent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXRoomTombStoneContent.m; sourceTree = "<group>"; };
 		B17982EF2119E49F001FD722 /* MXRoomPredecessorInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXRoomPredecessorInfo.h; sourceTree = "<group>"; };
@@ -2121,6 +2124,7 @@
 			children = (
 				327E9AE52285A8C400A98BC1 /* MXAggregationPaginatedResponse.h */,
 				327E9AE62285A8C400A98BC1 /* MXAggregationPaginatedResponse.m */,
+				B176B25023EB03E3001879C6 /* MXAggregationPaginatedResponse_Private.h */,
 			);
 			path = Aggregations;
 			sourceTree = "<group>";
@@ -2915,6 +2919,7 @@
 				327E9AFC228AC22800A98BC1 /* MXAggregationsStore.h in Headers */,
 				323547DC2226FC5700F15F94 /* MXCredentials.h in Headers */,
 				325AD43F23BE3E7500FF5277 /* MXCrossSigningInfo.h in Headers */,
+				B176B25123EB03E4001879C6 /* MXAggregationPaginatedResponse_Private.h in Headers */,
 				021AFBA62179E91900742B2C /* MXEncryptedContentKey.h in Headers */,
 				327187891DA7DCE50071C818 /* MXOlmEncryption.h in Headers */,
 				32A1514E1DAF897600400192 /* MXOlmSessionResult.h in Headers */,
@@ -3290,6 +3295,7 @@
 				B14EF3562397E90400758AF0 /* MXGroup.h in Headers */,
 				B14EF3572397E90400758AF0 /* MX3PidAddSession.h in Headers */,
 				B14EF3582397E90400758AF0 /* MXUser.h in Headers */,
+				B176B25223EB03E4001879C6 /* MXAggregationPaginatedResponse_Private.h in Headers */,
 				3297912823A93D4B00F7BB9B /* MXKeyVerification.h in Headers */,
 				B14EF3592397E90400758AF0 /* MXError.h in Headers */,
 				B14EF35A2397E90400758AF0 /* MXReplyEventFormattedBodyParts.h in Headers */,

--- a/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryRoomStore.h
+++ b/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryRoomStore.h
@@ -96,13 +96,22 @@
 - (id<MXEventsEnumerator>)enumeratorForMessagesWithTypeIn:(NSArray*)types;
 
 /**
- Get all events newer than the event with the passed id.
+  Get all events newer than the event with the passed id.
 
   @param eventId the event id to find.
   @param types a set of event types strings (MXEventTypeString).
   @return the messages events after an event Id
  */
 - (NSArray*)eventsAfter:(NSString *)eventId except:(NSString*)userId withTypeIn:(NSSet*)types;
+
+/**
+ Get events related to a specific event.
+
+ @param eventId The event id of the event to find.
+ @param relationType The related events relation type desired.
+ @return An array of events related to the given event id.
+ */
+- (NSArray<MXEvent*>*)relationsForEvent:(NSString*)eventId relationType:(NSString*)relationType;
 
 /**
  The text message partially typed by the user but not yet sent in the room.

--- a/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryRoomStore.m
+++ b/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryRoomStore.m
@@ -127,6 +127,23 @@
     return list;
 }
 
+- (NSArray<MXEvent*>*)relationsForEvent:(NSString*)eventId relationType:(NSString*)relationType
+{
+    NSMutableArray<MXEvent*>* referenceEvents = [NSMutableArray new];
+    
+    for (MXEvent* event in messages)
+    {
+        MXEventContentRelatesTo *relatesTo = event.relatesTo;
+        
+        if (relatesTo && [relatesTo.eventId isEqualToString:eventId] && [relatesTo.relationType isEqualToString:relationType])
+        {
+            [referenceEvents addObject:event];
+        }
+    }
+    
+    return referenceEvents;
+}
+
 - (void)storeOutgoingMessage:(MXEvent*)outgoingMessage
 {
     // Sanity check: prevent from adding multiple occurrences of the same object.

--- a/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryStore.m
+++ b/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryStore.m
@@ -278,6 +278,12 @@
     homeserverWellknown = wellknown;
 }
 
+- (NSArray<MXEvent*>* _Nonnull)relationsForEvent:(nonnull NSString*)eventId inRoom:(nonnull  NSString*)roomId relationType:(NSString*)relationType
+{
+    MXMemoryRoomStore *roomStore = [self getOrCreateRoomStore:roomId];
+    return [roomStore relationsForEvent:eventId relationType:relationType];
+}
+
 - (BOOL)isPermanent
 {
     return NO;

--- a/MatrixSDK/Data/Store/MXNoStore/MXNoStore.m
+++ b/MatrixSDK/Data/Store/MXNoStore/MXNoStore.m
@@ -235,6 +235,10 @@
     return [[MXEventsEnumeratorOnArray alloc] initWithMessages:@[lastMessages[roomId]]];
 }
 
+- (NSArray<MXEvent *> *)relationsForEvent:(NSString *)eventId inRoom:(NSString *)roomId relationType:(NSString *)relationType
+{
+    return @[];
+}
 
 #pragma mark - Matrix users
 - (void)storeUser:(MXUser *)user

--- a/MatrixSDK/Data/Store/MXStore.h
+++ b/MatrixSDK/Data/Store/MXStore.h
@@ -149,6 +149,16 @@
  */
 - (id<MXEventsEnumerator> _Nonnull)messagesEnumeratorForRoom:(nonnull NSString*)roomId withTypeIn:(nullable NSArray*)types;
 
+/**
+ Get events related to a specific event.
+ 
+ @param eventId The event id of the event to find.
+ @param roomId The room id.
+ @param relationType The related events relation type desired.
+ @return An array of events related to the given event id.
+ */
+- (NSArray<MXEvent*>* _Nonnull)relationsForEvent:(nonnull NSString*)eventId inRoom:(nonnull NSString*)roomId relationType:(nonnull NSString*)relationType;
+
 
 #pragma mark - Matrix users
 /**

--- a/MatrixSDK/JSONModels/Aggregations/MXAggregationPaginatedResponse.m
+++ b/MatrixSDK/JSONModels/Aggregations/MXAggregationPaginatedResponse.m
@@ -15,8 +15,21 @@
  */
 
 #import "MXAggregationPaginatedResponse.h"
+#import "MXAggregationPaginatedResponse_Private.h"
 
 @implementation MXAggregationPaginatedResponse
+
+- (instancetype)initWithOriginalEvent:(MXEvent*)originalEvent chunk:(NSArray<MXEvent*> *)chunk nextBatch:(NSString *)nextBatch;
+{
+    self = [super init];
+    if (self)
+    {
+        _originalEvent = originalEvent;
+        _chunk = chunk;
+        _nextBatch = nextBatch;
+    }
+    return self;
+}
 
 + (instancetype)modelFromJSON:(NSDictionary *)JSONDictionary
 {

--- a/MatrixSDK/JSONModels/Aggregations/MXAggregationPaginatedResponse_Private.h
+++ b/MatrixSDK/JSONModels/Aggregations/MXAggregationPaginatedResponse_Private.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MXAggregationPaginatedResponse()
 
-- (instancetype)initWithOriginalEvent:(nullable MXEvent*)originalEvent
+- (instancetype)initWithOriginalEvent:(MXEvent*)originalEvent
                                 chunk:(NSArray<MXEvent*> *)chunk
                             nextBatch:(nullable NSString *)nextBatch;
 

--- a/MatrixSDK/JSONModels/Aggregations/MXAggregationPaginatedResponse_Private.h
+++ b/MatrixSDK/JSONModels/Aggregations/MXAggregationPaginatedResponse_Private.h
@@ -1,0 +1,30 @@
+/*
+ Copyright 2020 New Vector Ltd
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ The `MXAggregationPaginatedResponse` extension exposes internal operations.
+ */
+@interface MXAggregationPaginatedResponse()
+
+- (instancetype)initWithOriginalEvent:(nullable MXEvent*)originalEvent
+                                chunk:(NSArray<MXEvent*> *)chunk
+                            nextBatch:(nullable NSString *)nextBatch;
+
+@end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
vector-im/riot-ios/issues/2927