### PR TITLE
Make sure we can make gossip requests again from a device already verified

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,14 @@
+Changes in Matrix iOS SDK in 0.16.3 (2020-05-xx)
+================================================
+
+Improvements:
+ * MXCrypto: Allow to verify a device again to request private keys again from it.
+
 Changes in Matrix iOS SDK in 0.16.2 (2020-04-30)
 ================================================
 
 Improvements:
-* Cross-signing: Make key gossip requests when the other device sent m.key.verification.done (vector-im/riot-ios/issues/3163).
+ * Cross-signing: Make key gossip requests when the other device sent m.key.verification.done (vector-im/riot-ios/issues/3163).
 
 Bug fix:
  * MXEventTimeline: Fix crash in paginate:.

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -835,37 +835,34 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
         return;
     }
     
-    if (device.trustLevel.localVerificationStatus != verificationStatus)
+    MXDeviceTrustLevel *trustLevel = [MXDeviceTrustLevel trustLevelWithLocalVerificationStatus:verificationStatus
+                                                                          crossSigningVerified:device.trustLevel.isCrossSigningVerified];
+    [device updateTrustLevel:trustLevel];
+    [self.store storeDeviceForUser:userId device:device];
+    
+    if ([userId isEqualToString:self.mxSession.myUserId])
     {
-        MXDeviceTrustLevel *trustLevel = [MXDeviceTrustLevel trustLevelWithLocalVerificationStatus:verificationStatus
-                                                                              crossSigningVerified:device.trustLevel.isCrossSigningVerified];
-        [device updateTrustLevel:trustLevel];
-        [self.store storeDeviceForUser:userId device:device];
+        // If one of the user's own devices is being marked as verified / unverified,
+        // check the key backup status, since whether or not we use this depends on
+        // whether it has a signature from a verified device
+        [self.backup checkAndStartKeyBackup];
         
-        if ([userId isEqualToString:self.mxSession.myUserId])
+        // Manage self-verification
+        if (verificationStatus == MXDeviceVerified)
         {
-            // If one of the user's own devices is being marked as verified / unverified,
-            // check the key backup status, since whether or not we use this depends on
-            // whether it has a signature from a verified device
-            [self.backup checkAndStartKeyBackup];
+            // This is a good time to request all private keys
+            NSLog(@"[MXCrypto] setDeviceVerificationForDevice: Request all private keys");
+            [self scheduleRequestsForAllPrivateKeys];
             
-            // Manage self-verification
-            if (verificationStatus == MXDeviceVerified)
+            // Check cross-signing
+            if (self.crossSigning.canCrossSign)
             {
-                // This is a good time to request all private keys
-                NSLog(@"[MXCrypto] setDeviceVerificationForDevice: Request all private keys");
-                [self scheduleRequestsForAllPrivateKeys];
+                // Cross-sign our own device
+                NSLog(@"[MXCrypto] setDeviceVerificationForDevice: Mark device %@ as self verified", deviceId);
+                [self.crossSigning crossSignDeviceWithDeviceId:deviceId success:success failure:failure];
                 
-                // Check cross-signing
-                if (self.crossSigning.canCrossSign)
-                {
-                    // Cross-sign our own device
-                    NSLog(@"[MXCrypto] setDeviceVerificationForDevice: Mark device %@ as self verified", deviceId);
-                    [self.crossSigning crossSignDeviceWithDeviceId:deviceId success:success failure:failure];
-                    
-                    // Wait the end of cross-sign before returning
-                    return;
-                }
+                // Wait the end of cross-sign before returning
+                return;
             }
         }
     }

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -1244,7 +1244,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     }
     
     // Check cross-signing private keys
-    if (self.crossSigning.state == MXCrossSigningStateCrossSigningExists)
+    if (!self.crossSigning.canCrossSign)
     {
         NSLog(@"[MXCrypto] requestAllPrivateKeys: Request cross-signing private keys");
         [self.crossSigning requestPrivateKeys];


### PR DESCRIPTION
The goal of these 2 changes is to recover better from a weird state of the cross-signing or the key backup.
We will recover by cross-signing the device again.