### PR TITLE
Remove workaround in MXJingleCallAudioSessionConfigurator

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,7 @@ Improvements:
  * MXLogger: Add a parameter to indicate the number of log files.
  * MXThrottler: Add this tool class to throttle actions.
  * Make enums conform to `Equatable`/`Hashable` where applicable.
+ * MXJingleCallAudioSessionConfigurator: Remove workaround since it is no longer needed
 
 Bug fix:
  * MXEventType: Fix Swift refinement.

--- a/MatrixSDKExtensions/VoIP/Jingle/MXJingleCallAudioSessionConfigurator.m
+++ b/MatrixSDKExtensions/VoIP/Jingle/MXJingleCallAudioSessionConfigurator.m
@@ -21,47 +21,11 @@
 #import "MXJingleCallAudioSessionConfigurator.h"
 
 @import AVFoundation;
+@import WebRTC;
 
 #import <objc/message.h>
 #import <objc/runtime.h>
 #import <sys/utsname.h>
-
-// Preferred hardware sample rate (unit is in Hertz). The client sample rate
-// will be set to this value as well to avoid resampling the the audio unit's
-// format converter. Note that, some devices, e.g. BT headsets, only supports
-// 8000Hz as native sample rate.
-static const double kRTCAudioSessionHighPerformanceSampleRate = 48000.0;
-
-// A lower sample rate will be used for devices with only one core
-// (e.g. iPhone 4). The goal is to reduce the CPU load of the application.
-static const double kRTCAudioSessionLowComplexitySampleRate = 16000.0;
-
-// Use a hardware I/O buffer size (unit is in seconds) that matches the 10ms
-// size used by WebRTC. The exact actual size will differ between devices.
-// Example: using 48kHz on iPhone 6 results in a native buffer size of
-// ~10.6667ms or 512 audio frames per buffer. The FineAudioBuffer instance will
-// take care of any buffering required to convert between native buffers and
-// buffers used by WebRTC. It is beneficial for the performance if the native
-// size is as close to 10ms as possible since it results in "clean" callback
-// sequence without bursts of callbacks back to back.
-static const double kRTCAudioSessionHighPerformanceIOBufferDuration = 0.01;
-
-// Use a larger buffer size on devices with only one core (e.g. iPhone 4).
-// It will result in a lower CPU consumption at the cost of a larger latency.
-// The size of 60ms is based on instrumentation that shows a significant
-// reduction in CPU load compared with 10ms on low-end devices.
-// TODO(henrika): monitor this size and determine if it should be modified.
-static const double kRTCAudioSessionLowComplexityIOBufferDuration = 0.06;
-
-// Try to use mono to save resources. Also avoids channel format conversion
-// in the I/O audio unit. Initial tests have shown that it is possible to use
-// mono natively for built-in microphones and for BT headsets but not for
-// wired headsets. Wired headsets only support stereo as native channel format
-// but it is a low cost operation to do a format conversion to mono in the
-// audio unit. Hence, we will not hit a RTC_CHECK in
-// VerifyAudioParametersForActiveAudioSession() for a mismatch between the
-// preferred number of channels and the actual number of channels.
-static const int kRTCAudioSessionPreferredNumberOfChannels = 1;
 
 @implementation MXJingleCallAudioSessionConfigurator
 
@@ -125,57 +89,12 @@ static const int kRTCAudioSessionPreferredNumberOfChannels = 1;
     [audioSession setPreferredInputNumberOfChannels:kRTCAudioSessionPreferredNumberOfChannels error:nil];
     [audioSession setPreferredOutputNumberOfChannels:kRTCAudioSessionPreferredNumberOfChannels error:nil];
     
-    // Guys from Google have their own mind on priority of task devoted to make RTCAudioSession public to use.
-    // https://bugs.chromium.org/p/webrtc/issues/detail?id=7351
-    //
-    // They had already implemented neccesary methods to make it possible for WebRTC to work with CallKit. They will be available in v.60.
-    // https://bugs.chromium.org/p/webrtc/issues/detail?id=7446
-    //
-    // We use a bit of Obj-C runtime power and call neccesary methods on our own.
-    // It's safe since all necessary checks are performed.
-    // In the future when RTCAudioSession will become public we will switch to use methods directly.
-    //
-    // The reason of this runtime magic is that OS activates audio session earlier than it does WebRTC, it's worth mention that
-    // activation of audio session is expensive operation and it's better to avoid doing job twice
-    
-    Class cls = objc_getClass("RTCAudioSession");
-    Class metaCls = objc_getMetaClass("RTCAudioSession");
-    
-    SEL selSharedInstance = NSSelectorFromString(@"sharedInstance");
-    SEL selIncrementActivationCount = NSSelectorFromString(@"incrementActivationCount");
-    SEL selSetIsActive = NSSelectorFromString(@"setIsActive:");
-    
-    if (cls &&
-        metaCls &&
-        class_respondsToSelector(metaCls, selSharedInstance) &&
-        class_respondsToSelector(cls, selIncrementActivationCount) &&
-        class_respondsToSelector(cls, selSetIsActive))
-    {
-        id rtcAudioSession = ((id (*)(id, SEL))objc_msgSend)(cls, selSharedInstance);
-        ((void (*)(id, SEL))objc_msgSend)(rtcAudioSession, selIncrementActivationCount);
-        ((void (*)(id, SEL, BOOL))objc_msgSend)(rtcAudioSession, selSetIsActive, YES);
-    }
+    [RTCAudioSession.sharedInstance audioSessionDidActivate:audioSession];
 }
 
 - (void)audioSessionDidDeactivate:(AVAudioSession *)audioSession
 {
-    Class cls = objc_getClass("RTCAudioSession");
-    Class metaCls = objc_getMetaClass("RTCAudioSession");
-    
-    SEL selSharedInstance = NSSelectorFromString(@"sharedInstance");
-    SEL selDecrementActivationCount = NSSelectorFromString(@"decrementActivationCount");
-    SEL selSetIsActive = NSSelectorFromString(@"setIsActive:");
-    
-    if (cls &&
-        metaCls &&
-        class_respondsToSelector(metaCls, selSharedInstance) &&
-        class_respondsToSelector(cls, selDecrementActivationCount) &&
-        class_respondsToSelector(cls, selSetIsActive))
-    {
-        id rtcAudioSession = ((id (*)(id, SEL))objc_msgSend)(cls, selSharedInstance);
-        ((void (*)(id, SEL, BOOL))objc_msgSend)(rtcAudioSession, selSetIsActive, NO);
-        ((void (*)(id, SEL))objc_msgSend)(rtcAudioSession, selDecrementActivationCount);
-    }
+    [RTCAudioSession.sharedInstance audioSessionDidDeactivate:audioSession];
 }
 
 @end


### PR DESCRIPTION
This particular commit doesn't fix any issues to my knowledge. I just noticed this workaround and saw that it is no longer needed, since the required methods in RTCAudioSession are now available.