### PR TITLE
Cross-signing: Define a state

### DIFF
--- a/MatrixSDK/Crypto/CrossSigning/MXCrossSigning.h
+++ b/MatrixSDK/Crypto/CrossSigning/MXCrossSigning.h
@@ -37,29 +37,30 @@ typedef NS_ENUM(NSInteger, MXCrossSigningState)
     
     /**
      Cross-signing has been enabled for this account.
-     Cross-signing keys have been published on the server but they are not trusted by this device.
+     Cross-signing public keys have been published on the server but they are not trusted by this device.
      */
-    MXCrossSigningStatePublicKeysExist,
+    MXCrossSigningStateCrossSigningExists,
     
     /**
-     MXCrossSigningStatePublicKeysExist and they are trusted by this device.
-     We can read trust based on cross-signing:
-     - trust for other users and their cross-signed devices
-     - trust for other cross-signed devices of this account.
+     MXCrossSigningStateCrossSigningExists and it is trusted by this device.
+     Based on cross-signing:
+         - this device can trust other users and their cross-signed devices
+         - this device can trust other cross-signed devices of this account
      */
-    MXCrossSigningStateTrustPublicKeys,
+    MXCrossSigningStateTrustCrossSigning,
     
     /**
-     MXCrossSigningStateTrustPublicKeys and we can cross-sign other users or other devices of this account.
-     We can upload trust update to the homeserver.
+     MXCrossSigningStateTrustCrossSigning and we can cross-sign.
+     This device has cross-signing private keys.
+     It can cross-sign other users or other devices of this account.
      */
-    MXCrossSigningStateHavePrivateKeys,
+    MXCrossSigningStateCanCrossSign,
     
     /**
-     Same as MXCrossSigningStateHavePrivateKeys but private keys can only be used asynchronously.
-     Access to these key may require UI interaction with the user like passphrase, Face ID, etc.
+     Same as MXCrossSigningStateCanCrossSign but private keys can only be used asynchronously.
+     Access to these keys may require UI interaction with the user like passphrase, Face ID, etc.
      */
-    MXCrossSigningStateHavePrivateKeysAsynchronously,
+    MXCrossSigningStateCanCrossSignAsynchronously,
 };
 
 
@@ -119,7 +120,7 @@ typedef NS_ENUM(NSInteger, MXCrossSigningErrorCode)
  Cross-signing state for this account and this device.
  */
 @property (nonatomic, readonly) MXCrossSigningState state;
-@property (nonatomic, readonly) BOOL canReadCrossSignTrust;
+@property (nonatomic, readonly) BOOL canTrustCrossSigning;
 @property (nonatomic, readonly) BOOL canCrossSign;
 
 /**

--- a/MatrixSDK/Crypto/CrossSigning/MXCrossSigning.h
+++ b/MatrixSDK/Crypto/CrossSigning/MXCrossSigning.h
@@ -24,8 +24,46 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Constants
 
-FOUNDATION_EXPORT NSString *const MXCrossSigningErrorDomain;
+/**
+ Cross-signing state of the current acount.
+ */
+typedef NS_ENUM(NSInteger, MXCrossSigningState)
+{
+    /**
+     Cross-signing is not enabled for this account.
+     No cross-signing keys have been published on the server.
+     */
+    MXCrossSigningStateNotBootstrapped = 0,
+    
+    /**
+     Cross-signing has been enabled for this account.
+     Cross-signing keys have been published on the server but they are not trusted by this device.
+     */
+    MXCrossSigningStatePublicKeysExist,
+    
+    /**
+     MXCrossSigningStatePublicKeysExist and they are trusted by this device.
+     We can read trust based on cross-signing:
+     - trust for other users and their cross-signed devices
+     - trust for other cross-signed devices of this account.
+     */
+    MXCrossSigningStateTrustPublicKeys,
+    
+    /**
+     MXCrossSigningStateTrustPublicKeys and we can cross-sign other users or other devices of this account.
+     We can upload trust update to the homeserver.
+     */
+    MXCrossSigningStateHavePrivateKeys,
+    
+    /**
+     Same as MXCrossSigningStateHavePrivateKeys but private keys can only be used asynchronously.
+     Access to these key may require UI interaction with the user like passphrase, Face ID, etc.
+     */
+    MXCrossSigningStateHavePrivateKeysAsynchronously,
+};
 
+
+FOUNDATION_EXPORT NSString *const MXCrossSigningErrorDomain;
 typedef NS_ENUM(NSInteger, MXCrossSigningErrorCode)
 {
     MXCrossSigningUnknownUserIdErrorCode,
@@ -77,8 +115,12 @@ typedef NS_ENUM(NSInteger, MXCrossSigningErrorCode)
 
 @interface MXCrossSigning : NSObject
 
-// Flag indicating if cross-signing is set up on this device
-@property (nonatomic, readonly) BOOL isBootstrapped;
+/**
+ Cross-signing state for this account and this device.
+ */
+@property (nonatomic, readonly) MXCrossSigningState state;
+@property (nonatomic, readonly) BOOL canReadCrossSignTrust;
+@property (nonatomic, readonly) BOOL canCrossSign;
 
 /**
  Bootstrap cross-signing on this device.

--- a/MatrixSDK/Crypto/CrossSigning/MXCrossSigning.m
+++ b/MatrixSDK/Crypto/CrossSigning/MXCrossSigning.m
@@ -261,7 +261,6 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
     if (self)
     {
         _crypto = crypto;
-        [self loadCrossSigningKeys];
         _crossSigningTools = [MXCrossSigningTools new];
      }
     return self;

--- a/MatrixSDK/Crypto/CrossSigning/MXCrossSigning.m
+++ b/MatrixSDK/Crypto/CrossSigning/MXCrossSigning.m
@@ -36,12 +36,12 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
 
 - (BOOL)canCrossSign
 {
-    return (_state >= MXCrossSigningStateHavePrivateKeys);
+    return (_state >= MXCrossSigningStateCanCrossSign);
 }
 
-- (BOOL)canReadCrossSignTrust
+- (BOOL)canTrustCrossSigning
 {
-    return (_state >= MXCrossSigningStateTrustPublicKeys);
+    return (_state >= MXCrossSigningStateTrustCrossSigning);
 }
 
 - (void)setKeysStorageDelegate:(id<MXCrossSigningKeysStorageDelegate>)keysStorageDelegate
@@ -389,18 +389,19 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
     
     if (_myUserCrossSigningKeys)
     {
-        state = MXCrossSigningStatePublicKeysExist;
+        state = MXCrossSigningStateCrossSigningExists;
         
         if (_myUserCrossSigningKeys.trustLevel.isVerified)
         {
-            state = MXCrossSigningStateTrustPublicKeys;
+            state = MXCrossSigningStateTrustCrossSigning;
             
-            // TODO: MXCrossSigningStateHavePrivateKeys
+            // TODO: MXCrossSigningStateCanCrossSign
+            // This will happen with gossiping
             
             if (_keysStorageDelegate
-                /* && TODO */)
+                /* && TODO: Check this async storage has these keys */)     // This will happen with full implementation of SSSS
             {
-                state = MXCrossSigningStateHavePrivateKeysAsynchronously;
+                state = MXCrossSigningStateCanCrossSignAsynchronously;
             }
         }
     }

--- a/MatrixSDK/Crypto/CrossSigning/MXCrossSigning.m
+++ b/MatrixSDK/Crypto/CrossSigning/MXCrossSigning.m
@@ -34,11 +34,20 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
 
 @implementation MXCrossSigning
 
-- (BOOL)isBootstrapped
+- (BOOL)canCrossSign
 {
-    // TODO: Find a better way to know that we have cross-signing ON
-    return self.myUserCrossSigningKeys != nil
-    && self.keysStorageDelegate != nil;
+    return (_state >= MXCrossSigningStateHavePrivateKeys);
+}
+
+- (BOOL)canReadCrossSignTrust
+{
+    return (_state >= MXCrossSigningStateTrustPublicKeys);
+}
+
+- (void)setKeysStorageDelegate:(id<MXCrossSigningKeysStorageDelegate>)keysStorageDelegate
+{
+    _keysStorageDelegate = keysStorageDelegate;
+    [self computeState];
 }
 
 - (void)bootstrapWithPassword:(NSString*)password
@@ -81,6 +90,7 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
 
                 // Cross-signing is bootstrapped
                 self.myUserCrossSigningKeys = keys;
+                [self computeState];
 
                 // Expose this device to other users as signed by me
                 // TODO: Check if it is the right way to do so
@@ -260,8 +270,11 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
     self = [super init];
     if (self)
     {
+        _state = MXCrossSigningStateNotBootstrapped;
         _crypto = crypto;
         _crossSigningTools = [MXCrossSigningTools new];
+        
+        [self computeState];
      }
     return self;
 }
@@ -274,8 +287,11 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
 
     // Refresh user's keys
     [self.crypto.deviceList downloadKeys:@[myUserId] forceDownload:NO success:^(MXUsersDevicesMap<MXDeviceInfo *> *usersDevicesInfoMap, NSDictionary<NSString *,MXCrossSigningInfo *> *crossSigningKeysMap) {
+        
         self.myUserCrossSigningKeys = crossSigningKeysMap[myUserId];
+        [self computeState];
     } failure:^(NSError *error) {
+        NSLog(@"[MXCrossSigning] loadCrossSigningKeys: Failed to load my user's keys");
     }];
 }
 
@@ -366,6 +382,31 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
 
 
 #pragma mark - Private methods -
+
+- (void)computeState
+{
+    MXCrossSigningState state = MXCrossSigningStateNotBootstrapped;
+    
+    if (_myUserCrossSigningKeys)
+    {
+        state = MXCrossSigningStatePublicKeysExist;
+        
+        if (_myUserCrossSigningKeys.trustLevel.isVerified)
+        {
+            state = MXCrossSigningStateTrustPublicKeys;
+            
+            // TODO: MXCrossSigningStateHavePrivateKeys
+            
+            if (_keysStorageDelegate
+                /* && TODO */)
+            {
+                state = MXCrossSigningStateHavePrivateKeysAsynchronously;
+            }
+        }
+    }
+    
+    _state = state;
+}
 
 - (NSString *)makeSigningKey:(OLMPkSigning * _Nullable *)signing privateKey:(NSData* _Nullable *)privateKey
 {

--- a/MatrixSDK/Crypto/CrossSigning/MXCrossSigning_Private.h
+++ b/MatrixSDK/Crypto/CrossSigning/MXCrossSigning_Private.h
@@ -40,6 +40,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (instancetype)initWithCrypto:(MXCrypto *)crypto;
 
+- (void)loadCrossSigningKeys;
+
 - (BOOL)isUserWithCrossSigningKeysVerified:(MXCrossSigningInfo*)crossSigningKeys;
 - (BOOL)isDeviceVerified:(MXDeviceInfo*)device;
 

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -1538,9 +1538,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
                                                                          crossSigningVerified:NO]];
 
         // Add our own deviceinfo to the store
-        NSMutableDictionary *myDevices = [NSMutableDictionary dictionaryWithDictionary:[_store devicesForUser:userId]];
-        myDevices[_myDevice.deviceId] = _myDevice;
-        [_store storeDevicesForUser:userId devices:myDevices];
+        [_store storeDeviceForUser:userId device:_myDevice];
 
         oneTimeKeyCount = -1;
 

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -809,7 +809,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
         }
 
         // Cross-sign our own device
-        if (self.crossSigning.isBootstrapped
+        if (self.crossSigning.canCrossSign
             && verificationStatus == MXDeviceVerified
             && [userId isEqualToString:self.mxSession.myUser.userId])
         {

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -252,10 +252,12 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
             NSLog(@"[MXCrypto] Store: %@", self.store);
             NSLog(@"[MXCrypto] ");
 
+            [self->_crossSigning loadCrossSigningKeys];
+            
             [self->outgoingRoomKeyRequestManager start];
 
             [self->_backup checkAndStartKeyBackup];
-
+            
             dispatch_async(dispatch_get_main_queue(), ^{
                 self->startOperation = nil;
                 success();

--- a/MatrixSDK/Crypto/Verification/Transactions/QRCode/MXQRCodeTransaction.m
+++ b/MatrixSDK/Crypto/Verification/Transactions/QRCode/MXQRCodeTransaction.m
@@ -310,47 +310,14 @@ NSString * const MXKeyVerificationMethodReciprocate = @"m.reciprocate.v1";
 
 - (void)trustOtherDeviceWithId:(NSString*)otherDeviceId
 {
-    if (!self.manager.crypto.crossSigning.canCrossSign)
-    {
-        // Cross-signing ability should have been checked before going into this hole
-        NSLog(@"[MXKeyVerification][MXQRCodeTransaction] trustOtherDeviceWithId: Cannot mark device %@ as verified because this device cannot cross-sign", otherDeviceId);
-        [self cancelWithCancelCode:MXTransactionCancelCode.user];
-        return;
-    }
+    NSString *currentUserId = self.manager.crypto.mxSession.myUser.userId;
     
-    __block MXTransactionCancelCode *cancelCode;
-    dispatch_group_t group = dispatch_group_create();
-    
-    dispatch_group_enter(group);
-    
-    [self.manager.crypto.crossSigning crossSignDeviceWithDeviceId:self.otherDeviceId success:^{
-        dispatch_group_leave(group);
-    } failure:^(NSError * _Nonnull error) {
-        NSLog(@"[MXKeyVerification][MXQRCodeTransaction] trustOtherDeviceWithId: Fail to cross sign other device with id: %@", self.otherUserId);
-        cancelCode = MXTransactionCancelCode.invalidMessage;
-        dispatch_group_leave(group);
-    }];
-    
-    dispatch_group_enter(group);
-    
-    [self.manager.crypto setDeviceVerification:MXDeviceVerified forDevice:self.otherDeviceId ofUser:self.otherUserId success:^{
-        dispatch_group_leave(group);
+    // setDeviceVerification will automatically cross sign the device
+    [self.manager.crypto setDeviceVerification:MXDeviceVerified forDevice:otherDeviceId ofUser:currentUserId success:^{
+        [self sendVerified];
     } failure:^(NSError *error) {
-        // Should never happen
-        cancelCode = MXTransactionCancelCode.invalidMessage;
-        dispatch_group_leave(group);
+        [self cancelWithCancelCode:MXTransactionCancelCode.invalidMessage];
     }];
-    
-    dispatch_group_notify(group, self.manager.crypto.cryptoQueue, ^{
-        if (cancelCode)
-        {
-            [self cancelWithCancelCode:cancelCode];
-        }
-        else
-        {
-            [self sendVerified];
-        }
-    });
 }
 
 - (void)sendVerified

--- a/MatrixSDK/Crypto/Verification/Transactions/QRCode/MXQRCodeTransaction.m
+++ b/MatrixSDK/Crypto/Verification/Transactions/QRCode/MXQRCodeTransaction.m
@@ -291,10 +291,10 @@ NSString * const MXKeyVerificationMethodReciprocate = @"m.reciprocate.v1";
 
 - (void)trustOtherUserWithId:(NSString*)otherUserId
 {
-    if (!self.manager.crypto.crossSigning.isBootstrapped)
+    if (!self.manager.crypto.crossSigning.canCrossSign)
     {
-        // TODO (MXCrossSigning.isBootstrapped will be removed in the future)
-        NSLog(@"[MXKeyVerification][MXQRCodeTransaction] trustOtherDeviceWithId: Cannot Mark user %@ as verified as cross-signing is not fully implemented", otherUserId);
+        // Cross-signing ability should have been checked before going into this hole
+        NSLog(@"[MXKeyVerification][MXQRCodeTransaction] trustOtherUserWithId: Cannot mark user %@ as verified because this device cannot cross-sign", otherUserId);
         [self cancelWithCancelCode:MXTransactionCancelCode.user];
         return;
     }
@@ -310,10 +310,10 @@ NSString * const MXKeyVerificationMethodReciprocate = @"m.reciprocate.v1";
 
 - (void)trustOtherDeviceWithId:(NSString*)otherDeviceId
 {
-    if (!self.manager.crypto.crossSigning.isBootstrapped)
+    if (!self.manager.crypto.crossSigning.canCrossSign)
     {
-        // TODO (MXCrossSigning.isBootstrapped will be removed in the future)
-        NSLog(@"[MXKeyVerification][MXQRCodeTransaction] trustOtherDeviceWithId: Cannot Mark device %@ as verified as cross-signing is not fully implemented", otherDeviceId);
+        // Cross-signing ability should have been checked before going into this hole
+        NSLog(@"[MXKeyVerification][MXQRCodeTransaction] trustOtherDeviceWithId: Cannot mark device %@ as verified because this device cannot cross-sign", otherDeviceId);
         [self cancelWithCancelCode:MXTransactionCancelCode.user];
         return;
     }

--- a/MatrixSDK/Crypto/Verification/Transactions/SAS/MXSASTransaction.m
+++ b/MatrixSDK/Crypto/Verification/Transactions/SAS/MXSASTransaction.m
@@ -385,7 +385,7 @@ static NSArray<MXEmojiRepresentation*> *kSasEmojis;
                     if ([key.value isEqualToString:[self macUsingAgreedMethod:otherUserMasterKeys.keys
                                                                          info:[NSString stringWithFormat:@"%@%@", baseInfo, keyFullId]]])
                     {
-                        if (self.manager.crypto.crossSigning.isBootstrapped)
+                        if (self.manager.crypto.crossSigning.canCrossSign)
                         {
                             // Mark user as verified
                             NSLog(@"[MXKeyVerification][MXSASTransaction] verifyMacs: Mark user %@ as verified", self.otherDevice.userId);
@@ -402,8 +402,8 @@ static NSArray<MXEmojiRepresentation*> *kSasEmojis;
                         }
                         else
                         {
-                            // TODO (MXCrossSigning.isBootstrapped will be removed in the future)
-                            NSLog(@"[MXKeyVerification][MXSASTransaction] verifyMacs: Cannot Mark user %@ as verified as cross-signing is not fully implemented", self.otherDevice.userId);
+                            // Cross-signing ability should have been checked before going into this hole
+                            NSLog(@"[MXKeyVerification][MXSASTransaction] verifyMacs: Cannot Mark user %@ as verified because this device cannot cross-sign", self.otherDevice.userId);
                         }
 
                     }

--- a/MatrixSDKTests/MXCrossSigningTests.m
+++ b/MatrixSDKTests/MXCrossSigningTests.m
@@ -369,14 +369,18 @@
     // - Create Alice & Bob account
     [matrixSDKTestsE2EData doE2ETestWithBobAndAlice:self readyToTest:^(MXSession *bobSession, MXSession *aliceSession, XCTestExpectation *expectation) {
 
-        XCTAssertFalse(aliceSession.crypto.crossSigning.isBootstrapped);
+        XCTAssertEqual(aliceSession.crypto.crossSigning.state, MXCrossSigningStateNotBootstrapped);
+        XCTAssertFalse(aliceSession.crypto.crossSigning.canCrossSign);
+        XCTAssertFalse(aliceSession.crypto.crossSigning.canReadCrossSignTrust);
 
         // - Bootstrap cross-singing on Alice using password
         aliceSession.crypto.crossSigning.keysStorageDelegate = self;
         [aliceSession.crypto.crossSigning bootstrapWithPassword:MXTESTS_ALICE_PWD success:^{
 
             // -> Cross-signing must be bootstrapped
-            XCTAssertTrue(aliceSession.crypto.crossSigning.isBootstrapped);
+            XCTAssertEqual(aliceSession.crypto.crossSigning.state, MXCrossSigningStateHavePrivateKeysAsynchronously);
+            XCTAssertTrue(aliceSession.crypto.crossSigning.canCrossSign);
+            XCTAssertTrue(aliceSession.crypto.crossSigning.canReadCrossSignTrust);
 
             // -> Alice must see their device trusted
             MXDeviceTrustLevel *aliceDevice1Trust = [aliceSession.crypto deviceTrustLevelForDevice:aliceSession.matrixRestClient.credentials.deviceId ofUser:aliceSession.matrixRestClient.credentials.userId];

--- a/MatrixSDKTests/MXCrossSigningTests.m
+++ b/MatrixSDKTests/MXCrossSigningTests.m
@@ -371,16 +371,16 @@
 
         XCTAssertEqual(aliceSession.crypto.crossSigning.state, MXCrossSigningStateNotBootstrapped);
         XCTAssertFalse(aliceSession.crypto.crossSigning.canCrossSign);
-        XCTAssertFalse(aliceSession.crypto.crossSigning.canReadCrossSignTrust);
+        XCTAssertFalse(aliceSession.crypto.crossSigning.canTrustCrossSigning);
 
         // - Bootstrap cross-singing on Alice using password
         aliceSession.crypto.crossSigning.keysStorageDelegate = self;
         [aliceSession.crypto.crossSigning bootstrapWithPassword:MXTESTS_ALICE_PWD success:^{
 
             // -> Cross-signing must be bootstrapped
-            XCTAssertEqual(aliceSession.crypto.crossSigning.state, MXCrossSigningStateHavePrivateKeysAsynchronously);
+            XCTAssertEqual(aliceSession.crypto.crossSigning.state, MXCrossSigningStateCanCrossSignAsynchronously);
             XCTAssertTrue(aliceSession.crypto.crossSigning.canCrossSign);
-            XCTAssertTrue(aliceSession.crypto.crossSigning.canReadCrossSignTrust);
+            XCTAssertTrue(aliceSession.crypto.crossSigning.canTrustCrossSigning);
 
             // -> Alice must see their device trusted
             MXDeviceTrustLevel *aliceDevice1Trust = [aliceSession.crypto deviceTrustLevelForDevice:aliceSession.matrixRestClient.credentials.deviceId ofUser:aliceSession.matrixRestClient.credentials.userId];


### PR DESCRIPTION
The 2 first commits fix the `testBootstrapWithPassword` test.
Then, I introduced `MXCrossSigningState`.
