### PR TITLE
MXStore: Add a method to remove all the messages sent before a specific timestamp in a room.

### DIFF
--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
@@ -319,6 +319,18 @@ static NSUInteger preloadOptions;
     }
 }
 
+- (BOOL)removeAllMessagesSentBefore:(uint64_t)limitTs inRoom:(nonnull NSString *)roomId
+{
+    BOOL ret = [super removeAllMessagesSentBefore:limitTs inRoom:roomId];
+    
+    if (ret && NSNotFound == [roomsToCommitForMessages indexOfObject:roomId])
+    {
+        [roomsToCommitForMessages addObject:roomId];
+    }
+    
+    return ret;
+}
+
 - (void)deleteAllMessagesInRoom:(NSString *)roomId
 {
     [super deleteAllMessagesInRoom:roomId];

--- a/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryRoomStore.h
+++ b/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryRoomStore.h
@@ -52,6 +52,16 @@
 - (void)replaceEvent:(MXEvent*)event;
 
 /**
+ Remove all the messages sent before a specific timestamp in a room.
+ The state events are not removed during this operation. We keep them in the timeline.
+ 
+ @param limitTs the timestamp from which the messages are kept.
+ 
+ @return YES if at least one event has been removed.
+ */
+- (BOOL)removeAllMessagesSentBefore:(uint64_t)limitTs;
+
+/**
  Get an event from this room.
 
  @return the MXEvent object or nil if not found.

--- a/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryRoomStore.m
+++ b/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryRoomStore.m
@@ -76,6 +76,33 @@
     }
 }
 
+- (BOOL)removeAllMessagesSentBefore:(uint64_t)limitTs
+{
+    NSUInteger index = 0;
+    BOOL didChange = NO;
+    while (index < messages.count)
+    {
+        MXEvent *anEvent = [messages objectAtIndex:index];
+        if (anEvent.isState)
+        {
+            // Keep state event
+            index ++;
+        }
+        else if (anEvent.originServerTs < limitTs)
+        {
+            [messages removeObjectAtIndex:index];
+            [messagesByEventIds removeObjectForKey:anEvent.eventId];
+            didChange = YES;
+        }
+        else
+        {
+            // Break the loop, we've reached the first non-state event in the timeline which is not expired
+            break;
+        }
+    }
+    return didChange;
+}
+
 - (MXEvent *)eventWithEventId:(NSString *)eventId
 {
     return messagesByEventIds[eventId];

--- a/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryStore.m
+++ b/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryStore.m
@@ -68,6 +68,12 @@
     [roomStore replaceEvent:event];
 }
 
+- (BOOL)removeAllMessagesSentBefore:(uint64_t)limitTs inRoom:(nonnull NSString *)roomId
+{
+    MXMemoryRoomStore *roomStore = [self getOrCreateRoomStore:roomId];
+    return [roomStore removeAllMessagesSentBefore:limitTs];
+}
+
 - (BOOL)eventExistsWithEventId:(NSString *)eventId inRoom:(NSString *)roomId
 {
     return (nil != [self eventWithEventId:eventId inRoom:roomId]);

--- a/MatrixSDK/Data/Store/MXNoStore/MXNoStore.m
+++ b/MatrixSDK/Data/Store/MXNoStore/MXNoStore.m
@@ -105,6 +105,17 @@
     }
 }
 
+- (BOOL)removeAllMessagesSentBefore:(uint64_t)limitTs inRoom:(nonnull NSString *)roomId
+{
+    // Only the last message is stored
+    MXEvent *lastMessage = lastMessages[roomId];
+    if (!lastMessage.isState && lastMessage.originServerTs < limitTs) {
+        lastMessages[roomId] = nil;
+        return YES;
+    }
+    return NO;
+}
+
 - (BOOL)eventExistsWithEventId:(NSString *)eventId inRoom:(NSString *)roomId
 {
     // Events are not stored. So, we cannot find it.

--- a/MatrixSDK/Data/Store/MXStore.h
+++ b/MatrixSDK/Data/Store/MXStore.h
@@ -71,6 +71,18 @@
 - (void)replaceEvent:(nonnull MXEvent*)event inRoom:(nonnull NSString*)roomId;
 
 /**
+ Remove all the messages sent before a specific timestamp in a room.
+ The state events are not removed during this operation. We keep them in the timeline.
+ This operation doesn't change the pagination token, and the flag indicating that the SDK has reached the end of pagination.
+ 
+ @param limitTs the timestamp from which the messages are kept.
+ @param roomId the id of the room.
+ 
+ @return YES if at least one event has been removed.
+ */
+- (BOOL)removeAllMessagesSentBefore:(uint64_t)limitTs inRoom:(nonnull NSString *)roomId;
+
+/**
  Returns a Boolean value that indicates whether an event is already stored.
  
  @param eventId the id of the event to retrieve.


### PR DESCRIPTION
Remove all the messages sent before a specific timestamp in a room.
The state events are not removed during this operation. We keep them in the timeline.
This operation doesn't change the pagination token, and the flag indicating that the SDK has reached the end of pagination.
