### PR TITLE
BF: App crashes if two devices gossip a secret

### DIFF
--- a/MatrixSDK/Crypto/KeySharing/Secret/MXSecretShareManager.m
+++ b/MatrixSDK/Crypto/KeySharing/Secret/MXSecretShareManager.m
@@ -104,6 +104,8 @@ static NSArray<MXEventTypeString> *kMXSecretShareEventTypes;
         return nil;
     }
     
+    [self->pendingSecretShareRequests removeObjectForKey:requestId];
+    
     MXCredentials *myUser = _crypto.mxSession.matrixRestClient.credentials;
     
     MXSecretShareRequest *request = [MXSecretShareRequest new];
@@ -111,12 +113,7 @@ static NSArray<MXEventTypeString> *kMXSecretShareEventTypes;
     request.requestingDeviceId = myUser.deviceId;
     request.requestId = requestId;
     
-    MXWeakify(self);
     return [self sendMessage:request.JSONDictionary toDeviceIds:pendingRequest.requestedDeviceIds success:^{
-        MXStrongifyAndReturnIfNil(self);
-
-        [self->pendingSecretShareRequests removeObjectForKey:request.requestId];
-        
         dispatch_async(dispatch_get_main_queue(), ^{
             success();
         });


### PR DESCRIPTION
Kill the request as soon as we get the secret from a 1st device. Thus, we will ignore the secret coming from the 2nd device

Fixes https://github.com/vector-im/riot-ios/issues/3101.
