### PR TITLE
MXDeviceListOperationsPool: Post MXDeviceListDidUpdateUsersDevicesNotification notification only for new changes never seen before

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Bug fix:
  * Fix race condition in MXSecretShareManager (vector-im/riot-ios/issues/3123).
  * Too much MXDeviceInfoTrustLevelDidChangeNotification and MXCrossSigningInfoTrustLevelDidChangeNotification (vector-im/riot-ios/issues/3121).
  * VoiP: Fix remote ice candidates being added before remote description is setup (vector-im/riot-ios/issues/1784).
+ * MXDeviceListOperationsPool: Post MXDeviceListDidUpdateUsersDevicesNotification notification only for new changes never seen before (vector-im/riot-ios/issues/3120).
 
 API break:
  * MXCrypto: trustLevelSummaryForUserIds: is now async.

--- a/MatrixSDK/Crypto/Data/MXDeviceListOperationsPool.m
+++ b/MatrixSDK/Crypto/Data/MXDeviceListOperationsPool.m
@@ -186,11 +186,22 @@
                     [mutabledevices[deviceId] updateTrustLevel:trustLevel];
                 }
 
-                usersDevices[userId] = mutabledevices.allValues;
+                NSArray *mutableDevicesValues = mutabledevices.allValues;
+                usersDevices[userId] = mutableDevicesValues;
                 
                 if (![mutabledevices isEqualToDictionary:storedDevices])
                 {
-                    updatedUsersDevices[userId] = usersDevices[userId];
+                    NSArray *storedDevicesValues = storedDevices.allValues;
+                    
+                    // Keep only devices that are not identical to those present in the database
+                    NSArray *updatedUserDevices = [mutableDevicesValues filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(id evaluatedObject, NSDictionary *bindings) {
+                        return ![storedDevicesValues containsObject:evaluatedObject];
+                    }]];
+
+                    if (updatedUserDevices.count)
+                    {
+                        updatedUsersDevices[userId] = updatedUserDevices;
+                    }
                     
                     // Update the store
                     // Note that devices which aren't in the response will be removed from the store


### PR DESCRIPTION
Fix vector-im/riot-ios/issues/3120