### PR TITLE
Key Verification: Implement better self verification request to many

### DIFF
--- a/MatrixSDK/Crypto/Verification/MXKeyVerificationManager.h
+++ b/MatrixSDK/Crypto/Verification/MXKeyVerificationManager.h
@@ -40,6 +40,7 @@ FOUNDATION_EXPORT NSString *const MXKeyVerificationErrorDomain;
 typedef enum : NSUInteger
 {
     MXKeyVerificationUnknownDeviceCode,
+    MXKeyVerificatioNoOtherDeviceCode,
     MXKeyVerificationUnsupportedMethodCode,
     MXKeyVerificationInvalidStateCode,
     MXKeyVerificationUnknownRoomCode,

--- a/MatrixSDK/Crypto/Verification/MXKeyVerificationManager.h
+++ b/MatrixSDK/Crypto/Verification/MXKeyVerificationManager.h
@@ -94,7 +94,7 @@ FOUNDATION_EXPORT NSString *const MXKeyVerificationManagerNotificationTransactio
  Make a key verification request by to_device events.
  
  @param userId the other user id.
- @param deviceIds array of device IDs to send requests to. Use nil for all devices owned by the user
+ @param deviceIds array of device IDs to send requests to. Use nil for all other devices owned by the user
  @param methods Verification methods like MXKeyVerificationMethodSAS.
  @param success a block called when the operation succeeds.
  @param failure a block called when the operation fails.

--- a/MatrixSDK/Crypto/Verification/MXKeyVerificationManager.m
+++ b/MatrixSDK/Crypto/Verification/MXKeyVerificationManager.m
@@ -107,7 +107,12 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerDMEventTypes;
             }
             else
             {
-               // TODO
+                NSError *error = [NSError errorWithDomain:MXKeyVerificationErrorDomain
+                                                     code:MXKeyVerificatioNoOtherDeviceCode
+                                                 userInfo:@{
+                                                            NSLocalizedDescriptionKey: [NSString stringWithFormat:@"The user has no other device"]
+                                                            }];
+                failure(error);
             }
         } failure:failure];
     }

--- a/MatrixSDK/Crypto/Verification/MXKeyVerificationManager.m
+++ b/MatrixSDK/Crypto/Verification/MXKeyVerificationManager.m
@@ -635,7 +635,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerDMEventTypes;
     {
         // Else only cancel the request
         MXKeyVerificationCancel *cancel = [MXKeyVerificationCancel new];
-        cancel.transactionId = transaction.transactionId;
+        cancel.transactionId = request.requestId;
         cancel.code = cancelCode.value;
         cancel.reason = cancelCode.humanReadable;
         

--- a/MatrixSDK/Crypto/Verification/Requests/MXKeyVerificationByToDeviceRequest.m
+++ b/MatrixSDK/Crypto/Verification/Requests/MXKeyVerificationByToDeviceRequest.m
@@ -92,18 +92,7 @@
 
 - (NSString *)otherDevice
 {
-    NSString* otherDeviceId;
-    
-    if (self.isFromMyDevice)
-    {
-        otherDeviceId = self.acceptedData.fromDevice ?: self.requestedOtherDeviceIds.firstObject;
-    }
-    else
-    {
-        otherDeviceId = _request.fromDevice;
-    }
-    
-    return otherDeviceId;
+    return self.isFromMyDevice ? self.acceptedData.fromDevice : _request.fromDevice;
 }
 
 @end

--- a/MatrixSDKTests/MXCryptoKeyVerificationTests.m
+++ b/MatrixSDKTests/MXCryptoKeyVerificationTests.m
@@ -413,8 +413,8 @@
 /**
  Test self verification request cancellation with 3 devices.
  - Have Alice with 3 sessions
- - Alice sends a self verifcation request to her all other devices
- - -> The other device list should have been computed well
+ - Alice sends a self verification request to her all other devices
+ -> The other device list should have been computed well
  - Alice cancels it from device #1
  -> All other devices should get the cancellation
  */
@@ -434,7 +434,7 @@
                 
                 NSArray *methods = @[MXKeyVerificationMethodSAS];
             
-                // - Alice sends a self verifcation request to her all other devices
+                // - Alice sends a self verification request to her all other devices
                 [aliceSession1.crypto.keyVerificationManager requestVerificationByToDeviceWithUserId:aliceUserId
                                                                                           deviceIds:nil
                                                                                             methods:methods
@@ -497,6 +497,40 @@
     }];
 }
 
+/**
+ Test self verification request when no other device.
+ - Have Alice with 1 device
+ - Alice sends a self verification request to her all other devices
+ -> The request must fail as she has no other device.
+ */
+- (void)testVerificationByToDeviceRequestWithNoOtherDevice
+{
+    // - Have Alice with 1 device
+    [matrixSDKTestsE2EData doE2ETestWithAliceAndBobInARoom:self cryptedBob:YES warnOnUnknowDevices:YES aliceStore:[[MXMemoryStore alloc] init] bobStore:[[MXMemoryStore alloc] init] readyToTest:^(MXSession *aliceSession, MXSession *bobSession, NSString *roomId, XCTestExpectation *expectation) {
+        
+        NSString *aliceUserId = aliceSession.matrixRestClient.credentials.userId;
+        
+        NSArray *methods = @[MXKeyVerificationMethodSAS];
+        
+        // - Alice sends a self verification request to her all other devices
+        [aliceSession.crypto.keyVerificationManager requestVerificationByToDeviceWithUserId:aliceUserId
+                                                                                  deviceIds:nil
+                                                                                    methods:methods
+                                                                                    success:^(MXKeyVerificationRequest *requestFromAliceDevice1POV)
+         {
+             XCTFail(@"The request should not succeed ");
+             [expectation fulfill];
+         }
+                                                                                    failure:^(NSError * _Nonnull error)
+         {
+             //  -> The request must fail as she has no other device.
+             XCTAssertEqualObjects(error.domain, MXKeyVerificationErrorDomain);
+             XCTAssertEqual(error.code, MXKeyVerificatioNoOtherDeviceCode);
+             
+             [expectation fulfill];
+         }];
+    }];
+}
 
 
 #pragma mark - Verification by to_device (legacy)


### PR DESCRIPTION
I thought it was required for https://github.com/vector-im/riot-ios/issues/3003 but it is surprisingly not the case.

Requests are now sent to other devices using their device id. Knowing all device ids makes request cancellation much more easier to implement.

I rolled back the patch made on `MXKeyVerificationByToDeviceRequest.otherDeviceId`. All tests pass now.