### PR TITLE
Release 0.16.8

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-Changes in Matrix iOS SDK in 0.16.8 (2020-07-)
+Changes in 0.16.8 (2020-07-28)
 ================================================
 
 Improvements:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+Changes in Matrix iOS SDK in 0.16.7 (2020-07-13)
+================================================
+
+Bug fix:
+ * MXCreateRoomReponse: Remove undocumented roomAlias property (vector-im/riot-ios/issues/3300).
+ * MXPushRuleSenderNotificationPermissionConditionChecker & MXPushRuleRoomMemberCountConditionChecker: Remove redundant room check (vector-im/riot-ios/issues/3354).
+ * MXSDKOptions: Introduce enableKeyBackupWhenStartingMXCrypto option (vector-im/riot-ios/issues/3371).
+
 Changes in Matrix iOS SDK in 0.16.6 (2020-06-30)
 ================================================
 
@@ -16,11 +24,8 @@ Bug fix:
  * MXSecretShareManager: Fix crash in cancelRequestWithRequestId (vector-im/riot-ios/issues/3272).
  * MXIdentityService: Fix crash in handleHTTPClientError (vector-im/riot-ios/issues/3273).
  * MXSession: Add ignoreSessionState to backgroundSync method.
- * MXCreateRoomReponse: Remove undocumented roomAlias property (vector-im/riot-ios/issues/3300).
  * MXDeviceList: Fix crash in refreshOutdatedDeviceLists (vector-im/riot-ios/issues/3118).
- * MXPushRuleSenderNotificationPermissionConditionChecker & MXPushRuleRoomMemberCountConditionChecker: Remove redundant room check (vector-im/riot-ios/issues/3354).
  * MXDeviceListOperationsPool: Fix current device verification status put in MXDeviceUnknown instead of MXDeviceVerified (vector-im/riot-ios/issues/3343).
- * MXSDKOptions: Introduce enableKeyBackupWhenStartingMXCrypto option (vector-im/riot-ios/issues/3371).
 
 API break:
  * MXCrossSigning: Removed MXCrossSigningStateCanCrossSignAsynchronously.

--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "MatrixSDK"
-  s.version      = "0.16.6"
+  s.version      = "0.16.7"
   s.summary      = "The iOS SDK to build apps compatible with Matrix (https://www.matrix.org)"
 
   s.description  = <<-DESC

--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "MatrixSDK"
-  s.version      = "0.16.7"
+  s.version      = "0.16.8"
   s.summary      = "The iOS SDK to build apps compatible with Matrix (https://www.matrix.org)"
 
   s.description  = <<-DESC

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -47,7 +47,7 @@
 
 #pragma mark - Constants definitions
 
-const NSString *MatrixSDKVersion = @"0.16.6";
+const NSString *MatrixSDKVersion = @"0.16.7";
 NSString *const kMXSessionStateDidChangeNotification = @"kMXSessionStateDidChangeNotification";
 NSString *const kMXSessionNewRoomNotification = @"kMXSessionNewRoomNotification";
 NSString *const kMXSessionWillLeaveRoomNotification = @"kMXSessionWillLeaveRoomNotification";

--- a/MatrixSDK/MatrixSDKVersion.m
+++ b/MatrixSDK/MatrixSDKVersion.m
@@ -16,4 +16,4 @@
 
 #import <Foundation/Foundation.h>
 
-NSString *const MatrixSDKVersion = @"0.16.7";
+NSString *const MatrixSDKVersion = @"0.16.8";

--- a/SwiftMatrixSDK.podspec
+++ b/SwiftMatrixSDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "SwiftMatrixSDK"
-  s.version      = "0.16.6"
+  s.version      = "0.16.7"
   s.summary      = "The iOS SDK to build apps compatible with Matrix (https://www.matrix.org)"
 
   s.description  = <<-DESC


### PR DESCRIPTION
This PR prepares the release of MatrixSDK v0.16.8.

:bulb: This PR targets `master` to respect git flow, but if you want to just review the changes made since the
`release/0.16.8` was cut from `develop`, you can [check those here](git@github.com:matrix-org/matrix-ios-sdk.git/compare/develop...release/0.16.8)

As of now, there are still some steps to do manually before going forward with the release process:

- [ ] Check the `CHANGES.rst` file, especially manually add a line to mention when any of the dependendices
      of MatrixSDK have been updated (see `Podfile.lock` changes)[^1]
- [ ] After cloning the PR locally, update the `MatrixSDK.podspec` to point it to the pending release branches of any of the dependencies,
      then run `pod lib lint` manually to validate the podspec [^2]

Once the PR has been reviewed and merged, run the `rake release:finish` command from the element-ios-tools to finish the process.
:warning: Be sure to merge the PRs in the right order before continuing the release process (`MatrixSDK`, then `MatrixKit`, then `Element`)      

[^1]: In a later version of the scripts, that will be automatically done by the scripts, but that part is not automated yet
[^2]: In the future, that will be performed by our CI
