### PR TITLE
Add some fastlane tasks for CI

### DIFF
--- a/MatrixSDK.xcodeproj/xcshareddata/xcschemes/MatrixSDK-iOS.xcscheme
+++ b/MatrixSDK.xcodeproj/xcshareddata/xcschemes/MatrixSDK-iOS.xcscheme
@@ -40,8 +40,17 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      codeCoverageEnabled = "YES"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "32C6F92C19DD814400EA4E9C"
+            BuildableName = "MatrixSDK.framework"
+            BlueprintName = "MatrixSDK-iOS"
+            ReferencedContainer = "container:MatrixSDK.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -54,17 +63,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "32C6F92C19DD814400EA4E9C"
-            BuildableName = "MatrixSDK.framework"
-            BlueprintName = "MatrixSDK-iOS"
-            ReferencedContainer = "container:MatrixSDK.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -85,8 +83,6 @@
             ReferencedContainer = "container:MatrixSDK.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -17,73 +17,95 @@ platform :ios do
   #### Pod ####
 
   desc "Lint all podspecs"
-  lane :lint_pods do  	
-  	lint_pod_MatrixSDK
-  	lint_pod_SwiftMatrixSDK
+  lane :lint_pods do
+    lint_pod_MatrixSDK
+    lint_pod_SwiftMatrixSDK
   end
 
   desc "Lint MatrixSDK podspec"
-  lane :lint_pod_MatrixSDK do  	
-  	custom_pod_lib_lint(podspec: "../MatrixSDK.podspec", parameters: ['--allow-warnings'])
+  lane :lint_pod_MatrixSDK do
+    custom_pod_lib_lint(podspec: "../MatrixSDK.podspec", parameters: ["--allow-warnings"])
   end
 
   desc "Lint SwiftMatrixSDK podspec"
-  lane :lint_pod_SwiftMatrixSDK do  	
-  	custom_pod_lib_lint(podspec: "../SwiftMatrixSDK.podspec", parameters: ['--allow-warnings'])    
+  lane :lint_pod_SwiftMatrixSDK do
+    custom_pod_lib_lint(podspec: "../SwiftMatrixSDK.podspec", parameters: ["--allow-warnings"])
   end
 
   desc "Push all pods"
-  lane :push_pods do  	
-  	push_pod_MatrixSDK
-  	push_pod_SwiftMatrixSDK
+  lane :push_pods do
+    push_pod_MatrixSDK
+    push_pod_SwiftMatrixSDK
   end
 
   desc "Push MatrixSDK pod"
-    lane :push_pod_MatrixSDK do  	
-  	pod_push(path: "MatrixSDK.podspec", allow_warnings: true)
+  lane :push_pod_MatrixSDK do
+    pod_push(path: "MatrixSDK.podspec", allow_warnings: true)
   end
 
   desc "Push SwiftMatrixSDK pod"
-    lane :push_pod_SwiftMatrixSDK do  	
-  	pod_push(path: "SwiftMatrixSDK.podspec", allow_warnings: true)
+  lane :push_pod_SwiftMatrixSDK do
+    pod_push(path: "SwiftMatrixSDK.podspec", allow_warnings: true)
+  end
+
+  #### Build ####
+
+  desc "Ensure the iOS framework builds"
+  lane :build_ios do
+    build_scheme(scheme: "MatrixSDK-iOS", destination: "generic/platform=iOS Simulator")
+  end
+
+  desc "Ensure the macOS framework builds"
+  lane :build_macos do
+    build_scheme(scheme: "MatrixSDK-macOS", destination: "generic/platform=macOS")
   end
 
   #### Tests ####
 
-  desc "Run integration tests (Be sure to set up the homeserver before like described here https://github.com/matrix-org/matrix-ios-sdk#tests)"  
-  lane :test do	
-  	cocoapods
-  	      
+  desc "Run integration tests (Be sure to set up the homeserver before like described here https://github.com/matrix-org/matrix-ios-sdk#tests)"
+  lane :test do
+    cocoapods
+
     opts = {
       :clean => true,
-      :scheme =>  'MatrixSDK',
-      :workspace => 'MatrixSDK.xcworkspace',
-      :configuration => 'Debug',      
-      :code_coverage => true
+      :scheme => "MatrixSDK",
+      :workspace => "MatrixSDK.xcworkspace",
+      :configuration => "Debug",
+      :code_coverage => true,
     }
     scan(opts)
   end
 
   #### Private ####
-  
+
+  private_lane :build_scheme do |options|
+    gym(
+      workspace: "MatrixSDK.xcworkspace",
+      scheme: options[:scheme],
+      skip_package_ipa: true,
+      skip_archive: true,
+      derived_data_path: "./DerivedData",
+      destination: options[:destination],
+    )
+  end
+
   desc "Returns bundle Cocoapods version"
   private_lane :cocoapods_version do
-  	sh('bundle exec pod --version', log: false)  	
+    sh("bundle exec pod --version", log: false)
   end
 
   desc "Pod lib lint with podspec parameter"
   private_lane :custom_pod_lib_lint do |options|
-  	
     puts "Lint pod " << options[:podspec] << " with Cocoapods version " << cocoapods_version
 
-  	command = []
-  	command << "bundle exec pod lib lint"
-  	command << options[:podspec]
+    command = []
+    command << "bundle exec pod lib lint"
+    command << options[:podspec]
 
     if options[:parameters]
-    	command.concat(options[:parameters])
-	end
+      command.concat(options[:parameters])
+    end
 
-	sh(command.join(' '))
+    sh(command.join(" "))
   end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -24,12 +24,12 @@ platform :ios do
 
   desc "Lint MatrixSDK podspec"
   lane :lint_pod_MatrixSDK do
-    custom_pod_lib_lint(podspec: "../MatrixSDK.podspec", parameters: ["--allow-warnings"])
+    custom_pod_lib_lint(podspec: "../MatrixSDK.podspec", parameters: ["--allow-warnings", "--verbose"])
   end
 
   desc "Lint SwiftMatrixSDK podspec"
   lane :lint_pod_SwiftMatrixSDK do
-    custom_pod_lib_lint(podspec: "../SwiftMatrixSDK.podspec", parameters: ["--allow-warnings"])
+    custom_pod_lib_lint(podspec: "../SwiftMatrixSDK.podspec", parameters: ["--allow-warnings", "--verbose"])
   end
 
   desc "Push all pods"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -78,6 +78,7 @@ platform :ios do
 
   #### Private ####
 
+  desc "Just build the provided :scheme / :destination (without doing any xcarchive)"
   private_lane :build_scheme do |options|
     gym(
       workspace: "MatrixSDK.xcworkspace",


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [ ] Pull request updates [CHANGES.rst](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CHANGES.rst)
* [ ] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)

---

Adds `build_macos` and `build_ios` lanes to the `Fastfile` – as well as a `build_scheme(…)` private lane used by those – which will be the lanes triggered by CI.

(The rest of the changes is mainly re-formatting done by vscode, that I kept applied for consistency)