### PR TITLE
MXRecoveryService: Add options to create and delete key backup automatically

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Improvements:
  * MXCrossSigning: Add the bootstrapWithAuthParams method.
  * MXRecoveryService: Create this service to manage keys we want to store in SSSS.
  * MXRecoveryService: Add deleteRecovery.
+ * MXRecoveryService: Add options to create and delete key backup automatically (vector-im/riot-ios/issues/3361).
  * MXSecretStorage: Add options to remove secrets and SSSS. 
  * MXWellKnown: Add JSONDictionary implementation to return original and extended data.
  * MXCrossSigning: Gossip the master key (vector-im/riot-ios/issues/3346).

--- a/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.m
+++ b/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.m
@@ -187,9 +187,10 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
     NSLog(@"[MXKeyBackup] resetKeyBackupData");
     
     [self resetBackupAllGroupSessionsObjects];
-
+    
     self->crypto.store.backupVersion = nil;
-    _backupKey = nil;
+    [self->crypto.store deleteSecretWithSecretId:MXSecretId.keyBackup];
+   _backupKey = nil;
 
     // Reset backup markers
     [self->crypto.store resetBackupMarkers];

--- a/MatrixSDK/Crypto/Recovery/MXRecoveryService.h
+++ b/MatrixSDK/Crypto/Recovery/MXRecoveryService.h
@@ -28,6 +28,7 @@ FOUNDATION_EXPORT NSString *const MXRecoveryServiceErrorDomain;
 typedef NS_ENUM(NSInteger, MXRecoveryServiceErrorCode)
 {
     MXRecoveryServiceSSSSAlreadyExistsErrorCode,
+    MXRecoveryServiceKeyBackupExistsButNoPrivateKeyErrorCode,
     MXRecoveryServiceNoSSSSErrorCode,
     MXRecoveryServiceNotProtectedByPassphraseErrorCode,
     MXRecoveryServiceBadRecoveryKeyErrorCode,
@@ -76,11 +77,14 @@ typedef NS_ENUM(NSInteger, MXRecoveryServiceErrorCode)
 /**
  Delete the current recovery.
  
+ @param deleteServicesBackups YES to delete backups for associated services. Only keyBackup is supported.
+ 
  @param success A block object called when the operation succeeds.
  @param failure A block object called when the operation fails.
  */
-- (void)deleteRecoveryWithSuccess:(void (^)(void))success
-                          failure:(void (^)(NSError *error))failure;
+- (void)deleteRecoveryWithDeleteServicesBackups:(BOOL)deleteServicesBackups
+                                        success:(void (^)(void))success
+                                        failure:(void (^)(NSError *error))failure;
 
 
 #pragma mark - Secrets in the recovery
@@ -106,12 +110,14 @@ typedef NS_ENUM(NSInteger, MXRecoveryServiceErrorCode)
  
  @param secrets secrets ids to store in the recovery. Nil for all self.supportedSecrets.
  @param passphrase a passphrase used to generate the recovery key to encrypt keys. Nil will generate it.
+ @param createServicesBackups YES to create backups for associated services. Only keyBackup is supported.
  
  @param success A block object called when the operation succeeds.
  @param failure A block object called when the operation fails.
  */
 - (void)createRecoveryForSecrets:(nullable NSArray<NSString*>*)secrets
                   withPassphrase:(nullable NSString*)passphrase
+           createServicesBackups:(BOOL)createServicesBackups
                          success:(void (^)(MXSecretStorageKeyCreationInfo *keyCreationInfo))success
                          failure:(void (^)(NSError *error))failure;
 

--- a/MatrixSDK/Crypto/Recovery/MXRecoveryService.m
+++ b/MatrixSDK/Crypto/Recovery/MXRecoveryService.m
@@ -303,8 +303,8 @@ NSString *const MXRecoveryServiceErrorDomain = @"org.matrix.sdk.recoveryService"
     
     [keyBackup forceRefresh:^(BOOL usingLastVersion) {
         
-        // If there is a
-        if (keyBackup.enabled)
+        // If a backup already exists, make sure we have the private key locally
+        if (keyBackup.keyBackupVersion)
         {
             if ([self.cryptoStore secretWithSecretId:MXSecretId.keyBackup])
             {

--- a/MatrixSDK/Crypto/Recovery/MXRecoveryService.m
+++ b/MatrixSDK/Crypto/Recovery/MXRecoveryService.m
@@ -165,6 +165,11 @@ NSString *const MXRecoveryServiceErrorDomain = @"org.matrix.sdk.recoveryService"
     NSLog(@"[MXRecoveryService] deleteKeyBackup");
     
     MXKeyBackup *keyBackup = self.crypto.backup;
+    if (!keyBackup)
+    {
+        success();
+        return;
+    }
     
     [keyBackup forceRefresh:^(BOOL usingLastVersion) {
         
@@ -290,6 +295,11 @@ NSString *const MXRecoveryServiceErrorDomain = @"org.matrix.sdk.recoveryService"
     NSLog(@"[MXRecoveryService] createKeyBackup");
     
     MXKeyBackup *keyBackup = self.crypto.backup;
+    if (!keyBackup)
+    {
+        success();
+        return;
+    }
     
     [keyBackup forceRefresh:^(BOOL usingLastVersion) {
         


### PR DESCRIPTION
Part of vector-im/riot-ios/issues/3361
