### PR TITLE
MXCrypto: Add the option to disable sending key share requests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Improvements:
  * MXCrypto: Expose devicesForUser.
  * MXCrypto: Restart broken Olm sessions ([MSC1719](https://github.com/matrix-org/matrix-doc/pull/1719)) (vector-im/riot-ios/issues/2129).
  * MXCrypto: the `setDeviceVerification` method now downloads all user's devices if the device is not yet known.
+ * MXCrypto: Add the option to disable sending key share requests (`[MXCrypto setOutgoingKeyRequestsEnabled:]`).
  * MXRoomSummary: Add the trust property to indicate trust in other users and devices in the room (vector-im/riot-ios/issues/2906).
  * MXStore: Add a method to get related events for a specific event.
  * MXPublicRoom: Add canonical alias property.

--- a/MatrixSDK/Crypto/Data/Store/MXCryptoStore.h
+++ b/MatrixSDK/Crypto/Data/Store/MXCryptoStore.h
@@ -320,6 +320,14 @@
 - (MXOutgoingRoomKeyRequest*)outgoingRoomKeyRequestWithState:(MXRoomKeyRequestState)state;
 
 /**
+ Get all outgoing key requests that match the state.
+ 
+ @param state to look for.
+ @return a MXOutgoingRoomKeyRequest matching the request, or nil if not found.
+ */
+- (NSArray<MXOutgoingRoomKeyRequest*> *)allOutgoingRoomKeyRequestsWithState:(MXRoomKeyRequestState)state;
+
+/**
  Store an outgoing room key request.
 
  @param request the room key request to store.

--- a/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
+++ b/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
@@ -971,6 +971,18 @@ RLM_ARRAY_TYPE(MXRealmSecret)
     return request;
 }
 
+- (NSArray<MXOutgoingRoomKeyRequest*> *)allOutgoingRoomKeyRequestsWithState:(MXRoomKeyRequestState)state
+{
+    NSMutableArray<MXOutgoingRoomKeyRequest*> *allOutgoingRoomKeyRequests = [NSMutableArray array];
+    
+    for (MXRealmOutgoingRoomKeyRequest *realmOutgoingRoomKeyRequest in [MXRealmOutgoingRoomKeyRequest allObjectsInRealm:self.realm])
+    {
+        [allOutgoingRoomKeyRequests addObject:realmOutgoingRoomKeyRequest.outgoingRoomKeyRequest];
+    }
+    
+    return allOutgoingRoomKeyRequests;
+}
+
 - (void)storeOutgoingRoomKeyRequest:(MXOutgoingRoomKeyRequest*)request
 {
     RLMRealm *realm = self.realm;

--- a/MatrixSDK/Crypto/KeyBackup/MXKeyBackup_Private.h
+++ b/MatrixSDK/Crypto/KeyBackup/MXKeyBackup_Private.h
@@ -50,7 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)maybeSendKeyBackup;
 
-- (void)scheduleRequestForPrivateKey;
+- (void)scheduleRequestForPrivateKey:(void (^)(void))onComplete;
 
 @end
 

--- a/MatrixSDK/Crypto/KeySharing/Data/MXOutgoingRoomKeyRequest.h
+++ b/MatrixSDK/Crypto/KeySharing/Data/MXOutgoingRoomKeyRequest.h
@@ -86,6 +86,12 @@ typedef enum : NSUInteger
  */
 @property (nonatomic) NSDictionary *requestBody;
 
+// Shorcuts to requestBody data
+@property (nonatomic, readonly) NSString *algorithm;
+@property (nonatomic, readonly) NSString *roomId;
+@property (nonatomic, readonly) NSString *sessionId;
+@property (nonatomic, readonly) NSString *senderKey;
+
 /**
  The current state of this request.
  */

--- a/MatrixSDK/Crypto/KeySharing/Data/MXOutgoingRoomKeyRequest.m
+++ b/MatrixSDK/Crypto/KeySharing/Data/MXOutgoingRoomKeyRequest.m
@@ -18,4 +18,24 @@
 
 @implementation MXOutgoingRoomKeyRequest
 
+- (NSString *)algorithm
+{
+    return _requestBody[@"algorithm"];
+}
+
+- (NSString *)roomId
+{
+    return _requestBody[@"room_id"];
+}
+
+- (NSString *)sessionId
+{
+    return _requestBody[@"session_id"];
+}
+
+- (NSString *)senderKey
+{
+    return _requestBody[@"sender_key"];
+}
+
 @end

--- a/MatrixSDK/Crypto/KeySharing/MXOutgoingRoomKeyRequestManager.h
+++ b/MatrixSDK/Crypto/KeySharing/MXOutgoingRoomKeyRequestManager.h
@@ -51,6 +51,16 @@
 - (void)start;
 
 /**
+ Enable or disable key share requests.
+ Enabled by default
+ 
+ @param enabled the new enable state.
+ @param onComplete the block called when the operation completes
+ */
+- (void)setEnabled:(BOOL)enabled onComplete:(void (^)(void))onComplete;
+- (BOOL)isEnabled;
+
+/**
  Called when the client is stopped. Stops any running background processes.
  */
 - (void)close;

--- a/MatrixSDK/Crypto/KeySharing/MXOutgoingRoomKeyRequestManager.h
+++ b/MatrixSDK/Crypto/KeySharing/MXOutgoingRoomKeyRequestManager.h
@@ -55,9 +55,8 @@
  Enabled by default
  
  @param enabled the new enable state.
- @param onComplete the block called when the operation completes
  */
-- (void)setEnabled:(BOOL)enabled onComplete:(void (^)(void))onComplete;
+- (void)setEnabled:(BOOL)enabled;
 - (BOOL)isEnabled;
 
 /**

--- a/MatrixSDK/Crypto/KeySharing/MXOutgoingRoomKeyRequestManager.m
+++ b/MatrixSDK/Crypto/KeySharing/MXOutgoingRoomKeyRequestManager.m
@@ -77,7 +77,7 @@ NSUInteger const SEND_KEY_REQUESTS_DELAY_MS = 500;
     sendOutgoingRoomKeyRequestsTimer = nil;
 }
 
-- (void)setEnabled:(BOOL)enabled onComplete:(void (^)(void))onComplete
+- (void)setEnabled:(BOOL)enabled
 {
     NSLog(@"[MXOutgoingRoomKeyRequestManager] setEnabled: %@ (old: %@)", @(enabled), @(_enabled));
     if (enabled == _enabled)
@@ -93,11 +93,6 @@ NSUInteger const SEND_KEY_REQUESTS_DELAY_MS = 500;
     
     _enabled = enabled;
     [self startTimer];
-    
-    if (onComplete)
-    {
-        onComplete();
-    }
 }
 
 

--- a/MatrixSDK/Crypto/KeySharing/MXOutgoingRoomKeyRequestManager.m
+++ b/MatrixSDK/Crypto/KeySharing/MXOutgoingRoomKeyRequestManager.m
@@ -94,7 +94,10 @@ NSUInteger const SEND_KEY_REQUESTS_DELAY_MS = 500;
     _enabled = enabled;
     [self startTimer];
     
-    onComplete();
+    if (onComplete)
+    {
+        onComplete();
+    }
 }
 
 

--- a/MatrixSDK/Crypto/KeySharing/MXOutgoingRoomKeyRequestManager.m
+++ b/MatrixSDK/Crypto/KeySharing/MXOutgoingRoomKeyRequestManager.m
@@ -190,8 +190,13 @@ NSUInteger const SEND_KEY_REQUESTS_DELAY_MS = 500;
     MXWeakify(self);
     dispatch_async(dispatch_get_main_queue(), ^{
         MXStrongifyAndReturnIfNil(self);
+        
+        if (self->sendOutgoingRoomKeyRequestsTimer)
+        {
+            return;
+        }
 
-        // Start expiration timer
+        // Start timer
         self->sendOutgoingRoomKeyRequestsTimer = [[NSTimer alloc] initWithFireDate:[NSDate dateWithTimeIntervalSinceNow:SEND_KEY_REQUESTS_DELAY_MS / 1000.0]
                                                                           interval:0
                                                                             target:self
@@ -205,9 +210,7 @@ NSUInteger const SEND_KEY_REQUESTS_DELAY_MS = 500;
 - (void)checkAllPendingOutgoingRoomKeyRequests
 {
     NSArray<MXOutgoingRoomKeyRequest*> *requests = [self->cryptoStore allOutgoingRoomKeyRequestsWithState:MXRoomKeyRequestStateUnsent];
-    
-    NSLog(@"[MXOutgoingRoomKeyRequestManager] checkAllPendingOutgoingRoomKeyRequests: %@ requests", @(requests.count));
-    
+        
     NSUInteger deleted = 0;
     for (MXOutgoingRoomKeyRequest *request in requests)
     {
@@ -220,7 +223,7 @@ NSUInteger const SEND_KEY_REQUESTS_DELAY_MS = 500;
         }
     }
     
-        NSLog(@"[MXOutgoingRoomKeyRequestManager] checkAllPendingOutgoingRoomKeyRequests: Cleared %@ requests", @(deleted));
+    NSLog(@"[MXOutgoingRoomKeyRequestManager] checkAllPendingOutgoingRoomKeyRequests: Cleared %@ requests out of %@", @(deleted), @(requests.count));
 }
 
 - (void)sendOutgoingRoomKeyRequests
@@ -231,7 +234,7 @@ NSUInteger const SEND_KEY_REQUESTS_DELAY_MS = 500;
     // Do not start
     if (!self.isEnabled)
     {
-        NSLog(@"[MXOutgoingRoomKeyRequestManager] startSendingOutgoingRoomKeyRequests: Looking for queued outgoing room key requests.");
+        NSLog(@"[MXOutgoingRoomKeyRequestManager] startSendingOutgoingRoomKeyRequests: Disabled.");
         return;
     }
     

--- a/MatrixSDK/Crypto/MXCrypto.h
+++ b/MatrixSDK/Crypto/MXCrypto.h
@@ -462,6 +462,13 @@ extern NSString *const MXDeviceListDidUpdateUsersDevicesNotification;
 - (BOOL)isOutgoingKeyRequestsEnabled;
 
 /**
+ Automatically re-enable outgoing key share requests once another device has been verified.
+ 
+ Default is YES.
+ */
+@property (nonatomic) BOOL enableOutgoingKeyRequestsOnceSelfVerificationDone;
+
+/**
  Rerequest the encryption keys required to decrypt an event.
 
  @param event the event to decrypt again.

--- a/MatrixSDK/Crypto/MXCrypto.h
+++ b/MatrixSDK/Crypto/MXCrypto.h
@@ -452,6 +452,16 @@ extern NSString *const MXDeviceListDidUpdateUsersDevicesNotification;
 - (void)ignoreAllPendingKeyRequestsFromUser:(NSString*)userId andDevice:(NSString*)deviceId onComplete:(void (^)(void))onComplete;
 
 /**
+ Enable or disable outgoing key share requests.
+ Enabled by default
+ 
+ @param enabled the new enable state.
+ @param onComplete the block called when the operation completes
+ */
+- (void)setOutgoingKeyRequestsEnabled:(BOOL)enabled onComplete:(void (^)(void))onComplete;
+- (BOOL)isOutgoingKeyRequestsEnabled;
+
+/**
  Rerequest the encryption keys required to decrypt an event.
 
  @param event the event to decrypt again.

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -843,7 +843,12 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
                 // Request backup private keys
                 if (!self.backup.hasPrivateKeyInCryptoStore)
                 {
-                    [self.backup scheduleRequestForPrivateKey];
+                    [self.backup scheduleRequestForPrivateKey:^{
+                        if (self.enableOutgoingKeyRequestsOnceSelfVerificationDone)
+                        {
+                            [self setOutgoingKeyRequestsEnabled:YES onComplete:nil];
+                        }
+                    }];
                 }
                 
                 // Check cross-signing
@@ -1571,6 +1576,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 
         // Default configuration
         _warnOnUnknowDevices = YES;
+        _enableOutgoingKeyRequestsOnceSelfVerificationDone = YES;
 
         _decryptionQueue = [MXCrypto dispatchQueueForUser:_mxSession.matrixRestClient.credentials.userId];
 

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -849,7 +849,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
                         
                         if (self.enableOutgoingKeyRequestsOnceSelfVerificationDone)
                         {
-                            [self->outgoingRoomKeyRequestManager setEnabled:YES onComplete:nil];
+                            [self->outgoingRoomKeyRequestManager setEnabled:YES];
                         }
                     }];
                 }
@@ -1483,14 +1483,14 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     dispatch_async(_decryptionQueue, ^{
         MXStrongifyAndReturnIfNil(self);
         
-        [self->outgoingRoomKeyRequestManager setEnabled:enabled onComplete:^{
-            if (onComplete)
-            {
-                dispatch_async(dispatch_get_main_queue(), ^{
-                    onComplete();
-                });
-            }
-        }];
+        [self->outgoingRoomKeyRequestManager setEnabled:enabled];
+        
+        if (onComplete)
+        {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                onComplete();
+            });
+        }
     });
 #endif
 }

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -1467,6 +1467,31 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 }
 #endif
 
+
+- (void)setOutgoingKeyRequestsEnabled:(BOOL)enabled onComplete:(void (^)(void))onComplete
+{
+#ifdef MX_CRYPTO
+    MXWeakify(self);
+    dispatch_async(_decryptionQueue, ^{
+        MXStrongifyAndReturnIfNil(self);
+        
+        [self->outgoingRoomKeyRequestManager setEnabled:enabled onComplete:^{
+            if (onComplete)
+            {
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    onComplete();
+                });
+            }
+        }];
+    });
+#endif
+}
+
+- (BOOL)isOutgoingKeyRequestsEnabled
+{
+    return outgoingRoomKeyRequestManager.isEnabled;
+}
+
 - (void)reRequestRoomKeyForEvent:(MXEvent *)event
 {
 #ifdef MX_CRYPTO

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -843,10 +843,13 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
                 // Request backup private keys
                 if (!self.backup.hasPrivateKeyInCryptoStore)
                 {
+                    MXWeakify(self);
                     [self.backup scheduleRequestForPrivateKey:^{
+                        MXStrongifyAndReturnIfNil(self);
+                        
                         if (self.enableOutgoingKeyRequestsOnceSelfVerificationDone)
                         {
-                            [self setOutgoingKeyRequestsEnabled:YES onComplete:nil];
+                            [self->outgoingRoomKeyRequestManager setEnabled:YES onComplete:nil];
                         }
                     }];
                 }

--- a/MatrixSDK/Data/MXRoomSummary.m
+++ b/MatrixSDK/Data/MXRoomSummary.m
@@ -375,10 +375,15 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
                 newOperation = [liveTimeline paginate:messagesToPaginate direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^{
 
                     // Received messages have been stored in the store. We can make a new loop
-                    [self fetchLastMessage:complete failure:failure
-                        lastEventIdChecked:lastEventIdCheckedInBlock
-                                 operation:(operation ? operation : newOperation)
-                                    commit:commit];
+                    // XXX: This is only true for a permanent storage. Only MXNoStore is not permanent.
+                    // MXNoStore is only used for tests. We can skip it here.
+                    if (self.mxSession.store.isPermanent)
+                    {
+                        [self fetchLastMessage:complete failure:failure
+                            lastEventIdChecked:lastEventIdCheckedInBlock
+                                     operation:(operation ? operation : newOperation)
+                                        commit:commit];
+                    }
 
                 } failure:failure];
 

--- a/MatrixSDKTests/MXCryptoShareTests.m
+++ b/MatrixSDKTests/MXCryptoShareTests.m
@@ -128,6 +128,115 @@
 
 
 /**
+ Check that a new device makes requests for keys of messages it cannot decrypt.
+ 
+ - Have Alice and Bob in e2ee room with messages
+ - Alice signs in on a new device
+ - Alice2 paginates
+ -> Key share requests must be pending
+ -> Then, they must have been sent
+ */
+- (void)testKeyShareRequestFromNewDevice
+{
+    //  - Have Alice and Bob in e2ee room with messages
+    [matrixSDKTestsE2EData doE2ETestWithAliceAndBobInARoomWithCryptedMessages:self cryptedBob:YES readyToTest:^(MXSession *aliceSession1, MXSession *bobSession, NSString *roomId, XCTestExpectation *expectation) {
+        
+        //- Alice signs in on a new device
+        [matrixSDKTestsE2EData loginUserOnANewDevice:aliceSession1.matrixRestClient.credentials withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *aliceSession2) {
+            
+            // - Alice2 paginates in the room
+            MXRoom *roomFromAlice2POV = [aliceSession2 roomWithRoomId:roomId];
+            [roomFromAlice2POV liveTimeline:^(MXEventTimeline *liveTimeline) {
+                [liveTimeline resetPagination];
+                [liveTimeline paginate:10 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^{
+                    
+                    // - Key share requests must be pending
+                    XCTAssertNotNil([aliceSession2.crypto.store outgoingRoomKeyRequestWithState:MXRoomKeyRequestStateUnsent]);
+                    
+                    // Wait a bit
+                    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 1 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+                        
+                        // -> Then, they must have been sent
+                        XCTAssertNil([aliceSession2.crypto.store outgoingRoomKeyRequestWithState:MXRoomKeyRequestStateUnsent]);
+                        XCTAssertNotNil([aliceSession2.crypto.store outgoingRoomKeyRequestWithState:MXRoomKeyRequestStateSent]);
+                        [expectation fulfill];
+                    });
+                    
+                } failure:^(NSError *error) {
+                    XCTFail(@"Cannot set up intial test conditions - error: %@", error);
+                    [expectation fulfill];
+                }];
+            }];
+        }];
+    }];
+}
+
+
+/**
+ Full flow for the nominal case:
+ Check that a new device gets messages keys from a device that trusts it.
+ 
+ - Have Alice and Bob in e2ee room with messages
+ - Alice signs in on a new device
+ - Make each Alice device trust each other
+ - Alice2 paginates in the room
+ -> Key share requests must be pending
+ -> Key share requests should have complete
+ */
+- (void)testNominalCase
+{
+    //  - Have Alice and Bob in e2ee room with messages
+    [matrixSDKTestsE2EData doE2ETestWithAliceAndBobInARoomWithCryptedMessages:self cryptedBob:YES readyToTest:^(MXSession *aliceSession1, MXSession *bobSession, NSString *roomId, XCTestExpectation *expectation) {
+        
+        //- Alice signs in on a new device
+        [matrixSDKTestsE2EData loginUserOnANewDevice:aliceSession1.matrixRestClient.credentials withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *aliceSession2) {
+            
+            NSString *aliceUserId = aliceSession1.matrixRestClient.credentials.userId;
+            
+            NSString *aliceSession1DeviceId = aliceSession1.matrixRestClient.credentials.deviceId;
+            NSString *aliceSession2DeviceId = aliceSession2.matrixRestClient.credentials.deviceId;
+            
+            // - Make each Alice device trust each other
+            // This simulates a self verification and trigger cross-signing behind the shell
+            [aliceSession1.crypto setDeviceVerification:MXDeviceVerified forDevice:aliceSession2DeviceId ofUser:aliceUserId success:^{
+                [aliceSession2.crypto setDeviceVerification:MXDeviceVerified forDevice:aliceSession1DeviceId ofUser:aliceUserId success:^{
+                    
+                    // - Alice2 pagingates in the room
+                    MXRoom *roomFromAlice2POV = [aliceSession2 roomWithRoomId:roomId];
+                    [roomFromAlice2POV liveTimeline:^(MXEventTimeline *liveTimeline) {
+                        [liveTimeline resetPagination];
+                        [liveTimeline paginate:10 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^{
+                            
+                            // -> Key share requests must be pending
+                            XCTAssertNotNil([aliceSession2.crypto.store outgoingRoomKeyRequestWithState:MXRoomKeyRequestStateUnsent]);
+                            
+                            // Wait a bit
+                            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 1 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+                                
+                                // -> Key share requests should have complete
+                                XCTAssertNil([aliceSession2.crypto.store outgoingRoomKeyRequestWithState:MXRoomKeyRequestStateUnsent]);
+                                XCTAssertNil([aliceSession2.crypto.store outgoingRoomKeyRequestWithState:MXRoomKeyRequestStateSent]);
+                                [expectation fulfill];
+                            });
+                            
+                        } failure:^(NSError *error) {
+                            XCTFail(@"Cannot set up intial test conditions - error: %@", error);
+                            [expectation fulfill];
+                        }];
+                    }];
+                    
+                } failure:^(NSError *error) {
+                    XCTFail(@"Cannot set up intial test conditions - error: %@", error);
+                    [expectation fulfill];
+                }];
+            } failure:^(NSError *error) {
+                XCTFail(@"Cannot set up intial test conditions - error: %@", error);
+                [expectation fulfill];
+            }];
+        }];
+    }];
+}
+/**
  Test that a partial shared session does not cancel key share requests.
 
  From the scenario:


### PR DESCRIPTION
Part of https://github.com/vector-im/riot-ios/issues/3089

With the option, key share requests are made only after we made a self-verification.