### PR TITLE
MXCrypto: Make trustLevelSummaryForUserIds async …

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+Changes in Matrix iOS SDK in 0.16.1 (2020-04-xx)
+================================================
+
+Improvements:
+ * MXCrypto: Make trustLevelSummaryForUserIds async (vector-im/riot-ios/issues/3126).
+
+API break:
+ * MXCrypto: trustLevelSummaryForUserIds: is now async.
+
 Changes in Matrix iOS SDK in 0.16.0 (2020-04-17)
 ================================================
 

--- a/MatrixSDK/Crypto/MXCrypto.h
+++ b/MatrixSDK/Crypto/MXCrypto.h
@@ -288,9 +288,9 @@ extern NSString *const MXDeviceListDidUpdateUsersDevicesNotification;
  Get the stored summary of users trust level (trusted users and devices count).
  
  @param userIds The user ids.
- @return the trust summary.
+ @param onComplete the callback called once operation is done.
  */
-- (MXUsersTrustLevelSummary *)trustLevelSummaryForUserIds:(NSArray<NSString*>*)userIds;
+- (void)trustLevelSummaryForUserIds:(NSArray<NSString*>*)userIds onComplete:(void (^)(MXUsersTrustLevelSummary *trustLevelSummary))onComplete;
 
 
 #pragma mark - Users keys

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -3121,7 +3121,9 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
             }
             else
             {
-                success([crypto trustLevelSummaryForUserIds:memberIds]);
+                [crypto trustLevelSummaryForUserIds:memberIds onComplete:^(MXUsersTrustLevelSummary *trustLevelSummary) {
+                    success(trustLevelSummary);
+                }];
             }
             
         } failure:failure];


### PR DESCRIPTION
and execute it from a separated queue

Fixes vector-im/riot-ios/issues/3126.
