### PR TITLE
BF: Too much MXDeviceInfoTrustLevelDidChangeNotification and MXCrossS…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+Changes in Matrix iOS SDK in 0.16.1 (2020-04-xx)
+================================================
+
+Bug fix:
+ * Too much MXDeviceInfoTrustLevelDidChangeNotification and MXCrossSigningInfoTrustLevelDidChangeNotification (vector-im/riot-ios/issues/3121).
+
 Changes in Matrix iOS SDK in 0.16.0 (2020-04-17)
 ================================================
 

--- a/MatrixSDK/Crypto/CrossSigning/Data/MXCrossSigningInfo.m
+++ b/MatrixSDK/Crypto/CrossSigning/Data/MXCrossSigningInfo.m
@@ -92,7 +92,12 @@ NSString *const MXCrossSigningInfoTrustLevelDidChangeNotification = @"MXCrossSig
     return self;
 }
 
-- (BOOL)updateTrustLevel:(MXUserTrustLevel*)trustLevel;
+- (void)setTrustLevel:(MXUserTrustLevel*)trustLevel
+{
+    _trustLevel = trustLevel;
+}
+
+- (BOOL)updateTrustLevel:(MXUserTrustLevel*)trustLevel
 {
     BOOL updated = NO;
 

--- a/MatrixSDK/Crypto/CrossSigning/Data/MXCrossSigningInfo_Private.h
+++ b/MatrixSDK/Crypto/CrossSigning/Data/MXCrossSigningInfo_Private.h
@@ -23,6 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithUserId:(NSString *)userId;
 
+- (void)setTrustLevel:(MXUserTrustLevel*)trustLevel;
 - (BOOL)updateTrustLevel:(MXUserTrustLevel*)trustLevel;
 - (void)addCrossSigningKey:(MXCrossSigningKey*)crossSigningKey type:(NSString*)type;
 

--- a/MatrixSDK/Crypto/CrossSigning/MXCrossSigning.m
+++ b/MatrixSDK/Crypto/CrossSigning/MXCrossSigning.m
@@ -535,8 +535,10 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
                   @(isCrossSigningVerified));
             
             MXUserTrustLevel *newTrustLevel = [MXUserTrustLevel trustLevelWithCrossSigningVerified:isCrossSigningVerified locallyVerified:crossSigningInfo.trustLevel.isLocallyVerified];
-            [crossSigningInfo updateTrustLevel:newTrustLevel];
-            [self.crypto.store storeCrossSigningKeys:crossSigningInfo];
+            if ([crossSigningInfo updateTrustLevel:newTrustLevel])
+            {
+                [self.crypto.store storeCrossSigningKeys:crossSigningInfo];
+            }
             
             // Update trust on associated devices
             [self checkTrustLevelForDevicesOfUser:crossSigningInfo.userId];

--- a/MatrixSDK/Crypto/Data/MXDeviceInfo.m
+++ b/MatrixSDK/Crypto/Data/MXDeviceInfo.m
@@ -58,6 +58,11 @@ NSString *const MXDeviceInfoTrustLevelDidChangeNotification = @"MXDeviceInfoTrus
 
 #pragma mark - SDK-Private methods
 
+- (void)setTrustLevel:(MXDeviceTrustLevel *)trustLevel
+{
+    _trustLevel = trustLevel;
+}
+
 - (BOOL)updateTrustLevel:(MXDeviceTrustLevel*)trustLevel
 {
     BOOL updated = NO;

--- a/MatrixSDK/Crypto/Data/MXDeviceInfo_Private.h
+++ b/MatrixSDK/Crypto/Data/MXDeviceInfo_Private.h
@@ -21,6 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MXDeviceInfo ()
 
+- (void)setTrustLevel:(MXDeviceTrustLevel*)trustLevel;
 - (BOOL)updateTrustLevel:(MXDeviceTrustLevel*)trustLevel;
 
 @end


### PR DESCRIPTION
…igningInfoTrustLevelDidChangeNotification

It fixes vector-im/riot-ios/issues/3121 by setting current trust value (with new `setTrustLevel:` methods) in intermediate `MXDeviceInfo` and `MXCrossSigningInfo` objects.

This should improve perf in https://github.com/vector-im/riot-ios/issues/3126 too.