### PR TITLE
Cross-signing: Quick fix for self verification

### DIFF
--- a/MatrixSDK/Crypto/Verification/Requests/MXKeyVerificationByToDeviceRequest.m
+++ b/MatrixSDK/Crypto/Verification/Requests/MXKeyVerificationByToDeviceRequest.m
@@ -94,7 +94,7 @@
 {
     NSString* otherDeviceId;
     
-    if (self.isFromMyUser)
+    if (self.isFromMyDevice)
     {
         otherDeviceId = self.acceptedData.fromDevice ?: self.requestedOtherDeviceIds.firstObject;
     }


### PR DESCRIPTION
testVerificationByToDeviceSelfVerificationFullFlow did not pass. The accept method was not sent to the other peer.
Probably a typo in the last PR.