### PR TITLE
Fix remote ice candidates being added before remote description is setup

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,6 +41,7 @@ Bug fix:
  * MXEventType: Fix Swift refinement.
  * MXCrypto: Fix users keys download that can fail in some condition
  * MXCryptoStore does not store device.algorithm (https://github.com/vector-im/riot-ios/issues/2896).
+ * VoiP: Fix remote ice candidates being added before remote description is setup (vector-im/riot-ios/issues/1784)
 
 API break:
  * MXCrypto: Rename MXDeviceVerificationManager to MXKeyVerificationManager.


### PR DESCRIPTION
The peer connection requires the remote description to be setup before any remote ice candidates are added to it.

In the current implementation, ice candidates are sent before the called device has responded with an answer. Therefore there can be a case where the called device handles incoming ice candidates before it handles the initial offer from the caller.

This often happens when the called device is not having the app open **and** is not in the same network (e.g. one device using wifi, one using cellular), leaving the call to be stuck in "connecting" until the call is either ended or times out.

This potentially fixes multiple issues in vector-im/riot-ios. I think this is the initial one describing the issue best:
https://github.com/vector-im/riot-ios/issues/1784