### PR TITLE
MXCrypto: Only create one olm session at a time per device

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@ Changes in Matrix iOS SDK in 0.16.6 (2020-05-xx)
 ================================================
 
 Improvements:
+ * MXCrypto: Only create one olm session at a time per device (vector-im/riot-ios/issues/2331).
 
 Bug fix:
  * MXSecretShareManager: Fix crash in cancelRequestWithRequestId (vector-im/riot-ios/issues/3272).

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -2013,6 +2013,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
             [ensureOlmSessionsInProgress addObject:deviceIdentityKey];
         }
         
+        // In both case, we need to wait for the creation of the olm session for this device
         [devicesInProgress addObject:deviceIdentityKey];
     }
     
@@ -2026,7 +2027,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     observer = [[NSNotificationCenter defaultCenter] addObserverForName:kMXCryptoOneTimeKeyClaimCompleteNotification object:self queue:nil usingBlock:^(NSNotification * _Nonnull note) {
         MXStrongifyAndReturnIfNil(self);
         
-        NSMutableArray<NSString*> *devices = note.userInfo[kMXCryptoOneTimeKeyClaimCompleteNotificationDevicesKey];
+        NSArray<NSString*> *devices = note.userInfo[kMXCryptoOneTimeKeyClaimCompleteNotificationDevicesKey];
         NSError *error = note.userInfo[kMXCryptoOneTimeKeyClaimCompleteNotificationErrorKey];
         
         // Was it a /claim request for us?

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -2038,7 +2038,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
                 NSLog(@"[MXCrypto] ensureOlmSessionsForDevices: Got a notification failure for %@ devices. Fail our current pool of %@ devices", @(devices.count), @(devicesInProgress.count));
                 
                 // Consider the failure for all requests of the current pool
-                [self->ensureOlmSessionsInProgress removeObjectsInArray:devicesInProgress];
+                [self->ensureOlmSessionsInProgress removeObjectsInArray:devices];
                 [devicesInProgress removeAllObjects];
                 
                 // The game is over for this pool

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -45,6 +45,8 @@
 #import "MXCrossSigningInfo_Private.h"
 #import "MXCrossSigning_Private.h"
 
+#import "NSArray+MatrixSDK.h"
+
 /**
  The store to use for crypto.
  */
@@ -56,6 +58,11 @@ NSString *const kMXCryptoRoomKeyRequestCancellationNotification = @"kMXCryptoRoo
 NSString *const kMXCryptoRoomKeyRequestCancellationNotificationRequestKey = @"kMXCryptoRoomKeyRequestCancellationNotificationRequestKey";
 
 NSString *const MXDeviceListDidUpdateUsersDevicesNotification = @"MXDeviceListDidUpdateUsersDevicesNotification";
+
+static NSString *const kMXCryptoOneTimeKeyClaimCompleteNotification             = @"kMXCryptoOneTimeKeyClaimCompleteNotification";
+static NSString *const kMXCryptoOneTimeKeyClaimCompleteNotificationDevicesKey   = @"kMXCryptoOneTimeKeyClaimCompleteNotificationDevicesKey";
+static NSString *const kMXCryptoOneTimeKeyClaimCompleteNotificationErrorKey     = @"kMXCryptoOneTimeKeyClaimCompleteNotificationErrorKey";
+
 
 #ifdef MX_CRYPTO
 
@@ -111,6 +118,10 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     // The queue to manage bulk import and export of keys.
     // It only reads and writes keys from and to the crypto store.
     dispatch_queue_t cargoQueue;
+    
+    // The list of devices (by their identity key) we are establishing
+    // an olm session with.
+    NSMutableArray<NSString*> *ensureOlmSessionsInProgress;
 }
 @end
 
@@ -1729,7 +1740,8 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
         decryptionQueue = [MXCrypto dispatchQueueForUser:_mxSession.matrixRestClient.credentials.userId];
         
         cargoQueue = dispatch_queue_create([NSString stringWithFormat:@"MXCrypto-Cargo-%@", _mxSession.myDeviceId].UTF8String, DISPATCH_QUEUE_SERIAL);
-
+        
+        ensureOlmSessionsInProgress = [NSMutableArray array];
 
         _olmDevice = [[MXOlmDevice alloc] initWithStore:_store];
 
@@ -1964,6 +1976,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 
     if (devicesWithoutSession.count == 0)
     {
+        NSLog(@"[MXCrypto] ensureOlmSessionsForDevices: Have already sessions for all");
         if (success)
         {
             success(results);
@@ -1971,20 +1984,110 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
         return nil;
     }
 
+    
     NSString *oneTimeKeyAlgorithm = kMXKeySignedCurve25519Type;
-
-    // Prepare the request for claiming one-time keys
+    
+    // Devices for which we will make a /claim request
     MXUsersDevicesMap<NSString*> *usersDevicesToClaim = [[MXUsersDevicesMap<NSString*> alloc] init];
+    // The same but devices are listed by their identity key
+    NSMutableArray<NSString*> *devicesToClaim = [NSMutableArray array];
+    
+    // Devices (by their identity key) that are waiting for a response to /claim request
+    // That can be devices for which we are going to make a /claim request OR devices that
+    // already have a pending requests.
+    // Once we have emptied this array, we can call the success or the failure block. The
+    // operation is complete.
+    NSMutableArray<NSString*> *devicesInProgress = [NSMutableArray array];
+    
+    // Prepare the request for claiming one-time keys
     for (MXDeviceInfo *device in devicesWithoutSession)
     {
-        [usersDevicesToClaim setObject:oneTimeKeyAlgorithm forUser:device.userId andDevice:device.deviceId];
+        NSString *deviceIdentityKey = device.identityKey;
+        
+        // Claim only if a request is not yet pending
+        if (![ensureOlmSessionsInProgress containsObject:deviceIdentityKey])
+        {
+            [usersDevicesToClaim setObject:oneTimeKeyAlgorithm forUser:device.userId andDevice:device.deviceId];
+            [devicesToClaim addObject:deviceIdentityKey];
+            
+            [ensureOlmSessionsInProgress addObject:deviceIdentityKey];
+        }
+        
+        [devicesInProgress addObject:deviceIdentityKey];
     }
-
-    // TODO: this has a race condition - if we try to send another message
-    // while we are claiming a key, we will end up claiming two and setting up
-    // two sessions.
-    //
-    // That should eventually resolve itself, but it's poor form.
+    
+    NSLog(@"[MXCrypto] ensureOlmSessionsForDevices: %@ out of %@ sessions to claim one time keys", @(usersDevicesToClaim.count), @(devicesWithoutSession.count));
+    
+    
+    // Wait for the result of claim request(s)
+    // Listen to the dedicated notification
+    MXWeakify(self);
+    __block id observer;
+    observer = [[NSNotificationCenter defaultCenter] addObserverForName:kMXCryptoOneTimeKeyClaimCompleteNotification object:self queue:nil usingBlock:^(NSNotification * _Nonnull note) {
+        MXStrongifyAndReturnIfNil(self);
+        
+        NSMutableArray<NSString*> *devices = note.userInfo[kMXCryptoOneTimeKeyClaimCompleteNotificationDevicesKey];
+        NSError *error = note.userInfo[kMXCryptoOneTimeKeyClaimCompleteNotificationErrorKey];
+        
+        // Was it a /claim request for us?
+        if ([devicesInProgress mx_intersectArray:devices])
+        {
+            if (error)
+            {
+                NSLog(@"[MXCrypto] ensureOlmSessionsForDevices: Got a notification failure for %@ devices. Fail our current pool of %@ devices", @(devices.count), @(devicesInProgress.count));
+                
+                // Consider the failure for all requests of the current pool
+                [self->ensureOlmSessionsInProgress removeObjectsInArray:devicesInProgress];
+                [devicesInProgress removeAllObjects];
+                
+                // The game is over for this pool
+                [[NSNotificationCenter defaultCenter] removeObserver:observer];
+                if (failure)
+                {
+                    failure(error);
+                }
+            }
+            else
+            {
+                for (NSString *deviceIdentityKey in devices)
+                {
+                    if ([devicesInProgress containsObject:deviceIdentityKey])
+                    {
+                        MXDeviceInfo *device = [self.store deviceWithIdentityKey:deviceIdentityKey];
+                        NSString *olmSessionId = [self.olmDevice sessionIdForDevice:deviceIdentityKey];
+                        
+                        // Update the result
+                        MXOlmSessionResult *olmSessionResult = [results objectForDevice:device.deviceId forUser:device.userId];
+                        olmSessionResult.sessionId = olmSessionId;
+                        
+                        // This device is no more in progress
+                        [devicesInProgress removeObject:deviceIdentityKey];
+                        [self->ensureOlmSessionsInProgress removeObject:deviceIdentityKey];
+                    }
+                }
+                
+                NSLog(@"[MXCrypto] ensureOlmSessionsForDevices: Got olm sessions for %@ devices. Still missing %@ sessions", @(devices.count), @(devicesInProgress.count));
+                
+                // If the pool is empty, we are done
+                if (!devicesInProgress.count)
+                {
+                    [[NSNotificationCenter defaultCenter] removeObserver:observer];
+                    if (success)
+                    {
+                        success(results);
+                    }
+                }
+            }
+        }
+    }];
+    
+    
+    if (usersDevicesToClaim.count == 0)
+    {
+        NSLog(@"[MXCrypto] ensureOlmSessionsForDevices: All missing sessions are already pending");
+        return nil;
+    }
+    
 
     NSLog(@"[MXCrypto] ensureOlmSessionsForDevices: claimOneTimeKeysForUsersDevices (users: %tu - devices: %tu)",
           usersDevicesToClaim.map.count, usersDevicesToClaim.count);
@@ -2020,27 +2123,29 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
                         continue;
                     }
 
-                    NSString *sid = [self verifyKeyAndStartSession:oneTimeKey userId:userId deviceInfo:deviceInfo];
-
-                    // Update the result for this device in results
-                    olmSessionResult.sessionId = sid;
+                    [self verifyKeyAndStartSession:oneTimeKey userId:userId deviceInfo:deviceInfo];
                 }
             }
         }
-
-        if (success)
-        {
-            success(results);
-        }
+        
+        // Broadcast the /claim request is done
+        [[NSNotificationCenter defaultCenter] postNotificationName:kMXCryptoOneTimeKeyClaimCompleteNotification
+                                                            object:self
+                                                          userInfo: @{
+                                                                      kMXCryptoOneTimeKeyClaimCompleteNotificationDevicesKey: devicesToClaim
+                                                                      }];
 
     } failure:^(NSError *error) {
 
         NSLog(@"[MXCrypto] ensureOlmSessionsForDevices: claimOneTimeKeysForUsersDevices request failed.");
 
-        if (failure)
-        {
-            failure(error);
-        }
+        // Broadcast the /claim request is done
+        [[NSNotificationCenter defaultCenter] postNotificationName:kMXCryptoOneTimeKeyClaimCompleteNotification
+                                                            object:self
+                                                          userInfo: @{
+                                                                      kMXCryptoOneTimeKeyClaimCompleteNotificationDevicesKey: devicesToClaim,
+                                                                      kMXCryptoOneTimeKeyClaimCompleteNotificationErrorKey: error
+                                                                      }];
     }];
 }
 


### PR DESCRIPTION
Fix vector-im/riot-ios/issues/2331