### PR TITLE
MXCrypto: Restart broken Olm sessions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Improvements:
  * MXSession: Add createRoomWithParameters with a MXRoomCreationParameters model class.
  * MXRoomCreationParameters: Support the initial_state parameter and allow e2e on room creation (vector-im/riot-ios/issues/2943).
  * MXCrypto: Expose devicesForUser.
+ * MXCrypto: Restart broken Olm sessions ([MSC1719](https://github.com/matrix-org/matrix-doc/pull/1719)) (vector-im/riot-ios/issues/2129).
  * MXRoomSummary: Add the trust property to indicate trust in other users and devices in the room (vector-im/riot-ios/issues/2906).
  * MXStore: Add a method to get related events for a specific event.
 

--- a/MatrixSDK/Crypto/Algorithms/MXEncrypting.h
+++ b/MatrixSDK/Crypto/Algorithms/MXEncrypting.h
@@ -64,4 +64,25 @@
                                   success:(void (^)(NSObject *sessionInfo))success
                                   failure:(void (^)(NSError *error))failure;
 
+/**
+ Re-shares a session key with devices if the key has already been
+ sent to them.
+ 
+ @param sessionId The id of the outbound session to share.
+ @param userId The id of the user who owns the target device.
+ @param deviceId he id of the target device.
+ @param senderKey The key of the originating device for the session.
+
+ @param success A block object called when the operation succeeds.
+ @param failure A block object called when the operation fails.
+ 
+ @return a MXHTTPOperation instance.
+ */
+- (MXHTTPOperation*)reshareKey:(NSString*)sessionId
+                      withUser:(NSString*)userId
+                     andDevice:(NSString*)deviceId
+                     senderKey:(NSString*)senderKey
+                       success:(void (^)(void))success
+                       failure:(void (^)(NSError *error))failure;
+
 @end

--- a/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmDecryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmDecryption.m
@@ -297,6 +297,7 @@
     operation = [crypto ensureOlmSessionsForDevices:@{
                                           userId: @[deviceInfo]
                                           }
+                                              force:NO
                                 success:^(MXUsersDevicesMap<MXOlmSessionResult *> *results)
      {
          MXStrongifyAndReturnIfNil(self);

--- a/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmDecryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmDecryption.m
@@ -324,7 +324,7 @@
 
          NSLog(@"[MXMegolmDecryption] shareKeysWithDevice: sharing keys for session %@|%@ with device %@:%@", senderKey, sessionId, userId, deviceId);
 
-         NSDictionary *payload = [self buildKeyForwardingMessage:roomId senderKey:senderKey sessionId:sessionId];
+         NSDictionary *payload = [self->crypto buildMegolmKeyForwardingMessage:roomId senderKey:senderKey sessionId:sessionId];
 
          MXDeviceInfo *deviceInfo = olmSessionResult.device;
 
@@ -462,29 +462,6 @@
     {
         NSLog(@"[MXMegolmDecryption] requestKeysForEvent: ERROR: missing fields in event %@", event);
     }
-}
-
-- (NSDictionary*)buildKeyForwardingMessage:(NSString*)roomId senderKey:(NSString*)senderKey sessionId:(NSString*)sessionId
-{
-    NSDictionary *key = [olmDevice getInboundGroupSessionKey:roomId senderKey:senderKey sessionId:sessionId];
-    if (key)
-    {
-        return @{
-                 @"type": kMXEventTypeStringRoomForwardedKey,
-                 @"content": @{
-                         @"algorithm": kMXCryptoMegolmAlgorithm,
-                         @"room_id": roomId,
-                         @"sender_key": senderKey,
-                         @"sender_claimed_ed25519_key": key[@"sender_claimed_ed25519_key"],
-                         @"session_id": sessionId,
-                         @"session_key": key[@"key"],
-                         @"chain_index": key[@"chain_index"],
-                         @"forwarding_curve25519_key_chain": key[@"forwarding_curve25519_key_chain"]
-                         }
-                 };
-    }
-
-    return nil;
 }
 
 @end

--- a/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmDecryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmDecryption.m
@@ -324,7 +324,7 @@
 
          NSLog(@"[MXMegolmDecryption] shareKeysWithDevice: sharing keys for session %@|%@ with device %@:%@", senderKey, sessionId, userId, deviceId);
 
-         NSDictionary *payload = [self->crypto buildMegolmKeyForwardingMessage:roomId senderKey:senderKey sessionId:sessionId];
+         NSDictionary *payload = [self->crypto buildMegolmKeyForwardingMessage:roomId senderKey:senderKey sessionId:sessionId chainIndex:nil];
 
          MXDeviceInfo *deviceInfo = olmSessionResult.device;
 

--- a/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmEncryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmEncryption.m
@@ -495,6 +495,7 @@
         return nil;
     }
     
+    // @TODO: Manu: To use
     NSUInteger chainIndex = [chainIndexNumber unsignedIntegerValue];
 
     MXHTTPOperation *operation;
@@ -526,7 +527,7 @@
                      
                      NSLog(@"[MXMegolmEncryption] reshareKey: sharing keys for session %@|%@:%@ with device %@:%@", senderKey, sessionId, @(chainIndex), userId, deviceId);
                      
-                     NSDictionary *payload = [self buildKeyForwardingMessage:self->roomId senderKey:senderKey sessionId:sessionId];
+                     NSDictionary *payload = [self->crypto buildMegolmKeyForwardingMessage:self->roomId senderKey:senderKey sessionId:sessionId];
                     
                      
                      MXUsersDevicesMap<NSDictionary*> *contentMap = [[MXUsersDevicesMap alloc] init];
@@ -539,29 +540,6 @@
                  } failure:failure];
     
     return operation;
-}
-
-- (NSDictionary*)buildKeyForwardingMessage:(NSString*)roomId senderKey:(NSString*)senderKey sessionId:(NSString*)sessionId
-{
-    NSDictionary *key = [crypto.olmDevice getInboundGroupSessionKey:roomId senderKey:senderKey sessionId:sessionId];
-    if (key)
-    {
-        return @{
-                 @"type": kMXEventTypeStringRoomForwardedKey,
-                 @"content": @{
-                         @"algorithm": kMXCryptoMegolmAlgorithm,
-                         @"room_id": roomId,
-                         @"sender_key": senderKey,
-                         @"sender_claimed_ed25519_key": key[@"sender_claimed_ed25519_key"],
-                         @"session_id": sessionId,
-                         @"session_key": key[@"key"],
-                         @"chain_index": key[@"chain_index"],
-                         @"forwarding_curve25519_key_chain": key[@"forwarding_curve25519_key_chain"]
-                         }
-                 };
-    }
-    
-    return nil;
 }
 
 - (void)processPendingEncryptionsInSession:(MXOutboundSessionInfo*)session withError:(NSError*)error

--- a/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmEncryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmEncryption.m
@@ -82,6 +82,10 @@
     // that even if this is non-null, it may not be ready for use (in which
     // case outboundSession.shareOperation will be non-nill.)
     MXOutboundSessionInfo *outboundSession;
+    
+    // Map of outbound sessions by sessions ID. Used if we need a particular
+    // session.
+    NSMutableDictionary<NSString*, MXOutboundSessionInfo*> *outboundSessions;
 
     NSMutableArray<MXQueuedEncryption*> *pendingEncryptions;
 
@@ -112,6 +116,7 @@
         roomId = theRoomId;
         deviceId = crypto.store.deviceId;
 
+        outboundSessions = [NSMutableDictionary dictionary];
         pendingEncryptions = [NSMutableArray array];
 
         // Default rotation periods
@@ -285,6 +290,7 @@
     if (!session)
     {
         outboundSession = session = [self prepareNewSession];
+        outboundSessions[outboundSession.sessionId] = outboundSession;
     }
 
     if (session.shareOperation)
@@ -372,7 +378,7 @@
 
     MXHTTPOperation *operation;
     MXWeakify(self);
-    operation = [crypto ensureOlmSessionsForDevices:devicesByUser success:^(MXUsersDevicesMap<MXOlmSessionResult *> *results) {
+    operation = [crypto ensureOlmSessionsForDevices:devicesByUser force:NO success:^(MXUsersDevicesMap<MXOlmSessionResult *> *results) {
         MXStrongifyAndReturnIfNil(self);
 
         NSLog(@"[MXMegolmEncryption] shareKey: ensureOlmSessionsForDevices result (users: %tu - devices: %tu): %@", results.map.count,  results.count, results);
@@ -460,6 +466,102 @@
     }];
 
     return operation;
+}
+
+- (MXHTTPOperation*)reshareKey:(NSString*)sessionId
+                      withUser:(NSString*)userId
+                     andDevice:(NSString*)deviceId
+                     senderKey:(NSString*)senderKey
+                       success:(void (^)(void))success
+                       failure:(void (^)(NSError *error))failure
+{
+    NSLog(@"[MXMegolmEncryption] reshareKey: %@ to %@:%@", sessionId, userId, deviceId);
+    
+    MXDeviceInfo *deviceInfo = [crypto.store deviceWithDeviceId:deviceId forUser:userId];
+    if (!deviceInfo)
+    {
+        NSLog(@"[MXMegolmEncryption] reshareKey: ERROR: Unknown device");
+        failure(nil);
+        return nil;
+    }
+    
+    // Get the chain index of the key we previously sent this device
+    MXOutboundSessionInfo *obSessionInfo = outboundSessions[sessionId];
+    NSNumber *chainIndexNumber = [obSessionInfo.sharedWithDevices objectForDevice:deviceId forUser:userId];
+    if (!chainIndexNumber)
+    {
+        NSLog(@"[MXMegolmEncryption] reshareKey: ERROR: Never share megolm with this device");
+        failure(nil);
+        return nil;
+    }
+    
+    NSUInteger chainIndex = [chainIndexNumber unsignedIntegerValue];
+
+    MXHTTPOperation *operation;
+    MXWeakify(self);
+    operation = [crypto ensureOlmSessionsForDevices:@{
+                                                      userId: @[deviceInfo]
+                                                      }
+                                              force:NO
+                                            success:^(MXUsersDevicesMap<MXOlmSessionResult *> *results)
+                 {
+                     MXStrongifyAndReturnIfNil(self);
+                     
+                     MXOlmSessionResult *olmSessionResult = [results objectForDevice:deviceId forUser:userId];
+                     if (!olmSessionResult.sessionId)
+                     {
+                         // no session with this device, probably because there
+                         // were no one-time keys.
+                         //
+                         // ensureOlmSessionsForUsers has already done the logging,
+                         // so just skip it.
+                         if (success)
+                         {
+                             success();
+                         }
+                         return;
+                     }
+                     
+                     MXDeviceInfo *deviceInfo = olmSessionResult.device;
+                     
+                     NSLog(@"[MXMegolmEncryption] reshareKey: sharing keys for session %@|%@:%@ with device %@:%@", senderKey, sessionId, @(chainIndex), userId, deviceId);
+                     
+                     NSDictionary *payload = [self buildKeyForwardingMessage:self->roomId senderKey:senderKey sessionId:sessionId];
+                    
+                     
+                     MXUsersDevicesMap<NSDictionary*> *contentMap = [[MXUsersDevicesMap alloc] init];
+                     [contentMap setObject:[self->crypto encryptMessage:payload forDevices:@[deviceInfo]]
+                                   forUser:userId andDevice:deviceId];
+                     
+                     MXHTTPOperation *operation2 = [self->crypto.matrixRestClient sendToDevice:kMXEventTypeStringRoomEncrypted contentMap:contentMap txnId:nil success:success failure:failure];
+                     [operation mutateTo:operation2];
+                     
+                 } failure:failure];
+    
+    return operation;
+}
+
+- (NSDictionary*)buildKeyForwardingMessage:(NSString*)roomId senderKey:(NSString*)senderKey sessionId:(NSString*)sessionId
+{
+    NSDictionary *key = [crypto.olmDevice getInboundGroupSessionKey:roomId senderKey:senderKey sessionId:sessionId];
+    if (key)
+    {
+        return @{
+                 @"type": kMXEventTypeStringRoomForwardedKey,
+                 @"content": @{
+                         @"algorithm": kMXCryptoMegolmAlgorithm,
+                         @"room_id": roomId,
+                         @"sender_key": senderKey,
+                         @"sender_claimed_ed25519_key": key[@"sender_claimed_ed25519_key"],
+                         @"session_id": sessionId,
+                         @"session_key": key[@"key"],
+                         @"chain_index": key[@"chain_index"],
+                         @"forwarding_curve25519_key_chain": key[@"forwarding_curve25519_key_chain"]
+                         }
+                 };
+    }
+    
+    return nil;
 }
 
 - (void)processPendingEncryptionsInSession:(MXOutboundSessionInfo*)session withError:(NSError*)error

--- a/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmEncryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmEncryption.m
@@ -487,16 +487,13 @@
     
     // Get the chain index of the key we previously sent this device
     MXOutboundSessionInfo *obSessionInfo = outboundSessions[sessionId];
-    NSNumber *chainIndexNumber = [obSessionInfo.sharedWithDevices objectForDevice:deviceId forUser:userId];
-    if (!chainIndexNumber)
+    NSNumber *chainIndex = [obSessionInfo.sharedWithDevices objectForDevice:deviceId forUser:userId];
+    if (!chainIndex)
     {
         NSLog(@"[MXMegolmEncryption] reshareKey: ERROR: Never share megolm with this device");
         failure(nil);
         return nil;
     }
-    
-    // @TODO: Manu: To use
-    NSUInteger chainIndex = [chainIndexNumber unsignedIntegerValue];
 
     MXHTTPOperation *operation;
     MXWeakify(self);
@@ -525,9 +522,9 @@
                      
                      MXDeviceInfo *deviceInfo = olmSessionResult.device;
                      
-                     NSLog(@"[MXMegolmEncryption] reshareKey: sharing keys for session %@|%@:%@ with device %@:%@", senderKey, sessionId, @(chainIndex), userId, deviceId);
+                     NSLog(@"[MXMegolmEncryption] reshareKey: sharing keys for session %@|%@:%@ with device %@:%@", senderKey, sessionId, chainIndex, userId, deviceId);
                      
-                     NSDictionary *payload = [self->crypto buildMegolmKeyForwardingMessage:self->roomId senderKey:senderKey sessionId:sessionId];
+                     NSDictionary *payload = [self->crypto buildMegolmKeyForwardingMessage:self->roomId senderKey:senderKey sessionId:sessionId chainIndex:chainIndex];
                     
                      
                      MXUsersDevicesMap<NSDictionary*> *contentMap = [[MXUsersDevicesMap alloc] init];

--- a/MatrixSDK/Crypto/Algorithms/Olm/MXOlmEncryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Olm/MXOlmEncryption.m
@@ -122,6 +122,17 @@
     return operation;
 }
 
+- (MXHTTPOperation*)reshareKey:(NSString*)sessionId
+                      withUser:(NSString*)userId
+                     andDevice:(NSString*)deviceId
+                     senderKey:(NSString*)senderKey
+                       success:(void (^)(void))success
+                       failure:(void (^)(NSError *error))failure
+{
+    // No need for olm
+    return nil;
+}
+
 @end
 
 #endif

--- a/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
+++ b/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
@@ -656,7 +656,7 @@ RLM_ARRAY_TYPE(MXRealmOlmInboundGroupSession)
 
 - (void)storeSession:(MXOlmSession*)session forDevice:(NSString*)deviceKey
 {
-    BOOL isNew = NO;
+    __block BOOL isNew = NO;
     NSDate *startDate = [NSDate date];
 
     RLMRealm *realm = self.realm;
@@ -671,6 +671,7 @@ RLM_ARRAY_TYPE(MXRealmOlmInboundGroupSession)
         else
         {
             // Create it
+            isNew = YES;
             realmOlmSession = [[MXRealmOlmSession alloc] initWithValue:@{
                                                                          @"sessionId": session.session.sessionIdentifier,
                                                                          @"deviceKey": deviceKey,

--- a/MatrixSDK/Crypto/KeySharing/MXIncomingRoomKeyRequestManager.m
+++ b/MatrixSDK/Crypto/KeySharing/MXIncomingRoomKeyRequestManager.m
@@ -131,9 +131,27 @@
 
     if (![userId isEqualToString:crypto.matrixRestClient.credentials.userId])
     {
-        // TODO: determine if we sent this device the keys already: in
-        // which case we can do so again.
-        NSLog(@"[MXIncomingRoomKeyRequestManager] Ignoring room key request from other user for now");
+        NSString *senderKey, *sessionId;
+        MXJSONModelSetString(senderKey, body[@"sender_key"]);
+        MXJSONModelSetString(sessionId, body[@"session_id"]);
+        
+        if (!senderKey && !sessionId)
+        {
+            return;
+        }
+        
+        id<MXEncrypting> encryptor = [crypto getRoomEncryptor:roomId algorithm:alg];
+        if (!encryptor)
+        {
+            NSLog(@"[MXIncomingRoomKeyRequestManager] room key request for unknown alg %@ in room %@", alg, roomId);
+            return;
+        }
+        
+        [encryptor reshareKey:sessionId withUser:userId andDevice:deviceId senderKey:senderKey success:^{
+            
+        } failure:^(NSError *error) {
+            
+        }];
         return;
     }
 
@@ -170,7 +188,7 @@
         NSLog(@"[MXIncomingRoomKeyRequestManager] Already have this key request, ignoring");
         return;
     }
-
+    
     // Add it to pending key requests
     [crypto.store storeIncomingRoomKeyRequest:req];
 

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -1941,6 +1941,28 @@ NSTimeInterval kMXCryptoUploadOneTimeKeysPeriod = 60.0; // one minute
     [outgoingRoomKeyRequestManager cancelRoomKeyRequest:requestBody];
 }
 
+- (NSDictionary*)buildMegolmKeyForwardingMessage:(NSString*)roomId senderKey:(NSString*)senderKey sessionId:(NSString*)sessionId
+{
+    NSDictionary *key = [self.olmDevice getInboundGroupSessionKey:roomId senderKey:senderKey sessionId:sessionId];
+    if (key)
+    {
+        return @{
+                 @"type": kMXEventTypeStringRoomForwardedKey,
+                 @"content": @{
+                         @"algorithm": kMXCryptoMegolmAlgorithm,
+                         @"room_id": roomId,
+                         @"sender_key": senderKey,
+                         @"sender_claimed_ed25519_key": key[@"sender_claimed_ed25519_key"],
+                         @"session_id": sessionId,
+                         @"session_key": key[@"key"],
+                         @"chain_index": key[@"chain_index"],
+                         @"forwarding_curve25519_key_chain": key[@"forwarding_curve25519_key_chain"]
+                         }
+                 };
+    }
+    
+    return nil;
+}
 
 #pragma mark - Private methods
 /**

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -1941,9 +1941,9 @@ NSTimeInterval kMXCryptoUploadOneTimeKeysPeriod = 60.0; // one minute
     [outgoingRoomKeyRequestManager cancelRoomKeyRequest:requestBody];
 }
 
-- (NSDictionary*)buildMegolmKeyForwardingMessage:(NSString*)roomId senderKey:(NSString*)senderKey sessionId:(NSString*)sessionId
+- (NSDictionary*)buildMegolmKeyForwardingMessage:(NSString*)roomId senderKey:(NSString*)senderKey sessionId:(NSString*)sessionId  chainIndex:(NSNumber*)chainIndex
 {
-    NSDictionary *key = [self.olmDevice getInboundGroupSessionKey:roomId senderKey:senderKey sessionId:sessionId];
+    NSDictionary *key = [self.olmDevice getInboundGroupSessionKey:roomId senderKey:senderKey sessionId:sessionId chainIndex:chainIndex];
     if (key)
     {
         return @{

--- a/MatrixSDK/Crypto/MXCrypto_Private.h
+++ b/MatrixSDK/Crypto/MXCrypto_Private.h
@@ -210,7 +210,7 @@
 - (void)cancelRoomKeyRequest:(NSDictionary*)requestBody;
 
 // Create a message to forward a megolm session
-- (NSDictionary*)buildMegolmKeyForwardingMessage:(NSString*)roomId senderKey:(NSString*)senderKey sessionId:(NSString*)sessionId;
+- (NSDictionary*)buildMegolmKeyForwardingMessage:(NSString*)roomId senderKey:(NSString*)senderKey sessionId:(NSString*)sessionId chainIndex:(NSNumber*)chainIndex;
 
 @end
 

--- a/MatrixSDK/Crypto/MXCrypto_Private.h
+++ b/MatrixSDK/Crypto/MXCrypto_Private.h
@@ -209,6 +209,9 @@
  */
 - (void)cancelRoomKeyRequest:(NSDictionary*)requestBody;
 
+// Create a message to forward a megolm session
+- (NSDictionary*)buildMegolmKeyForwardingMessage:(NSString*)roomId senderKey:(NSString*)senderKey sessionId:(NSString*)sessionId;
+
 @end
 
 #endif

--- a/MatrixSDK/Crypto/MXCrypto_Private.h
+++ b/MatrixSDK/Crypto/MXCrypto_Private.h
@@ -131,6 +131,7 @@
  @param failure A block object called when the operation fails.
  */
 - (MXHTTPOperation*)ensureOlmSessionsForDevices:(NSDictionary<NSString* /* userId */, NSArray<MXDeviceInfo*>*>*)devicesByUser
+                                          force:(BOOL)force
                                       success:(void (^)(MXUsersDevicesMap<MXOlmSessionResult*> *results))success
                                       failure:(void (^)(NSError *error))failure;
 
@@ -155,6 +156,15 @@
  @return the decryptor.
  */
 - (id<MXDecrypting>)getRoomDecryptor:(NSString*)roomId algorithm:(NSString*)algorithm;
+
+/**
+ Get the encryptor for a given room and algorithm.
+ 
+ @param roomId room id for encryptor.
+ @param algorithm the crypto algorithm.
+ @return the decryptor.
+ */
+- (id<MXEncrypting>)getRoomEncryptor:(NSString*)roomId algorithm:(NSString*)algorithm;
 
 /**
  Sign the given object with our ed25519 key.

--- a/MatrixSDK/Crypto/MXOlmDevice.h
+++ b/MatrixSDK/Crypto/MXOlmDevice.h
@@ -278,6 +278,8 @@ Determine if an incoming messages is a prekey message matching an existing sessi
  @param roomId the room in which the message was received.
  @param senderKey the base64-encoded curve25519 key of the sender.
  @param sessionId the session identifier.
+ @param chainIndex The chain index at which to export the session.
+                   If nil, export at the first index we know about.
 
  @return a dictinary {
      chain_index: number,
@@ -286,7 +288,7 @@ Determine if an incoming messages is a prekey message matching an existing sessi
      sender_claimed_ed25519_key: string
  } details of the session key. The key is a base64-encoded megolm key in export format.
  */
-- (NSDictionary*)getInboundGroupSessionKey:(NSString*)roomId senderKey:(NSString*)senderKey sessionId:(NSString*)sessionId;
+- (NSDictionary*)getInboundGroupSessionKey:(NSString*)roomId senderKey:(NSString*)senderKey sessionId:(NSString*)sessionId chainIndex:(NSNumber*)chainIndex;
 
 
 #pragma mark - Utilities

--- a/MatrixSDK/Crypto/MXOlmDevice.m
+++ b/MatrixSDK/Crypto/MXOlmDevice.m
@@ -542,7 +542,7 @@
     return YES;
 }
 
-- (NSDictionary*)getInboundGroupSessionKey:(NSString*)roomId senderKey:(NSString*)senderKey sessionId:(NSString*)sessionId
+- (NSDictionary*)getInboundGroupSessionKey:(NSString*)roomId senderKey:(NSString*)senderKey sessionId:(NSString*)sessionId chainIndex:(NSNumber*)chainIndex
 {
     NSDictionary *inboundGroupSessionKey;
 
@@ -550,16 +550,20 @@
     MXOlmInboundGroupSession *session = [self inboundGroupSessionWithId:sessionId senderKey:senderKey roomId:roomId error:&error];
     if (session)
     {
-        NSUInteger messageIndex = session.session.firstKnownIndex;
+        NSNumber *messageIndex = chainIndex;
+        if (!messageIndex)
+        {
+            messageIndex = @(session.session.firstKnownIndex);
+        }
 
         NSDictionary *claimedKeys = session.keysClaimed;
         NSString *senderEd25519Key = claimedKeys[@"ed25519"];
 
-        MXMegolmSessionData *sessionData = [session exportSessionDataAtMessageIndex:messageIndex];
+        MXMegolmSessionData *sessionData = [session exportSessionDataAtMessageIndex:[messageIndex unsignedIntegerValue]];
         NSArray<NSString*> *forwardingCurve25519KeyChain = sessionData.forwardingCurve25519KeyChain;
 
         inboundGroupSessionKey = @{
-                                   @"chain_index": @(messageIndex),
+                                   @"chain_index": messageIndex,
                                    @"key": sessionData.sessionKey,
                                    @"forwarding_curve25519_key_chain": forwardingCurve25519KeyChain ? forwardingCurve25519KeyChain : @[],
                                    @"sender_claimed_ed25519_key": senderEd25519Key ? senderEd25519Key : [NSNull null]


### PR DESCRIPTION
By implementing [MSC1719](https://github.com/matrix-org/matrix-doc/pull/1719)
Closes https://github.com/vector-im/riot-ios/issues/2129

Reading the test `testOlmSessionUnwedging` in this PR may help to understand the goal.