### PR TITLE
MXDeviceListOperationsPool: Fix current device verification status put in MXDeviceUnknown instead of MXDeviceVerified

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Bug fix:
  * MXSecretShareManager: Fix crash in cancelRequestWithRequestId (vector-im/riot-ios/issues/3272).
  * MXIdentityService: Fix crash in handleHTTPClientError (vector-im/riot-ios/issues/3273).
  * MXDeviceList: Fix crash in refreshOutdatedDeviceLists (vector-im/riot-ios/issues/3118).
+ * MXDeviceListOperationsPool: Fix current device verification status put in MXDeviceUnknown instead of MXDeviceVerified (vector-im/riot-ios/issues/3343).
 
 API break:
  * MXCrossSigning: Removed MXCrossSigningStateCanCrossSignAsynchronously.

--- a/MatrixSDK/Crypto/Data/MXDeviceListOperationsPool.m
+++ b/MatrixSDK/Crypto/Data/MXDeviceListOperationsPool.m
@@ -173,6 +173,12 @@
                         previousLocalState = previouslyStoredDeviceKeys.trustLevel.localVerificationStatus;
                     }
                     
+                    // Be sure to force previous local state to verified for current device. Our own device il always locally verified.
+                    if ([self->crypto.mxSession.myDeviceId isEqualToString:deviceId])
+                    {
+                        previousLocalState = MXDeviceVerified;
+                    }
+                    
                     // Use current trust level
                     MXDeviceTrustLevel *oldTrustLevel = [MXDeviceTrustLevel trustLevelWithLocalVerificationStatus:previousLocalState
                                                                                              crossSigningVerified:previouslyStoredDeviceKeys.trustLevel.isCrossSigningVerified];

--- a/MatrixSDK/Crypto/Data/MXDeviceListOperationsPool.m
+++ b/MatrixSDK/Crypto/Data/MXDeviceListOperationsPool.m
@@ -174,7 +174,8 @@
                     }
                     
                     // Be sure to force previous local state to verified for current device. Our own device il always locally verified.
-                    if ([self->crypto.mxSession.myDeviceId isEqualToString:deviceId])
+                    if ([self->crypto.mxSession.myUserId isEqualToString:userId]
+                        && [self->crypto.mxSession.myDeviceId isEqualToString:deviceId])
                     {
                         previousLocalState = MXDeviceVerified;
                     }


### PR DESCRIPTION
Fix vector-im/riot-ios/issues/3343