### PR TITLE
BF: Shields of verified users are black on a fresh new sign-in in

### DIFF
--- a/MatrixSDK/Data/MXRoomSummary.m
+++ b/MatrixSDK/Data/MXRoomSummary.m
@@ -547,7 +547,8 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
     // Decide what to do
     if (nextTrustComputation == MXRoomSummaryNextTrustComputationNone)
     {
-        nextTrustComputation = MXRoomSummaryNextTrustComputationPending;
+        nextTrustComputation = forceDownload ? MXRoomSummaryNextTrustComputationPendingWithForceDownload
+        : MXRoomSummaryNextTrustComputationPending;
     }
     else
     {
@@ -567,10 +568,10 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
     MXWeakify(self);
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, kMXRoomSummaryTrustComputationDelayMs * NSEC_PER_MSEC), dispatch_get_main_queue(), ^{
         MXStrongifyAndReturnIfNil(self);
-        self->nextTrustComputation = MXRoomSummaryNextTrustComputationNone;
 
         BOOL forceDownload = (self->nextTrustComputation == MXRoomSummaryNextTrustComputationPendingWithForceDownload);
-        
+        self->nextTrustComputation = MXRoomSummaryNextTrustComputationNone;
+
         if (self.mxSession.state == MXSessionStateRunning)
         {
             [self computeTrust:forceDownload];


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-ios/issues/3102.

Fix 2 bugs made in FOSDEM corridors. 
Make sure we download keys for users we want to compute trusts. Once their keys in the crypto store, we will be updated on our cross-signing state updates
