### PR TITLE
Verification: Ignore requests when we got a ready or a start event from another device

### DIFF
--- a/MatrixSDK/Crypto/Verification/MXKeyVerificationManager.m
+++ b/MatrixSDK/Crypto/Verification/MXKeyVerificationManager.m
@@ -859,15 +859,19 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerDMEventTypes;
     MXKeyVerificationRequest *request = [self pendingRequestWithRequestId:requestId];
     if (request)
     {
-        // The other party decided to create a transaction from the request
-        // The request is complete
+        // We have a start response. The request is complete
         [self removePendingRequestWithRequestId:request.requestId];
     }
-    else if ([event.relatesTo.relationType isEqualToString:MXEventRelationTypeReference])
+    
+    if ([event.relatesTo.relationType isEqualToString:MXEventRelationTypeReference])
     {
-        // This is a start response to a request we did not make. Ignore it
-        NSLog(@"[MXKeyVerification] handleStartEvent: Start event for verification by DM(%@) not triggered by this device. Ignore it", requestId);
-        return;
+        if (!request
+            || (request.isFromMyUser && !request.isFromMyDevice))
+        {
+            // This is a start response to a request we did not make. Ignore it
+            NSLog(@"[MXKeyVerification] handleStartEvent: Start event for verification by DM(%@) not triggered by this device. Ignore it", requestId);
+            return;
+        }
     }
     
     if (!keyVerificationStart.isValid)
@@ -1028,15 +1032,19 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerDMEventTypes;
     MXKeyVerificationRequest *request = [self pendingRequestWithRequestId:requestId];
     if (request)
     {
-        // The other party decided to create a transaction from the request
-        // The request is complete
+        // We have a start response. The request is complete
         [self removePendingRequestWithRequestId:request.requestId];
     }
-    else if ([event.relatesTo.relationType isEqualToString:MXEventRelationTypeReference])
+    
+    if ([event.relatesTo.relationType isEqualToString:MXEventRelationTypeReference])
     {
-        // This is a start response to a request we did not make. Ignore it
-        NSLog(@"[MXKeyVerification] handleStartEvent: Start event for verification by DM(%@) not triggered by this device. Ignore it", requestId);
-        return;
+        if (!request
+            || (request.isFromMyUser && !request.isFromMyDevice))
+        {
+            // This is a start response to a request we did not make. Ignore it
+            NSLog(@"[MXKeyVerification] handleStartEvent: Start event for verification by DM(%@) not triggered by this device. Ignore it", requestId);
+            return;
+        }
     }
     
     if (!keyVerificationStart.isValid)


### PR DESCRIPTION
Closes https://github.com/vector-im/riot-ios/issues/3016

The start event is better managed than in https://github.com/matrix-org/matrix-ios-sdk/pull/773/commits/3819ad6c918895a6aabd5cdde69965dc66ce70df. The 2nd commit is to handle the ready.
