### PR TITLE
Create MXSecretStorage to support SSSS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Changes in Matrix iOS SDK in 0.16.5 (2020-05-xx)
 
 Improvements:
  * MXSession: Update account data as soon as the endpoint returns.
+ * MXSecretStorage: Add this class to support SSSS ([MSC1946(]https://github.com/matrix-org/matrix-doc/pull/1946).
 
 Changes in Matrix iOS SDK in 0.16.4 (2020-05-07)
 ================================================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+Changes in Matrix iOS SDK in 0.16.5 (2020-05-xx)
+================================================
+
+Improvements:
+ * MXSession: Update account data as soon as the endpoint returns.
+
 Changes in Matrix iOS SDK in 0.16.4 (2020-05-07)
 ================================================
 

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -153,6 +153,24 @@
 		324BE4691E3FADB1008D99D4 /* MXMegolmExportEncryption.m in Sources */ = {isa = PBXBuildFile; fileRef = 324BE4671E3FADB1008D99D4 /* MXMegolmExportEncryption.m */; };
 		324BE46C1E422766008D99D4 /* MXMegolmSessionData.h in Headers */ = {isa = PBXBuildFile; fileRef = 324BE46A1E422766008D99D4 /* MXMegolmSessionData.h */; };
 		324BE46D1E422766008D99D4 /* MXMegolmSessionData.m in Sources */ = {isa = PBXBuildFile; fileRef = 324BE46B1E422766008D99D4 /* MXMegolmSessionData.m */; };
+		324DD299246AD2B500377005 /* MXSecretStorageManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 324DD297246AD2B500377005 /* MXSecretStorageManager.h */; };
+		324DD29A246AD2B500377005 /* MXSecretStorageManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 324DD297246AD2B500377005 /* MXSecretStorageManager.h */; };
+		324DD29B246AD2B500377005 /* MXSecretStorageManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 324DD298246AD2B500377005 /* MXSecretStorageManager.m */; };
+		324DD29C246AD2B500377005 /* MXSecretStorageManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 324DD298246AD2B500377005 /* MXSecretStorageManager.m */; };
+		324DD2A0246AE1EF00377005 /* MXEncryptedSecretContent.h in Headers */ = {isa = PBXBuildFile; fileRef = 324DD29E246AE1EF00377005 /* MXEncryptedSecretContent.h */; };
+		324DD2A1246AE1EF00377005 /* MXEncryptedSecretContent.h in Headers */ = {isa = PBXBuildFile; fileRef = 324DD29E246AE1EF00377005 /* MXEncryptedSecretContent.h */; };
+		324DD2A2246AE1EF00377005 /* MXEncryptedSecretContent.m in Sources */ = {isa = PBXBuildFile; fileRef = 324DD29F246AE1EF00377005 /* MXEncryptedSecretContent.m */; };
+		324DD2A3246AE1EF00377005 /* MXEncryptedSecretContent.m in Sources */ = {isa = PBXBuildFile; fileRef = 324DD29F246AE1EF00377005 /* MXEncryptedSecretContent.m */; };
+		324DD2A6246AE81300377005 /* MXSecretStorageKeyContent.h in Headers */ = {isa = PBXBuildFile; fileRef = 324DD2A4246AE81300377005 /* MXSecretStorageKeyContent.h */; };
+		324DD2A7246AE81300377005 /* MXSecretStorageKeyContent.h in Headers */ = {isa = PBXBuildFile; fileRef = 324DD2A4246AE81300377005 /* MXSecretStorageKeyContent.h */; };
+		324DD2A8246AE81300377005 /* MXSecretStorageKeyContent.m in Sources */ = {isa = PBXBuildFile; fileRef = 324DD2A5246AE81300377005 /* MXSecretStorageKeyContent.m */; };
+		324DD2A9246AE81300377005 /* MXSecretStorageKeyContent.m in Sources */ = {isa = PBXBuildFile; fileRef = 324DD2A5246AE81300377005 /* MXSecretStorageKeyContent.m */; };
+		324DD2AC246AEB7B00377005 /* MXSecretStoragePassphrase.h in Headers */ = {isa = PBXBuildFile; fileRef = 324DD2AA246AEB7B00377005 /* MXSecretStoragePassphrase.h */; };
+		324DD2AD246AEB7B00377005 /* MXSecretStoragePassphrase.h in Headers */ = {isa = PBXBuildFile; fileRef = 324DD2AA246AEB7B00377005 /* MXSecretStoragePassphrase.h */; };
+		324DD2AE246AEB7B00377005 /* MXSecretStoragePassphrase.m in Sources */ = {isa = PBXBuildFile; fileRef = 324DD2AB246AEB7B00377005 /* MXSecretStoragePassphrase.m */; };
+		324DD2AF246AEB7B00377005 /* MXSecretStoragePassphrase.m in Sources */ = {isa = PBXBuildFile; fileRef = 324DD2AB246AEB7B00377005 /* MXSecretStoragePassphrase.m */; };
+		324DD2B1246BDC6800377005 /* MXSecretStorageManager_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 324DD2B0246BDC6800377005 /* MXSecretStorageManager_Private.h */; };
+		324DD2B2246BDC6800377005 /* MXSecretStorageManager_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 324DD2B0246BDC6800377005 /* MXSecretStorageManager_Private.h */; };
 		3250E7CA220C913900736CB5 /* MXCryptoTools.h in Headers */ = {isa = PBXBuildFile; fileRef = 3250E7C8220C913900736CB5 /* MXCryptoTools.h */; };
 		3250E7CB220C913900736CB5 /* MXCryptoTools.m in Sources */ = {isa = PBXBuildFile; fileRef = 3250E7C9220C913900736CB5 /* MXCryptoTools.m */; };
 		3252DCAE224BE5D40032264F /* MXKeyVerificationManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 3252DCAC224BE5D40032264F /* MXKeyVerificationManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1276,6 +1294,15 @@
 		324BE4671E3FADB1008D99D4 /* MXMegolmExportEncryption.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXMegolmExportEncryption.m; sourceTree = "<group>"; };
 		324BE46A1E422766008D99D4 /* MXMegolmSessionData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXMegolmSessionData.h; sourceTree = "<group>"; };
 		324BE46B1E422766008D99D4 /* MXMegolmSessionData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXMegolmSessionData.m; sourceTree = "<group>"; };
+		324DD297246AD2B500377005 /* MXSecretStorageManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXSecretStorageManager.h; sourceTree = "<group>"; };
+		324DD298246AD2B500377005 /* MXSecretStorageManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXSecretStorageManager.m; sourceTree = "<group>"; };
+		324DD29E246AE1EF00377005 /* MXEncryptedSecretContent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXEncryptedSecretContent.h; sourceTree = "<group>"; };
+		324DD29F246AE1EF00377005 /* MXEncryptedSecretContent.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXEncryptedSecretContent.m; sourceTree = "<group>"; };
+		324DD2A4246AE81300377005 /* MXSecretStorageKeyContent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXSecretStorageKeyContent.h; sourceTree = "<group>"; };
+		324DD2A5246AE81300377005 /* MXSecretStorageKeyContent.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXSecretStorageKeyContent.m; sourceTree = "<group>"; };
+		324DD2AA246AEB7B00377005 /* MXSecretStoragePassphrase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXSecretStoragePassphrase.h; sourceTree = "<group>"; };
+		324DD2AB246AEB7B00377005 /* MXSecretStoragePassphrase.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXSecretStoragePassphrase.m; sourceTree = "<group>"; };
+		324DD2B0246BDC6800377005 /* MXSecretStorageManager_Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXSecretStorageManager_Private.h; sourceTree = "<group>"; };
 		3250E7C8220C913900736CB5 /* MXCryptoTools.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXCryptoTools.h; sourceTree = "<group>"; };
 		3250E7C9220C913900736CB5 /* MXCryptoTools.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXCryptoTools.m; sourceTree = "<group>"; };
 		3252DCAC224BE5D40032264F /* MXKeyVerificationManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXKeyVerificationManager.h; sourceTree = "<group>"; };
@@ -1984,11 +2011,12 @@
 		322A51B31D9AB13E00C8536D /* Crypto */ = {
 			isa = PBXGroup;
 			children = (
-				32CEEF3F23AD2A340039BA98 /* CrossSigning */,
 				322A51C01D9AC8FE00C8536D /* Algorithms */,
+				32CEEF3F23AD2A340039BA98 /* CrossSigning */,
 				32A1513B1DAF768D00400192 /* Data */,
 				32BBAE642178E99100D85F46 /* KeyBackup */,
 				32FA10B21FA1C28100E54233 /* KeySharing */,
+				324DD296246AD25E00377005 /* SecretStorage */,
 				324BE4651E3FADB1008D99D4 /* Utils */,
 				3252DCAB224BE59E0032264F /* Verification */,
 				322A51B41D9AB15900C8536D /* MXCrypto.h */,
@@ -2092,6 +2120,30 @@
 				324BE4671E3FADB1008D99D4 /* MXMegolmExportEncryption.m */,
 			);
 			path = Utils;
+			sourceTree = "<group>";
+		};
+		324DD296246AD25E00377005 /* SecretStorage */ = {
+			isa = PBXGroup;
+			children = (
+				324DD29D246AE1CA00377005 /* JSONModels */,
+				324DD297246AD2B500377005 /* MXSecretStorageManager.h */,
+				324DD2B0246BDC6800377005 /* MXSecretStorageManager_Private.h */,
+				324DD298246AD2B500377005 /* MXSecretStorageManager.m */,
+			);
+			path = SecretStorage;
+			sourceTree = "<group>";
+		};
+		324DD29D246AE1CA00377005 /* JSONModels */ = {
+			isa = PBXGroup;
+			children = (
+				324DD29E246AE1EF00377005 /* MXEncryptedSecretContent.h */,
+				324DD29F246AE1EF00377005 /* MXEncryptedSecretContent.m */,
+				324DD2A4246AE81300377005 /* MXSecretStorageKeyContent.h */,
+				324DD2A5246AE81300377005 /* MXSecretStorageKeyContent.m */,
+				324DD2AA246AEB7B00377005 /* MXSecretStoragePassphrase.h */,
+				324DD2AB246AEB7B00377005 /* MXSecretStoragePassphrase.m */,
+			);
+			path = JSONModels;
 			sourceTree = "<group>";
 		};
 		3252DCAB224BE59E0032264F /* Verification */ = {
@@ -3049,6 +3101,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				32A9F8DE244720B10069C65B /* MXThrottler.h in Headers */,
+				324DD299246AD2B500377005 /* MXSecretStorageManager.h in Headers */,
 				322A51B61D9AB15900C8536D /* MXCrypto.h in Headers */,
 				324AAC71239913AD00380A66 /* MXKeyVerificationRequestByDMJSONModel.h in Headers */,
 				32114A8F1A262ECB00FF2EC4 /* MXNoStore.h in Headers */,
@@ -3129,6 +3182,7 @@
 				324BE46C1E422766008D99D4 /* MXMegolmSessionData.h in Headers */,
 				324AAC6F239913AD00380A66 /* MXKeyVerificationJSONModel.h in Headers */,
 				327E9AFC228AC22800A98BC1 /* MXAggregationsStore.h in Headers */,
+				324DD2AC246AEB7B00377005 /* MXSecretStoragePassphrase.h in Headers */,
 				323547DC2226FC5700F15F94 /* MXCredentials.h in Headers */,
 				B19A30CA2404268600FB6F35 /* MXQRCodeDataCodable.h in Headers */,
 				325AD43F23BE3E7500FF5277 /* MXCrossSigningInfo.h in Headers */,
@@ -3164,6 +3218,7 @@
 				C60165381E3AA57900B92CFA /* MXSDKOptions.h in Headers */,
 				32CEEF4F23B0AB030039BA98 /* MXCrossSigning.h in Headers */,
 				320B3934239FA56900BE2C06 /* MXKeyVerificationByDMRequest.h in Headers */,
+				324DD2A6246AE81300377005 /* MXSecretStorageKeyContent.h in Headers */,
 				3281E8B919E42DFE00976E1A /* MXJSONModels.h in Headers */,
 				B19A30D424042F2700FB6F35 /* MXSelfVerifyingMasterKeyNotTrustedQRCodeData.h in Headers */,
 				323F3F9420D3F0C700D26D6A /* MXRoomEventFilter.h in Headers */,
@@ -3277,6 +3332,7 @@
 				9274AFE81EE580240009BEB6 /* MXCallKitAdapter.h in Headers */,
 				321CFDE622525A49004D31DF /* MXSASTransaction.h in Headers */,
 				B19A30CE24042F0800FB6F35 /* MXSelfVerifyingMasterKeyTrustedQRCodeData.h in Headers */,
+				324DD2B1246BDC6800377005 /* MXSecretStorageManager_Private.h in Headers */,
 				32DC15D01A8CF7AE006F9AD3 /* MXNotificationCenter.h in Headers */,
 				3275FD9C21A6B60B00B9C13D /* MXLoginPolicy.h in Headers */,
 				3250E7CA220C913900736CB5 /* MXCryptoTools.h in Headers */,
@@ -3284,6 +3340,7 @@
 				32D2CC0523422462002BD8CA /* MX3PidAddSession.h in Headers */,
 				329FB17F1A0B665800A5E88E /* MXUser.h in Headers */,
 				320DFDE219DD99B60068622A /* MXError.h in Headers */,
+				324DD2A0246AE1EF00377005 /* MXEncryptedSecretContent.h in Headers */,
 				B11BD45922CB58850064D8B0 /* MXReplyEventFormattedBodyParts.h in Headers */,
 				32BBAE702178E99100D85F46 /* MXKeyBackupData.h in Headers */,
 				32999DDF22DCD183004FF987 /* MXPusher.h in Headers */,
@@ -3342,6 +3399,7 @@
 				324AAC7F2399143400380A66 /* MXKeyVerificationDone.h in Headers */,
 				B14EF2B32397E90400758AF0 /* MXRoomFilter.h in Headers */,
 				B14EF2B42397E90400758AF0 /* MXAntivirusScanStatus.h in Headers */,
+				324DD2A7246AE81300377005 /* MXSecretStorageKeyContent.h in Headers */,
 				B14EF2B52397E90400758AF0 /* MXDeviceListOperationsPool.h in Headers */,
 				B14EF2B62397E90400758AF0 /* MXJSONModel.h in Headers */,
 				B14EF2B72397E90400758AF0 /* MXCryptoStore.h in Headers */,
@@ -3372,6 +3430,7 @@
 				B14EF2CA2397E90400758AF0 /* MXAnalyticsDelegate.h in Headers */,
 				B14EF2CB2397E90400758AF0 /* MXCallAudioSessionConfigurator.h in Headers */,
 				B14EF2CC2397E90400758AF0 /* MXMatrixVersions.h in Headers */,
+				324DD2A1246AE1EF00377005 /* MXEncryptedSecretContent.h in Headers */,
 				B14EF2CD2397E90400758AF0 /* MXRealmEventScanStore.h in Headers */,
 				B14EF2CE2397E90400758AF0 /* MXFileRoomStore.h in Headers */,
 				B14EF2CF2397E90400758AF0 /* (null) in Headers */,
@@ -3476,6 +3535,7 @@
 				B14EF31F2397E90400758AF0 /* MXPusherData.h in Headers */,
 				B14EF3202397E90400758AF0 /* MXKeyBackupPassword.h in Headers */,
 				B14EF3212397E90400758AF0 /* MXRestClient.h in Headers */,
+				324DD2B2246BDC6800377005 /* MXSecretStorageManager_Private.h in Headers */,
 				32B0E33A23A2989A0054FF1A /* MXEventReferenceChunk.h in Headers */,
 				B14EF3222397E90400758AF0 /* MXKeyVerificationManager.h in Headers */,
 				B14EF3232397E90400758AF0 /* MXRoomState.h in Headers */,
@@ -3555,9 +3615,11 @@
 				B19A30C92404268600FB6F35 /* MXQRCodeDataBuilder.h in Headers */,
 				B14EF3612397E90400758AF0 /* MXMegolmBackupAuthData.h in Headers */,
 				B14EF3622397E90400758AF0 /* MXReactionCountChange.h in Headers */,
+				324DD29A246AD2B500377005 /* MXSecretStorageManager.h in Headers */,
 				B14EF3632397E90400758AF0 /* MXScanRealmFileProvider.h in Headers */,
 				B14EF3642397E90400758AF0 /* MXRoom.h in Headers */,
 				B14EF3652397E90400758AF0 /* MXServiceTerms.h in Headers */,
+				324DD2AD246AEB7B00377005 /* MXSecretStoragePassphrase.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3857,6 +3919,7 @@
 				322A51C41D9AC8FE00C8536D /* MXCryptoAlgorithms.m in Sources */,
 				B1798D0824091A0100308A8F /* MXBase64Tools.m in Sources */,
 				B182B08823167A640057972E /* MXIdentityServerHashDetails.m in Sources */,
+				324DD2A2246AE1EF00377005 /* MXEncryptedSecretContent.m in Sources */,
 				329FB1761A0A3A1600A5E88E /* MXRoomMember.m in Sources */,
 				B1136965230AC9D900E2B2FA /* MXIdentityService.m in Sources */,
 				B11BD44922CB56790064D8B0 /* MXReplyEventParser.m in Sources */,
@@ -3953,6 +4016,7 @@
 				32CAB10C1A925B41008C5BB9 /* MXHTTPOperation.m in Sources */,
 				32BBAE6C2178E99100D85F46 /* MXKeyBackupData.m in Sources */,
 				32AF928C240EA3880008A0FD /* MXSecretShareSend.m in Sources */,
+				324DD29B246AD2B500377005 /* MXSecretStorageManager.m in Sources */,
 				3281E8BA19E42DFE00976E1A /* MXJSONModels.m in Sources */,
 				3245A7531AF7B2930001D8A7 /* MXCallManager.m in Sources */,
 				32E226A71D06AC9F00E6CA54 /* MXPeekingRoom.m in Sources */,
@@ -3966,6 +4030,7 @@
 				32792BD52295A86600F4FC9D /* MXAggregatedReactionsUpdater.m in Sources */,
 				32618E7C20EFA45B00E1D2EA /* MXRoomMembers.m in Sources */,
 				32B0E34123A378320054FF1A /* MXEventReference.m in Sources */,
+				324DD2A8246AE81300377005 /* MXSecretStorageKeyContent.m in Sources */,
 				02CAD43A217DD12F0074700B /* MXContentScanEncryptedBody.m in Sources */,
 				F03EF5091DF071D5009DF592 /* MXEncryptedAttachments.m in Sources */,
 				3274538623FD69D600438328 /* MXKeyVerificationRequestByToDeviceJSONModel.m in Sources */,
@@ -4001,6 +4066,7 @@
 				B146D47B21A5958400D8C2C6 /* MXAntivirusScanStatusFormatter.m in Sources */,
 				32133022228BF7BC0070BA9B /* MXReactionCountChange.m in Sources */,
 				32A151491DAF7C0C00400192 /* MXKey.m in Sources */,
+				324DD2AE246AEB7B00377005 /* MXSecretStoragePassphrase.m in Sources */,
 				B1136964230AC9D900E2B2FA /* MXIdentityServerRestClient.m in Sources */,
 				F0C34CBB1C18C93700C36F09 /* MXSDKOptions.m in Sources */,
 				320BBF441D6C81550079890E /* MXEventsEnumeratorOnArray.m in Sources */,
@@ -4164,6 +4230,7 @@
 				B14EF1EC2397E90400758AF0 /* MXCryptoAlgorithms.m in Sources */,
 				B14EF1ED2397E90400758AF0 /* MXIdentityServerHashDetails.m in Sources */,
 				B14EF1EE2397E90400758AF0 /* MXRoomMember.m in Sources */,
+				324DD2AF246AEB7B00377005 /* MXSecretStoragePassphrase.m in Sources */,
 				B14EF1EF2397E90400758AF0 /* MXIdentityService.m in Sources */,
 				B14EF1F02397E90400758AF0 /* MXReplyEventParser.m in Sources */,
 				B14EF1F12397E90400758AF0 /* MXFileStore.m in Sources */,
@@ -4200,6 +4267,7 @@
 				3297913123AA126500F7BB9B /* MXKeyVerificationStatusResolver.m in Sources */,
 				B14EF2082397E90400758AF0 /* MX3PidAddManager.m in Sources */,
 				B14EF2092397E90400758AF0 /* MXCallKitConfiguration.m in Sources */,
+				324DD2A9246AE81300377005 /* MXSecretStorageKeyContent.m in Sources */,
 				B14EF20A2397E90400758AF0 /* MXRoomState.m in Sources */,
 				B14EF20B2397E90400758AF0 /* MXJSONModel.m in Sources */,
 				B14EF20C2397E90400758AF0 /* MXEventContentRelatesTo.m in Sources */,
@@ -4320,6 +4388,7 @@
 				B14EF26C2397E90400758AF0 /* MXRoom.m in Sources */,
 				B14EF26D2397E90400758AF0 /* NSData+MatrixSDK.m in Sources */,
 				B14EF26E2397E90400758AF0 /* MXFileRoomStore.m in Sources */,
+				324DD29C246AD2B500377005 /* MXSecretStorageManager.m in Sources */,
 				B14EF26F2397E90400758AF0 /* MXUser.m in Sources */,
 				324AAC772399140D00380A66 /* MXKeyVerificationDone.m in Sources */,
 				B14EF2702397E90400758AF0 /* MXIdentityServerRestClient.swift in Sources */,
@@ -4352,6 +4421,7 @@
 				32CEEF5223B0AB030039BA98 /* MXCrossSigning.m in Sources */,
 				B14EF2862397E90400758AF0 /* MXRealmMediaScanStore.m in Sources */,
 				B14EF2872397E90400758AF0 /* MXPusherData.m in Sources */,
+				324DD2A3246AE1EF00377005 /* MXEncryptedSecretContent.m in Sources */,
 				B14EF2882397E90400758AF0 /* MXOlmDevice.m in Sources */,
 				B14766BA23D9D9420091F721 /* MXUsersTrustLevelSummary.m in Sources */,
 				B14EF2892397E90400758AF0 /* MXKeyBackupPassword.m in Sources */,

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -175,6 +175,8 @@
 		324DD2B7246C21C700377005 /* MXSecretStorageKeyCreationInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 324DD2B4246C21C700377005 /* MXSecretStorageKeyCreationInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		324DD2B8246C21C700377005 /* MXSecretStorageKeyCreationInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 324DD2B5246C21C700377005 /* MXSecretStorageKeyCreationInfo.m */; };
 		324DD2B9246C21C700377005 /* MXSecretStorageKeyCreationInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 324DD2B5246C21C700377005 /* MXSecretStorageKeyCreationInfo.m */; };
+		324DD2BB246C3ADE00377005 /* MXCryptoSecretStorageTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 324DD2BA246C3ADE00377005 /* MXCryptoSecretStorageTests.m */; };
+		324DD2BC246C3ADE00377005 /* MXCryptoSecretStorageTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 324DD2BA246C3ADE00377005 /* MXCryptoSecretStorageTests.m */; };
 		3250E7CA220C913900736CB5 /* MXCryptoTools.h in Headers */ = {isa = PBXBuildFile; fileRef = 3250E7C8220C913900736CB5 /* MXCryptoTools.h */; };
 		3250E7CB220C913900736CB5 /* MXCryptoTools.m in Sources */ = {isa = PBXBuildFile; fileRef = 3250E7C9220C913900736CB5 /* MXCryptoTools.m */; };
 		3252DCAE224BE5D40032264F /* MXKeyVerificationManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 3252DCAC224BE5D40032264F /* MXKeyVerificationManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1309,6 +1311,7 @@
 		324DD2B0246BDC6800377005 /* MXSecretStorage_Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXSecretStorage_Private.h; sourceTree = "<group>"; };
 		324DD2B4246C21C700377005 /* MXSecretStorageKeyCreationInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXSecretStorageKeyCreationInfo.h; sourceTree = "<group>"; };
 		324DD2B5246C21C700377005 /* MXSecretStorageKeyCreationInfo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXSecretStorageKeyCreationInfo.m; sourceTree = "<group>"; };
+		324DD2BA246C3ADE00377005 /* MXCryptoSecretStorageTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXCryptoSecretStorageTests.m; sourceTree = "<group>"; };
 		3250E7C8220C913900736CB5 /* MXCryptoTools.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXCryptoTools.h; sourceTree = "<group>"; };
 		3250E7C9220C913900736CB5 /* MXCryptoTools.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXCryptoTools.m; sourceTree = "<group>"; };
 		3252DCAC224BE5D40032264F /* MXKeyVerificationManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXKeyVerificationManager.h; sourceTree = "<group>"; };
@@ -2699,6 +2702,7 @@
 		32C6F93919DD814400EA4E9C /* MatrixSDKTests */ = {
 			isa = PBXGroup;
 			children = (
+				324DD2BA246C3ADE00377005 /* MXCryptoSecretStorageTests.m */,
 				B19A30AE240425D000FB6F35 /* MXQRCodeDataTests.m */,
 				32AF9291241112850008A0FD /* MXCryptoSecretShareTests.m */,
 				32C9B71723E81A1C00C6F30A /* MXCrossSigningVerificationTests.m */,
@@ -4169,6 +4173,7 @@
 				32322A481E57264E005DD155 /* MXSelfSignedHomeserverTests.m in Sources */,
 				325653831A2E14ED00CC0423 /* MXStoreTests.m in Sources */,
 				3295719A1B024D2B00ABB3BA /* MXMockCallStackCall.m in Sources */,
+				324DD2BB246C3ADE00377005 /* MXCryptoSecretStorageTests.m in Sources */,
 				B19A30D82404335D00FB6F35 /* MXQRCodeDataTests.m in Sources */,
 				B11BD45C22CB8ABC0064D8B0 /* MXReplyEventParserTests.m in Sources */,
 				32AF9292241112850008A0FD /* MXCryptoSecretShareTests.m in Sources */,
@@ -4485,6 +4490,7 @@
 				B1E09A1E2397FCE90057C069 /* MXCryptoShareTests.m in Sources */,
 				B1E09A422397FD820057C069 /* MXCryptoTests.m in Sources */,
 				B1E09A382397FD7D0057C069 /* MXUserTests.m in Sources */,
+				324DD2BC246C3ADE00377005 /* MXCryptoSecretStorageTests.m in Sources */,
 				B19A30D92404335D00FB6F35 /* MXQRCodeDataTests.m in Sources */,
 				B1E09A212397FCE90057C069 /* DirectRoomTests.m in Sources */,
 				32AF9293241112850008A0FD /* MXCryptoSecretShareTests.m in Sources */,

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -177,6 +177,14 @@
 		324DD2B9246C21C700377005 /* MXSecretStorageKeyCreationInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 324DD2B5246C21C700377005 /* MXSecretStorageKeyCreationInfo.m */; };
 		324DD2BB246C3ADE00377005 /* MXCryptoSecretStorageTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 324DD2BA246C3ADE00377005 /* MXCryptoSecretStorageTests.m */; };
 		324DD2BC246C3ADE00377005 /* MXCryptoSecretStorageTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 324DD2BA246C3ADE00377005 /* MXCryptoSecretStorageTests.m */; };
+		324DD2BF246D658500377005 /* MXHkdfSha256.h in Headers */ = {isa = PBXBuildFile; fileRef = 324DD2BD246D658500377005 /* MXHkdfSha256.h */; };
+		324DD2C0246D658500377005 /* MXHkdfSha256.h in Headers */ = {isa = PBXBuildFile; fileRef = 324DD2BD246D658500377005 /* MXHkdfSha256.h */; };
+		324DD2C1246D658500377005 /* MXHkdfSha256.m in Sources */ = {isa = PBXBuildFile; fileRef = 324DD2BE246D658500377005 /* MXHkdfSha256.m */; };
+		324DD2C2246D658500377005 /* MXHkdfSha256.m in Sources */ = {isa = PBXBuildFile; fileRef = 324DD2BE246D658500377005 /* MXHkdfSha256.m */; };
+		324DD2C5246E638B00377005 /* MXAesHmacSha2.h in Headers */ = {isa = PBXBuildFile; fileRef = 324DD2C3246E638B00377005 /* MXAesHmacSha2.h */; };
+		324DD2C6246E638B00377005 /* MXAesHmacSha2.h in Headers */ = {isa = PBXBuildFile; fileRef = 324DD2C3246E638B00377005 /* MXAesHmacSha2.h */; };
+		324DD2C7246E638B00377005 /* MXAesHmacSha2.m in Sources */ = {isa = PBXBuildFile; fileRef = 324DD2C4246E638B00377005 /* MXAesHmacSha2.m */; };
+		324DD2C8246E638B00377005 /* MXAesHmacSha2.m in Sources */ = {isa = PBXBuildFile; fileRef = 324DD2C4246E638B00377005 /* MXAesHmacSha2.m */; };
 		3250E7CA220C913900736CB5 /* MXCryptoTools.h in Headers */ = {isa = PBXBuildFile; fileRef = 3250E7C8220C913900736CB5 /* MXCryptoTools.h */; };
 		3250E7CB220C913900736CB5 /* MXCryptoTools.m in Sources */ = {isa = PBXBuildFile; fileRef = 3250E7C9220C913900736CB5 /* MXCryptoTools.m */; };
 		3252DCAE224BE5D40032264F /* MXKeyVerificationManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 3252DCAC224BE5D40032264F /* MXKeyVerificationManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1312,6 +1320,10 @@
 		324DD2B4246C21C700377005 /* MXSecretStorageKeyCreationInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXSecretStorageKeyCreationInfo.h; sourceTree = "<group>"; };
 		324DD2B5246C21C700377005 /* MXSecretStorageKeyCreationInfo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXSecretStorageKeyCreationInfo.m; sourceTree = "<group>"; };
 		324DD2BA246C3ADE00377005 /* MXCryptoSecretStorageTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXCryptoSecretStorageTests.m; sourceTree = "<group>"; };
+		324DD2BD246D658500377005 /* MXHkdfSha256.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXHkdfSha256.h; sourceTree = "<group>"; };
+		324DD2BE246D658500377005 /* MXHkdfSha256.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXHkdfSha256.m; sourceTree = "<group>"; };
+		324DD2C3246E638B00377005 /* MXAesHmacSha2.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXAesHmacSha2.h; sourceTree = "<group>"; };
+		324DD2C4246E638B00377005 /* MXAesHmacSha2.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXAesHmacSha2.m; sourceTree = "<group>"; };
 		3250E7C8220C913900736CB5 /* MXCryptoTools.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXCryptoTools.h; sourceTree = "<group>"; };
 		3250E7C9220C913900736CB5 /* MXCryptoTools.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXCryptoTools.m; sourceTree = "<group>"; };
 		3252DCAC224BE5D40032264F /* MXKeyVerificationManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXKeyVerificationManager.h; sourceTree = "<group>"; };
@@ -2127,6 +2139,10 @@
 				3250E7C9220C913900736CB5 /* MXCryptoTools.m */,
 				324BE4661E3FADB1008D99D4 /* MXMegolmExportEncryption.h */,
 				324BE4671E3FADB1008D99D4 /* MXMegolmExportEncryption.m */,
+				324DD2BD246D658500377005 /* MXHkdfSha256.h */,
+				324DD2BE246D658500377005 /* MXHkdfSha256.m */,
+				324DD2C3246E638B00377005 /* MXAesHmacSha2.h */,
+				324DD2C4246E638B00377005 /* MXAesHmacSha2.m */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -3217,6 +3233,7 @@
 				3245A7501AF7B2930001D8A7 /* MXCall.h in Headers */,
 				02CAD43B217DD12F0074700B /* MXContentScanEncryptedBody.h in Headers */,
 				32D2CC0423422462002BD8CA /* MX3PidAddManager.h in Headers */,
+				324DD2C5246E638B00377005 /* MXAesHmacSha2.h in Headers */,
 				3271877D1DA7CB2F0071C818 /* MXDecrypting.h in Headers */,
 				32114A851A262CE000FF2EC4 /* MXStore.h in Headers */,
 				32BA86AF2152A79E008F277E /* MXRoomNameDefaultStringLocalizations.h in Headers */,
@@ -3247,6 +3264,7 @@
 				325D1C261DFECE0D0070B8BF /* MXCrypto_Private.h in Headers */,
 				B10AFB4322A970060092E6AF /* MXEventReplace.h in Headers */,
 				327A5F4D239805F600ED6329 /* MXKeyVerificationStart.h in Headers */,
+				324DD2BF246D658500377005 /* MXHkdfSha256.h in Headers */,
 				32E402B921C957D2004E87A6 /* MXOlmSession.h in Headers */,
 				32792BD42295A86600F4FC9D /* MXAggregatedReactionsUpdater.h in Headers */,
 				B146D4D621A5A44E00D8C2C6 /* MXScanRealmInMemoryProvider.h in Headers */,
@@ -3457,6 +3475,7 @@
 				B14EF2CF2397E90400758AF0 /* (null) in Headers */,
 				B14EF2D02397E90400758AF0 /* MXWellknownIntegrations.h in Headers */,
 				324AAC832399143400380A66 /* MXKeyVerificationRequestByDMJSONModel.h in Headers */,
+				324DD2C0246D658500377005 /* MXHkdfSha256.h in Headers */,
 				B14EF2D12397E90400758AF0 /* MXEventsEnumeratorOnArray.h in Headers */,
 				B1DDC9D72418098200D208E3 /* MXIncomingSASTransaction_Private.h in Headers */,
 				B14EF2D22397E90400758AF0 /* MXReplyEventParts.h in Headers */,
@@ -3601,6 +3620,7 @@
 				B14EF3422397E90400758AF0 /* MXPeekingRoomSummary.h in Headers */,
 				B14EF3432397E90400758AF0 /* MXEventTimeline.h in Headers */,
 				B14EF3442397E90400758AF0 /* NSArray+MatrixSDK.h in Headers */,
+				324DD2C6246E638B00377005 /* MXAesHmacSha2.h in Headers */,
 				B14EF3452397E90400758AF0 /* MXReplyEventParser.h in Headers */,
 				B14EF3462397E90400758AF0 /* MXIncomingSASTransaction.h in Headers */,
 				B14EF3472397E90400758AF0 /* MXCryptoAlgorithms.h in Headers */,
@@ -4056,7 +4076,9 @@
 				324DD2A8246AE81300377005 /* MXSecretStorageKeyContent.m in Sources */,
 				02CAD43A217DD12F0074700B /* MXContentScanEncryptedBody.m in Sources */,
 				F03EF5091DF071D5009DF592 /* MXEncryptedAttachments.m in Sources */,
+				324DD2C1246D658500377005 /* MXHkdfSha256.m in Sources */,
 				3274538623FD69D600438328 /* MXKeyVerificationRequestByToDeviceJSONModel.m in Sources */,
+				324DD2C7246E638B00377005 /* MXAesHmacSha2.m in Sources */,
 				B172857D2100D4F60052C51E /* MXSendReplyEventDefaultStringLocalizations.m in Sources */,
 				321CFDEF225264C4004D31DF /* NSArray+MatrixSDK.m in Sources */,
 				327A5F52239805F600ED6329 /* MXKeyVerificationStart.m in Sources */,
@@ -4216,6 +4238,7 @@
 				B14EF1CB2397E90400758AF0 /* MXRoomAccountData.m in Sources */,
 				B14EF1CC2397E90400758AF0 /* MXEventAnnotationChunk.m in Sources */,
 				B14EF1CD2397E90400758AF0 /* MXRealmEventScanStore.m in Sources */,
+				324DD2C2246D658500377005 /* MXHkdfSha256.m in Sources */,
 				B14EF1CE2397E90400758AF0 /* MXScanRealmFileProvider.m in Sources */,
 				B14EF1CF2397E90400758AF0 /* MXScanManager.m in Sources */,
 				3291DC8623DF52E20009732F /* MXRoomCreationParameters.m in Sources */,
@@ -4444,6 +4467,7 @@
 				32A9F8E1244720B10069C65B /* MXThrottler.m in Sources */,
 				3274538D23FD918800438328 /* MXKeyVerificationByToDeviceRequest.m in Sources */,
 				32CEEF5223B0AB030039BA98 /* MXCrossSigning.m in Sources */,
+				324DD2C8246E638B00377005 /* MXAesHmacSha2.m in Sources */,
 				B14EF2862397E90400758AF0 /* MXRealmMediaScanStore.m in Sources */,
 				B14EF2872397E90400758AF0 /* MXPusherData.m in Sources */,
 				324DD2A3246AE1EF00377005 /* MXEncryptedSecretContent.m in Sources */,

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -153,24 +153,28 @@
 		324BE4691E3FADB1008D99D4 /* MXMegolmExportEncryption.m in Sources */ = {isa = PBXBuildFile; fileRef = 324BE4671E3FADB1008D99D4 /* MXMegolmExportEncryption.m */; };
 		324BE46C1E422766008D99D4 /* MXMegolmSessionData.h in Headers */ = {isa = PBXBuildFile; fileRef = 324BE46A1E422766008D99D4 /* MXMegolmSessionData.h */; };
 		324BE46D1E422766008D99D4 /* MXMegolmSessionData.m in Sources */ = {isa = PBXBuildFile; fileRef = 324BE46B1E422766008D99D4 /* MXMegolmSessionData.m */; };
-		324DD299246AD2B500377005 /* MXSecretStorageManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 324DD297246AD2B500377005 /* MXSecretStorageManager.h */; };
-		324DD29A246AD2B500377005 /* MXSecretStorageManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 324DD297246AD2B500377005 /* MXSecretStorageManager.h */; };
-		324DD29B246AD2B500377005 /* MXSecretStorageManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 324DD298246AD2B500377005 /* MXSecretStorageManager.m */; };
-		324DD29C246AD2B500377005 /* MXSecretStorageManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 324DD298246AD2B500377005 /* MXSecretStorageManager.m */; };
+		324DD299246AD2B500377005 /* MXSecretStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 324DD297246AD2B500377005 /* MXSecretStorage.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		324DD29A246AD2B500377005 /* MXSecretStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 324DD297246AD2B500377005 /* MXSecretStorage.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		324DD29B246AD2B500377005 /* MXSecretStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = 324DD298246AD2B500377005 /* MXSecretStorage.m */; };
+		324DD29C246AD2B500377005 /* MXSecretStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = 324DD298246AD2B500377005 /* MXSecretStorage.m */; };
 		324DD2A0246AE1EF00377005 /* MXEncryptedSecretContent.h in Headers */ = {isa = PBXBuildFile; fileRef = 324DD29E246AE1EF00377005 /* MXEncryptedSecretContent.h */; };
 		324DD2A1246AE1EF00377005 /* MXEncryptedSecretContent.h in Headers */ = {isa = PBXBuildFile; fileRef = 324DD29E246AE1EF00377005 /* MXEncryptedSecretContent.h */; };
 		324DD2A2246AE1EF00377005 /* MXEncryptedSecretContent.m in Sources */ = {isa = PBXBuildFile; fileRef = 324DD29F246AE1EF00377005 /* MXEncryptedSecretContent.m */; };
 		324DD2A3246AE1EF00377005 /* MXEncryptedSecretContent.m in Sources */ = {isa = PBXBuildFile; fileRef = 324DD29F246AE1EF00377005 /* MXEncryptedSecretContent.m */; };
-		324DD2A6246AE81300377005 /* MXSecretStorageKeyContent.h in Headers */ = {isa = PBXBuildFile; fileRef = 324DD2A4246AE81300377005 /* MXSecretStorageKeyContent.h */; };
-		324DD2A7246AE81300377005 /* MXSecretStorageKeyContent.h in Headers */ = {isa = PBXBuildFile; fileRef = 324DD2A4246AE81300377005 /* MXSecretStorageKeyContent.h */; };
+		324DD2A6246AE81300377005 /* MXSecretStorageKeyContent.h in Headers */ = {isa = PBXBuildFile; fileRef = 324DD2A4246AE81300377005 /* MXSecretStorageKeyContent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		324DD2A7246AE81300377005 /* MXSecretStorageKeyContent.h in Headers */ = {isa = PBXBuildFile; fileRef = 324DD2A4246AE81300377005 /* MXSecretStorageKeyContent.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		324DD2A8246AE81300377005 /* MXSecretStorageKeyContent.m in Sources */ = {isa = PBXBuildFile; fileRef = 324DD2A5246AE81300377005 /* MXSecretStorageKeyContent.m */; };
 		324DD2A9246AE81300377005 /* MXSecretStorageKeyContent.m in Sources */ = {isa = PBXBuildFile; fileRef = 324DD2A5246AE81300377005 /* MXSecretStorageKeyContent.m */; };
-		324DD2AC246AEB7B00377005 /* MXSecretStoragePassphrase.h in Headers */ = {isa = PBXBuildFile; fileRef = 324DD2AA246AEB7B00377005 /* MXSecretStoragePassphrase.h */; };
-		324DD2AD246AEB7B00377005 /* MXSecretStoragePassphrase.h in Headers */ = {isa = PBXBuildFile; fileRef = 324DD2AA246AEB7B00377005 /* MXSecretStoragePassphrase.h */; };
+		324DD2AC246AEB7B00377005 /* MXSecretStoragePassphrase.h in Headers */ = {isa = PBXBuildFile; fileRef = 324DD2AA246AEB7B00377005 /* MXSecretStoragePassphrase.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		324DD2AD246AEB7B00377005 /* MXSecretStoragePassphrase.h in Headers */ = {isa = PBXBuildFile; fileRef = 324DD2AA246AEB7B00377005 /* MXSecretStoragePassphrase.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		324DD2AE246AEB7B00377005 /* MXSecretStoragePassphrase.m in Sources */ = {isa = PBXBuildFile; fileRef = 324DD2AB246AEB7B00377005 /* MXSecretStoragePassphrase.m */; };
 		324DD2AF246AEB7B00377005 /* MXSecretStoragePassphrase.m in Sources */ = {isa = PBXBuildFile; fileRef = 324DD2AB246AEB7B00377005 /* MXSecretStoragePassphrase.m */; };
-		324DD2B1246BDC6800377005 /* MXSecretStorageManager_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 324DD2B0246BDC6800377005 /* MXSecretStorageManager_Private.h */; };
-		324DD2B2246BDC6800377005 /* MXSecretStorageManager_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 324DD2B0246BDC6800377005 /* MXSecretStorageManager_Private.h */; };
+		324DD2B1246BDC6800377005 /* MXSecretStorage_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 324DD2B0246BDC6800377005 /* MXSecretStorage_Private.h */; };
+		324DD2B2246BDC6800377005 /* MXSecretStorage_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 324DD2B0246BDC6800377005 /* MXSecretStorage_Private.h */; };
+		324DD2B6246C21C700377005 /* MXSecretStorageKeyCreationInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 324DD2B4246C21C700377005 /* MXSecretStorageKeyCreationInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		324DD2B7246C21C700377005 /* MXSecretStorageKeyCreationInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 324DD2B4246C21C700377005 /* MXSecretStorageKeyCreationInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		324DD2B8246C21C700377005 /* MXSecretStorageKeyCreationInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 324DD2B5246C21C700377005 /* MXSecretStorageKeyCreationInfo.m */; };
+		324DD2B9246C21C700377005 /* MXSecretStorageKeyCreationInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 324DD2B5246C21C700377005 /* MXSecretStorageKeyCreationInfo.m */; };
 		3250E7CA220C913900736CB5 /* MXCryptoTools.h in Headers */ = {isa = PBXBuildFile; fileRef = 3250E7C8220C913900736CB5 /* MXCryptoTools.h */; };
 		3250E7CB220C913900736CB5 /* MXCryptoTools.m in Sources */ = {isa = PBXBuildFile; fileRef = 3250E7C9220C913900736CB5 /* MXCryptoTools.m */; };
 		3252DCAE224BE5D40032264F /* MXKeyVerificationManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 3252DCAC224BE5D40032264F /* MXKeyVerificationManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1294,15 +1298,17 @@
 		324BE4671E3FADB1008D99D4 /* MXMegolmExportEncryption.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXMegolmExportEncryption.m; sourceTree = "<group>"; };
 		324BE46A1E422766008D99D4 /* MXMegolmSessionData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXMegolmSessionData.h; sourceTree = "<group>"; };
 		324BE46B1E422766008D99D4 /* MXMegolmSessionData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXMegolmSessionData.m; sourceTree = "<group>"; };
-		324DD297246AD2B500377005 /* MXSecretStorageManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXSecretStorageManager.h; sourceTree = "<group>"; };
-		324DD298246AD2B500377005 /* MXSecretStorageManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXSecretStorageManager.m; sourceTree = "<group>"; };
+		324DD297246AD2B500377005 /* MXSecretStorage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXSecretStorage.h; sourceTree = "<group>"; };
+		324DD298246AD2B500377005 /* MXSecretStorage.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXSecretStorage.m; sourceTree = "<group>"; };
 		324DD29E246AE1EF00377005 /* MXEncryptedSecretContent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXEncryptedSecretContent.h; sourceTree = "<group>"; };
 		324DD29F246AE1EF00377005 /* MXEncryptedSecretContent.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXEncryptedSecretContent.m; sourceTree = "<group>"; };
 		324DD2A4246AE81300377005 /* MXSecretStorageKeyContent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXSecretStorageKeyContent.h; sourceTree = "<group>"; };
 		324DD2A5246AE81300377005 /* MXSecretStorageKeyContent.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXSecretStorageKeyContent.m; sourceTree = "<group>"; };
 		324DD2AA246AEB7B00377005 /* MXSecretStoragePassphrase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXSecretStoragePassphrase.h; sourceTree = "<group>"; };
 		324DD2AB246AEB7B00377005 /* MXSecretStoragePassphrase.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXSecretStoragePassphrase.m; sourceTree = "<group>"; };
-		324DD2B0246BDC6800377005 /* MXSecretStorageManager_Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXSecretStorageManager_Private.h; sourceTree = "<group>"; };
+		324DD2B0246BDC6800377005 /* MXSecretStorage_Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXSecretStorage_Private.h; sourceTree = "<group>"; };
+		324DD2B4246C21C700377005 /* MXSecretStorageKeyCreationInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXSecretStorageKeyCreationInfo.h; sourceTree = "<group>"; };
+		324DD2B5246C21C700377005 /* MXSecretStorageKeyCreationInfo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXSecretStorageKeyCreationInfo.m; sourceTree = "<group>"; };
 		3250E7C8220C913900736CB5 /* MXCryptoTools.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXCryptoTools.h; sourceTree = "<group>"; };
 		3250E7C9220C913900736CB5 /* MXCryptoTools.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXCryptoTools.m; sourceTree = "<group>"; };
 		3252DCAC224BE5D40032264F /* MXKeyVerificationManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXKeyVerificationManager.h; sourceTree = "<group>"; };
@@ -2125,10 +2131,11 @@
 		324DD296246AD25E00377005 /* SecretStorage */ = {
 			isa = PBXGroup;
 			children = (
+				324DD2B3246C21B000377005 /* Data */,
 				324DD29D246AE1CA00377005 /* JSONModels */,
-				324DD297246AD2B500377005 /* MXSecretStorageManager.h */,
-				324DD2B0246BDC6800377005 /* MXSecretStorageManager_Private.h */,
-				324DD298246AD2B500377005 /* MXSecretStorageManager.m */,
+				324DD297246AD2B500377005 /* MXSecretStorage.h */,
+				324DD2B0246BDC6800377005 /* MXSecretStorage_Private.h */,
+				324DD298246AD2B500377005 /* MXSecretStorage.m */,
 			);
 			path = SecretStorage;
 			sourceTree = "<group>";
@@ -2144,6 +2151,15 @@
 				324DD2AB246AEB7B00377005 /* MXSecretStoragePassphrase.m */,
 			);
 			path = JSONModels;
+			sourceTree = "<group>";
+		};
+		324DD2B3246C21B000377005 /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				324DD2B4246C21C700377005 /* MXSecretStorageKeyCreationInfo.h */,
+				324DD2B5246C21C700377005 /* MXSecretStorageKeyCreationInfo.m */,
+			);
+			path = Data;
 			sourceTree = "<group>";
 		};
 		3252DCAB224BE59E0032264F /* Verification */ = {
@@ -3101,7 +3117,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				32A9F8DE244720B10069C65B /* MXThrottler.h in Headers */,
-				324DD299246AD2B500377005 /* MXSecretStorageManager.h in Headers */,
+				324DD299246AD2B500377005 /* MXSecretStorage.h in Headers */,
 				322A51B61D9AB15900C8536D /* MXCrypto.h in Headers */,
 				324AAC71239913AD00380A66 /* MXKeyVerificationRequestByDMJSONModel.h in Headers */,
 				32114A8F1A262ECB00FF2EC4 /* MXNoStore.h in Headers */,
@@ -3322,6 +3338,7 @@
 				B146D47C21A5958400D8C2C6 /* MXAntivirusScanStatusFormatter.h in Headers */,
 				3220093819EFA4C9008DE41D /* MXEventListener.h in Headers */,
 				327C3E4B23A39D91006183D1 /* MXAggregatedReferencesUpdater.h in Headers */,
+				324DD2B6246C21C700377005 /* MXSecretStorageKeyCreationInfo.h in Headers */,
 				B146D47721A5950800D8C2C6 /* MXMediaScan.h in Headers */,
 				32C235721F827F3800E38FC5 /* MXRoomOperation.h in Headers */,
 				71DE22E11BC7C51200284153 /* MXReceiptData.h in Headers */,
@@ -3332,7 +3349,7 @@
 				9274AFE81EE580240009BEB6 /* MXCallKitAdapter.h in Headers */,
 				321CFDE622525A49004D31DF /* MXSASTransaction.h in Headers */,
 				B19A30CE24042F0800FB6F35 /* MXSelfVerifyingMasterKeyTrustedQRCodeData.h in Headers */,
-				324DD2B1246BDC6800377005 /* MXSecretStorageManager_Private.h in Headers */,
+				324DD2B1246BDC6800377005 /* MXSecretStorage_Private.h in Headers */,
 				32DC15D01A8CF7AE006F9AD3 /* MXNotificationCenter.h in Headers */,
 				3275FD9C21A6B60B00B9C13D /* MXLoginPolicy.h in Headers */,
 				3250E7CA220C913900736CB5 /* MXCryptoTools.h in Headers */,
@@ -3513,6 +3530,7 @@
 				B14EF30D2397E90400758AF0 /* MXEventRelations.h in Headers */,
 				B14EF30E2397E90400758AF0 /* MXPushRuleRoomMemberCountConditionChecker.h in Headers */,
 				32261B8B23C74A230018F1E2 /* MXDeviceTrustLevel.h in Headers */,
+				324DD2B7246C21C700377005 /* MXSecretStorageKeyCreationInfo.h in Headers */,
 				B14EF30F2397E90400758AF0 /* SwiftMatrixSDK.h in Headers */,
 				B14EF3102397E90400758AF0 /* MXEmojiRepresentation.h in Headers */,
 				B14EF3112397E90400758AF0 /* MXMegolmExportEncryption.h in Headers */,
@@ -3535,7 +3553,7 @@
 				B14EF31F2397E90400758AF0 /* MXPusherData.h in Headers */,
 				B14EF3202397E90400758AF0 /* MXKeyBackupPassword.h in Headers */,
 				B14EF3212397E90400758AF0 /* MXRestClient.h in Headers */,
-				324DD2B2246BDC6800377005 /* MXSecretStorageManager_Private.h in Headers */,
+				324DD2B2246BDC6800377005 /* MXSecretStorage_Private.h in Headers */,
 				32B0E33A23A2989A0054FF1A /* MXEventReferenceChunk.h in Headers */,
 				B14EF3222397E90400758AF0 /* MXKeyVerificationManager.h in Headers */,
 				B14EF3232397E90400758AF0 /* MXRoomState.h in Headers */,
@@ -3615,7 +3633,7 @@
 				B19A30C92404268600FB6F35 /* MXQRCodeDataBuilder.h in Headers */,
 				B14EF3612397E90400758AF0 /* MXMegolmBackupAuthData.h in Headers */,
 				B14EF3622397E90400758AF0 /* MXReactionCountChange.h in Headers */,
-				324DD29A246AD2B500377005 /* MXSecretStorageManager.h in Headers */,
+				324DD29A246AD2B500377005 /* MXSecretStorage.h in Headers */,
 				B14EF3632397E90400758AF0 /* MXScanRealmFileProvider.h in Headers */,
 				B14EF3642397E90400758AF0 /* MXRoom.h in Headers */,
 				B14EF3652397E90400758AF0 /* MXServiceTerms.h in Headers */,
@@ -3927,6 +3945,7 @@
 				B1136967230C1E8600E2B2FA /* MXIdentityService.swift in Sources */,
 				32A9770521626E5C00919CC0 /* MXServerNotices.m in Sources */,
 				32D7767E1A27860600FC4AA2 /* MXMemoryStore.m in Sources */,
+				324DD2B8246C21C700377005 /* MXSecretStorageKeyCreationInfo.m in Sources */,
 				327E9AE82285A8C400A98BC1 /* MXAggregationPaginatedResponse.m in Sources */,
 				B10AFB4422A970060092E6AF /* MXEventReplace.m in Sources */,
 				3275FD9421A6B46600B9C13D /* MXLoginTerms.m in Sources */,
@@ -4016,7 +4035,7 @@
 				32CAB10C1A925B41008C5BB9 /* MXHTTPOperation.m in Sources */,
 				32BBAE6C2178E99100D85F46 /* MXKeyBackupData.m in Sources */,
 				32AF928C240EA3880008A0FD /* MXSecretShareSend.m in Sources */,
-				324DD29B246AD2B500377005 /* MXSecretStorageManager.m in Sources */,
+				324DD29B246AD2B500377005 /* MXSecretStorage.m in Sources */,
 				3281E8BA19E42DFE00976E1A /* MXJSONModels.m in Sources */,
 				3245A7531AF7B2930001D8A7 /* MXCallManager.m in Sources */,
 				32E226A71D06AC9F00E6CA54 /* MXPeekingRoom.m in Sources */,
@@ -4342,6 +4361,7 @@
 				B14EF2492397E90400758AF0 /* MXSendReplyEventDefaultStringLocalizations.m in Sources */,
 				B14EF24A2397E90400758AF0 /* NSArray+MatrixSDK.m in Sources */,
 				B19A30A92404257700FB6F35 /* MXSASKeyVerificationStart.m in Sources */,
+				324DD2B9246C21C700377005 /* MXSecretStorageKeyCreationInfo.m in Sources */,
 				B14EF24B2397E90400758AF0 /* MXServiceTermsRestClient.m in Sources */,
 				B14EF24C2397E90400758AF0 /* MXCredentials.m in Sources */,
 				B14EF24D2397E90400758AF0 /* MXOutgoingRoomKeyRequest.m in Sources */,
@@ -4388,7 +4408,7 @@
 				B14EF26C2397E90400758AF0 /* MXRoom.m in Sources */,
 				B14EF26D2397E90400758AF0 /* NSData+MatrixSDK.m in Sources */,
 				B14EF26E2397E90400758AF0 /* MXFileRoomStore.m in Sources */,
-				324DD29C246AD2B500377005 /* MXSecretStorageManager.m in Sources */,
+				324DD29C246AD2B500377005 /* MXSecretStorage.m in Sources */,
 				B14EF26F2397E90400758AF0 /* MXUser.m in Sources */,
 				324AAC772399140D00380A66 /* MXKeyVerificationDone.m in Sources */,
 				B14EF2702397E90400758AF0 /* MXIdentityServerRestClient.swift in Sources */,

--- a/MatrixSDK/Crypto/MXCrypto.h
+++ b/MatrixSDK/Crypto/MXCrypto.h
@@ -28,6 +28,7 @@
 #import "MXIncomingRoomKeyRequest.h"
 #import "MXIncomingRoomKeyRequestCancellation.h"
 
+#import "MXSecretStorage.h"
 #import "MXSecretShareManager.h"
 
 #import "MXKeyBackup.h"
@@ -97,6 +98,11 @@ extern NSString *const MXDeviceListDidUpdateUsersDevicesNotification;
  The device verification manager.
  */
 @property (nonatomic, readonly) MXKeyVerificationManager *keyVerificationManager;
+
+/**
+ The secret storage on homeserver manager.
+ */
+@property (nonatomic, readonly) MXSecretStorage *secretStorage;
 
 /**
  The secret share manager.

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -37,6 +37,7 @@
 #import "MXOutgoingRoomKeyRequestManager.h"
 #import "MXIncomingRoomKeyRequestManager.h"
 
+#import "MXSecretStorage_Private.h"
 #import "MXSecretShareManager_Private.h"
 
 #import "MXKeyVerificationManager_Private.h"
@@ -1786,6 +1787,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 
         _keyVerificationManager = [[MXKeyVerificationManager alloc] initWithCrypto:self];
         
+        _secretStorage = [[MXSecretStorage alloc] initWithMatrixSession:_mxSession processingQueue:_cryptoQueue];
         _secretShareManager = [[MXSecretShareManager alloc] initWithCrypto:self];
 
         _crossSigning = [[MXCrossSigning alloc] initWithCrypto:self];

--- a/MatrixSDK/Crypto/SecretStorage/Data/MXSecretStorageKeyCreationInfo.h
+++ b/MatrixSDK/Crypto/SecretStorage/Data/MXSecretStorageKeyCreationInfo.h
@@ -1,0 +1,37 @@
+/*
+ Copyright 2020 The Matrix.org Foundation C.I.C
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "MXSecretStorageKeyContent.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ Data returned by `[MXSecretStorageManager createKeyWithKeyId:]`.
+ */
+@interface MXSecretStorageKeyCreationInfo : NSObject
+
+@property (nonatomic) NSString *keyId;
+
+@property (nonatomic) MXSecretStorageKeyContent *content;
+
+@property (nonatomic) NSData *privateKey;
+@property (nonatomic) NSString *recoveryKey;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixSDK/Crypto/SecretStorage/Data/MXSecretStorageKeyCreationInfo.m
+++ b/MatrixSDK/Crypto/SecretStorage/Data/MXSecretStorageKeyCreationInfo.m
@@ -1,0 +1,21 @@
+/*
+ Copyright 2020 The Matrix.org Foundation C.I.C
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXSecretStorageKeyCreationInfo.h"
+
+@implementation MXSecretStorageKeyCreationInfo
+
+@end

--- a/MatrixSDK/Crypto/SecretStorage/JSONModels/MXEncryptedSecretContent.h
+++ b/MatrixSDK/Crypto/SecretStorage/JSONModels/MXEncryptedSecretContent.h
@@ -1,0 +1,37 @@
+/*
+ Copyright 2020 The Matrix.org Foundation C.I.C
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "MXJSONModel.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ `MXEncryptedSecretContent` describes the content of an encrypted secret in the user's account data.
+ */
+@interface MXEncryptedSecretContent : MXJSONModel
+
+// Unpadded base64-encoded ciphertext
+@property (nonatomic, nullable) NSString *ciphertext;
+
+@property (nonatomic, nullable) NSString *mac;
+@property (nonatomic, nullable) NSString *ephemeral;
+@property (nonatomic, nullable) NSString *iv;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixSDK/Crypto/SecretStorage/JSONModels/MXEncryptedSecretContent.h
+++ b/MatrixSDK/Crypto/SecretStorage/JSONModels/MXEncryptedSecretContent.h
@@ -25,9 +25,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MXEncryptedSecretContent : MXJSONModel
 
-// Unpadded base64-encoded ciphertext
+// Unpadded base64-encoded
 @property (nonatomic, nullable) NSString *ciphertext;
-
 @property (nonatomic, nullable) NSString *mac;
 @property (nonatomic, nullable) NSString *iv;
 

--- a/MatrixSDK/Crypto/SecretStorage/JSONModels/MXEncryptedSecretContent.h
+++ b/MatrixSDK/Crypto/SecretStorage/JSONModels/MXEncryptedSecretContent.h
@@ -29,7 +29,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, nullable) NSString *ciphertext;
 
 @property (nonatomic, nullable) NSString *mac;
-@property (nonatomic, nullable) NSString *ephemeral;
 @property (nonatomic, nullable) NSString *iv;
 
 @end

--- a/MatrixSDK/Crypto/SecretStorage/JSONModels/MXEncryptedSecretContent.m
+++ b/MatrixSDK/Crypto/SecretStorage/JSONModels/MXEncryptedSecretContent.m
@@ -22,17 +22,15 @@
 
 + (instancetype)modelFromJSON:(NSDictionary *)JSONDictionary
 {
-    NSString *ciphertext, *mac, *ephemeral, *iv;
+    NSString *ciphertext, *mac, *iv;
     
     MXJSONModelSetString(ciphertext, JSONDictionary[@"ciphertext"]);
     MXJSONModelSetString(mac, JSONDictionary[@"mac"]);
-    MXJSONModelSetString(ephemeral, JSONDictionary[@"ephemeral"]);
     MXJSONModelSetString(iv, JSONDictionary[@"iv"]);
     
     MXEncryptedSecretContent *model = [MXEncryptedSecretContent new];
     model.ciphertext = ciphertext;
     model.mac = mac;
-    model.ephemeral = ephemeral;
     model.iv = iv;
     
     return model;
@@ -49,10 +47,6 @@
     if (_mac)
     {
         JSONDictionary[@"mac"] = _mac;
-    }
-    if (_ephemeral)
-    {
-        JSONDictionary[@"ephemeral"] = _ephemeral;
     }
     if (_iv)
     {

--- a/MatrixSDK/Crypto/SecretStorage/JSONModels/MXEncryptedSecretContent.m
+++ b/MatrixSDK/Crypto/SecretStorage/JSONModels/MXEncryptedSecretContent.m
@@ -1,0 +1,65 @@
+/*
+ Copyright 2020 The Matrix.org Foundation C.I.C
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXEncryptedSecretContent.h"
+
+@implementation MXEncryptedSecretContent
+
+#pragma mark - MXJSONModel
+
++ (instancetype)modelFromJSON:(NSDictionary *)JSONDictionary
+{
+    NSString *ciphertext, *mac, *ephemeral, *iv;
+    
+    MXJSONModelSetString(ciphertext, JSONDictionary[@"ciphertext"]);
+    MXJSONModelSetString(mac, JSONDictionary[@"mac"]);
+    MXJSONModelSetString(ephemeral, JSONDictionary[@"ephemeral"]);
+    MXJSONModelSetString(iv, JSONDictionary[@"iv"]);
+    
+    MXEncryptedSecretContent *model = [MXEncryptedSecretContent new];
+    model.ciphertext = ciphertext;
+    model.mac = mac;
+    model.ephemeral = ephemeral;
+    model.iv = iv;
+    
+    return model;
+}
+
+- (NSDictionary *)JSONDictionary
+{
+    NSMutableDictionary *JSONDictionary = [NSMutableDictionary dictionary];
+    
+    if (_ciphertext)
+    {
+        JSONDictionary[@"ciphertext"] = _ciphertext;
+    }
+    if (_mac)
+    {
+        JSONDictionary[@"mac"] = _mac;
+    }
+    if (_ephemeral)
+    {
+        JSONDictionary[@"ephemeral"] = _ephemeral;
+    }
+    if (_iv)
+    {
+        JSONDictionary[@"iv"] = _iv;
+    }
+
+    return JSONDictionary;
+}
+
+@end

--- a/MatrixSDK/Crypto/SecretStorage/JSONModels/MXSecretStorageKeyContent.h
+++ b/MatrixSDK/Crypto/SecretStorage/JSONModels/MXSecretStorageKeyContent.h
@@ -43,7 +43,7 @@ extern const struct MXSecretStorageKeyAlgorithm {
 @interface MXSecretStorageKeyContent : MXJSONModel
 
 /**
- Key name.
+ A human-readable name.
  */
 @property (nonatomic, nullable) NSString *name;
 
@@ -51,12 +51,6 @@ extern const struct MXSecretStorageKeyAlgorithm {
  The algorithm ("m.secret_storage.v1.aes-hmac-sha2")
  */
 @property (nonatomic) NSString *algorithm;
-
-/**
- Signatures by userId by public key.
- MXUsersDevicesMap is abused here. Public keys replace device ids.
- */
-@property (nonatomic) MXUsersDevicesMap<NSString*> *signatures;
 
 /**
  Passphrase configuration if a passphrase was used.

--- a/MatrixSDK/Crypto/SecretStorage/JSONModels/MXSecretStorageKeyContent.h
+++ b/MatrixSDK/Crypto/SecretStorage/JSONModels/MXSecretStorageKeyContent.h
@@ -57,10 +57,10 @@ extern const struct MXSecretStorageKeyAlgorithm {
 @property (nonatomic, nullable) MXSecretStoragePassphrase *passphrase;
 
 /**
- aes-hmac-sha2 materials
+ aes-hmac-sha2 materials.
  */
-@property (nonatomic) NSString *iv;
-@property (nonatomic) NSString *mac;
+@property (nonatomic, nullable) NSString *iv;
+@property (nonatomic, nullable) NSString *mac;
 
 @end
 

--- a/MatrixSDK/Crypto/SecretStorage/JSONModels/MXSecretStorageKeyContent.h
+++ b/MatrixSDK/Crypto/SecretStorage/JSONModels/MXSecretStorageKeyContent.h
@@ -1,0 +1,74 @@
+/*
+ Copyright 2020 The Matrix.org Foundation C.I.C
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "MXJSONModel.h"
+#import "MXUsersDevicesMap.h"
+#import "MXSecretStoragePassphrase.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+
+#pragma mark - Constants
+
+//! Secret storage key algorithms
+extern const struct MXSecretStorageKeyAlgorithm {
+    __unsafe_unretained NSString *aesHmacSha2;
+    __unsafe_unretained NSString *curve25519AesSha2;
+} MXSecretStorageKeyAlgorithm;
+
+
+
+/**
+ `MXSecretStorageKeyContent` describes the content of a secret storage key "m.secret_storage.key.[keyId]" in
+ the user's account data.
+ 
+ This model corresponds to the "m.secret_storage.v1.aes-hmac-sha2" algorithm described at
+ https://github.com/uhoreg/matrix-doc/blob/symmetric_ssss/proposals/2472-symmetric-ssss.md
+ */
+@interface MXSecretStorageKeyContent : MXJSONModel
+
+/**
+ Key name.
+ */
+@property (nonatomic, nullable) NSString *name;
+
+/**
+ The algorithm ("m.secret_storage.v1.aes-hmac-sha2")
+ */
+@property (nonatomic) NSString *algorithm;
+
+/**
+ Signatures by userId by public key.
+ MXUsersDevicesMap is abused here. Public keys replace device ids.
+ */
+@property (nonatomic) MXUsersDevicesMap<NSString*> *signatures;
+
+/**
+ Passphrase configuration if a passphrase was used.
+ */
+@property (nonatomic, nullable) MXSecretStoragePassphrase *passphrase;
+
+/**
+ aes-hmac-sha2 materials
+ */
+@property (nonatomic) NSString *iv;
+@property (nonatomic) NSString *mac;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixSDK/Crypto/SecretStorage/JSONModels/MXSecretStorageKeyContent.h
+++ b/MatrixSDK/Crypto/SecretStorage/JSONModels/MXSecretStorageKeyContent.h
@@ -28,7 +28,6 @@ NS_ASSUME_NONNULL_BEGIN
 //! Secret storage key algorithms
 extern const struct MXSecretStorageKeyAlgorithm {
     __unsafe_unretained NSString *aesHmacSha2;
-    __unsafe_unretained NSString *curve25519AesSha2;
 } MXSecretStorageKeyAlgorithm;
 
 

--- a/MatrixSDK/Crypto/SecretStorage/JSONModels/MXSecretStorageKeyContent.m
+++ b/MatrixSDK/Crypto/SecretStorage/JSONModels/MXSecretStorageKeyContent.m
@@ -26,6 +26,8 @@ const struct MXSecretStorageKeyAlgorithm MXSecretStorageKeyAlgorithm = {
 
 @implementation MXSecretStorageKeyContent
 
+#pragma mark - MXJSONModel
+
 + (instancetype)modelFromJSON:(NSDictionary *)JSONDictionary
 {
     NSString *name, *algorithm, *iv, *mac;
@@ -55,6 +57,32 @@ const struct MXSecretStorageKeyAlgorithm MXSecretStorageKeyAlgorithm = {
     }
     
     return model;
+}
+
+- (NSDictionary *)JSONDictionary
+{
+    NSMutableDictionary *JSONDictionary = [@{
+                                             @"algorithm": _algorithm,
+                                             } mutableCopy];
+    
+    if (_name)
+    {
+        JSONDictionary[@"name"] = _name;
+    }
+    if (_passphrase)
+    {
+        JSONDictionary[@"passphrase"] = _passphrase.JSONDictionary;
+    }
+    if (_iv)
+    {
+        JSONDictionary[@"iv"] = _iv;
+    }
+    if (_mac)
+    {
+        JSONDictionary[@"mac"] = _mac;
+    }
+
+    return JSONDictionary;
 }
 
 @end

--- a/MatrixSDK/Crypto/SecretStorage/JSONModels/MXSecretStorageKeyContent.m
+++ b/MatrixSDK/Crypto/SecretStorage/JSONModels/MXSecretStorageKeyContent.m
@@ -30,12 +30,10 @@ const struct MXSecretStorageKeyAlgorithm MXSecretStorageKeyAlgorithm = {
 + (instancetype)modelFromJSON:(NSDictionary *)JSONDictionary
 {
     NSString *name, *algorithm, *iv, *mac;
-    NSDictionary *signaturesDict;
     MXSecretStoragePassphrase *passphrase;
     
     MXJSONModelSetString(name, JSONDictionary[@"name"]);
     MXJSONModelSetString(algorithm, JSONDictionary[@"algorithm"]);
-    MXJSONModelSetDictionary(signaturesDict, JSONDictionary[@"signatures"]);
     MXJSONModelSetMXJSONModel(passphrase, MXSecretStoragePassphrase.class, JSONDictionary[@"passphrase"]);
     MXJSONModelSetString(iv, JSONDictionary[@"iv"]);
     MXJSONModelSetString(mac, JSONDictionary[@"mac"]);
@@ -55,16 +53,6 @@ const struct MXSecretStorageKeyAlgorithm MXSecretStorageKeyAlgorithm = {
         model.passphrase = passphrase;
         model.iv = iv;
         model.mac = mac;
-        
-        MXJSONModelSetDictionary(signaturesDict, JSONDictionary[@"signatures"]);
-        if (signaturesDict)
-        {
-            model.signatures = [[MXUsersDevicesMap<NSString*> alloc] initWithMap:signaturesDict];
-        }
-        else
-        {
-            model.signatures  = [MXUsersDevicesMap<NSString*> new];
-        }
     }
     
     return model;

--- a/MatrixSDK/Crypto/SecretStorage/JSONModels/MXSecretStorageKeyContent.m
+++ b/MatrixSDK/Crypto/SecretStorage/JSONModels/MXSecretStorageKeyContent.m
@@ -45,7 +45,7 @@ const struct MXSecretStorageKeyAlgorithm MXSecretStorageKeyAlgorithm = {
     }
     
     MXSecretStorageKeyContent *model;
-    if (algorithm && iv && mac)
+    if (algorithm)
     {
         model = [MXSecretStorageKeyContent new];
         model.name = name;

--- a/MatrixSDK/Crypto/SecretStorage/JSONModels/MXSecretStorageKeyContent.m
+++ b/MatrixSDK/Crypto/SecretStorage/JSONModels/MXSecretStorageKeyContent.m
@@ -21,7 +21,6 @@
 
 const struct MXSecretStorageKeyAlgorithm MXSecretStorageKeyAlgorithm = {
     .aesHmacSha2 = @"m.secret_storage.v1.aes-hmac-sha2",
-    .curve25519AesSha2 = @"m.secret_storage.v1.curve25519-aes-sha2",
 };
 
 

--- a/MatrixSDK/Crypto/SecretStorage/JSONModels/MXSecretStorageKeyContent.m
+++ b/MatrixSDK/Crypto/SecretStorage/JSONModels/MXSecretStorageKeyContent.m
@@ -1,0 +1,73 @@
+/*
+ Copyright 2020 The Matrix.org Foundation C.I.C
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXSecretStorageKeyContent.h"
+
+
+#pragma mark - Constants
+
+const struct MXSecretStorageKeyAlgorithm MXSecretStorageKeyAlgorithm = {
+    .aesHmacSha2 = @"m.secret_storage.v1.aes-hmac-sha2",
+    .curve25519AesSha2 = @"m.secret_storage.v1.curve25519-aes-sha2",
+};
+
+
+@implementation MXSecretStorageKeyContent
+
++ (instancetype)modelFromJSON:(NSDictionary *)JSONDictionary
+{
+    NSString *name, *algorithm, *iv, *mac;
+    NSDictionary *signaturesDict;
+    MXSecretStoragePassphrase *passphrase;
+    
+    MXJSONModelSetString(name, JSONDictionary[@"name"]);
+    MXJSONModelSetString(algorithm, JSONDictionary[@"algorithm"]);
+    MXJSONModelSetDictionary(signaturesDict, JSONDictionary[@"signatures"]);
+    MXJSONModelSetMXJSONModel(passphrase, MXSecretStoragePassphrase.class, JSONDictionary[@"passphrase"]);
+    MXJSONModelSetString(iv, JSONDictionary[@"iv"]);
+    MXJSONModelSetString(mac, JSONDictionary[@"mac"]);
+    
+    if (![algorithm isEqualToString:MXSecretStorageKeyAlgorithm.aesHmacSha2])
+    {
+        NSLog(@"[MXSecretStorageKeyContent] modelFromJSON: ERROR: Unsupported algorithm: %@", JSONDictionary);
+        return nil;
+    }
+    
+    MXSecretStorageKeyContent *model;
+    if (algorithm && iv && mac)
+    {
+        model = [MXSecretStorageKeyContent new];
+        model.name = name;
+        model.algorithm = algorithm;
+        model.passphrase = passphrase;
+        model.iv = iv;
+        model.mac = mac;
+        
+        MXJSONModelSetDictionary(signaturesDict, JSONDictionary[@"signatures"]);
+        if (signaturesDict)
+        {
+            model.signatures = [[MXUsersDevicesMap<NSString*> alloc] initWithMap:signaturesDict];
+        }
+        else
+        {
+            model.signatures  = [MXUsersDevicesMap<NSString*> new];
+        }
+    }
+    
+    return model;
+}
+
+@end

--- a/MatrixSDK/Crypto/SecretStorage/JSONModels/MXSecretStoragePassphrase.h
+++ b/MatrixSDK/Crypto/SecretStorage/JSONModels/MXSecretStoragePassphrase.h
@@ -1,0 +1,38 @@
+/*
+ Copyright 2020 The Matrix.org Foundation C.I.C
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "MXJSONModel.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ `MXSecretStoragePassphrase` describes information about the passphrase used for SSSS.
+
+ https://github.com/uhoreg/matrix-doc/blob/ssss/proposals/1946-secure_server-side_storage.md#passphrase
+ */
+@interface MXSecretStoragePassphrase : MXJSONModel
+
+// "m.pbkdf2"
+@property (nonatomic) NSString *algorithm;
+@property (nonatomic) NSUInteger iterations;
+@property (nonatomic) NSString *salt;
+@property (nonatomic) NSUInteger bits;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixSDK/Crypto/SecretStorage/JSONModels/MXSecretStoragePassphrase.m
+++ b/MatrixSDK/Crypto/SecretStorage/JSONModels/MXSecretStoragePassphrase.m
@@ -1,0 +1,53 @@
+/*
+ Copyright 2020 The Matrix.org Foundation C.I.C
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXSecretStoragePassphrase.h"
+
+@implementation MXSecretStoragePassphrase
+
+#pragma mark - MXJSONModel
+
++ (instancetype)modelFromJSON:(NSDictionary *)JSONDictionary
+{
+    NSString *algorithm, *salt;
+    NSUInteger iterations = 0, bits = 0;
+    
+    MXJSONModelSetString(algorithm, JSONDictionary[@"algorithm"]);
+    MXJSONModelSetUInteger(iterations, JSONDictionary[@"iterations"]);
+    MXJSONModelSetString(salt, JSONDictionary[@"salt"]);
+    MXJSONModelSetUInteger(bits, JSONDictionary[@"bits"]);
+    
+    // The key size that is generated is given by the bits parameter,
+    // or 256 bits if no bits parameter is given.
+    if (bits == 0)
+    {
+        bits = 256;
+    }
+
+    MXSecretStoragePassphrase *model;
+    if (algorithm && iterations && salt)
+    {
+        model = [MXSecretStoragePassphrase new];
+        model.algorithm = algorithm;
+        model.iterations = iterations;
+        model.salt = salt;
+        model.bits = bits;
+    }
+    
+    return model;
+}
+
+@end

--- a/MatrixSDK/Crypto/SecretStorage/JSONModels/MXSecretStoragePassphrase.m
+++ b/MatrixSDK/Crypto/SecretStorage/JSONModels/MXSecretStoragePassphrase.m
@@ -18,6 +18,18 @@
 
 @implementation MXSecretStoragePassphrase
 
+- (instancetype)init
+{
+    self = [super init];
+    if (self)
+    {
+        // The key size that is generated is given by the bits parameter,
+        // or 256 bits if no bits parameter is given.
+        _bits = 256;
+    }
+    return self;
+}
+
 #pragma mark - MXJSONModel
 
 + (instancetype)modelFromJSON:(NSDictionary *)JSONDictionary
@@ -29,13 +41,6 @@
     MXJSONModelSetUInteger(iterations, JSONDictionary[@"iterations"]);
     MXJSONModelSetString(salt, JSONDictionary[@"salt"]);
     MXJSONModelSetUInteger(bits, JSONDictionary[@"bits"]);
-    
-    // The key size that is generated is given by the bits parameter,
-    // or 256 bits if no bits parameter is given.
-    if (bits == 0)
-    {
-        bits = 256;
-    }
 
     MXSecretStoragePassphrase *model;
     if (algorithm && iterations && salt)
@@ -44,7 +49,10 @@
         model.algorithm = algorithm;
         model.iterations = iterations;
         model.salt = salt;
-        model.bits = bits;
+        if (bits != 0)
+        {
+            model.bits = bits;
+        }
     }
     
     return model;

--- a/MatrixSDK/Crypto/SecretStorage/JSONModels/MXSecretStoragePassphrase.m
+++ b/MatrixSDK/Crypto/SecretStorage/JSONModels/MXSecretStoragePassphrase.m
@@ -50,4 +50,20 @@
     return model;
 }
 
+- (NSDictionary *)JSONDictionary
+{
+    NSMutableDictionary *JSONDictionary = [@{
+                                             @"algorithm": _algorithm,
+                                             @"iterations": @(_iterations),
+                                             @"salt": _salt,
+                                             } mutableCopy];
+    
+    if (_bits)
+    {
+        JSONDictionary[@"bits"] = @(_bits);
+    }
+    
+    return JSONDictionary;
+}
+
 @end

--- a/MatrixSDK/Crypto/SecretStorage/MXSecretStorage.h
+++ b/MatrixSDK/Crypto/SecretStorage/MXSecretStorage.h
@@ -76,6 +76,15 @@ typedef enum : NSUInteger
 - (nullable MXSecretStorageKeyContent *)keyWithKeyId:(NSString*)keyId;
 
 /**
+ Check whether a private key matches what we expect based on the key info.
+ 
+ @param privateKey the private key.
+ @param key the key.
+ @return complete called with a boolean that indicates whether or not the key matches
+ */
+- (void)checkPrivateKey:(NSData*)privateKey withKey:(MXSecretStorageKeyContent*)key complete:(void (^)(BOOL match))complete;
+
+/**
  Mark a key as default in the user's account_data.
 
  The default key will be used to encrypt all secrets that the user would expect to be available on all their clients.

--- a/MatrixSDK/Crypto/SecretStorage/MXSecretStorage.h
+++ b/MatrixSDK/Crypto/SecretStorage/MXSecretStorage.h
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Constants
 
 FOUNDATION_EXPORT NSString *const MXSecretStorageErrorDomain;
-typedef enum : NSUInteger
+typedef NS_ENUM(NSUInteger, MXSecretStorageErrorCode)
 {
     MXSecretStorageUnknownSecretCode,
     MXSecretStorageUnknownKeyCode,
@@ -35,8 +35,7 @@ typedef enum : NSUInteger
     MXSecretStorageBadCiphertextCode,
     MXSecretStorageBadSecretFormatCode,
     MXSecretStorageBadMacCode,
-    
-} MXSecretStorageErrorCode;
+};
 
  
 /**

--- a/MatrixSDK/Crypto/SecretStorage/MXSecretStorage.h
+++ b/MatrixSDK/Crypto/SecretStorage/MXSecretStorage.h
@@ -21,6 +21,24 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+
+#pragma mark - Constants
+
+FOUNDATION_EXPORT NSString *const MXSecretStorageErrorDomain;
+typedef enum : NSUInteger
+{
+    MXSecretStorageUnknownSecretCode,
+    MXSecretStorageUnknownKeyCode,
+    MXSecretStorageSecretNotEncryptedCode,
+    MXSecretStorageSecretNotEncryptedWithKeyCode,
+    MXSecretStorageUnsupportedAlgorithmCode,
+
+    MXSecretStorageBadCiphertextCode,
+    MXSecretStorageBadMacCode,
+    
+} MXSecretStorageErrorCode;
+
+ 
 /**
  Secure Secret Storage Server-side manager.
  
@@ -102,11 +120,11 @@ withSecretStorageKeys:(NSDictionary<NSString*, NSData*> *)keys
  @param secretId the id of the secret.
  @return the secret. Nil if the secret does not exist.
  */
-- (MXHTTPOperation *)secretWithSecretId:(NSString*)secretId
-                 withSecretStorageKeyId:(nullable NSString*)keyId
-                             privateKey:(NSData*)privateKey
-                                success:(void (^)(NSString *secret))success
-                                failure:(void (^)(NSError *error))failure;
+- (void)secretWithSecretId:(NSString*)secretId
+    withSecretStorageKeyId:(nullable NSString*)keyId
+                privateKey:(NSData*)privateKey
+                   success:(void (^)(NSString *secret))success
+                   failure:(void (^)(NSError *error))failure;
 
 
 /**

--- a/MatrixSDK/Crypto/SecretStorage/MXSecretStorage.h
+++ b/MatrixSDK/Crypto/SecretStorage/MXSecretStorage.h
@@ -1,0 +1,122 @@
+/*
+ Copyright 2020 The Matrix.org Foundation C.I.C
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "MXSecretStorageKeyCreationInfo.h"
+#import "MXHTTPOperation.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ Secure Secret Storage Server-side manager.
+ 
+ See https://github.com/uhoreg/matrix-doc/blob/ssss/proposals/1946-secure_server-side_storage.md
+ */
+@interface MXSecretStorage : NSObject
+
+#pragma mark - Secret Storage Key
+
+/**
+  Create a SSSS key for encrypting secrets.
+ 
+  Use the `MXSecretStorageKeyCreationInfo` object returned by the callback to get more information about
+  the created passphrase key (private key, recovery key, ...).
+ 
+  @param keyId the ID of the key.
+  @param keyName a human readable name.
+  @param passphrase a passphrase used to generate the key. Nil will generate a key.
+  @param callback Get key creation info
+ */
+- (MXHTTPOperation*)createKeyWithKeyId:(nullable NSString*)keyId
+                               keyName:(nullable NSString*)keyName
+                            passphrase:(nullable NSString*)passphrase
+                               success:(void (^)(MXSecretStorageKeyCreationInfo *keyCreationInfo))success
+                               failure:(void (^)(NSError *error))failure;
+
+/**
+ Retrieve a key from the user's account_data.
+ 
+ @return the key.
+ */
+- (nullable MXSecretStorageKeyContent *)keyWithKeyId:(NSString*)keyId;
+
+/**
+ Mark a key as default in the user's account_data.
+
+ The default key will be used to encrypt all secrets that the user would expect to be available on all their clients.
+ 
+ @param success A block object called when the operation succeeds.
+ @param failure A block object called when the operation fails
+ */
+- (MXHTTPOperation *)setAsDefaultKeyWithKeyId:(NSString*)keyId
+                                      success:(void (^)(void))success
+                                      failure:(void (^)(NSError *error))failure;
+
+/**
+ The current default key id.
+ */
+- (nullable NSString *)defaultKeyId;
+
+/**
+ The current default key.
+ */
+- (nullable MXSecretStorageKeyContent *)defaultKey;
+
+
+#pragma mark - Secret storage
+
+/**
+ Store an encrypted secret on the server.
+ 
+ @param secret the secret.
+ @param secretId the id of the secret.
+ */
+//- (void)storeSecret:(NSString*)secret withSecretId:(NSString*)secretId;
+
+/**
+ Retrieve a secret from the server.
+ 
+ @param secretId the id of the secret.
+ @return the secret. Nil if the secret does not exist.
+ */
+//- (NSString*)secretWithSecretId:(NSString*)secretId;
+
+
+/**
+ Delete a secret from the server.
+ 
+ @param secretId the id of the secret.
+ */
+//- (void)deleteSecretWithSecretId:(NSString*)secretId;
+
+
+/**
+ * Check if a secret is stored on the server.
+ *
+ * @param {string} name the name of the secret
+ * @param {boolean} checkKey check if the secret is encrypted by a trusted key
+ *
+ * @return {object?} map of key name to key info the secret is encrypted
+ *     with, or null if it is not present or not encrypted with a trusted
+ *     key
+ */
+//async isStored(name, checkKey) {
+
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixSDK/Crypto/SecretStorage/MXSecretStorage.h
+++ b/MatrixSDK/Crypto/SecretStorage/MXSecretStorage.h
@@ -59,7 +59,8 @@ typedef enum : NSUInteger
   @param passphrase a passphrase used to generate the key. Nil will generate a key.
  
   @param success A block object called when the operation succeeds.
-  @param failure A block object called when the operation fails
+  @param failure A block object called when the operation fails.
+  @return a MXHTTPOperation instance.
  */
 - (MXHTTPOperation*)createKeyWithKeyId:(nullable NSString*)keyId
                                keyName:(nullable NSString*)keyName
@@ -79,8 +80,10 @@ typedef enum : NSUInteger
 
  The default key will be used to encrypt all secrets that the user would expect to be available on all their clients.
  
+ @param keyId the id of the key to set as default.
  @param success A block object called when the operation succeeds.
- @param failure A block object called when the operation fails
+ @param failure A block object called when the operation fails.
+ @return a MXHTTPOperation instance.
  */
 - (MXHTTPOperation *)setAsDefaultKeyWithKeyId:(NSString*)keyId
                                       success:(void (^)(void))success
@@ -102,14 +105,18 @@ typedef enum : NSUInteger
 /**
  Store an encrypted secret on the server.
  
- @param secret the secret.
+ @param unpaddedBase64Secret the secret in unpadded Base64 format.
  @param secretId the id of the secret.
+ @param keys the keys to encrypt the secret. A map keyId -> privateKey.
+ @param success A block object called when the operation succeeds.
+ @param failure A block object called when the operation fails.
+ @return a MXHTTPOperation instance.
  */
-- (MXHTTPOperation *)storeSecret:(NSString*)secret
-       withSecretId:(nullable NSString*)secretId
-withSecretStorageKeys:(NSDictionary<NSString*, NSData*> *)keys
-            success:(void (^)(void))success
-            failure:(void (^)(NSError *error))failure;
+- (MXHTTPOperation *)storeSecret:(NSString*)unpaddedBase64Secret
+                    withSecretId:(nullable NSString*)secretId
+           withSecretStorageKeys:(NSDictionary<NSString*, NSData*> *)keys
+                         success:(void (^)(NSString *secretId))success
+                         failure:(void (^)(NSError *error))failure;
 
 
 - (nullable NSDictionary<NSString*, MXSecretStorageKeyContent*> *)secretStorageKeysUsedForSecretWithSecretId:(NSString*)secretId;
@@ -129,27 +136,6 @@ withSecretStorageKeys:(NSDictionary<NSString*, NSData*> *)keys
                 privateKey:(NSData*)privateKey
                    success:(void (^)(NSString *unpaddedBase64Secret))success
                    failure:(void (^)(NSError *error))failure;
-
-
-/**
- Delete a secret from the server.
- 
- @param secretId the id of the secret.
- */
-//- (void)deleteSecretWithSecretId:(NSString*)secretId;
-
-
-/**
- * Check if a secret is stored on the server.
- *
- * @param {string} name the name of the secret
- * @param {boolean} checkKey check if the secret is encrypted by a trusted key
- *
- * @return {object?} map of key name to key info the secret is encrypted
- *     with, or null if it is not present or not encrypted with a trusted
- *     key
- */
-//async isStored(name, checkKey) {
 
 
 @end

--- a/MatrixSDK/Crypto/SecretStorage/MXSecretStorage.h
+++ b/MatrixSDK/Crypto/SecretStorage/MXSecretStorage.h
@@ -32,8 +32,8 @@ typedef enum : NSUInteger
     MXSecretStorageSecretNotEncryptedCode,
     MXSecretStorageSecretNotEncryptedWithKeyCode,
     MXSecretStorageUnsupportedAlgorithmCode,
-
     MXSecretStorageBadCiphertextCode,
+    MXSecretStorageBadSecretFormatCode,
     MXSecretStorageBadMacCode,
     
 } MXSecretStorageErrorCode;
@@ -118,12 +118,16 @@ withSecretStorageKeys:(NSDictionary<NSString*, NSData*> *)keys
  Retrieve a secret from the server.
  
  @param secretId the id of the secret.
- @return the secret. Nil if the secret does not exist.
+ @param keyId the id of the key to use to decrypt it. Use secretStorageKeysUsedForSecretWithSecretId to get it.
+              Nil will use the default key.
+ @param privateKey the private key for this key.
+ @param success A block object called when the operation succeeds.
+ @param failure A block object called when the operation fails.
  */
 - (void)secretWithSecretId:(NSString*)secretId
     withSecretStorageKeyId:(nullable NSString*)keyId
                 privateKey:(NSData*)privateKey
-                   success:(void (^)(NSString *secret))success
+                   success:(void (^)(NSString *unpaddedBase64Secret))success
                    failure:(void (^)(NSError *error))failure;
 
 

--- a/MatrixSDK/Crypto/SecretStorage/MXSecretStorage.h
+++ b/MatrixSDK/Crypto/SecretStorage/MXSecretStorage.h
@@ -39,7 +39,9 @@ NS_ASSUME_NONNULL_BEGIN
   @param keyId the ID of the key.
   @param keyName a human readable name.
   @param passphrase a passphrase used to generate the key. Nil will generate a key.
-  @param callback Get key creation info
+ 
+  @param success A block object called when the operation succeeds.
+  @param failure A block object called when the operation fails
  */
 - (MXHTTPOperation*)createKeyWithKeyId:(nullable NSString*)keyId
                                keyName:(nullable NSString*)keyName
@@ -85,7 +87,14 @@ NS_ASSUME_NONNULL_BEGIN
  @param secret the secret.
  @param secretId the id of the secret.
  */
-//- (void)storeSecret:(NSString*)secret withSecretId:(NSString*)secretId;
+- (MXHTTPOperation *)storeSecret:(NSString*)secret
+       withSecretId:(nullable NSString*)secretId
+withSecretStorageKeys:(NSDictionary<NSString*, NSData*> *)keys
+            success:(void (^)(void))success
+            failure:(void (^)(NSError *error))failure;
+
+
+- (nullable NSDictionary<NSString*, MXSecretStorageKeyContent*> *)secretStorageKeysUsedForSecretWithSecretId:(NSString*)secretId;
 
 /**
  Retrieve a secret from the server.
@@ -93,7 +102,11 @@ NS_ASSUME_NONNULL_BEGIN
  @param secretId the id of the secret.
  @return the secret. Nil if the secret does not exist.
  */
-//- (NSString*)secretWithSecretId:(NSString*)secretId;
+- (MXHTTPOperation *)secretWithSecretId:(NSString*)secretId
+                 withSecretStorageKeyId:(nullable NSString*)keyId
+                             privateKey:(NSData*)privateKey
+                                success:(void (^)(NSString *secret))success
+                                failure:(void (^)(NSError *error))failure;
 
 
 /**

--- a/MatrixSDK/Crypto/SecretStorage/MXSecretStorage.m
+++ b/MatrixSDK/Crypto/SecretStorage/MXSecretStorage.m
@@ -180,15 +180,15 @@ static NSString* const kSecretStorageZeroString = @"\0\0\0\0\0\0\0\0\0\0\0\0\0\0
     dispatch_async(processingQueue, ^{
         MXStrongifyAndReturnIfNil(self);
         
-        NSData *iv = [MXBase64Tools dataFromBase64:key.iv];
+        NSData *iv = key.iv ? [MXBase64Tools dataFromBase64:key.iv] : nil;
         
         // MACs should match
         NSError *error;
         MXEncryptedSecretContent *encryptedZeroString = [self encryptedZeroStringWithPrivateKey:privateKey iv:iv error:&error];
         
         // Compare bytes instead of base64 strings to avoid base64 padding issue
-        NSData *keyMac = [MXBase64Tools dataFromBase64:key.mac];
-        NSData *encryptedZeroStringMac = [MXBase64Tools dataFromBase64:encryptedZeroString.mac];
+        NSData *keyMac = key.mac ? [MXBase64Tools dataFromBase64:key.mac] : nil;
+        NSData *encryptedZeroStringMac = encryptedZeroString.mac ? [MXBase64Tools dataFromBase64:encryptedZeroString.mac] : nil;
         
         BOOL match = !key.mac   // If we have no information, we have to assume the key is right
         || [keyMac isEqualToData:encryptedZeroStringMac];
@@ -533,7 +533,7 @@ static NSString* const kSecretStorageZeroString = @"\0\0\0\0\0\0\0\0\0\0\0\0\0\0
 
     NSData *iv = secretContent.iv ? [MXBase64Tools dataFromBase64:secretContent.iv] : [NSMutableData dataWithLength:16];
     
-    NSData *hmac = [MXBase64Tools dataFromBase64:secretContent.mac];
+    NSData *hmac = secretContent.mac ? [MXBase64Tools dataFromBase64:secretContent.mac] : nil;
     if (!hmac)
     {
         NSLog(@"[MXSecretStorage] decryptSecret: ERROR: Bad base64 format for MAC: %@", secretContent.mac);
@@ -541,7 +541,7 @@ static NSString* const kSecretStorageZeroString = @"\0\0\0\0\0\0\0\0\0\0\0\0\0\0
         return nil;
     }
 
-    NSData *cipher = [MXBase64Tools dataFromBase64:secretContent.ciphertext];
+    NSData *cipher = secretContent.ciphertext ? [MXBase64Tools dataFromBase64:secretContent.ciphertext] : nil;
     if (!cipher)
     {
         NSLog(@"[MXSecretStorage] decryptSecret: ERROR: Bad base64 format for ciphertext: %@", secretContent.ciphertext);

--- a/MatrixSDK/Crypto/SecretStorage/MXSecretStorage.m
+++ b/MatrixSDK/Crypto/SecretStorage/MXSecretStorage.m
@@ -482,7 +482,7 @@ static NSString* const kSecretStorageZeroString = @"\0\0\0\0\0\0\0\0\0\0\0\0\0\0
     NSData *aesKey = [pseudoRandomKey subdataWithRange:NSMakeRange(0, 32)];
     NSData *hmacKey = [pseudoRandomKey subdataWithRange:NSMakeRange(32, pseudoRandomKey.length - 32)];
     
-    NSData *iv = [MXAesHmacSha2 iv];
+    iv = iv ?: [MXAesHmacSha2 iv];
     
     NSData *hmac;
     NSData *cipher = [MXAesHmacSha2 encrypt:secret aesKey:aesKey iv:iv hmacKey:hmacKey hmac:&hmac error:error];
@@ -494,8 +494,8 @@ static NSString* const kSecretStorageZeroString = @"\0\0\0\0\0\0\0\0\0\0\0\0\0\0
     
     MXEncryptedSecretContent *secretContent = [MXEncryptedSecretContent new];
     secretContent.ciphertext = [MXBase64Tools unpaddedBase64FromData:cipher];
-    secretContent.mac = [MXBase64Tools unpaddedBase64FromData:hmac];
-    secretContent.iv = [MXBase64Tools unpaddedBase64FromData:iv];
+    secretContent.mac = [MXBase64Tools base64FromData:hmac];
+    secretContent.iv = [MXBase64Tools base64FromData:iv];
     
     return secretContent;
 }
@@ -527,9 +527,9 @@ static NSString* const kSecretStorageZeroString = @"\0\0\0\0\0\0\0\0\0\0\0\0\0\0
     NSData *hmacKey = [pseudoRandomKey subdataWithRange:NSMakeRange(32, pseudoRandomKey.length - 32)];
 
 
-    NSData *iv = secretContent.iv ? [MXBase64Tools dataFromUnpaddedBase64:secretContent.iv] : [NSMutableData dataWithLength:16];
+    NSData *iv = secretContent.iv ? [MXBase64Tools dataFromBase64:secretContent.iv] : [NSMutableData dataWithLength:16];
     
-    NSData *hmac = [MXBase64Tools dataFromUnpaddedBase64:secretContent.mac];
+    NSData *hmac = [MXBase64Tools dataFromBase64:secretContent.mac];
     if (!hmac)
     {
         NSLog(@"[MXSecretStorage] decryptSecret: ERROR: Bad base64 format for MAC: %@", secretContent.mac);

--- a/MatrixSDK/Crypto/SecretStorage/MXSecretStorage.m
+++ b/MatrixSDK/Crypto/SecretStorage/MXSecretStorage.m
@@ -180,7 +180,7 @@ static NSString* const kSecretStorageZeroString = @"\0\0\0\0\0\0\0\0\0\0\0\0\0\0
     dispatch_async(processingQueue, ^{
         MXStrongifyAndReturnIfNil(self);
         
-        NSData *iv = [MXBase64Tools dataFromUnpaddedBase64:key.iv];
+        NSData *iv = [MXBase64Tools dataFromBase64:key.iv];
         
         // MACs should match
         NSError *error;
@@ -493,7 +493,7 @@ static NSString* const kSecretStorageZeroString = @"\0\0\0\0\0\0\0\0\0\0\0\0\0\0
     }
     
     MXEncryptedSecretContent *secretContent = [MXEncryptedSecretContent new];
-    secretContent.ciphertext = [MXBase64Tools unpaddedBase64FromData:cipher];
+    secretContent.ciphertext = [MXBase64Tools base64FromData:cipher];
     secretContent.mac = [MXBase64Tools base64FromData:hmac];
     secretContent.iv = [MXBase64Tools base64FromData:iv];
     
@@ -537,7 +537,7 @@ static NSString* const kSecretStorageZeroString = @"\0\0\0\0\0\0\0\0\0\0\0\0\0\0
         return nil;
     }
 
-    NSData *cipher = [MXBase64Tools dataFromUnpaddedBase64:secretContent.ciphertext];
+    NSData *cipher = [MXBase64Tools dataFromBase64:secretContent.ciphertext];
     if (!cipher)
     {
         NSLog(@"[MXSecretStorage] decryptSecret: ERROR: Bad base64 format for ciphertext: %@", secretContent.ciphertext);

--- a/MatrixSDK/Crypto/SecretStorage/MXSecretStorage.m
+++ b/MatrixSDK/Crypto/SecretStorage/MXSecretStorage.m
@@ -1,0 +1,231 @@
+/*
+ Copyright 2020 The Matrix.org Foundation C.I.C
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXSecretStorage_Private.h"
+
+#import "MXSession.h"
+#import "MXTools.h"
+#import "MXKeyBackupPassword.h"
+#import "MXRecoveryKey.h"
+#import <OLMKit/OLMKit.h>
+
+#pragma mark - Constants
+
+static NSString* const kSecretStorageKeyIdFormat = @"m.secret_storage.key.%@";
+
+
+
+@interface MXSecretStorage ()
+{
+    // The queue to run background tasks
+    dispatch_queue_t processingQueue;
+}
+
+@property (nonatomic, readonly, weak) MXSession *mxSession;
+
+@end
+
+
+@implementation MXSecretStorage
+
+
+#pragma mark - SDK-Private methods -
+
+- (instancetype)initWithMatrixSession:(MXSession *)mxSession processingQueue:(dispatch_queue_t)aProcessingQueue
+{
+    self = [super init];
+    if (self)
+    {
+        _mxSession = mxSession;
+        processingQueue = aProcessingQueue;
+    }
+    return self;
+}
+
+
+#pragma mark - Public methods -
+
+#pragma mark - Secret Storage Key
+
+- (MXHTTPOperation*)createKeyWithKeyId:(nullable NSString*)keyId
+                               keyName:(nullable NSString*)keyName
+                            passphrase:(nullable NSString*)passphrase
+                               success:(void (^)(MXSecretStorageKeyCreationInfo *keyCreationInfo))success
+                               failure:(void (^)(NSError *error))failure
+{
+    keyId = keyId ?: [[NSUUID UUID] UUIDString];
+    
+    MXHTTPOperation *operation = [MXHTTPOperation new];
+    
+    MXWeakify(self);
+    dispatch_async(processingQueue, ^{
+        MXStrongifyAndReturnIfNil(self);
+        
+        NSError *error;
+        
+        NSData *privateKey;
+        MXSecretStoragePassphrase *passphraseInfo;
+        
+        if (passphrase)
+        {
+            // Generate a private key from the passphrase
+            NSString *salt;
+            NSUInteger iterations;
+            privateKey = [MXKeyBackupPassword generatePrivateKeyWithPassword:passphrase
+                                                                        salt:&salt
+                                                                  iterations:&iterations
+                                                                       error:&error];
+            if (!error)
+            {
+                passphraseInfo = [MXSecretStoragePassphrase new];
+                passphraseInfo.algorithm = @"m.pbkdf2";
+                passphraseInfo.salt = salt;
+                passphraseInfo.iterations = iterations;
+            }
+        }
+        else
+        {
+            OLMPkDecryption *decryption = [OLMPkDecryption new];
+            [decryption generateKey:&error];
+            privateKey = decryption.privateKey;
+        }
+        
+        if (error)
+        {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                failure(error);
+            });
+            return;
+        }
+        
+        MXSecretStorageKeyContent *ssssKeyContent = [MXSecretStorageKeyContent new];
+        ssssKeyContent.name = keyName;
+        ssssKeyContent.algorithm = MXSecretStorageKeyAlgorithm.aesHmacSha2;
+        ssssKeyContent.passphrase = passphraseInfo;
+        // TODO
+        // ssssKeyContent.iv = ...
+        // ssssKeyContent.mac =
+        
+        NSString *accountDataId = [self storageKeyIdForKey:keyId];
+        MXHTTPOperation *operation2 = [self setAccountData:ssssKeyContent.JSONDictionary forType:accountDataId success:^{
+            
+            MXSecretStorageKeyCreationInfo *keyCreationInfo = [MXSecretStorageKeyCreationInfo new];
+            keyCreationInfo.keyId = keyId;
+            keyCreationInfo.content = ssssKeyContent;
+            keyCreationInfo.privateKey = privateKey;
+            keyCreationInfo.recoveryKey = [MXRecoveryKey encode:privateKey];
+            
+            dispatch_async(dispatch_get_main_queue(), ^{
+                success(keyCreationInfo);
+            });
+            
+        } failure:^(NSError *error) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                failure(error);
+            });
+        }];
+        
+        [operation mutateTo:operation2];
+    });
+    
+    return operation;
+}
+
+- (nullable MXSecretStorageKeyContent *)keyWithKeyId:(NSString*)keyId
+{
+    MXSecretStorageKeyContent *key;
+
+    NSString *accountDataId = [self storageKeyIdForKey:keyId];
+    NSDictionary *keyDict = [self.mxSession.accountData accountDataForEventType:accountDataId];
+    if (keyDict)
+    {
+        MXJSONModelSetMXJSONModel(key, MXSecretStorageKeyContent.class, keyDict);
+    }
+    
+    return key;
+}
+
+- (MXHTTPOperation *)setAsDefaultKeyWithKeyId:(NSString*)keyId
+                                      success:(void (^)(void))success
+                                      failure:(void (^)(NSError *error))failure
+{
+    return [self.mxSession setAccountData:@{
+                                            @"key": keyId
+                                            } forType:kMXEventTypeStringSecretStorageDefaultKey
+                                  success:success failure:failure];
+}
+
+- (nullable NSString *)defaultKeyId
+{
+    NSString *defaultKeyId;
+    NSDictionary *defaultKeyDict = [self.mxSession.accountData accountDataForEventType:kMXEventTypeStringSecretStorageDefaultKey];
+    if (defaultKeyDict)
+    {
+        MXJSONModelSetString(defaultKeyId, defaultKeyDict[@"key"]);
+    }
+    
+    return defaultKeyId;
+}
+
+- (nullable MXSecretStorageKeyContent *)defaultKey
+{
+    MXSecretStorageKeyContent *defaultKey;
+    NSString *defaultKeyId = self.defaultKeyId;
+    if (defaultKeyId)
+    {
+        defaultKey = [self keyWithKeyId:defaultKeyId];
+    }
+    
+    return defaultKey;
+}
+
+
+#pragma mark - Private methods -
+
+- (NSString *)storageKeyIdForKey:(NSString*)key
+{
+    return [NSString stringWithFormat:kSecretStorageKeyIdFormat, key];
+}
+
+// Do accountData update on the main thread as expected by MXSession
+- (MXHTTPOperation*)setAccountData:(NSDictionary*)data
+                           forType:(NSString*)type
+                           success:(void (^)(void))success
+                           failure:(void (^)(NSError *error))failure
+{
+    MXHTTPOperation *operation = [MXHTTPOperation new];
+    
+    MXWeakify(self);
+    dispatch_async(dispatch_get_main_queue(), ^{
+        MXStrongifyAndReturnIfNil(self);
+        
+        MXHTTPOperation *operation2 = [self.mxSession setAccountData:data forType:type success:^{
+            dispatch_async(self->processingQueue, ^{
+                success();
+            });
+        } failure:^(NSError *error) {
+            dispatch_async(self->processingQueue, ^{
+                failure(error);
+            });
+        }];
+        
+        [operation mutateTo:operation2];
+    });
+    
+    return operation;
+}
+
+@end

--- a/MatrixSDK/Crypto/SecretStorage/MXSecretStorage.m
+++ b/MatrixSDK/Crypto/SecretStorage/MXSecretStorage.m
@@ -193,6 +193,55 @@ static NSString* const kSecretStorageKeyIdFormat = @"m.secret_storage.key.%@";
 }
 
 
+#pragma mark - Secret storage
+
+- (MXHTTPOperation *)storeSecret:(NSString*)secret
+                    withSecretId:(nullable NSString*)secretId
+           withSecretStorageKeys:(NSDictionary<NSString*, NSData*> *)keys
+                         success:(void (^)(void))success
+                         failure:(void (^)(NSError *error))failure
+{
+    failure(nil);
+    return nil;
+}
+
+
+- (nullable NSDictionary<NSString*, MXSecretStorageKeyContent*> *)secretStorageKeysUsedForSecretWithSecretId:(NSString*)secretId
+{
+    NSDictionary *accountData = [_mxSession.accountData accountDataForEventType:secretId];
+    if (!accountData)
+    {
+        NSLog(@"[MXSecretStorage] secretStorageKeysUsedForSecretWithSecretId: No Secret for secret id %@", secretId);
+        return nil;
+    }
+    
+    NSDictionary *encryptedContent;
+    MXJSONModelSetDictionary(encryptedContent, accountData[@"encrypted"]);
+    
+    NSMutableDictionary *secretStorageKeys = [NSMutableDictionary dictionary];
+    for (NSString *keyId in encryptedContent)
+    {
+        MXSecretStorageKeyContent *key = [self keyWithKeyId:keyId];
+        if (key)
+        {
+            secretStorageKeys[keyId] = key;
+        }
+    }
+    
+    return secretStorageKeys;
+}
+
+- (MXHTTPOperation *)secretWithSecretId:(NSString*)secretId
+                 withSecretStorageKeyId:(nullable NSString*)keyId
+                             privateKey:(NSData*)privateKey
+                                success:(void (^)(NSString *secret))success
+                                failure:(void (^)(NSError *error))failure
+{
+    failure(nil);
+    return nil;
+}
+
+
 #pragma mark - Private methods -
 
 - (NSString *)storageKeyIdForKey:(NSString*)key

--- a/MatrixSDK/Crypto/SecretStorage/MXSecretStorage.m
+++ b/MatrixSDK/Crypto/SecretStorage/MXSecretStorage.m
@@ -186,8 +186,12 @@ static NSString* const kSecretStorageZeroString = @"\0\0\0\0\0\0\0\0\0\0\0\0\0\0
         NSError *error;
         MXEncryptedSecretContent *encryptedZeroString = [self encryptedZeroStringWithPrivateKey:privateKey iv:iv error:&error];
         
+        // Compare bytes instead of base64 strings to avoid base64 padding issue
+        NSData *keyMac = [MXBase64Tools dataFromBase64:key.mac];
+        NSData *encryptedZeroStringMac = [MXBase64Tools dataFromBase64:encryptedZeroString.mac];
+        
         BOOL match = !key.mac   // If we have no information, we have to assume the key is right
-        || [key.mac isEqualToString:encryptedZeroString.mac];
+        || [keyMac isEqualToData:encryptedZeroStringMac];
         
         dispatch_async(dispatch_get_main_queue(), ^{
             complete(match);

--- a/MatrixSDK/Crypto/SecretStorage/MXSecretStorage_Private.h
+++ b/MatrixSDK/Crypto/SecretStorage/MXSecretStorage_Private.h
@@ -1,0 +1,34 @@
+/*
+ Copyright 2020 The Matrix.org Foundation C.I.C
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXSecretStorage.h"
+
+@class MXSession;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MXSecretStorage ()
+
+/**
+ Constructor.
+ 
+ @param mxSession the related 'MXSession' instance.
+ */
+- (instancetype)initWithMatrixSession:(MXSession *)mxSession  processingQueue:(dispatch_queue_t)processingQueue;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixSDK/Crypto/Utils/MXAesHmacSha2.h
+++ b/MatrixSDK/Crypto/Utils/MXAesHmacSha2.h
@@ -25,8 +25,9 @@ typedef enum : NSUInteger
 {
     MXAesHmacSha2BadMacCode,
     MXAesHmacSha2CannotInitialiseCryptorCode,
+    MXAesHmacSha2EncryptionFailedCode,
     MXAesHmacSha2DecryptionFailedCode,
-    
+
 } MXAesHmacSha2ErrorCode;
 
 
@@ -34,6 +35,16 @@ typedef enum : NSUInteger
  `MXAesHmacSha2` exposes AES-HMAC primitives used in Matrix.
  */
 @interface MXAesHmacSha2 : NSObject
+
+/**
+ Create a suitable initilisation vector.
+ */
++ (NSData*)iv;
+
++ (nullable NSData*)encrypt:(NSData*)data
+                     aesKey:(NSData*)aesKey iv:(NSData*)iv
+                    hmacKey:(NSData*)hmacKey hmac:(NSData*_Nullable*_Nonnull)hmac
+                      error:(NSError**)error;
 
 + (nullable NSData*)decrypt:(NSData*)cipher
                      aesKey:(NSData*)aesKey iv:(NSData*)iv

--- a/MatrixSDK/Crypto/Utils/MXAesHmacSha2.h
+++ b/MatrixSDK/Crypto/Utils/MXAesHmacSha2.h
@@ -1,0 +1,45 @@
+/*
+ Copyright 2020 The Matrix.org Foundation C.I.C
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+#pragma mark - Constants
+
+FOUNDATION_EXPORT NSString *const MXAesHmacSha2ErrorDomain;
+typedef enum : NSUInteger
+{
+    MXAesHmacSha2BadMacCode,
+    MXAesHmacSha2CannotInitialiseCryptorCode,
+    MXAesHmacSha2DecryptionFailedCode,
+    
+} MXAesHmacSha2ErrorCode;
+
+
+/**
+ `MXAesHmacSha2` exposes AES-HMAC primitives used in Matrix.
+ */
+@interface MXAesHmacSha2 : NSObject
+
++ (nullable NSData*)decrypt:(NSData*)cipher
+                     aesKey:(NSData*)aesKey iv:(NSData*)iv
+                    hmacKey:(NSData*)hmacKey hmac:(NSData*)hmac
+                      error:(NSError**)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixSDK/Crypto/Utils/MXAesHmacSha2.h
+++ b/MatrixSDK/Crypto/Utils/MXAesHmacSha2.h
@@ -21,14 +21,14 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Constants
 
 FOUNDATION_EXPORT NSString *const MXAesHmacSha2ErrorDomain;
-typedef enum : NSUInteger
+typedef NS_ENUM(NSUInteger, MXAesHmacSha2ErrorCode)
 {
     MXAesHmacSha2BadMacCode,
     MXAesHmacSha2CannotInitialiseCryptorCode,
     MXAesHmacSha2EncryptionFailedCode,
     MXAesHmacSha2DecryptionFailedCode,
 
-} MXAesHmacSha2ErrorCode;
+};
 
 
 /**

--- a/MatrixSDK/Crypto/Utils/MXAesHmacSha2.m
+++ b/MatrixSDK/Crypto/Utils/MXAesHmacSha2.m
@@ -1,0 +1,95 @@
+/*
+ Copyright 2020 The Matrix.org Foundation C.I.C
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXAesHmacSha2.h"
+
+#import <CommonCrypto/CommonKeyDerivation.h>
+#import <CommonCrypto/CommonCryptor.h>
+
+
+#pragma mark - Constants
+
+NSString *const MXAesHmacSha2ErrorDomain = @"org.matrix.sdk.MXAesHmacSha2";
+const NSUInteger kMXAesHmacSha2HashLength = CC_SHA256_DIGEST_LENGTH;
+const CCHmacAlgorithm kMXAesHmacSha2HashAlgorithm = kCCHmacAlgSHA256;
+
+
+@implementation MXAesHmacSha2
+
++ (nullable NSData*)decrypt:(NSData*)cipher
+                     aesKey:(NSData*)aesKey iv:(NSData*)iv
+                    hmacKey:(NSData*)hmacKey hmac:(NSData*)hmac
+                      error:(NSError**)error
+{
+    // Authentication check
+    NSMutableData* mac = [NSMutableData dataWithLength:kMXAesHmacSha2HashLength];
+    CCHmac(kMXAesHmacSha2HashAlgorithm, hmacKey.bytes, hmacKey.length, cipher.bytes, cipher.length, mac.mutableBytes);
+    
+    if (![hmac isEqualToData:mac])
+    {
+        *error = [NSError errorWithDomain:MXAesHmacSha2ErrorDomain
+                                     code:MXAesHmacSha2BadMacCode
+                                 userInfo:@{
+                                            NSLocalizedDescriptionKey: @"MXAesHmacSha2: Bad MAC",
+                                            }];
+        return nil;
+    }
+    
+    
+    // Decryption
+    CCCryptorRef cryptor;
+    CCCryptorStatus status;
+    
+    status = CCCryptorCreateWithMode(kCCDecrypt, kCCModeCTR, kCCAlgorithmAES,
+                                     ccNoPadding, iv.bytes, aesKey.bytes, kCCKeySizeAES256,
+                                     NULL, 0, 0, kCCModeOptionCTR_BE, &cryptor);
+    if (status != kCCSuccess)
+    {
+        *error = [NSError errorWithDomain:MXAesHmacSha2ErrorDomain
+                                     code:MXAesHmacSha2CannotInitialiseCryptorCode
+                                 userInfo:@{
+                                            NSLocalizedDescriptionKey: @"MXAesHmacSha2: Cannot initialise decryptor",
+                                            }];
+        return nil;
+    }
+    
+    size_t bufferLength = CCCryptorGetOutputLength(cryptor, cipher.length, false);
+    NSMutableData *buffer = [NSMutableData dataWithLength:bufferLength];
+    
+    size_t outLength;
+    status |= CCCryptorUpdate(cryptor,
+                              cipher.bytes,
+                              cipher.length,
+                              [buffer mutableBytes],
+                              [buffer length],
+                              &outLength);
+    
+    status |= CCCryptorRelease(cryptor);
+    
+    if (status != kCCSuccess)
+    {
+        *error = [NSError errorWithDomain:MXAesHmacSha2ErrorDomain
+                                     code:MXAesHmacSha2DecryptionFailedCode
+                                 userInfo:@{
+                                            NSLocalizedDescriptionKey: [NSString stringWithFormat:@"MXAesHmacSha2: Decryption failed: %@", @(status)]
+                                            }];
+        return nil;
+    }
+    
+    return buffer;
+}
+
+@end

--- a/MatrixSDK/Crypto/Utils/MXHkdfSha256.h
+++ b/MatrixSDK/Crypto/Utils/MXHkdfSha256.h
@@ -1,0 +1,43 @@
+/*
+ Copyright 2020 The Matrix.org Foundation C.I.C
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ HMAC-based Extract-and-Expand Key Derivation Function (HkdfSha256)
+ [RFC-5869] https://tools.ietf.org/html/rfc5869
+ */
+@interface MXHkdfSha256 : NSObject
+
+/**
+ Derive a key.
+ 
+ @param secret IKM the input key materiak.
+ @param salt the salt value (a non-secret random value).
+ @param info context and application specific information (can be empty).
+ @param outputLength length of output keying material in bytes.
+ @return OKM the output keying material
+ */
++ (NSData *)deriveSecret:(NSData*)secret
+                    salt:(nullable NSData*)salt
+                    info:(NSData*)info
+            outputLength:(NSUInteger)outputLength;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixSDK/Crypto/Utils/MXHkdfSha256.m
+++ b/MatrixSDK/Crypto/Utils/MXHkdfSha256.m
@@ -1,0 +1,120 @@
+/*
+ Copyright 2020 The Matrix.org Foundation C.I.C
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXHkdfSha256.h"
+
+#import <CommonCrypto/CommonKeyDerivation.h>
+
+
+const NSUInteger kMXHkdfSha256HashLength = CC_SHA256_DIGEST_LENGTH;
+const CCHmacAlgorithm kMXHkdfSha256Algorithm = kCCHmacAlgSHA256;
+
+
+@implementation MXHkdfSha256
+
++ (NSData *)deriveSecret:(NSData*)secret
+                    salt:(nullable NSData*)salt
+                    info:(NSData*)info
+            outputLength:(NSUInteger)outputLength
+{
+    NSData *prk = [self extractPrkWithSalt:salt ikm:secret];
+    return [self expandWithPrk:prk info:info outputLength:outputLength];
+}
+
+
+#pragma mark - Private methods -
+
+/**
+ HkdfSha256-Extract(salt, IKM) -> PRK
+ 
+ @param salt the salt value (a non-secret random value).
+             if nil, it is set to a string of HashLen (size in octets) zeros.
+ @param ikm the input keying material.
+ */
++ (NSData*)extractPrkWithSalt:(nullable NSData*)salt ikm:(NSData*)ikm
+{
+    if (!salt)
+    {
+        NSMutableData *zeroSalt = [NSMutableData dataWithLength:kMXHkdfSha256HashLength];
+        [zeroSalt resetBytesInRange:NSMakeRange(0, zeroSalt.length)];
+        salt = zeroSalt;
+    }
+    
+    NSMutableData *prk = [NSMutableData dataWithLength:kMXHkdfSha256HashLength];
+    [prk resetBytesInRange:NSMakeRange(0, prk.length)];
+    
+    CCHmac(kMXHkdfSha256Algorithm,
+           salt.bytes, salt.length,
+           ikm.bytes, ikm.length,
+           prk.mutableBytes);
+
+    return prk;
+}
+
+/**
+ HkdfSha256-Expand(PRK, info, L) -> OKM
+ 
+ @param prk a pseudorandom key of at least HashLen bytes (usually, the output from the extract step).
+ @param info optional context and application specific information (can be empty)
+ @param outputLength length of output keying material in bytes (<= 255*HashLen)
+ @return OKM output keying material
+ */
++ (NSData*)expandWithPrk:(NSData*)prk info:(NSData*)info outputLength:(NSUInteger)outputLength
+{
+    NSParameterAssert(outputLength < 255 * kMXHkdfSha256HashLength);
+    
+    /*
+     The output OKM is calculated as follows:
+     Notation | -> When the message is composed of several elements we use concatenation (denoted |) in the second argument;
+     
+     
+     N = ceil(L/HashLen)
+     T = T(1) | T(2) | T(3) | ... | T(N)
+     OKM = first L octets of T
+     
+     where:
+     T(0) = empty string (zero length)
+     T(1) = HMAC-Hash(PRK, T(0) | info | 0x01)
+     T(2) = HMAC-Hash(PRK, T(1) | info | 0x02)
+     T(3) = HMAC-Hash(PRK, T(2) | info | 0x03)
+     ...
+     */
+    NSUInteger n = (int)ceil(outputLength / kMXHkdfSha256HashLength);
+    
+    NSData *stepHash = [NSData dataWithBytes:nil length:0]; // T(0) empty string (zero length)
+    
+    NSMutableData *generatedBytes = [NSMutableData data];
+    
+    for (NSUInteger roundNum = 1; roundNum <= n; roundNum++)
+    {
+        CCHmacContext hmacContext;
+        CCHmacInit(&hmacContext, kMXHkdfSha256Algorithm, prk.bytes, prk.length);
+        CCHmacUpdate(&hmacContext, stepHash.bytes, stepHash.length);
+        CCHmacUpdate(&hmacContext, info.bytes, info.length);
+        unsigned char byte = roundNum;
+        CCHmacUpdate(&hmacContext, &byte, 1);
+        
+        NSMutableData *t = [NSMutableData dataWithLength:kMXHkdfSha256HashLength];
+        CCHmacFinal(&hmacContext, t.mutableBytes);
+        stepHash = [t copy];
+        
+        [generatedBytes appendData:stepHash];
+    }
+    
+    return [generatedBytes subdataWithRange:NSMakeRange(0, outputLength)];
+}
+
+@end

--- a/MatrixSDK/Data/MXAccountData.h
+++ b/MatrixSDK/Data/MXAccountData.h
@@ -1,6 +1,7 @@
 /*
  Copyright 2016 OpenMarket Ltd
-
+ Copyright 2020 The Matrix.org Foundation C.I.C
+ 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
@@ -29,9 +30,21 @@
 /**
  Update the account data with the passed event.
  
+ For internal use only. Use [MXSession setAccountData:] to update account data.
+ 
  @param event one event of the "account_data" field of a `/sync` response.
  */
 - (void)updateWithEvent:(NSDictionary*)event;
+
+/**
+ Update the account data with the passed data.
+ 
+ For internal use only.  Use [MXSession setAccountData:] to update account data.
+ 
+ @param type the event type in the account adata.
+ @param data the data to store.
+ */
+- (void)updateDataWithType:(NSString*)type data:(NSDictionary*)data;
 
 /**
  Get account data event by event type.

--- a/MatrixSDK/Data/MXAccountData.m
+++ b/MatrixSDK/Data/MXAccountData.m
@@ -1,5 +1,6 @@
 /*
  Copyright 2016 OpenMarket Ltd
+ Copyright 2020 The Matrix.org Foundation C.I.C
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -39,7 +40,12 @@
 
 - (void)updateWithEvent:(NSDictionary<NSString *, id> *)event
 {
-    accountDataDict[event[@"type"]] = event[@"content"];
+    [self updateDataWithType:event[@"type"] data:event[@"content"]];
+}
+
+- (void)updateDataWithType:(NSString *)type data:(NSDictionary *)data
+{
+    accountDataDict[type] = data;
 }
 
 - (NSDictionary *)accountDataForEventType:(NSString*)eventType

--- a/MatrixSDK/JSONModels/MXEvent.h
+++ b/MatrixSDK/JSONModels/MXEvent.h
@@ -81,6 +81,7 @@ typedef NS_ENUM(NSInteger, MXEventType)
     MXEventTypeKeyVerificationDone,
     MXEventTypeSecretRequest,
     MXEventTypeSecretSend,
+    MXEventTypeSecretStorageDefaultKey,
 
     // The event is a custom event. Refer to its `MXEventTypeString` version
     MXEventTypeCustom = 1000
@@ -142,6 +143,9 @@ FOUNDATION_EXPORT NSString *const kMXEventTypeStringKeyVerificationDone;
 // Secret sharing
 FOUNDATION_EXPORT NSString *const kMXEventTypeStringSecretRequest;
 FOUNDATION_EXPORT NSString *const kMXEventTypeStringSecretSend;
+
+// Secret Storage
+FOUNDATION_EXPORT NSString *const kMXEventTypeStringSecretStorageDefaultKey;
 
 
 /**

--- a/MatrixSDK/JSONModels/MXEvent.m
+++ b/MatrixSDK/JSONModels/MXEvent.m
@@ -72,6 +72,7 @@ NSString *const kMXEventTypeStringKeyVerificationCancel = @"m.key.verification.c
 NSString *const kMXEventTypeStringKeyVerificationDone   = @"m.key.verification.done";
 NSString *const kMXEventTypeStringSecretRequest         = @"m.secret.request";
 NSString *const kMXEventTypeStringSecretSend            = @"m.secret.send";
+NSString *const kMXEventTypeStringSecretStorageDefaultKey   = @"m.secret_storage.default_key";
 
 NSString *const kMXMessageTypeText          = @"m.text";
 NSString *const kMXMessageTypeEmote         = @"m.emote";

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -3444,7 +3444,19 @@ typedef void (^MXOnResumeDone)(void);
                            success:(void (^)(void))success
                            failure:(void (^)(NSError *error))failure
 {
-    return [matrixRestClient setAccountData:data forType:type success:success failure:failure];
+    MXWeakify(self);
+    return [matrixRestClient setAccountData:data forType:type success:^{
+        MXStrongifyAndReturnIfNil(self);
+        
+        // Update data in place
+        [self->_accountData updateDataWithType:type data:data];
+        
+        if (success)
+        {
+            success();
+        }
+        
+    } failure:failure];
 }
 
 - (MXHTTPOperation *)setAccountDataIdentityServer:(NSString *)identityServer

--- a/MatrixSDK/Utils/MXBase64Tools.h
+++ b/MatrixSDK/Utils/MXBase64Tools.h
@@ -35,10 +35,10 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Data
 
 + (NSData *)dataFromUnpaddedBase64:(NSString *)unpaddedBase64;
-
-+ (NSString *)base64FromData:(NSData *)data;
-
 + (NSString *)unpaddedBase64FromData:(NSData *)data;
+
++ (NSData *)dataFromBase64:(NSString *)base64;
++ (NSString *)base64FromData:(NSData *)data;
 
 @end
 

--- a/MatrixSDK/Utils/MXBase64Tools.m
+++ b/MatrixSDK/Utils/MXBase64Tools.m
@@ -64,15 +64,21 @@
     return [[NSData alloc] initWithBase64EncodedString:base64String options:NSDataBase64DecodingIgnoreUnknownCharacters];
 }
 
-+ (NSString *)base64FromData:(NSData *)data
-{
-    return [data base64EncodedStringWithOptions:0];
-}
-
 + (NSString *)unpaddedBase64FromData:(NSData *)data
 {
     NSString *base64 = [[self class] base64FromData:data];
     return [[self class] base64ToUnpaddedBase64:base64];
+}
+
+
++ (NSData *)dataFromBase64:(NSString *)base64
+{
+     return [[NSData alloc] initWithBase64EncodedString:base64 options:NSDataBase64DecodingIgnoreUnknownCharacters];
+}
+
++ (NSString *)base64FromData:(NSData *)data
+{
+    return [data base64EncodedStringWithOptions:0];
 }
 
 @end

--- a/MatrixSDK/Utils/MXTools.m
+++ b/MatrixSDK/Utils/MXTools.m
@@ -115,6 +115,7 @@ NSCharacterSet *uriComponentCharset;
                                 kMXEventTypeStringKeyVerificationDone,
                                 kMXEventTypeStringSecretRequest,
                                 kMXEventTypeStringSecretSend,
+                                kMXEventTypeStringSecretStorageDefaultKey,
                                 ];
 
         NSMutableDictionary *map = [NSMutableDictionary dictionaryWithCapacity:eventTypeMapEnumToString.count];

--- a/MatrixSDKTests/MXCryptoSecretStorageTests.m
+++ b/MatrixSDKTests/MXCryptoSecretStorageTests.m
@@ -345,13 +345,13 @@ UInt8 privateKeyBytes[] = {
         XCTAssertNotNil(privateKey);
         
         // - Get the backup key from SSSS using the default key
-        [secretStorage secretWithSecretId:MXSecretId.keyBackup withSecretStorageKeyId:nil privateKey:privateKey success:^(NSString * _Nonnull secret) {
+        [secretStorage secretWithSecretId:MXSecretId.keyBackup withSecretStorageKeyId:nil privateKey:privateKey success:^(NSString * _Nonnull unpaddedBase64Secret) {
             
             // -> We should get it
-            XCTAssertNotNil(secret);
+            XCTAssertNotNil(unpaddedBase64Secret);
             
             // -> It should be the one created by matrix-js-sdk
-            NSData *key = [MXBase64Tools dataFromUnpaddedBase64:secret];
+            NSData *key = [MXBase64Tools dataFromUnpaddedBase64:unpaddedBase64Secret];
             NSData *jsKey = [NSData dataWithBytes:jsSDKDataBackupKeyBytes length:sizeof(jsSDKDataBackupKeyBytes)];
             
             XCTAssertEqualObjects(key, jsKey);

--- a/MatrixSDKTests/MXCryptoSecretStorageTests.m
+++ b/MatrixSDKTests/MXCryptoSecretStorageTests.m
@@ -62,13 +62,72 @@
             // -> MXSecretStorageKeyCreationInfo must be filled as expected
             XCTAssert(keyCreationInfo);
             XCTAssert(keyCreationInfo.keyId);
-            XCTAssert(keyCreationInfo.content);
-            XCTAssertEqualObjects(keyCreationInfo.content.algorithm, MXSecretStorageKeyAlgorithm.aesHmacSha2);
-            XCTAssertNil(keyCreationInfo.content.passphrase);
-            XCTAssert(keyCreationInfo.content.iv);
-            XCTAssert(keyCreationInfo.content.mac);
             XCTAssert(keyCreationInfo.privateKey);
             XCTAssert(keyCreationInfo.recoveryKey);
+            
+            MXSecretStorageKeyContent *keyContent = keyCreationInfo.content;
+            XCTAssert(keyContent);
+            XCTAssertEqualObjects(keyContent.algorithm, MXSecretStorageKeyAlgorithm.aesHmacSha2);
+            XCTAssertNil(keyContent.name);
+            XCTAssert(keyContent.iv);
+            XCTAssert(keyContent.mac);
+            XCTAssertNil(keyContent.passphrase);
+            
+
+            // - Get back the key
+            MXSecretStorageKeyContent *key = [secretStorage keyWithKeyId:keyCreationInfo.keyId];
+            
+            // -> We must get it with the same value as MXSecretStorageKeyCreationInfo
+            XCTAssert(key);
+            XCTAssertEqualObjects(key.JSONDictionary, keyContent.JSONDictionary);
+            
+            [expectation fulfill];
+        } failure:^(NSError * _Nonnull error) {
+            XCTFail(@"The operation should not fail - NSError: %@", error);
+            [expectation fulfill];
+        }];
+    }];
+}
+
+// - Have Alice with encryption
+// - Create a new secret storage key with a passphrase
+// -> MXSecretStorageKeyCreationInfo must be filled as expected
+// - Get back the key
+// -> We must get it with the same value as MXSecretStorageKeyCreationInfo
+- (void)testSecretStorageKeyCreationWithPassphrase
+{
+    // - Have Alice with encryption
+    [matrixSDKTestsE2EData doE2ETestWithAliceInARoom:self readyToTest:^(MXSession *aliceSession, NSString *roomId, XCTestExpectation *expectation) {
+        
+        NSString *KEY_ID = @"KEYID";
+        NSString *KEY_NAME = @"A Key Name";
+        NSString *PASSPHRASE = @"a passphrase";
+
+        
+        // - Create a new secret storage key
+        MXSecretStorage *secretStorage = aliceSession.crypto.secretStorage;
+        [secretStorage createKeyWithKeyId:KEY_ID keyName:KEY_NAME passphrase:PASSPHRASE success:^(MXSecretStorageKeyCreationInfo * _Nonnull keyCreationInfo) {
+            
+            // -> MXSecretStorageKeyCreationInfo must be filled as expected
+            XCTAssert(keyCreationInfo);
+            XCTAssertEqualObjects(keyCreationInfo.keyId, KEY_ID);
+            XCTAssert(keyCreationInfo.privateKey);
+            XCTAssert(keyCreationInfo.recoveryKey);
+            
+            MXSecretStorageKeyContent *keyContent = keyCreationInfo.content;
+            XCTAssert(keyContent);
+            XCTAssertEqualObjects(keyContent.algorithm, MXSecretStorageKeyAlgorithm.aesHmacSha2);
+            XCTAssertEqualObjects(keyContent.name, KEY_NAME);
+            XCTAssert(keyContent.iv);
+            XCTAssert(keyContent.mac);
+            
+            MXSecretStoragePassphrase *passphraseInfo = keyContent.passphrase;
+            XCTAssert(passphraseInfo);
+            XCTAssertEqualObjects(passphraseInfo.algorithm, @"m.pbkdf2");
+            XCTAssertGreaterThan(passphraseInfo.iterations, 0);
+            XCTAssert(passphraseInfo.salt);
+            XCTAssertEqual(passphraseInfo.bits, 256);
+    
             
             // - Get back the key
             MXSecretStorageKeyContent *key = [secretStorage keyWithKeyId:keyCreationInfo.keyId];
@@ -78,6 +137,44 @@
             XCTAssertEqualObjects(key.JSONDictionary, keyCreationInfo.content.JSONDictionary);
             
             [expectation fulfill];
+        } failure:^(NSError * _Nonnull error) {
+            XCTFail(@"The operation should not fail - NSError: %@", error);
+            [expectation fulfill];
+        }];
+    }];
+}
+
+// - Have Alice with encryption
+// - Create a secret storage key
+// - Set it as default
+// - Get back the default key
+// -> We must get it with the same value as MXSecretStorageKeyCreationInfo
+- (void)testDefaultSecretStorageKey
+{
+    // - Have Alice with encryption
+    [matrixSDKTestsE2EData doE2ETestWithAliceInARoom:self readyToTest:^(MXSession *aliceSession, NSString *roomId, XCTestExpectation *expectation) {
+        
+        // - Create a secret storage key
+        MXSecretStorage *secretStorage = aliceSession.crypto.secretStorage;
+        [secretStorage createKeyWithKeyId:nil keyName:nil passphrase:nil success:^(MXSecretStorageKeyCreationInfo * _Nonnull keyCreationInfo) {
+            
+            // - Set it as default
+            [secretStorage setAsDefaultKeyWithKeyId:keyCreationInfo.keyId success:^{
+                
+                // - Get back the default key
+                MXSecretStorageKeyContent *defaultKey = secretStorage.defaultKey;
+                
+                // -> We must get it with the same value as MXSecretStorageKeyCreationInfo
+                XCTAssert(defaultKey);
+                XCTAssertEqualObjects(defaultKey.JSONDictionary, keyCreationInfo.content.JSONDictionary);
+                
+                [expectation fulfill];
+                
+            } failure:^(NSError * _Nonnull error) {
+                XCTFail(@"The operation should not fail - NSError: %@", error);
+                [expectation fulfill];
+            }];
+
         } failure:^(NSError * _Nonnull error) {
             XCTFail(@"The operation should not fail - NSError: %@", error);
             [expectation fulfill];

--- a/MatrixSDKTests/MXCryptoSecretStorageTests.m
+++ b/MatrixSDKTests/MXCryptoSecretStorageTests.m
@@ -299,6 +299,35 @@ UInt8 privateKeyBytes[] = {
     }];
 }
 
+// Test MXSecretStorage.checkPrivateKey
+// - Have Alice with SSSS bootstrapped
+// - Check the private key we have match the SSSS key
+// -> It must match
+- (void)testCheckPrivateKey
+{
+    // - Have Alice with SSSS bootstrapped
+    [self createScenarioWithMatrixJsSDKData:^(MXSession *aliceSession, NSString *roomId, XCTestExpectation *expectation) {
+        
+        MXSecretStorage *secretStorage = aliceSession.crypto.secretStorage;
+        
+        NSError *error;
+        NSData *privateKey = [MXRecoveryKey decode:jsSDKDataRecoveryKey error:&error];
+        XCTAssertNotNil(privateKey);
+        
+        MXSecretStorageKeyContent *defaultKey = secretStorage.defaultKey;
+        XCTAssert(defaultKey);
+        
+        // - Check the private key we have match the SSSS key
+        [secretStorage checkPrivateKey:privateKey withKey:defaultKey complete:^(BOOL match) {
+            
+            // -> It must match
+            XCTAssertTrue(match);
+            
+            [expectation fulfill];
+        }];
+    }];
+}
+
 
 #pragma mark - Secret storage
 
@@ -313,7 +342,7 @@ UInt8 privateKeyBytes[] = {
         
         MXSecretStorage *secretStorage = aliceSession.crypto.secretStorage;
         
-        // Test scenarion creation
+        // Test scenario creation
         MXSecretStorageKeyContent *defaultKey = secretStorage.defaultKey;
         XCTAssert(defaultKey);
         

--- a/MatrixSDKTests/MXCryptoSecretStorageTests.m
+++ b/MatrixSDKTests/MXCryptoSecretStorageTests.m
@@ -1,0 +1,88 @@
+/*
+ Copyright 2020 The Matrix.org Foundation C.I.C
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "MXCrypto.h"
+
+#import "MatrixSDKTestsData.h"
+#import "MatrixSDKTestsE2EData.h"
+
+@interface MXCryptoSecretStorageTests : XCTestCase
+{
+    MatrixSDKTestsData *matrixSDKTestsData;
+    MatrixSDKTestsE2EData *matrixSDKTestsE2EData;
+}
+
+@end
+
+@implementation MXCryptoSecretStorageTests
+
+- (void)setUp
+{
+    [super setUp];
+    
+    matrixSDKTestsData = [[MatrixSDKTestsData alloc] init];
+    matrixSDKTestsE2EData = [[MatrixSDKTestsE2EData alloc] initWithMatrixSDKTestsData:matrixSDKTestsData];
+}
+
+- (void)tearDown
+{
+    matrixSDKTestsData = nil;
+    matrixSDKTestsE2EData = nil;
+}
+
+// - Have Alice with encryption
+// - Create a new secret storage key
+// -> MXSecretStorageKeyCreationInfo must be filled as expected
+// - Get back the key
+// -> We must get it with the same value as MXSecretStorageKeyCreationInfo
+- (void)testSecretStorageKeyCreation
+{
+    // - Have Alice with encryption
+    [matrixSDKTestsE2EData doE2ETestWithAliceInARoom:self readyToTest:^(MXSession *aliceSession, NSString *roomId, XCTestExpectation *expectation) {
+        
+        // - Create a new secret storage key
+        MXSecretStorage *secretStorage = aliceSession.crypto.secretStorage;
+        [secretStorage createKeyWithKeyId:nil keyName:nil passphrase:nil success:^(MXSecretStorageKeyCreationInfo * _Nonnull keyCreationInfo) {
+            
+            // -> MXSecretStorageKeyCreationInfo must be filled as expected
+            XCTAssert(keyCreationInfo);
+            XCTAssert(keyCreationInfo.keyId);
+            XCTAssert(keyCreationInfo.content);
+            XCTAssertEqualObjects(keyCreationInfo.content.algorithm, MXSecretStorageKeyAlgorithm.aesHmacSha2);
+            XCTAssertNil(keyCreationInfo.content.passphrase);
+            XCTAssert(keyCreationInfo.content.iv);
+            XCTAssert(keyCreationInfo.content.mac);
+            XCTAssert(keyCreationInfo.privateKey);
+            XCTAssert(keyCreationInfo.recoveryKey);
+            
+            // - Get back the key
+            MXSecretStorageKeyContent *key = [secretStorage keyWithKeyId:keyCreationInfo.keyId];
+            
+            // -> We must get it with the same value as MXSecretStorageKeyCreationInfo
+            XCTAssert(key);
+            XCTAssertEqualObjects(key.JSONDictionary, keyCreationInfo.content.JSONDictionary);
+            
+            [expectation fulfill];
+        } failure:^(NSError * _Nonnull error) {
+            XCTFail(@"The operation should not fail - NSError: %@", error);
+            [expectation fulfill];
+        }];
+    }];
+}
+
+@end


### PR DESCRIPTION
Fix https://github.com/vector-im/riot-ios/issues/2926

Spec: ([MSC1946(]https://github.com/matrix-org/matrix-doc/pull/1946)

This module will be used for bootstrap and account keys recovery.


![image](https://user-images.githubusercontent.com/8418515/82064933-b22d5980-96cd-11ea-813d-95e05941971e.png)

