### PR TITLE
Update AFNetworking version

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Improvements:
  * MXPublicRoom: Add canonical alias property.
  * MXLogger: Add a parameter to indicate the number of log files.
  * MXDeviceList: Post `MXDeviceListDidUpdateUsersDevicesNotification` notification when users devices list are updated.
+ * Pod: Update AFNetworking version (#793)
 
 Bug fix:
  * MXEventType: Fix Swift refinement.

--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -31,7 +31,8 @@ Pod::Spec.new do |s|
       
       ss.source_files = "MatrixSDK", "MatrixSDK/**/*.{h,m}"
       
-      ss.dependency 'AFNetworking', '~> 3.2.0'
+
+      ss.dependency 'AFNetworking', '~> 4.0.0'
       ss.dependency 'GZIP', '~> 1.2.2'
 
       # Requirements for e2e encryption

--- a/MatrixSDK/Utils/MXBugReportRestClient.m
+++ b/MatrixSDK/Utils/MXBugReportRestClient.m
@@ -289,7 +289,7 @@
 
 - (void)cancel
 {
-    [manager invalidateSessionCancelingTasks:YES];
+    [manager invalidateSessionCancelingTasks:YES resetSession:NO];
 
     _state = MXBugReportStateReady;
 

--- a/MatrixSDK/Utils/MXHTTPClient.m
+++ b/MatrixSDK/Utils/MXHTTPClient.m
@@ -778,7 +778,7 @@ static NSUInteger requestCount = 0;
 - (void)cancel
 {
     NSLog(@"[MXHTTPClient] cancel");
-    [httpManager invalidateSessionCancelingTasks:YES];
+    [httpManager invalidateSessionCancelingTasks:YES resetSession:YES];
 }
 
 - (void)setUpNetworkReachibility

--- a/Podfile
+++ b/Podfile
@@ -2,7 +2,7 @@
 
 abstract_target 'MatrixSDK' do
     
-    pod 'AFNetworking', '~> 3.2.0'
+    pod 'AFNetworking', '~> 4.0.0'
     pod 'GZIP', '~> 1.2.2'
     
     pod 'OLMKit', '~> 3.1.0', :inhibit_warnings => true

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,18 +1,18 @@
 PODS:
-  - AFNetworking (3.2.1):
-    - AFNetworking/NSURLSession (= 3.2.1)
-    - AFNetworking/Reachability (= 3.2.1)
-    - AFNetworking/Security (= 3.2.1)
-    - AFNetworking/Serialization (= 3.2.1)
-    - AFNetworking/UIKit (= 3.2.1)
-  - AFNetworking/NSURLSession (3.2.1):
+  - AFNetworking (4.0.0):
+    - AFNetworking/NSURLSession (= 4.0.0)
+    - AFNetworking/Reachability (= 4.0.0)
+    - AFNetworking/Security (= 4.0.0)
+    - AFNetworking/Serialization (= 4.0.0)
+    - AFNetworking/UIKit (= 4.0.0)
+  - AFNetworking/NSURLSession (4.0.0):
     - AFNetworking/Reachability
     - AFNetworking/Security
     - AFNetworking/Serialization
-  - AFNetworking/Reachability (3.2.1)
-  - AFNetworking/Security (3.2.1)
-  - AFNetworking/Serialization (3.2.1)
-  - AFNetworking/UIKit (3.2.1):
+  - AFNetworking/Reachability (4.0.0)
+  - AFNetworking/Security (4.0.0)
+  - AFNetworking/Serialization (4.0.0)
+  - AFNetworking/UIKit (4.0.0):
     - AFNetworking/NSURLSession
   - GZIP (1.2.3)
   - libbase58 (0.1.4)
@@ -39,7 +39,7 @@ PODS:
   - Realm/Headers (3.17.3)
 
 DEPENDENCIES:
-  - AFNetworking (~> 3.2.0)
+  - AFNetworking (~> 4.0.0)
   - GZIP (~> 1.2.2)
   - libbase58 (~> 0.1.4)
   - OHHTTPStubs (~> 6.1.0)
@@ -56,13 +56,13 @@ SPEC REPOS:
     - Realm
 
 SPEC CHECKSUMS:
-  AFNetworking: b6f891fdfaed196b46c7a83cf209e09697b94057
+  AFNetworking: d9fdf484a3c723ec3c558a41cc5754c7e845ee77
   GZIP: af5c90ef903776a7e9afe6ebebd794a84a2929d4
   libbase58: 7c040313537b8c44b6e2d15586af8e21f7354efd
   OHHTTPStubs: 1e21c7d2c084b8153fc53d48400d8919d2d432d0
   OLMKit: 4ee0159d63feeb86d836fdcfefe418e163511639
   Realm: 5a1d9d47bfc101dd597668b1a8af4288a2557f6d
 
-PODFILE CHECKSUM: 4ec0d0bfa4adbb70b7830ee9cfaebc174cc9eba9
+PODFILE CHECKSUM: 7c4f18c087227a14dec1806657b8b2b5a1fc69df
 
 COCOAPODS: 1.8.4

--- a/SwiftMatrixSDK.podspec
+++ b/SwiftMatrixSDK.podspec
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
 
   s.requires_arc  = true
 
-  s.dependency 'AFNetworking', '~> 3.2.0'
+  s.dependency 'AFNetworking', '~> 4.0.0'
   s.dependency 'GZIP', '~> 1.2.2'
   
   # Requirements for e2e encryption


### PR DESCRIPTION
Updates AFNetworking library version to > 4.0.0.
Also removes UIWebView dependency for the SDK (#793)