### PR TITLE
Introduce `enableKeyBackupWhenStartingMXCrypto` in MXSDKOptions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@ Bug fix:
  * MXDeviceList: Fix crash in refreshOutdatedDeviceLists (vector-im/riot-ios/issues/3118).
  * MXPushRuleSenderNotificationPermissionConditionChecker & MXPushRuleRoomMemberCountConditionChecker: Remove redundant room check (vector-im/riot-ios/issues/3354).
  * MXDeviceListOperationsPool: Fix current device verification status put in MXDeviceUnknown instead of MXDeviceVerified (vector-im/riot-ios/issues/3343).
+ * MXSDKOptions: Introduce enableKeyBackupWhenStartingMXCrypto option (vector-im/riot-ios/issues/3371).
 
 API break:
  * MXCrossSigning: Removed MXCrossSigningStateCanCrossSignAsynchronously.

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -1788,7 +1788,10 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 
         oneTimeKeyCount = -1;
 
-        _backup = [[MXKeyBackup alloc] initWithCrypto:self];
+        if ([MXSDKOptions sharedInstance].enableKeyBackupWhenStartingMXCrypto)
+        {
+            _backup = [[MXKeyBackup alloc] initWithCrypto:self];
+        }
 
         outgoingRoomKeyRequestManager = [[MXOutgoingRoomKeyRequestManager alloc]
                                          initWithMatrixRestClient:_matrixRestClient

--- a/MatrixSDK/MXSDKOptions.h
+++ b/MatrixSDK/MXSDKOptions.h
@@ -57,6 +57,12 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) BOOL enableCryptoWhenStartingMXSession;
 
 /**
+ Automatically enable key backup when initializing a new MXCrypto.
+ YES by default.
+ */
+@property (nonatomic) BOOL enableKeyBackupWhenStartingMXCrypto;
+
+/**
  Compute and maintain MXRommSummary.trust value.
  NO by default.
  This requires to load all room members to compute it.

--- a/MatrixSDK/MXSDKOptions.m
+++ b/MatrixSDK/MXSDKOptions.m
@@ -37,6 +37,7 @@ static MXSDKOptions *sharedOnceInstance = nil;
     {
         _disableIdenticonUseForUserAvatar = NO;
         _enableCryptoWhenStartingMXSession = NO;
+        _enableKeyBackupWhenStartingMXCrypto = YES;
         _mediaCacheAppVersion = 0;
         _applicationGroupIdentifier = nil;
     }


### PR DESCRIPTION
Part of vector-im/riot-ios#3371