### PR TITLE
MXKeyBackup: Do not clear the private key on resetKeyBackupData

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Improvements:
 
 Bug fix:
  * MXEventTimeline: Fix crash in paginate:.
+ * MXSession: Fix crash in runNextDirectRoomOperation.
 
 Changes in Matrix iOS SDK in 0.16.1 (2020-04-24)
 ================================================

--- a/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.m
+++ b/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.m
@@ -184,10 +184,11 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
 
 - (void)resetKeyBackupData
 {
+    NSLog(@"[MXKeyBackup] resetKeyBackupData");
+    
     [self resetBackupAllGroupSessionsObjects];
 
     self->crypto.store.backupVersion = nil;
-    [self->crypto.store deleteSecretWithSecretId:MXSecretId.keyBackup];
     _backupKey = nil;
 
     // Reset backup markers

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -2222,7 +2222,10 @@ typedef void (^MXOnResumeDone)(void);
 - (void)runNextDirectRoomOperation
 {
     // Dequeue the completed operation
-    [directRoomsOperationsQueue removeObjectAtIndex:0];
+    if (directRoomsOperationsQueue.count)
+    {
+        [directRoomsOperationsQueue removeObjectAtIndex:0];
+    }
 
     // And run the next one if any
     if (directRoomsOperationsQueue.firstObject)


### PR DESCRIPTION
This method can be called at anytime. The key will be validated (and erased if needed) once the module fetches the available backup version.
