### PR TITLE
MXSession: Add credentials, myUserId and myDeviceId shorcuts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Improvements:
  * Cross-Signing: Add a new module, MXCrossSigning, to handle device cross-signing (vector-im/riot-ios/issues/2890).
  * Verification by DM: Support QR code (vector-im/riot-ios/issues/2921).
  * MXRoom: Add a method to retrieve trusted members count in an encrypted room.
+ * MXSession: Add credentials, myUserId and myDeviceId shorcuts.
  * MXSession: Add createRoomWithParameters with a MXRoomCreationParameters model class.
  * MXRoomCreationParameters: Support the initial_state parameter and allow e2e on room creation (vector-im/riot-ios/issues/2943).
  * MXCrypto: Expose devicesForUser.

--- a/MatrixSDK/Crypto/CrossSigning/Data/MXCrossSigningInfo.m
+++ b/MatrixSDK/Crypto/CrossSigning/Data/MXCrossSigningInfo.m
@@ -125,4 +125,9 @@ NSString *const MXCrossSigningInfoTrustLevelDidChangeNotification = @"MXCrossSig
     _keys = keys;
 }
 
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<MXCrossSigningInfo: %p> Trusted: %@\nMSK: %@\nSSK: %@\nUSK: %@", self, @(self.trustLevel.isCrossSigningVerified), self.masterKeys, self.selfSignedKeys, self.userSignedKeys];
+}
+
 @end

--- a/MatrixSDK/Crypto/CrossSigning/JSONModels/MXCrossSigningKey.m
+++ b/MatrixSDK/Crypto/CrossSigning/JSONModels/MXCrossSigningKey.m
@@ -152,4 +152,9 @@ const struct MXCrossSigningKeyType MXCrossSigningKeyType = {
     [aCoder encodeObject:_signatures forKey:@"signatures"];
 }
 
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<MXCrossSigningKey: %p> Keys: %@. Signatures: %@", self, self.keys, self.signatures];
+}
+
 @end

--- a/MatrixSDK/Crypto/CrossSigning/MXCrossSigning.m
+++ b/MatrixSDK/Crypto/CrossSigning/MXCrossSigning.m
@@ -175,7 +175,7 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
 {
     NSLog(@"[MXCrossSigning] crossSignDeviceWithDeviceId: %@", deviceId);
           
-    NSString *myUserId = self.crypto.mxSession.myUser.userId;
+    NSString *myUserId = self.crypto.mxSession.myUserId;
     
     dispatch_async(self.crypto.cryptoQueue, ^{
         
@@ -399,7 +399,7 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
 {
     BOOL isUserVerified = NO;
 
-    NSString *myUserId = _crypto.mxSession.myUser.userId;
+    NSString *myUserId = _crypto.mxSession.myUserId;
     if ([myUserId isEqualToString:crossSigningKeys.userId])
     {
         // Can we trust the current cross-signing setup?
@@ -580,7 +580,7 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
         return NO;
     }
     
-    NSString *myUserId = _crypto.mxSession.myUser.userId;
+    NSString *myUserId = _crypto.mxSession.matrixRestClient.credentials.userId;
     
     // Is it signed by a locally trusted device?
     NSDictionary<NSString*, NSString*> *myUserSignatures = myMasterKey.signatures.map[myUserId];
@@ -705,7 +705,7 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
            success:(void (^)(void))success
            failure:(void (^)(NSError *error))failure
 {
-    NSString *myUserId = _crypto.mxSession.myUser.userId;
+    NSString *myUserId = _crypto.mxSession.myUserId;
 
     NSDictionary *object = @{
                              @"algorithms": device.algorithms,
@@ -770,7 +770,7 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
 {
     [self crossSigningKeyWithKeyType:keyType success:^(NSString *publicKey, OLMPkSigning *signing) {
 
-        NSString *myUserId = self.crypto.mxSession.myUser.userId;
+        NSString *myUserId = self.crypto.mxSession.myUserId;
 
         NSError *error;
         NSDictionary *signedObject = [self.crossSigningTools pkSignObject:object withPkSigning:signing userId:myUserId publicKey:publicKey error:&error];

--- a/MatrixSDK/Crypto/CrossSigning/MXCrossSigning.m
+++ b/MatrixSDK/Crypto/CrossSigning/MXCrossSigning.m
@@ -357,7 +357,7 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
     NSString *myUserId = _crypto.mxSession.matrixRestClient.credentials.userId;
     _myUserCrossSigningKeys = [_crypto.store crossSigningKeysForUser:myUserId];
     
-    NSLog(@"[MXCrossSigning] refreshState for device %@: current state: %@ (%@)", self.crypto.store.deviceId, @(self.state), self.myUserCrossSigningKeys);
+    NSLog(@"[MXCrossSigning] refreshState for device %@: Current state: %@", self.crypto.store.deviceId, @(self.state));
 
     // Refresh user's keys
     [self.crypto.deviceList downloadKeys:@[myUserId] forceDownload:YES success:^(MXUsersDevicesMap<MXDeviceInfo *> *usersDevicesInfoMap, NSDictionary<NSString *,MXCrossSigningInfo *> *crossSigningKeysMap) {
@@ -375,7 +375,7 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
             [self resetTrust];
         }
         
-        NSLog(@"[MXCrossSigning] refreshState for device %@: updated state: %@ (%@)", self.crypto.store.deviceId, @(self.state), self.myUserCrossSigningKeys);
+        NSLog(@"[MXCrossSigning] refreshState for device %@: Updated state: %@", self.crypto.store.deviceId, @(self.state));
         
         if (success)
         {
@@ -515,6 +515,9 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
     }
     
     _state = state;
+    
+    NSLog(@"[MXCrossSigning] myUserCrossSigningKeys: %@", _myUserCrossSigningKeys);
+    NSLog(@"[MXCrossSigning] state: %@", @(_state));
 }
 
 // Recompute cross-signing trust on all users we know
@@ -606,7 +609,9 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
     
     if (!isMasterKeyTrusted)
     {
-        NSLog(@"[MXCrossSigning] isSelfTrusted: NO (MSK not trusted)");
+        NSLog(@"[MXCrossSigning] isSelfTrusted: NO (MSK not trusted). MSK: %@", myMasterKey);
+        NSLog(@"[MXCrossSigning] isSelfTrusted: My user devices: %@", [self.crypto.store devicesForUser:myUserId]);
+
         return NO;
     }
     
@@ -615,7 +620,8 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
     BOOL isUSKSignatureValid = [self checkSignatureOnKey:myUserKey byKey:myMasterKey userId:myUserId];
     if (!isUSKSignatureValid)
     {
-        NSLog(@"[MXCrossSigning] isSelfTrusted: NO (Invalid MSK signature for USK)");
+        NSLog(@"[MXCrossSigning] isSelfTrusted: NO (Invalid MSK signature for USK). USK: %@", myUserKey);
+        NSLog(@"[MXCrossSigning] isSelfTrusted: MSK: %@", myMasterKey);
         return NO;
     }
     
@@ -624,7 +630,8 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
     BOOL isSSKSignatureValid = [self checkSignatureOnKey:mySelfKey byKey:myMasterKey userId:myUserId];
     if (!isSSKSignatureValid)
     {
-        NSLog(@"[MXCrossSigning] isSelfTrusted: NO (Invalid MSK signature for SSK)");
+        NSLog(@"[MXCrossSigning] isSelfTrusted: NO (Invalid MSK signature for SSK). SSK: %@", mySelfKey);
+        NSLog(@"[MXCrossSigning] isSelfTrusted: MSK: %@", myMasterKey);
         return NO;
     }
     

--- a/MatrixSDK/Crypto/CrossSigning/MXCrossSigning.m
+++ b/MatrixSDK/Crypto/CrossSigning/MXCrossSigning.m
@@ -107,8 +107,8 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
 
 - (MXCrossSigningInfo *)createKeys:(NSDictionary<NSString *,NSData *> *__autoreleasing  _Nonnull *)outPrivateKeys
 {
-    NSString *myUserId = _crypto.mxSession.matrixRestClient.credentials.userId;
-    NSString *myDeviceId = _crypto.mxSession.matrixRestClient.credentials.deviceId;
+    NSString *myUserId = _crypto.mxSession.myUserId;
+    NSString *myDeviceId = _crypto.mxSession.myDeviceId;
 
     MXCrossSigningInfo *crossSigningKeys = [[MXCrossSigningInfo alloc] initWithUserId:myUserId];
 
@@ -338,7 +338,7 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
         _crypto = crypto;
         _crossSigningTools = [MXCrossSigningTools new];
         
-        NSString *myUserId = _crypto.mxSession.matrixRestClient.credentials.userId;
+        NSString *myUserId = _crypto.mxSession.myUserId;
         _myUserCrossSigningKeys = [_crypto.store crossSigningKeysForUser:myUserId];
         
         [self computeState];
@@ -354,7 +354,7 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
     BOOL canTrustCrossSigningBefore = self.canTrustCrossSigning;
     MXCrossSigningInfo *myUserCrossSigningKeysBefore = self.myUserCrossSigningKeys;
     
-    NSString *myUserId = _crypto.mxSession.matrixRestClient.credentials.userId;
+    NSString *myUserId = _crypto.mxSession.myUserId;
     _myUserCrossSigningKeys = [_crypto.store crossSigningKeysForUser:myUserId];
     
     NSLog(@"[MXCrossSigning] refreshState for device %@: Current state: %@", self.crypto.store.deviceId, @(self.state));
@@ -583,7 +583,7 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
         return NO;
     }
     
-    NSString *myUserId = _crypto.mxSession.matrixRestClient.credentials.userId;
+    NSString *myUserId = _crypto.mxSession.myUserId;
     
     // Is it signed by a locally trusted device?
     NSDictionary<NSString*, NSString*> *myUserSignatures = myMasterKey.signatures.map[myUserId];

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -244,7 +244,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
             MXStrongifyAndReturnIfNil(self);
 
             NSLog(@"[MXCrypto] start ###########################################################");
-            NSLog(@"[MXCrypto] uploadDeviceKeys done for %@: ", self.mxSession.myUser.userId);
+            NSLog(@"[MXCrypto] uploadDeviceKeys done for %@: ", self.mxSession.myUserId);
 
             NSLog(@"[MXCrypto]    - device id  : %@", self.store.deviceId);
             NSLog(@"[MXCrypto]    - ed25519    : %@", self.olmDevice.deviceEd25519Key);
@@ -830,7 +830,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
         [device updateTrustLevel:trustLevel];
         [self.store storeDeviceForUser:userId device:device];
         
-        if ([userId isEqualToString:self.mxSession.myUser.userId])
+        if ([userId isEqualToString:self.mxSession.myUserId])
         {
             // If one of the user's own devices is being marked as verified / unverified,
             // check the key backup status, since whether or not we use this depends on
@@ -840,7 +840,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     }
     
     if (verificationStatus == MXDeviceVerified
-        && [userId isEqualToString:self.mxSession.myUser.userId])
+        && [userId isEqualToString:self.mxSession.myUserId])
     {
         // Manage self-verification
         if (self.crossSigning.canCrossSign)
@@ -2539,7 +2539,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
         return;
     }
     
-    if ([sender isEqualToString:_mxSession.myUser.userId]
+    if ([sender isEqualToString:_mxSession.myUserId]
         && [deviceKey isEqualToString:self.olmDevice.deviceCurve25519Key])
     {
         NSLog(@"[MXCrypto] markOlmSessionForUnwedging: Do not unwedge ourselves");

--- a/MatrixSDK/Crypto/Verification/MXKeyVerificationManager.m
+++ b/MatrixSDK/Crypto/Verification/MXKeyVerificationManager.m
@@ -161,7 +161,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerDMEventTypes;
     [self.crypto.matrixRestClient sendToDevice:kMXMessageTypeKeyVerificationRequest contentMap:contentMap txnId:nil success:^{
         
         MXEvent *event = [MXEvent modelFromJSON:@{
-                                                  @"sender": self.crypto.mxSession.myUser.userId,
+                                                  @"sender": self.crypto.mxSession.myUserId,
                                                   @"type": kMXMessageTypeKeyVerificationRequest,
                                                   @"content": requestJSONModel.JSONDictionary
                                                   }];
@@ -797,7 +797,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerDMEventTypes;
 {
     dispatch_async(cryptoQueue, ^{
 
-        BOOL eventFromMyUser = [event.sender isEqualToString:self.crypto.mxSession.myUser.userId];
+        BOOL eventFromMyUser = [event.sender isEqualToString:self.crypto.mxSession.myUserId];
         BOOL isEventIntendedForMyDevice = isToDeviceEvent || !eventFromMyUser;
 
         NSLog(@"[MXKeyVerification] handleKeyVerificationEvent(from my user: %@, isToDeviceEvent: %@, intendedForMyDevice: %@): eventType: %@ \n%@",
@@ -864,7 +864,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerDMEventTypes;
 {
     NSLog(@"[MXKeyVerification] handleToDeviceRequestEvent");
     
-    MXKeyVerificationByToDeviceRequest *keyVerificationRequest = [[MXKeyVerificationByToDeviceRequest alloc] initWithEvent:event andManager:self to:self.crypto.mxSession.myUser.userId requestedOtherDeviceIds:@[]];
+    MXKeyVerificationByToDeviceRequest *keyVerificationRequest = [[MXKeyVerificationByToDeviceRequest alloc] initWithEvent:event andManager:self to:self.crypto.mxSession.myUserId requestedOtherDeviceIds:@[]];
     
     if (!keyVerificationRequest)
     {
@@ -1328,7 +1328,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerDMEventTypes;
 {
     NSLog(@"[MXKeyVerification] handleKeyVerificationRequestByDM: %@", request);
 
-    if (![request.request.to isEqualToString:self.crypto.mxSession.myUser.userId])
+    if (![request.request.to isEqualToString:self.crypto.mxSession.myUserId])
     {
         NSLog(@"[MXKeyVerification] handleKeyVerificationRequestByDM: Request for another user: %@", request.request.to);
         return;
@@ -1861,7 +1861,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerDMEventTypes;
 {
     MXQRCodeData *qrCodeData;
     
-    NSString *currentUserId = self.crypto.mxSession.myUser.userId;
+    NSString *currentUserId = self.crypto.mxSession.myUserId;
     MXUserTrustLevel *currentUserTrustLevel = [self.crypto trustLevelForUser:currentUserId];
     
     if ([otherUserId isEqualToString:currentUserId])
@@ -1910,7 +1910,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerDMEventTypes;
                                                                                                otherDeviceId:(NSString*)otherDeviceId
 {
     MXCrossSigningInfo *myUserCrossSigningKeys = self.crypto.crossSigning.myUserCrossSigningKeys;
-    NSString *currentUserId = self.crypto.mxSession.myUser.userId;
+    NSString *currentUserId = self.crypto.mxSession.myUserId;
     MXDeviceInfo *otherDevice = [self.crypto deviceWithDeviceId:otherDeviceId ofUser:currentUserId];
     
     NSString *userCrossSigningMasterKeyPublic = myUserCrossSigningKeys.masterKeys.keys;
@@ -1948,7 +1948,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerDMEventTypes;
 
 - (MXDeviceInfo*)currentDevice
 {
-    NSString *currentUserId = self.crypto.mxSession.myUser.userId;
+    NSString *currentUserId = self.crypto.mxSession.myUserId;
     NSString *currentDeviceId = self.crypto.mxSession.matrixRestClient.credentials.deviceId;
     return [self.crypto deviceWithDeviceId:currentDeviceId ofUser:currentUserId];
 }

--- a/MatrixSDK/Crypto/Verification/Status/MXKeyVerificationStatusResolver.m
+++ b/MatrixSDK/Crypto/Verification/Status/MXKeyVerificationStatusResolver.m
@@ -169,7 +169,7 @@
     }
     
     MXKeyVerificationRequestState requestState = MXKeyVerificationRequestStatePending;
-    NSString *myUserId = self.mxSession.myUser.userId;
+    NSString *myUserId = self.mxSession.myUserId;
     
     MXEvent *firstEvent = events.firstObject;
     if (firstEvent.eventType == MXEventTypeKeyVerificationCancel)
@@ -251,7 +251,7 @@
     
     for (MXEvent *event in events)
     {
-        NSString *myUserId = self.mxSession.myUser.userId;
+        NSString *myUserId = self.mxSession.myUserId;
         
         switch (event.eventType)
         {

--- a/MatrixSDK/Crypto/Verification/Transactions/QRCode/MXQRCodeTransaction.m
+++ b/MatrixSDK/Crypto/Verification/Transactions/QRCode/MXQRCodeTransaction.m
@@ -223,7 +223,7 @@ NSString * const MXKeyVerificationMethodReciprocate = @"m.reciprocate.v1";
         return;
     }
     
-    NSString *currentUserId = self.manager.crypto.mxSession.myUser.userId;
+    NSString *currentUserId = self.manager.crypto.mxSession.myUserId;
     BOOL isSelfVerification = [currentUserId isEqualToString:self.otherUserId];
     
     // If not me sign his MSK and upload the signature
@@ -263,7 +263,7 @@ NSString * const MXKeyVerificationMethodReciprocate = @"m.reciprocate.v1";
     
     MXQRCodeData *qrCodeData = self.qrCodeData;
     
-    NSString *currentUserId = self.manager.crypto.mxSession.myUser.userId;
+    NSString *currentUserId = self.manager.crypto.mxSession.myUserId;
     BOOL isSelfVerification = [currentUserId isEqualToString:self.otherUserId];
     
     // If not me, sign their MSK and upload the signature
@@ -310,7 +310,7 @@ NSString * const MXKeyVerificationMethodReciprocate = @"m.reciprocate.v1";
 
 - (void)trustOtherDeviceWithId:(NSString*)otherDeviceId
 {
-    NSString *currentUserId = self.manager.crypto.mxSession.myUser.userId;
+    NSString *currentUserId = self.manager.crypto.mxSession.myUserId;
     
     // setDeviceVerification will automatically cross sign the device
     [self.manager.crypto setDeviceVerification:MXDeviceVerified forDevice:otherDeviceId ofUser:currentUserId success:^{

--- a/MatrixSDK/Data/MXEventTimeline.m
+++ b/MatrixSDK/Data/MXEventTimeline.m
@@ -863,7 +863,7 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
     if (_isLiveTimeline && (direction == MXTimelineDirectionForwards))
     {
         // Check for local echo suppression
-        if (room.outgoingMessages.count && [event.sender isEqualToString:room.mxSession.myUser.userId])
+        if (room.outgoingMessages.count && [event.sender isEqualToString:room.mxSession.myUserId])
         {
             MXEvent *localEcho = [room pendingLocalEchoRelatedToEvent:event];
             if (localEcho)

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -406,7 +406,7 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
         // We can use roomState.members because, even in case of lazy loading of room members,
         // my user must be in roomState.members
         MXRoomMembers *roomMembers = roomState.members;
-        MXRoomMember *myUser = [roomMembers memberWithUserId:self.mxSession.myUser.userId];
+        MXRoomMember *myUser = [roomMembers memberWithUserId:self.mxSession.myUserId];
         BOOL isDirect = NO;
 
         if (myUser.originalEvent.content[@"is_direct"])
@@ -2272,7 +2272,7 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
     event.eventId = eventId;
     event.wireType = eventType;
     event.originServerTs = (uint64_t) ([[NSDate date] timeIntervalSince1970] * 1000);
-    event.sender = mxSession.myUser.userId;
+    event.sender = mxSession.myUserId;
     event.wireContent = content;
     
     return event;
@@ -2635,7 +2635,7 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
     // Prepare read receipt update.
     // Retrieve the current read receipt event id
     NSString *currentReadReceiptEventId;
-    NSString *myUserId = mxSession.myUser.userId;
+    NSString *myUserId = mxSession.myUserId;
     MXReceiptData* currentData = [mxSession.store getReceiptInRoom:self.roomId forUserId:myUserId];
     if (currentData)
     {
@@ -2754,7 +2754,7 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
     }
 
     MXEvent *event;
-    NSString* myUserId = mxSession.myUser.userId;
+    NSString* myUserId = mxSession.myUserId;
     MXReceiptData *currentReceiptData = [mxSession.store getReceiptInRoom:self.roomId forUserId:myUserId];
 
     // Prepare updated read receipt
@@ -2821,7 +2821,7 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
     // if some receipts are found
     if (receipts)
     {
-        NSString* myUserId = mxSession.myUser.userId;
+        NSString* myUserId = mxSession.myUserId;
         NSMutableArray* res = [[NSMutableArray alloc] init];
         
         // Remove the oneself receipts
@@ -2905,7 +2905,7 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
 - (void)forgetReadMarker
 {
     // Retrieve the current position
-    NSString *myUserId = mxSession.myUser.userId;
+    NSString *myUserId = mxSession.myUserId;
     MXReceiptData* currentData = [mxSession.store getReceiptInRoom:self.roomId forUserId:myUserId];
     if (currentData)
     {
@@ -2966,7 +2966,7 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
             operation = [self members:^(MXRoomMembers *roomMembers) {
                 MXStrongifyAndReturnIfNil(self);
 
-                NSString *myUserId = self.mxSession.myUser.userId;
+                NSString *myUserId = self.mxSession.myUserId;
 
                 // By default mark as direct this room for the oldest joined member.
                 NSArray<MXRoomMember *> *members = roomMembers.joinedMembers;

--- a/MatrixSDK/Data/MXRoomState.m
+++ b/MatrixSDK/Data/MXRoomState.m
@@ -399,7 +399,7 @@
                     NSDictionary *content = [self contentOfEvent:event];
 
                     // Compute my user membership indepently from MXRoomMembers
-                    if ([userId isEqualToString:mxSession.myUser.userId])
+                    if ([userId isEqualToString:mxSession.myUserId])
                     {
                         MXRoomMember *roomMember = [[MXRoomMember alloc] initWithMXEvent:event andEventContent:content];
                         _membership = roomMember.membership;

--- a/MatrixSDK/Data/MXRoomSummaryUpdater.m
+++ b/MatrixSDK/Data/MXRoomSummaryUpdater.m
@@ -514,7 +514,7 @@
     for (MXRoomMember *member in roomState.members.members)
     {
         if ((member.membership == MXMembershipJoin || member.membership == MXMembershipInvite)
-            && ![member.userId isEqualToString:session.myUser.userId])
+            && ![member.userId isEqualToString:session.myUserId])
         {
             [otherMembers addObject:member];
         }

--- a/MatrixSDK/MXSession.h
+++ b/MatrixSDK/MXSession.h
@@ -362,6 +362,13 @@ FOUNDATION_EXPORT NSString *const kMXSessionNoRoomTag;
 @interface MXSession : NSObject
 
 /**
+ Shortcuts to the credentials this session is using
+ */
+@property (nonatomic, readonly) MXCredentials *credentials;
+@property (nonatomic, readonly) NSString *myUserId;
+@property (nonatomic, readonly) NSString *myDeviceId;
+
+/**
  The matrix REST Client used to make Matrix API requests.
  */
 @property (nonatomic, readonly) MXRestClient *matrixRestClient;

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -254,6 +254,21 @@ typedef void (^MXOnResumeDone)(void);
     return self;
 }
 
+- (MXCredentials *)credentials
+{
+    return matrixRestClient.credentials;
+}
+
+- (NSString *)myUserId
+{
+    return matrixRestClient.credentials.userId;
+}
+
+- (NSString *)myDeviceId
+{
+    return matrixRestClient.credentials.deviceId;
+}
+
 - (void)setState:(MXSessionState)state
 {
     if (_state != state)

--- a/MatrixSDK/VoIP/MXCall.m
+++ b/MatrixSDK/VoIP/MXCall.m
@@ -97,7 +97,7 @@ NSString *const kMXCallStateDidChange = @"kMXCallStateDidChange";
 
         _callId = [[NSUUID UUID] UUIDString];
         _callUUID = [NSUUID UUID];
-        _callerId = callManager.mxSession.myUser.userId;
+        _callerId = callManager.mxSession.myUserId;
 
         _state = MXCallStateFledgling;
         _endReason = MXCallEndReasonUnknown;
@@ -184,13 +184,13 @@ NSString *const kMXCallStateDidChange = @"kMXCallStateDidChange";
         {
             callInviteEventContent = [MXCallInviteEventContent modelFromJSON:event.content];
 
-            if (![event.sender isEqualToString:_callSignalingRoom.mxSession.myUser.userId])
+            if (![event.sender isEqualToString:_callSignalingRoom.mxSession.myUserId])
             {
                 // Incoming call
 
                 _callId = callInviteEventContent.callId;
                 _callerId = event.sender;
-                calleeId = callManager.mxSession.myUser.userId;
+                calleeId = callManager.mxSession.myUserId;
                 _isIncoming = YES;
 
                 // Store if it is voice or video call
@@ -286,7 +286,7 @@ NSString *const kMXCallStateDidChange = @"kMXCallStateDidChange";
 
         case MXEventTypeCallCandidates:
         {
-            if (NO == [event.sender isEqualToString:_callSignalingRoom.mxSession.myUser.userId])
+            if (NO == [event.sender isEqualToString:_callSignalingRoom.mxSession.myUserId])
             {
                 MXCallCandidatesEventContent *content = [MXCallCandidatesEventContent modelFromJSON:event.content];
 
@@ -681,7 +681,7 @@ NSString *const kMXCallStateDidChange = @"kMXCallStateDidChange";
     // Determine call end reason
     if (event)
     {
-        if ([event.sender isEqualToString:callManager.mxSession.myUser.userId])
+        if ([event.sender isEqualToString:callManager.mxSession.myUserId])
             _endReason = MXCallEndReasonHangupElsewhere;
         else if (!self.isEstablished && !self.isIncoming)
             _endReason = MXCallEndReasonBusy;

--- a/MatrixSDK/VoIP/MXCallManager.m
+++ b/MatrixSDK/VoIP/MXCallManager.m
@@ -329,7 +329,7 @@ NSString *const kMXCallManagerConferenceFinished = @"kMXCallManagerConferenceFin
     if (event.age < content.lifetime)
     {
         // If it is an invite from the peer, we need to create the MXCall
-        if (![event.sender isEqualToString:_mxSession.myUser.userId])
+        if (![event.sender isEqualToString:_mxSession.myUserId])
         {
             MXCall *call = [self callWithCallId:content.callId];
             if (!call)
@@ -532,7 +532,7 @@ NSString *const kMXCallManagerConferenceUserDomain  = @"matrix.org";
     else
     {
         MXRoomPowerLevels *powerLevels = roomState.powerLevels;
-        NSInteger oneSelfPowerLevel = [powerLevels powerLevelOfUserWithUserID:room.mxSession.myUser.userId];
+        NSInteger oneSelfPowerLevel = [powerLevels powerLevelOfUserWithUserID:room.mxSession.myUserId];
 
         // Only member with invite power level can create a conference call
         if (oneSelfPowerLevel >= powerLevels.invite)

--- a/MatrixSDKTests/MXCryptoTests.m
+++ b/MatrixSDKTests/MXCryptoTests.m
@@ -208,7 +208,7 @@
             NSString *deviceCurve25519Key = mxSession2.crypto.olmDevice.deviceCurve25519Key;
             NSString *deviceEd25519Key = mxSession2.crypto.olmDevice.deviceEd25519Key;
 
-            NSArray<MXDeviceInfo *> *myUserDevices = [mxSession2.crypto.deviceList storedDevicesForUser:mxSession.myUser.userId];
+            NSArray<MXDeviceInfo *> *myUserDevices = [mxSession2.crypto.deviceList storedDevicesForUser:mxSession.myUserId];
             XCTAssertEqual(myUserDevices.count, 1);
 
             MXRestClient *bobRestClient = mxSession2.matrixRestClient;

--- a/MatrixSDKTests/MXSessionTests.m
+++ b/MatrixSDKTests/MXSessionTests.m
@@ -649,13 +649,13 @@
                     MXEvent *roomMemberEvent2 = roomMemberEvents[1];
                     
                     BOOL succeed;
-                    if ([roomMemberEvent1.stateKey isEqualToString:mxSession.myUser.userId])
+                    if ([roomMemberEvent1.stateKey isEqualToString:mxSession.myUserId])
                     {
                         succeed = [roomMemberEvent2.stateKey isEqualToString:matrixSDKTestsData.aliceCredentials.userId];
                     }
                     else if ([roomMemberEvent1.stateKey isEqualToString:matrixSDKTestsData.aliceCredentials.userId])
                     {
-                        succeed = [roomMemberEvent2.stateKey isEqualToString:mxSession.myUser.userId];
+                        succeed = [roomMemberEvent2.stateKey isEqualToString:mxSession.myUserId];
                     }
                     
                     XCTAssertTrue(succeed);
@@ -702,13 +702,13 @@
                     MXEvent *roomMemberEvent2 = roomMemberEvents[1];
                     
                     BOOL succeed;
-                    if ([roomMemberEvent1.stateKey isEqualToString:mxSession.myUser.userId])
+                    if ([roomMemberEvent1.stateKey isEqualToString:mxSession.myUserId])
                     {
                         succeed = [roomMemberEvent2.stateKey isEqualToString:matrixSDKTestsData.aliceCredentials.userId];
                     }
                     else if ([roomMemberEvent1.stateKey isEqualToString:matrixSDKTestsData.aliceCredentials.userId])
                     {
-                        succeed = [roomMemberEvent2.stateKey isEqualToString:mxSession.myUser.userId];
+                        succeed = [roomMemberEvent2.stateKey isEqualToString:mxSession.myUserId];
                     }
                     
                     XCTAssertTrue(succeed);
@@ -725,7 +725,7 @@
                             MXRoomPowerLevels *roomPowerLevels = roomState.powerLevels;
 
                             XCTAssertNotNil(roomPowerLevels);
-                            NSUInteger powerlLevel1 = [roomPowerLevels powerLevelOfUserWithUserID:mxSession.myUser.userId];
+                            NSUInteger powerlLevel1 = [roomPowerLevels powerLevelOfUserWithUserID:mxSession.myUserId];
                             NSUInteger powerlLevel2 = [roomPowerLevels powerLevelOfUserWithUserID:matrixSDKTestsData.aliceCredentials.userId];
                             XCTAssertEqual(powerlLevel1, powerlLevel2, @"The members must have the same power level");
 
@@ -1298,7 +1298,7 @@
                                          @"device_id": @"AliceDevice",
                                          @"rooms": @[roomId]
                                          }
-                                 } forUser:mxSession.myUser.userId];
+                                 } forUser:mxSession.myUserId];
 
         [aliceRestClient sendToDevice:kMXEventTypeStringRoomKeyRequest contentMap:contentMap txnId:nil success:^{
 


### PR DESCRIPTION
This fixes a race condition for cross-signing where MXSession.myUser can be nil.

In the second commit, I added logs to debug cross-signing. This gives:
```
2020-04-03 15:15:25.962714+0200 Riot[10860:124778] [MXCrossSigning] isSelfTrusted: NO (MSK not trusted). MSK: <MXCrossSigningKey: 0x600003028180> Keys: F0qYNM/wyloiDK961+3nrRjy5ZnguVKvwfpysAb7ozg. Signatures: {
    "@xcalice4:matrix.org" =     {
        "ed25519:AAUUEMWARH" = "yK78oLC6RImbjEOR3TnkYLIwOm3AVuf8edK5Psjikol8oYsuD+C/HdotcwApO10HPqcaJsnyvTgntdMRiIHGCQ";
    };
}
2020-04-03 15:15:25.964299+0200 Riot[10860:124778] [MXCrossSigning] isSelfTrusted: My user devices: {
    HCOMGMOFFM = "@xcalice4:matrix.org:HCOMGMOFFM - curve25519: iqPzoMwTCU4julRxhGTnOX82Wa3440TMTClQdszvpGc (trustLevel: MXDeviceTrustLevel: local: 1 - cross-signing: 0)";
    SVRVEDEAJI = "@xcalice4:matrix.org:SVRVEDEAJI - curve25519: WCrbOIn3LFe0C1V5C5n+th0VeBxd15rL74fhrkXKR0Q (trustLevel: MXDeviceTrustLevel: local: 1 - cross-signing: 0)";
}
```
We can see we do not trust the cross-signing because we do not know the device that created and signed it.
This bug happened because of the race described above.

