### PR TITLE
MXCrypto: Change the threading model

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Improvements:
  * MXSession: Add credentials, myUserId and myDeviceId shorcuts.
  * MXSession: Add createRoomWithParameters with a MXRoomCreationParameters model class.
  * MXRoomCreationParameters: Support the initial_state parameter and allow e2e on room creation (vector-im/riot-ios/issues/2943).
+ * MXCrypto: Change the threading model to make [MXCrypto decryptEvent:] less blocking.
  * MXCrypto: Expose devicesForUser.
  * MXCrypto: Restart broken Olm sessions ([MSC1719](https://github.com/matrix-org/matrix-doc/pull/1719)) (vector-im/riot-ios/issues/2129).
  * MXCrypto: the `setDeviceVerification` method now downloads all user's devices if the device is not yet known.

--- a/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmDecryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmDecryption.m
@@ -102,7 +102,10 @@
             // Manage OLMKit error
             if ([olmError.localizedDescription isEqualToString:@"UNKNOWN_MESSAGE_INDEX"])
             {
-                [self addEventToPendingList:event inTimeline:timeline];
+                // Do nothing more on the calling thread
+                dispatch_async(crypto.cryptoQueue, ^{
+                    [self addEventToPendingList:event inTimeline:timeline];
+                });
             }
 
             // Package olm error into MXDecryptingErrorDomain

--- a/MatrixSDK/Crypto/MXCrypto_Private.h
+++ b/MatrixSDK/Crypto/MXCrypto_Private.h
@@ -1,5 +1,6 @@
 /*
  Copyright 2016 OpenMarket Ltd
+ Copyright 2020 The Matrix.org Foundation C.I.C
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -73,21 +74,6 @@
  The list of devices.
  */
 @property (nonatomic, readonly) MXDeviceList *deviceList;
-
-/**
- The queue used for decryption.
-
- A less busy queue that can respond quicker to the UI.
-
- Encrypting the 1st event in a room is a long task (like 20s). We do not want the UI to
- wait the end of the encryption before being able to decrypt and display other messages
- of the room history.
- 
- We might miss a room key which is handled on cryptoQueue but the event will be decoded
- later once available. kMXEventDidDecryptNotification will then be sent. 
- */
-@property (nonatomic, readonly) dispatch_queue_t decryptionQueue;
-
 
 /**
  Get the device which sent an event.

--- a/MatrixSDK/Crypto/Verification/Transactions/MXKeyVerificationTransaction.m
+++ b/MatrixSDK/Crypto/Verification/Transactions/MXKeyVerificationTransaction.m
@@ -64,7 +64,7 @@ NSString * const MXKeyVerificationTransactionDidChangeNotification = @"MXKeyVeri
 
 - (void)cancelWithCancelCode:(MXTransactionCancelCode *)code
 {
-    dispatch_async(self.manager.crypto.decryptionQueue,^{
+    dispatch_async(self.manager.crypto.cryptoQueue,^{
         [self cancelWithCancelCodeFromCryptoQueue:code];
     });
 }

--- a/MatrixSDKTests/MatrixSDKTestsE2EData.m
+++ b/MatrixSDKTests/MatrixSDKTestsE2EData.m
@@ -324,7 +324,7 @@
 
 - (void)outgoingRoomKeyRequestInSession:(MXSession*)session complete:(void (^)(MXOutgoingRoomKeyRequest*))complete
 {
-    dispatch_async(session.crypto.decryptionQueue, ^{
+    dispatch_async(session.crypto.cryptoQueue, ^{
         MXOutgoingRoomKeyRequest *outgoingRoomKeyRequest = [session.crypto.store outgoingRoomKeyRequestWithState:MXRoomKeyRequestStateUnsent];
         if (!outgoingRoomKeyRequest)
         {


### PR DESCRIPTION
to make [MXCrypto decryptEvent:] less blocking when the UI calls it.

This is noticeable when keys import takes 20s. This operation blocked decryptEvent: before.
This threading model change is possible because we rely on the thread safety of the Realm DB.

Fixes https://github.com/vector-im/riot-ios/issues/3105.
