### PR TITLE
Update the CONTRIBUTING.rst to point to correct file.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ Improvements:
 Bug fix:
  * MXEventTimeline: Fix crash in paginate:.
 
+Doc fix:
+ * Update the CONTRIBUTING.rst to point to correct file.
+
 Changes in Matrix iOS SDK in 0.16.1 (2020-04-24)
 ================================================
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,4 +1,4 @@
 Contributing code to the Matrix iOS SDK
 =======================================
 
-matrix-ios-sdk follows the same pattern as https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst
+matrix-ios-sdk follows the same pattern as https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md


### PR DESCRIPTION
The file was changed to markdown [in December 2019](https://github.com/matrix-org/synapse/commit/c1ae453932da8b5761cd1644b4b0bbaa039ae6ab).

I guess it wouldn't be needed but as it's part of the checklist :wink:  :
Signed-off-by: Maximilian Müller <maxm123@techie.com>