### PR TITLE
Improve event type and similar types

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,13 @@
+Changes in Matrix iOS SDK in CURRENT RELEASE
+================================================
+
+Bug fix:
+* MXEventType: Fix `init(identifier:)`, which was erroneously turning `m.reaction` & `m.key.verification.…` events into `.custom(…)`, rather than the proper enum cases.
+* MXEventType: Improve performance of `init(identifier:)` by using a lookup-table (`O(1)`), instead of linear probing (`O(n)`) (tests showed a 32x speedup)
+* MXMessageType: Improve performance of `init(identifier:)` by using a lookup-table (`O(1)`), instead of linear probing (`O(n)`)
+* MXMembership: Improve performance of `init(identifier:)` by using a lookup-table (`O(1)`), instead of linear probing (`O(n)`)
+
+
 Changes in Matrix iOS SDK in 0.16.2 (2020-04-30)
 ================================================
 

--- a/MatrixSDK/Contrib/Swift/Data/MX3PID.swift
+++ b/MatrixSDK/Contrib/Swift/Data/MX3PID.swift
@@ -22,22 +22,28 @@ public struct MX3PID {
     
     /// Types of third-party identifiers.
     public enum Medium: Equatable, Hashable {
+        public typealias Identifier = String
+
         case email
         case msisdn
-        case other(String)
+        case other(Identifier)
         
-        public var identifier: String {
+        public var identifier: Identifier {
             switch self {
             case .email: return kMX3PIDMediumEmail
             case .msisdn: return kMX3PIDMediumMSISDN
             case .other(let value): return value
             }
         }
-        
-        public init(identifier: String) {
-            let possibleOptions: [Medium] = [.email, .msisdn]
-            if let selectedOption = possibleOptions.first(where: { $0.identifier == identifier }) {
-                self = selectedOption
+
+        private static let lookupTable: [Identifier: Self] = [
+            kMX3PIDMediumEmail: .email,
+            kMX3PIDMediumMSISDN: .msisdn,
+        ]
+
+        public init(identifier: Identifier) {
+            if let value = Self.lookupTable[identifier] {
+                self = value
             } else {
                 self = .other(identifier)
             }
@@ -56,7 +62,7 @@ public struct MX3PID {
 }
 
 extension MX3PID : Hashable {
-    
+
     /// Returns a Boolean value indicating whether two values are equal.
     ///
     /// Equality is the inverse of inequality. For any values `a` and `b`,
@@ -68,7 +74,7 @@ extension MX3PID : Hashable {
     public static func ==(lhs: MX3PID, rhs: MX3PID) -> Bool {
         return lhs.medium.identifier == rhs.medium.identifier && lhs.address == rhs.address
     }
-    
+
     public func hash(into hasher: inout Hasher) {
         hasher.combine(medium.identifier)
         hasher.combine(address)

--- a/MatrixSDK/Contrib/Swift/JSONModels/MXEvent.swift
+++ b/MatrixSDK/Contrib/Swift/JSONModels/MXEvent.swift
@@ -28,6 +28,8 @@ import Foundation
  `MXEventTypeString` must be checked.
  */
 public enum MXEventType: Equatable, Hashable {
+    public typealias Identifier = String
+
     case roomName
     case roomTopic
     case roomAvatar
@@ -65,9 +67,9 @@ public enum MXEventType: Equatable, Hashable {
     case keyVerificationCancel
     case keyVerificationDone
 
-    case custom(String)
-    
-    public var identifier: String {
+    case custom(Identifier)
+
+    public var identifier: Identifier {
         switch self {
         case .roomName: return kMXEventTypeStringRoomName
         case .roomTopic: return kMXEventTypeStringRoomTopic
@@ -113,9 +115,50 @@ public enum MXEventType: Equatable, Hashable {
         }
     }
 
-    public init(identifier: String) {
-        let events: [MXEventType] = [.roomName, .roomTopic, .roomAvatar, .roomMember, .roomCreate, .roomJoinRules, .roomPowerLevels, .roomAliases, .roomCanonicalAlias, .roomEncrypted, .roomEncryption, .roomGuestAccess, .roomHistoryVisibility, .roomKey, .roomForwardedKey, .roomKeyRequest, .roomMessage, .roomMessageFeedback, .roomRedaction, .roomThirdPartyInvite, .roomTag, .presence, .typing, .callInvite, .callCandidates, .callAnswer, .callHangup, .receipt, .roomTombStone]
-        self = events.first(where: { $0.identifier == identifier }) ?? .custom(identifier)
+    private static let lookupTable: [Identifier: Self] = [
+        kMXEventTypeStringRoomName: .roomName,
+        kMXEventTypeStringRoomTopic: .roomTopic,
+        kMXEventTypeStringRoomAvatar: .roomAvatar,
+        kMXEventTypeStringRoomMember: .roomMember,
+        kMXEventTypeStringRoomCreate: .roomCreate,
+        kMXEventTypeStringRoomJoinRules: .roomJoinRules,
+        kMXEventTypeStringRoomPowerLevels: .roomPowerLevels,
+        kMXEventTypeStringRoomAliases: .roomAliases,
+        kMXEventTypeStringRoomCanonicalAlias: .roomCanonicalAlias,
+        kMXEventTypeStringRoomEncrypted: .roomEncrypted,
+        kMXEventTypeStringRoomEncryption: .roomEncryption,
+        kMXEventTypeStringRoomGuestAccess: .roomGuestAccess,
+        kMXEventTypeStringRoomHistoryVisibility: .roomHistoryVisibility,
+        kMXEventTypeStringRoomKey: .roomKey,
+        kMXEventTypeStringRoomForwardedKey: .roomForwardedKey,
+        kMXEventTypeStringRoomKeyRequest: .roomKeyRequest,
+        kMXEventTypeStringRoomMessage: .roomMessage,
+        kMXEventTypeStringRoomMessageFeedback: .roomMessageFeedback,
+        kMXEventTypeStringRoomRedaction: .roomRedaction,
+        kMXEventTypeStringRoomThirdPartyInvite: .roomThirdPartyInvite,
+        kMXEventTypeStringRoomTag: .roomTag,
+        kMXEventTypeStringPresence: .presence,
+        kMXEventTypeStringCallInvite: .callInvite,
+        kMXEventTypeStringCallCandidates: .callCandidates,
+        kMXEventTypeStringCallAnswer: .callAnswer,
+        kMXEventTypeStringCallHangup: .callHangup,
+        kMXEventTypeStringReaction: .reaction,
+        kMXEventTypeStringReceipt: .receipt,
+        kMXEventTypeStringRoomTombStone: .roomTombStone,
+        kMXEventTypeStringKeyVerificationStart: .keyVerificationStart,
+        kMXEventTypeStringKeyVerificationAccept: .keyVerificationAccept,
+        kMXEventTypeStringKeyVerificationKey: .keyVerificationKey,
+        kMXEventTypeStringKeyVerificationMac: .keyVerificationMac,
+        kMXEventTypeStringKeyVerificationCancel: .keyVerificationCancel,
+        kMXEventTypeStringKeyVerificationDone: .keyVerificationDone,
+    ]
+
+    public init(identifier: Identifier) {
+        if let value = Self.lookupTable[identifier] {
+            self = value
+        } else {
+            self = .custom(identifier)
+        }
     }
 }
 
@@ -123,10 +166,12 @@ public enum MXEventType: Equatable, Hashable {
 
 /// Types of messages
 public enum MXMessageType: Equatable, Hashable {
+    public typealias Identifier = String
+
     case text, emote, notice, image, audio, video, location, file
-    case custom(String)
-    
-    public var identifier: String {
+    case custom(Identifier)
+
+    public var identifier: Identifier {
         switch self {
         case .text: return kMXMessageTypeText
         case .emote: return kMXMessageTypeEmote
@@ -140,18 +185,35 @@ public enum MXMessageType: Equatable, Hashable {
         }
     }
 
-    public init(identifier: String) {
-        let messages: [MXMessageType] = [.text, .emote, .notice, .image, .audio, .video, .location, .file]
-        self = messages.first(where: { $0.identifier == identifier }) ?? .custom(identifier)
+    private static let lookupTable: [Identifier: Self] = [
+        kMXMessageTypeText: .text,
+        kMXMessageTypeEmote: .emote,
+        kMXMessageTypeNotice: .notice,
+        kMXMessageTypeImage: .image,
+        kMXMessageTypeAudio: .audio,
+        kMXMessageTypeVideo: .video,
+        kMXMessageTypeLocation: .location,
+        kMXMessageTypeFile: .file,
+    ]
+
+    public init(identifier: Identifier) {
+        if let value = Self.lookupTable[identifier] {
+            self = value
+        } else {
+            self = .custom(identifier)
+        }
     }
 }
 
 
+
 /// Membership definitions
 public enum MXMembership: Equatable, Hashable {
+    public typealias Identifier = __MXMembership
+
     case unknown, invite, join, leave, ban
-    
-    public var identifier: __MXMembership {
+
+    public var identifier: Identifier {
         switch self {
         case .unknown: return __MXMembershipUnknown
         case .invite: return __MXMembershipInvite
@@ -160,9 +222,22 @@ public enum MXMembership: Equatable, Hashable {
         case .ban: return __MXMembershipBan
         }
     }
+
+    private static let lookupTable: [Identifier: Self] = [
+        __MXMembershipUnknown: .unknown,
+        __MXMembershipInvite: .invite,
+        __MXMembershipJoin: .join,
+        __MXMembershipLeave: .leave,
+        __MXMembershipBan: .ban,
+    ]
     
-    public init(identifier: __MXMembership) {
-        let possibilities: [MXMembership] = [.unknown, .invite, .join, .leave, .ban]
-        self = possibilities.first(where: { $0.identifier == identifier }) ?? .unknown
+    public init(identifier: Identifier) {
+        if let value = Self.lookupTable[identifier] {
+            self = value
+        } else {
+            self = .unknown
+        }
     }
 }
+
+extension __MXMembership: Hashable {}

--- a/MatrixSDK/Contrib/Swift/JSONModels/MXJSONModels.swift
+++ b/MatrixSDK/Contrib/Swift/JSONModels/MXJSONModels.swift
@@ -19,6 +19,8 @@ import Foundation
 
 /// Represents a login flow
 public enum MXLoginFlowType: Equatable, Hashable {
+    public typealias Identifier = String
+
     case password
     case recaptcha
     case OAuth2
@@ -26,9 +28,9 @@ public enum MXLoginFlowType: Equatable, Hashable {
     case token
     case dummy
     case emailCode
-    case other(String)
+    case other(Identifier)
     
-    public var identifier: String {
+    public var identifier: Identifier {
         switch self {
         case .password: return kMXLoginFlowTypePassword
         case .recaptcha: return kMXLoginFlowTypeRecaptcha
@@ -41,9 +43,22 @@ public enum MXLoginFlowType: Equatable, Hashable {
         }
     }
 
-    public init(identifier: String) {
-        let flowTypess: [MXLoginFlowType] = [.password, .recaptcha, .OAuth2, .emailIdentity, .token, .dummy, .emailCode]
-        self = flowTypess.first(where: { $0.identifier == identifier }) ?? .other(identifier)
+    private static let lookupTable: [Identifier: Self] = [
+        kMXLoginFlowTypePassword: .password,
+        kMXLoginFlowTypeRecaptcha: .recaptcha,
+        kMXLoginFlowTypeOAuth2: .OAuth2,
+        kMXLoginFlowTypeEmailIdentity: .emailIdentity,
+        kMXLoginFlowTypeToken: .token,
+        kMXLoginFlowTypeDummy: .dummy,
+        kMXLoginFlowTypeEmailCode: .emailCode,
+    ]
+    
+    public init(identifier: Identifier) {
+        if let value = Self.lookupTable[identifier] {
+            self = value
+        } else {
+            self = .other(identifier)
+        }
     }
 }
 
@@ -64,6 +79,7 @@ public enum MXPusherKind: Equatable, Hashable {
 }
 
 
+
 /**
  Push rules kind.
  
@@ -72,9 +88,11 @@ public enum MXPusherKind: Equatable, Hashable {
  Some category may define implicit conditions.
  */
 public enum MXPushRuleKind: Equatable, Hashable {
+    public typealias Identifier = __MXPushRuleKind
+
     case override, content, room, sender, underride
     
-    public var identifier: __MXPushRuleKind {
+    public var identifier: Identifier {
         switch self  {
         case .override: return __MXPushRuleKindOverride
         case .content: return __MXPushRuleKindContent
@@ -84,12 +102,26 @@ public enum MXPushRuleKind: Equatable, Hashable {
         }
     }
 
-    public init?(identifier: __MXPushRuleKind?) {
-        let pushRules: [MXPushRuleKind] = [.override, .content, .room, .sender, .underride]
-        guard let pushRule = pushRules.first(where: { $0.identifier == identifier }) else { return nil }
-        self = pushRule
+    private static let lookupTable: [Identifier: Self] = [
+        __MXPushRuleKindOverride: .override,
+        __MXPushRuleKindContent: .content,
+        __MXPushRuleKindRoom: .room,
+        __MXPushRuleKindSender: .sender,
+        __MXPushRuleKindUnderride: .underride,
+    ]
+
+    public init?(identifier: Identifier?) {
+        guard let identifier = identifier else {
+            return nil
+        }
+        guard let value = Self.lookupTable[identifier] else {
+            return nil
+        }
+        self = value
     }
 }
+
+extension __MXPushRuleKind: Hashable {}
 
 
 /**
@@ -98,6 +130,8 @@ public enum MXPushRuleKind: Equatable, Hashable {
  Push rules can be applied globally, or to a spefific device given a `profileTag`
  */
 public enum MXPushRuleScope: Equatable, Hashable {
+    public typealias Identifier = String
+
     case global, device(profileTag: String)
     
     public var identifier: String {
@@ -107,8 +141,15 @@ public enum MXPushRuleScope: Equatable, Hashable {
         }
     }
 
-    public init(identifier: String) {
-        let scopes: [MXPushRuleScope] = [.global]
-        self = scopes.first(where: { $0.identifier == identifier }) ?? .device(profileTag: identifier)
+    private static let lookupTable: [Identifier: Self] = [
+        kMXPushRuleScopeStringGlobal: .global,
+    ]
+
+    public init(identifier: Identifier) {
+        if let value = Self.lookupTable[identifier] {
+            self = value
+        } else {
+            self = .device(profileTag: identifier)
+        }
     }
 }

--- a/MatrixSDK/Contrib/Swift/MXEnumConstants.swift
+++ b/MatrixSDK/Contrib/Swift/MXEnumConstants.swift
@@ -18,9 +18,11 @@ import Foundation
 
 
 public enum MXRoomHistoryVisibility: Equatable, Hashable {
+    public typealias Identifier = String
+
     case worldReadable, shared, invited, joined
     
-    public var identifier: String {
+    public var identifier: Identifier {
         switch self {
         case .worldReadable: return kMXRoomHistoryVisibilityWorldReadable
         case .shared: return kMXRoomHistoryVisibilityShared
@@ -28,10 +30,21 @@ public enum MXRoomHistoryVisibility: Equatable, Hashable {
         case .joined: return kMXRoomHistoryVisibilityJoined
         }
     }
-    
-    public init?(identifier: String?) {
-        let historyVisibilities: [MXRoomHistoryVisibility] = [.worldReadable, .shared, .invited, .joined]
-        guard let value = historyVisibilities.first(where: {$0.identifier == identifier}) else { return nil }
+
+    private static let lookupTable: [Identifier: Self] = [
+        kMXRoomHistoryVisibilityWorldReadable: .worldReadable,
+        kMXRoomHistoryVisibilityShared: .shared,
+        kMXRoomHistoryVisibilityInvited: .invited,
+        kMXRoomHistoryVisibilityJoined: .joined,
+    ]
+
+    public init?(identifier: Identifier?) {
+        guard let identifier = identifier else {
+            return nil
+        }
+        guard let value = Self.lookupTable[identifier] else {
+            return nil
+        }
         self = value
     }
 }
@@ -44,7 +57,8 @@ public enum MXRoomHistoryVisibility: Equatable, Hashable {
  The default homeserver value is invite.
  */
 public enum MXRoomJoinRule: Equatable, Hashable {
-    
+    public typealias Identifier = String
+
     /// Anyone can join the room without any prior action
     case `public`
     
@@ -54,7 +68,7 @@ public enum MXRoomJoinRule: Equatable, Hashable {
     /// Reserved keyword which is not implemented by homeservers.
     case `private`, knock
     
-    public var identifier: String {
+    public var identifier: Identifier {
         switch self {
         case .public: return kMXRoomJoinRulePublic
         case .invite: return kMXRoomJoinRuleInvite
@@ -62,10 +76,21 @@ public enum MXRoomJoinRule: Equatable, Hashable {
         case .knock: return kMXRoomJoinRuleKnock
         }
     }
-    
-    public init?(identifier: String?) {
-        let joinRules: [MXRoomJoinRule] = [.public, .invite, .private, .knock]
-        guard let value = joinRules.first(where: { $0.identifier == identifier}) else { return nil }
+
+    private static let lookupTable: [Identifier: Self] = [
+        kMXRoomJoinRulePublic: .public,
+        kMXRoomJoinRuleInvite: .invite,
+        kMXRoomJoinRulePrivate: .private,
+        kMXRoomJoinRuleKnock: .knock,
+    ]
+
+    public init?(identifier: Identifier?) {
+        guard let identifier = identifier else {
+            return nil
+        }
+        guard let value = Self.lookupTable[identifier] else {
+            return nil
+        }
         self = value
     }
 }
@@ -74,7 +99,8 @@ public enum MXRoomJoinRule: Equatable, Hashable {
 
 /// Room guest access. The default homeserver value is forbidden.
 public enum MXRoomGuestAccess: Equatable, Hashable {
-    
+    public typealias Identifier = String
+
     /// Guests can join the room
     case canJoin
     
@@ -88,10 +114,19 @@ public enum MXRoomGuestAccess: Equatable, Hashable {
         case .forbidden: return kMXRoomGuestAccessForbidden
         }
     }
-    
-    public init?(identifier: String?) {
-        let accessRules: [MXRoomGuestAccess] = [.canJoin, .forbidden]
-        guard let value = accessRules.first(where: { $0.identifier == identifier}) else { return nil }
+
+    private static let lookupTable: [Identifier: Self] = [
+        kMXRoomGuestAccessCanJoin: .canJoin,
+        kMXRoomGuestAccessForbidden: .forbidden,
+    ]
+
+    public init?(identifier: Identifier?) {
+        guard let identifier = identifier else {
+            return nil
+        }
+        guard let value = Self.lookupTable[identifier] else {
+            return nil
+        }
         self = value
     }
 }
@@ -103,7 +138,8 @@ public enum MXRoomGuestAccess: Equatable, Hashable {
  The default homeserver value is private.
  */
 public enum MXRoomDirectoryVisibility: Equatable, Hashable {
-    
+    public typealias Identifier = String
+
     /// The room is not listed in the homeserver directory
     case `private`
     
@@ -117,9 +153,18 @@ public enum MXRoomDirectoryVisibility: Equatable, Hashable {
         }
     }
     
-    public init?(identifier: String?) {
-        let visibility: [MXRoomDirectoryVisibility] = [.public, .private]
-        guard let value = visibility.first(where: { $0.identifier == identifier}) else { return nil }
+    private static let lookupTable: [Identifier: Self] = [
+        kMXRoomDirectoryVisibilityPrivate: .private,
+        kMXRoomDirectoryVisibilityPublic: .public,
+    ]
+
+    public init?(identifier: Identifier?) {
+        guard let identifier = identifier else {
+            return nil
+        }
+        guard let value = Self.lookupTable[identifier] else {
+            return nil
+        }
         self = value
     }
 }
@@ -130,7 +175,8 @@ public enum MXRoomDirectoryVisibility: Equatable, Hashable {
 /// Room presets.
 /// Define a set of state events applied during a new room creation.
 public enum MXRoomPreset: Equatable, Hashable {
-    
+    public typealias Identifier = String
+
     /// join_rules is set to invite. history_visibility is set to shared.
     case privateChat
     
@@ -141,17 +187,27 @@ public enum MXRoomPreset: Equatable, Hashable {
     case publicChat
     
     
-    public var identifier: String {
+    public var identifier: Identifier {
         switch self {
         case .privateChat: return kMXRoomPresetPrivateChat
         case .trustedPrivateChat: return kMXRoomPresetTrustedPrivateChat
         case .publicChat: return kMXRoomPresetPublicChat
         }
     }
-    
-    public init?(identifier: String?) {
-        let presets: [MXRoomPreset] = [.privateChat, .trustedPrivateChat, .publicChat]
-        guard let value = presets.first(where: {$0.identifier == identifier }) else { return nil }
+
+    private static let lookupTable: [Identifier: Self] = [
+        kMXRoomPresetPrivateChat: .privateChat,
+        kMXRoomPresetTrustedPrivateChat: .trustedPrivateChat,
+        kMXRoomPresetPublicChat: .publicChat,
+    ]
+
+    public init?(identifier: Identifier?) {
+        guard let identifier = identifier else {
+            return nil
+        }
+        guard let value = Self.lookupTable[identifier] else {
+            return nil
+        }
         self = value
     }
 }
@@ -162,7 +218,8 @@ public enum MXRoomPreset: Equatable, Hashable {
  The direction of an event in the timeline.
  */
 public enum MXTimelineDirection: Equatable, Hashable {
-    
+    public typealias Identifier = __MXTimelineDirection
+
     /// Forwards when the event is added to the end of the timeline.
     /// These events come from the /sync stream or from forwards pagination.
     case forwards
@@ -177,9 +234,25 @@ public enum MXTimelineDirection: Equatable, Hashable {
         case .backwards: return __MXTimelineDirectionBackwards
         }
     }
+
+    private static let lookupTable: [Identifier: Self] = [
+        __MXTimelineDirectionForwards: .forwards,
+        __MXTimelineDirectionBackwards: .backwards,
+    ]
+
+    public init?(identifier: Identifier?) {
+        guard let identifier = identifier else {
+            return nil
+        }
+        guard let value = Self.lookupTable[identifier] else {
+            return nil
+        }
+        self = value
+    }
     
     public init(identifer _identifier: __MXTimelineDirection) {
         self = (_identifier == __MXTimelineDirectionForwards ? .forwards : .backwards)
     }
 }
 
+extension __MXTimelineDirection: Hashable {}


### PR DESCRIPTION
This PR most importantly addresses a bug in `MXEventType(identifier:)`, which was erroneously turning `.keyVerificationStart`, `.keyVerificationAccept`, `.keyVerificationKey`, `.keyVerificationMac`, `.keyVerificationCancel` & `.reaction` events into `.custom(…)`

Further more this PR:
 
Replaced linear probing (`O(n)`) in `init(identifier:)` with lookup-table (`O(1)`), where applicable:

- `MX3PID.Medium`,
- `MXEventType`,
- `MXMessageType`,
- `MXMembership`,
- `MXLoginFlowType`,
- `MXPushRuleKind`,
- `MXPushRuleScope`,
- `MXRoomHistoryVisibility`,
- `MXRoomJoinRule`,
- `MXRoomGuestAccess`,
- `MXRoomDirectoryVisibility`,
- `MXRoomPreset`,
- `MXTimelineDirection`

In order to uniformly change the implementations of `init(identifier:)` the following type were marked as `Hashable` (required for the lookup-table approach):

- `__MXMembership`,
- `__MXPushRuleKind`,
- `__MXTimelineDirection`

While clearly being an outlier in the number of associated cases quick performance test for `MXEventType(identifier:)` showed a 32x speedup compared to the previous implementation.

Signed-off-by: Vincent Esche <138017+regexident@users.noreply.github.com>