### PR TITLE
Test update

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,7 @@ Build:
 
 Test:
  * Make tests crash instantly if no local synapse is running.
+ * Do not use anymore NSAssert in tests.
 
 Changes in 0.16.8 (2020-07-28)
 ================================================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,7 @@ Build:
  * 
 
 Test:
+ * Fix "fastlane ios test" and generate html report.
  * Make tests crash instantly if no local synapse is running.
  * Do not use anymore NSAssert in tests.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,7 +23,7 @@ Build:
  * 
 
 Test:
- * 
+ * Make tests crash instantly if no local synapse is running.
 
 Changes in 0.16.8 (2020-07-28)
 ================================================

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -3802,7 +3802,7 @@
 		32C6F92419DD814400EA4E9C /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0940;
+				LastUpgradeCheck = 1160;
 				ORGANIZATIONNAME = matrix.org;
 				TargetAttributes = {
 					32C6F92C19DD814400EA4E9C = {
@@ -4627,6 +4627,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -4687,6 +4688,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;

--- a/MatrixSDK.xcodeproj/xcshareddata/xcschemes/MatrixSDK-iOS.xcscheme
+++ b/MatrixSDK.xcodeproj/xcshareddata/xcschemes/MatrixSDK-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0940"
+   LastUpgradeVersion = "1160"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MatrixSDK.xcodeproj/xcshareddata/xcschemes/MatrixSDK-macOS.xcscheme
+++ b/MatrixSDK.xcodeproj/xcshareddata/xcschemes/MatrixSDK-macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1030"
+   LastUpgradeVersion = "1160"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -41,6 +41,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B14EF1C72397E90400758AF0"
+            BuildableName = "MatrixSDK.framework"
+            BlueprintName = "MatrixSDK-macOS"
+            ReferencedContainer = "container:MatrixSDK.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -53,17 +62,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "B14EF1C72397E90400758AF0"
-            BuildableName = "MatrixSDK.framework"
-            BlueprintName = "MatrixSDK-macOS"
-            ReferencedContainer = "container:MatrixSDK.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -84,8 +82,6 @@
             ReferencedContainer = "container:MatrixSDK.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/MatrixSDKTests/MXAggregatedReactionTests.m
+++ b/MatrixSDKTests/MXAggregatedReactionTests.m
@@ -86,12 +86,12 @@
 
         // - Add enough messages while the session in background to trigger a gappy sync
         [mxSession pause];
-        [matrixSDKTestsData for:mxSession.matrixRestClient andRoom:room.roomId sendMessages:10 success:^{
+        [matrixSDKTestsData for:mxSession.matrixRestClient andRoom:room.roomId sendMessages:10 testCase:self success:^{
 
             // - Add a reaction in the gap
             [otherSession.aggregations addReaction:@"🙂" forEvent:eventId inRoom:room.roomId success:^() {
 
-                [matrixSDKTestsData for:mxSession.matrixRestClient andRoom:room.roomId sendMessages:20 success:^{
+                [matrixSDKTestsData for:mxSession.matrixRestClient andRoom:room.roomId sendMessages:20 testCase:self success:^{
 
                     [mxSession start:^{
                         readyToTest(mxSession, room, otherSession, expectation, eventId);

--- a/MatrixSDKTests/MXCrossSigningTests.m
+++ b/MatrixSDKTests/MXCrossSigningTests.m
@@ -118,7 +118,7 @@
 
         // - Log Alice on a new device
         [MXSDKOptions sharedInstance].enableCryptoWhenStartingMXSession = YES;
-        [self->matrixSDKTestsData relogUserSessionWithNewDevice:alice0Session withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *alice1Session) {
+        [self->matrixSDKTestsData relogUserSessionWithNewDevice:self session:alice0Session withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *alice1Session) {
             [MXSDKOptions sharedInstance].enableCryptoWhenStartingMXSession = NO;
 
             // - Bootstrap cross-siging from alice1

--- a/MatrixSDKTests/MXCrossSigningTests.m
+++ b/MatrixSDKTests/MXCrossSigningTests.m
@@ -396,7 +396,7 @@
             XCTAssertEqual(aliceSession.crypto.crossSigning.state, MXCrossSigningStateCanCrossSign);
             
             // - Create a 2nd device
-            [matrixSDKTestsE2EData loginUserOnANewDevice:aliceSession.matrixRestClient.credentials withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *newAliceSession) {
+            [matrixSDKTestsE2EData loginUserOnANewDevice:self credentials:aliceSession.matrixRestClient.credentials withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *newAliceSession) {
                 
                 // - Check 2nd device cross-signing state
                 [newAliceSession.crypto.crossSigning refreshStateWithSuccess:^(BOOL stateUpdated) {
@@ -481,7 +481,7 @@
             XCTAssertEqual(aliceSession.crypto.crossSigning.state, MXCrossSigningStateCanCrossSign);
             
             // - Create a 2nd device
-            [matrixSDKTestsE2EData loginUserOnANewDevice:aliceSession.matrixRestClient.credentials withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *newAliceSession) {
+            [matrixSDKTestsE2EData loginUserOnANewDevice:self credentials:aliceSession.matrixRestClient.credentials withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *newAliceSession) {
                 
                 // - Make each device trust each other
                 //   This simulates a self verification and trigger cross-signing behind the shell
@@ -980,7 +980,7 @@
     [matrixSDKTestsE2EData doTestWithBobAndAliceWithTwoDevicesAllTrusted:self readyToTest:^(MXSession *aliceSession1, MXSession *aliceSession2, MXSession *bobSession, NSString *roomId, XCTestExpectation *expectation) {
         
         // - Alice signs in on a new Device (Alice3)
-        [matrixSDKTestsE2EData loginUserOnANewDevice:aliceSession1.matrixRestClient.credentials withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *aliceSession3) {
+        [matrixSDKTestsE2EData loginUserOnANewDevice:self credentials:aliceSession1.matrixRestClient.credentials withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *aliceSession3) {
             
             NSString *aliceUserId = aliceSession1.myUserId;
             NSString *aliceSession1DeviceId = aliceSession1.myDeviceId;
@@ -1126,7 +1126,7 @@
         
         // - Alice logs in on a new device
         __block NSString *newDeviceId;
-        [matrixSDKTestsE2EData loginUserOnANewDevice:aliceSession.matrixRestClient.credentials withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *newAliceSession) {
+        [matrixSDKTestsE2EData loginUserOnANewDevice:self credentials:aliceSession.matrixRestClient.credentials withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *newAliceSession) {
             newDeviceId = newAliceSession.matrixRestClient.credentials.deviceId;
         }];
         

--- a/MatrixSDKTests/MXCrossSigningVerificationTests.m
+++ b/MatrixSDKTests/MXCrossSigningVerificationTests.m
@@ -184,7 +184,7 @@
         [self bootstrapCrossSigningOnSession:aliceSession1 password:MXTESTS_ALICE_PWD completion:^{
           
             // - Alice has a second sign-in
-            [matrixSDKTestsE2EData loginUserOnANewDevice:aliceSession1.matrixRestClient.credentials withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *aliceSession2) {
+            [matrixSDKTestsE2EData loginUserOnANewDevice:self credentials:aliceSession1.matrixRestClient.credentials withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *aliceSession2) {
                 __block NSString *requestId;
                 
                 MXCredentials *alice = aliceSession1.matrixRestClient.credentials;

--- a/MatrixSDKTests/MXCryptoBackupTests.m
+++ b/MatrixSDKTests/MXCryptoBackupTests.m
@@ -1499,7 +1499,7 @@
             [aliceSession1.crypto.backup createKeyBackupVersion:keyBackupCreationInfo success:^(MXKeyBackupVersion * _Nonnull keyBackupVersion) {
                 [aliceSession1.crypto.backup backupAllGroupSessions:^{
                     
-                    [matrixSDKTestsE2EData loginUserOnANewDevice:aliceSession1.matrixRestClient.credentials withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *aliceSession2) {
+                    [matrixSDKTestsE2EData loginUserOnANewDevice:self credentials:aliceSession1.matrixRestClient.credentials withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *aliceSession2) {
                         
                         // -> We must have the backup private key locally
                         XCTAssertFalse(aliceSession2.crypto.backup.hasPrivateKeyInCryptoStore);

--- a/MatrixSDKTests/MXCryptoBackupTests.m
+++ b/MatrixSDKTests/MXCryptoBackupTests.m
@@ -618,7 +618,7 @@
 
                     // - Log Alice on a new device
                     [MXSDKOptions sharedInstance].enableCryptoWhenStartingMXSession = YES;
-                    [matrixSDKTestsData relogUserSessionWithNewDevice:aliceSession withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *aliceSession2) {
+                    [matrixSDKTestsData relogUserSessionWithNewDevice:self session:aliceSession withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *aliceSession2) {
                         [MXSDKOptions sharedInstance].enableCryptoWhenStartingMXSession = NO;
 
                         // Test check: aliceSession2 has no keys at login
@@ -991,7 +991,7 @@
 
                     // - Log Alice on a new device
                     [MXSDKOptions sharedInstance].enableCryptoWhenStartingMXSession = YES;
-                    [matrixSDKTestsData relogUserSessionWithNewDevice:aliceSession withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *aliceSession2) {
+                    [matrixSDKTestsData relogUserSessionWithNewDevice:self session:aliceSession withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *aliceSession2) {
                         [MXSDKOptions sharedInstance].enableCryptoWhenStartingMXSession = NO;
 
                         // - Post a message to have a new megolm session

--- a/MatrixSDKTests/MXCryptoKeyVerificationTests.m
+++ b/MatrixSDKTests/MXCryptoKeyVerificationTests.m
@@ -372,7 +372,7 @@
     // - Alice and Bob are in a room
     [matrixSDKTestsE2EData doE2ETestWithAliceAndBobInARoom:self cryptedBob:YES warnOnUnknowDevices:YES aliceStore:[[MXMemoryStore alloc] init] bobStore:[[MXMemoryStore alloc] init] readyToTest:^(MXSession *aliceSession, MXSession *bobSession, NSString *roomId, XCTestExpectation *expectation) {
         
-        [matrixSDKTestsE2EData loginUserOnANewDevice:aliceSession.matrixRestClient.credentials withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *newAliceSession) {
+        [matrixSDKTestsE2EData loginUserOnANewDevice:self credentials:aliceSession.matrixRestClient.credentials withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *newAliceSession) {
             
             [self checkVerificationByToDeviceFullFlowWithBobSession:bobSession aliceSession:aliceSession roomId:roomId expectation:expectation];
         }];
@@ -387,7 +387,7 @@
     // - Alice and Bob are in a room
     [matrixSDKTestsE2EData doE2ETestWithAliceAndBobInARoom:self cryptedBob:YES warnOnUnknowDevices:YES aliceStore:[[MXMemoryStore alloc] init] bobStore:[[MXMemoryStore alloc] init] readyToTest:^(MXSession *aliceSession, MXSession *bobSession, NSString *roomId, XCTestExpectation *expectation) {
         
-        [matrixSDKTestsE2EData loginUserOnANewDevice:bobSession.matrixRestClient.credentials withPassword:MXTESTS_BOB_PWD onComplete:^(MXSession *newBobSession) {
+        [matrixSDKTestsE2EData loginUserOnANewDevice:self credentials:bobSession.matrixRestClient.credentials withPassword:MXTESTS_BOB_PWD onComplete:^(MXSession *newBobSession) {
             
             [self checkVerificationByToDeviceFullFlowWithBobSession:bobSession aliceSession:aliceSession roomId:roomId expectation:expectation];
         }];
@@ -402,7 +402,7 @@
     // - Alice and Bob are in a room
     [matrixSDKTestsE2EData doE2ETestWithAliceAndBobInARoom:self cryptedBob:YES warnOnUnknowDevices:YES aliceStore:[[MXMemoryStore alloc] init] bobStore:[[MXMemoryStore alloc] init] readyToTest:^(MXSession *aliceSession, MXSession *bobSession, NSString *roomId, XCTestExpectation *expectation) {
         
-        [matrixSDKTestsE2EData loginUserOnANewDevice:aliceSession.matrixRestClient.credentials withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *newAliceSession) {
+        [matrixSDKTestsE2EData loginUserOnANewDevice:self credentials:aliceSession.matrixRestClient.credentials withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *newAliceSession) {
             
             [self checkVerificationByToDeviceFullFlowWithBobSession:aliceSession aliceSession:newAliceSession roomId:roomId expectation:expectation];
         }];
@@ -423,9 +423,9 @@
     // - Have Alice with 3 sessions
     [matrixSDKTestsE2EData doE2ETestWithAliceAndBobInARoom:self cryptedBob:YES warnOnUnknowDevices:YES aliceStore:[[MXMemoryStore alloc] init] bobStore:[[MXMemoryStore alloc] init] readyToTest:^(MXSession *aliceSession1, MXSession *bobSession, NSString *roomId, XCTestExpectation *expectation) {
         
-        [matrixSDKTestsE2EData loginUserOnANewDevice:aliceSession1.matrixRestClient.credentials withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *aliceSession2) {
+        [matrixSDKTestsE2EData loginUserOnANewDevice:self credentials:aliceSession1.matrixRestClient.credentials withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *aliceSession2) {
             
-            [matrixSDKTestsE2EData loginUserOnANewDevice:aliceSession1.matrixRestClient.credentials withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *aliceSession3) {
+            [matrixSDKTestsE2EData loginUserOnANewDevice:self credentials:aliceSession1.matrixRestClient.credentials withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *aliceSession3) {
                 
                 NSString *aliceUserId = aliceSession1.matrixRestClient.credentials.userId;
 
@@ -1408,7 +1408,7 @@
     // - Alice and Bob are in a room
     [matrixSDKTestsE2EData doE2ETestWithAliceAndBobInARoom:self cryptedBob:YES warnOnUnknowDevices:YES aliceStore:[[MXMemoryStore alloc] init] bobStore:[[MXMemoryStore alloc] init] readyToTest:^(MXSession *aliceSession, MXSession *bobSession, NSString *roomId, XCTestExpectation *expectation) {
         
-        [matrixSDKTestsE2EData loginUserOnANewDevice:aliceSession.matrixRestClient.credentials withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *newAliceSession) {
+        [matrixSDKTestsE2EData loginUserOnANewDevice:self credentials:aliceSession.matrixRestClient.credentials withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *newAliceSession) {
             
             [self checkVerificationByDMFullFlowWithAliceSession:aliceSession bobSession:bobSession roomId:roomId expectation:expectation];
         }];
@@ -1423,7 +1423,7 @@
     // - Alice and Bob are in a room
     [matrixSDKTestsE2EData doE2ETestWithAliceAndBobInARoom:self cryptedBob:YES warnOnUnknowDevices:YES aliceStore:[[MXMemoryStore alloc] init] bobStore:[[MXMemoryStore alloc] init] readyToTest:^(MXSession *aliceSession, MXSession *bobSession, NSString *roomId, XCTestExpectation *expectation) {
         
-        [matrixSDKTestsE2EData loginUserOnANewDevice:bobSession.matrixRestClient.credentials withPassword:MXTESTS_BOB_PWD onComplete:^(MXSession *newBobSession) {
+        [matrixSDKTestsE2EData loginUserOnANewDevice:self credentials:bobSession.matrixRestClient.credentials withPassword:MXTESTS_BOB_PWD onComplete:^(MXSession *newBobSession) {
             [self checkVerificationByDMFullFlowWithAliceSession:aliceSession bobSession:bobSession roomId:roomId expectation:expectation];
         }];
     }];

--- a/MatrixSDKTests/MXCryptoRecoveryServiceTests.m
+++ b/MatrixSDKTests/MXCryptoRecoveryServiceTests.m
@@ -392,7 +392,7 @@
             
             // - Log Alice on a new device
             [MXSDKOptions sharedInstance].enableCryptoWhenStartingMXSession = YES;
-            [matrixSDKTestsData relogUserSessionWithNewDevice:aliceSession withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *aliceSession2) {
+            [matrixSDKTestsData relogUserSessionWithNewDevice:self session:aliceSession withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *aliceSession2) {
                 [MXSDKOptions sharedInstance].enableCryptoWhenStartingMXSession = NO;
                 
                 [aliceSession2.crypto.crossSigning refreshStateWithSuccess:^(BOOL stateUpdated) {

--- a/MatrixSDKTests/MXCryptoSecretShareTests.m
+++ b/MatrixSDKTests/MXCryptoSecretShareTests.m
@@ -95,7 +95,7 @@
         [aliceSession.crypto.store storeSecret:secret withSecretId:secretId];
         
         // - Alice logs in on a new device
-        [matrixSDKTestsE2EData loginUserOnANewDevice:aliceSession.matrixRestClient.credentials withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *newAliceSession) {
+        [matrixSDKTestsE2EData loginUserOnANewDevice:self credentials:aliceSession.matrixRestClient.credentials withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *newAliceSession) {
             
             MXCredentials *newAlice = newAliceSession.matrixRestClient.credentials;
             
@@ -142,7 +142,7 @@
         [aliceSession.crypto.store storeSecret:secret withSecretId:secretId];
         
         // - Alice logs in on a new device
-        [matrixSDKTestsE2EData loginUserOnANewDevice:aliceSession.matrixRestClient.credentials withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *newAliceSession) {
+        [matrixSDKTestsE2EData loginUserOnANewDevice:self credentials:aliceSession.matrixRestClient.credentials withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *newAliceSession) {
             
             MXCredentials *newAlice = newAliceSession.matrixRestClient.credentials;
             

--- a/MatrixSDKTests/MXCryptoShareTests.m
+++ b/MatrixSDKTests/MXCryptoShareTests.m
@@ -61,7 +61,7 @@
     [session.crypto importMegolmSessionDatas:@[sessionData] backUp:NO success:^(NSUInteger total, NSUInteger imported) {
         complete();
     } failure:^(NSError *error) {
-        NSAssert(NO, @"Cannot set up intial test conditions - error: %@", error);
+        [matrixSDKTestsData breakTestCase:self reason:@"Cannot set up intial test conditions - error: %@", error];
     }];
 }
 
@@ -92,7 +92,7 @@
                 } failure:nil];
             } failure:nil];
         } failure:^(NSError *error) {
-            NSAssert(NO, @"Cannot set up intial test conditions - error: %@", error);
+            [matrixSDKTestsData breakTestCase:self reason:@"Cannot set up intial test conditions - error: %@", error];
         }];
 
 

--- a/MatrixSDKTests/MXCryptoShareTests.m
+++ b/MatrixSDKTests/MXCryptoShareTests.m
@@ -146,7 +146,7 @@
     [matrixSDKTestsE2EData doE2ETestWithAliceAndBobInARoomWithCryptedMessages:self cryptedBob:YES readyToTest:^(MXSession *aliceSession1, MXSession *bobSession, NSString *roomId, XCTestExpectation *expectation) {
         
         //- Alice signs in on a new device
-        [matrixSDKTestsE2EData loginUserOnANewDevice:aliceSession1.matrixRestClient.credentials withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *aliceSession2) {
+        [matrixSDKTestsE2EData loginUserOnANewDevice:self credentials:aliceSession1.matrixRestClient.credentials withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *aliceSession2) {
             
             // - Alice2 paginates in the room
             MXRoom *roomFromAlice2POV = [aliceSession2 roomWithRoomId:roomId];
@@ -197,7 +197,7 @@
     [matrixSDKTestsE2EData doE2ETestWithAliceAndBobInARoomWithCryptedMessages:self cryptedBob:YES readyToTest:^(MXSession *aliceSession1, MXSession *bobSession, NSString *roomId, XCTestExpectation *expectation) {
         
         //- Alice signs in on a new device
-        [matrixSDKTestsE2EData loginUserOnANewDevice:aliceSession1.matrixRestClient.credentials withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *aliceSession2) {
+        [matrixSDKTestsE2EData loginUserOnANewDevice:self credentials:aliceSession1.matrixRestClient.credentials withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *aliceSession2) {
             
             NSString *aliceUserId = aliceSession1.matrixRestClient.credentials.userId;
             
@@ -268,7 +268,7 @@
     [matrixSDKTestsE2EData doE2ETestWithAliceAndBobInARoomWithCryptedMessages:self cryptedBob:YES readyToTest:^(MXSession *aliceSession1, MXSession *bobSession, NSString *roomId, XCTestExpectation *expectation) {
         
         //- Alice signs in on a new device
-        [matrixSDKTestsE2EData loginUserOnANewDevice:aliceSession1.matrixRestClient.credentials withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *aliceSession2) {
+        [matrixSDKTestsE2EData loginUserOnANewDevice:self credentials:aliceSession1.matrixRestClient.credentials withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *aliceSession2) {
             
             // - Disable key share requests on Alice2
             [aliceSession2.crypto setOutgoingKeyRequestsEnabled:NO onComplete:nil];
@@ -356,7 +356,7 @@
                     
                     
                     //- Alice signs in on a new device
-                    [matrixSDKTestsE2EData loginUserOnANewDevice:aliceSession1.matrixRestClient.credentials withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *aliceSession2) {
+                    [matrixSDKTestsE2EData loginUserOnANewDevice:self credentials:aliceSession1.matrixRestClient.credentials withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *aliceSession2) {
                         
                         // - Disable key share requests on Alice2
                         [aliceSession2.crypto setOutgoingKeyRequestsEnabled:NO onComplete:nil];

--- a/MatrixSDKTests/MXCryptoShareTests.m
+++ b/MatrixSDKTests/MXCryptoShareTests.m
@@ -119,7 +119,7 @@
 
                     // - Log Alice on a new device
                     [MXSDKOptions sharedInstance].enableCryptoWhenStartingMXSession = YES;
-                    [matrixSDKTestsData relogUserSessionWithNewDevice:aliceSession withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *aliceSession2) {
+                    [matrixSDKTestsData relogUserSessionWithNewDevice:self session:aliceSession withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *aliceSession2) {
                         [MXSDKOptions sharedInstance].enableCryptoWhenStartingMXSession = NO;
 
                         readyToTest(aliceSession2, roomId, sessionData, partialSessionData, expectation);

--- a/MatrixSDKTests/MXCryptoTests.m
+++ b/MatrixSDKTests/MXCryptoTests.m
@@ -675,11 +675,11 @@
                 }];
 
             } failure:^(NSError *error) {
-                NSAssert(NO, @"Cannot set up intial test conditions - error: %@", error);
+                XCTFail(@"Cannot set up intial test conditions - error: %@", error);
             }];
 
         } failure:^(NSError *error) {
-            NSAssert(NO, @"Cannot set up intial test conditions - error: %@", error);
+            XCTFail(@"Cannot set up intial test conditions - error: %@", error);
         }];
 
     }];
@@ -1593,7 +1593,7 @@
             }];
             
             [bobSession joinRoom:roomId viaServers:nil success:nil failure:^(NSError *error) {
-                NSAssert(NO, @"Cannot join a room - error: %@", error);
+                XCTFail(@"Cannot join a room - error: %@", error);
                 [expectation fulfill];
             }];
             
@@ -1631,7 +1631,7 @@
                         [expectation fulfill];
                     }];
                 } failure:^(NSError *error) {
-                    NSAssert(NO, @"Cannot join a room - error: %@", error);
+                    XCTFail(@"Cannot join a room - error: %@", error);
                     [expectation fulfill];
                 }];
                 

--- a/MatrixSDKTests/MXCryptoTests.m
+++ b/MatrixSDKTests/MXCryptoTests.m
@@ -2915,7 +2915,7 @@
     [matrixSDKTestsE2EData doE2ETestWithAliceInARoom:self readyToTest:^(MXSession *aliceSession, NSString *roomId, XCTestExpectation *expectation) {
         
         // - Alice logs in on a new device
-        [matrixSDKTestsE2EData loginUserOnANewDevice:aliceSession.matrixRestClient.credentials withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *newAliceSession) {
+        [matrixSDKTestsE2EData loginUserOnANewDevice:self credentials:aliceSession.matrixRestClient.credentials withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *newAliceSession) {
         }];
         
         // -> The first device must get notified by the new sign-in

--- a/MatrixSDKTests/MXCryptoTests.m
+++ b/MatrixSDKTests/MXCryptoTests.m
@@ -892,7 +892,7 @@
 
             // Relog alice to simulate a new device
             [MXSDKOptions sharedInstance].enableCryptoWhenStartingMXSession = YES;
-            [matrixSDKTestsData relogUserSession:aliceSession withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *aliceSession2) {
+            [matrixSDKTestsData relogUserSession:self session:aliceSession withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *aliceSession2) {
                 [MXSDKOptions sharedInstance].enableCryptoWhenStartingMXSession = NO;
 
                 aliceSessionToClose = aliceSession2;
@@ -927,7 +927,7 @@
 
         // Relog alice to simulate a new device
         [MXSDKOptions sharedInstance].enableCryptoWhenStartingMXSession = YES;
-        [matrixSDKTestsData relogUserSession:aliceSession withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *aliceSession2) {
+        [matrixSDKTestsData relogUserSession:self session:aliceSession withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *aliceSession2) {
             [MXSDKOptions sharedInstance].enableCryptoWhenStartingMXSession = NO;
 
             aliceSessionToClose = aliceSession2;
@@ -974,7 +974,7 @@
 
                 // Relog bob to simulate a new device
                 [MXSDKOptions sharedInstance].enableCryptoWhenStartingMXSession = YES;
-                [matrixSDKTestsData relogUserSession:bobSession withPassword:MXTESTS_BOB_PWD onComplete:^(MXSession *bobSession2) {
+                [matrixSDKTestsData relogUserSession:self session:bobSession withPassword:MXTESTS_BOB_PWD onComplete:^(MXSession *bobSession2) {
                     [MXSDKOptions sharedInstance].enableCryptoWhenStartingMXSession = NO;
 
                     aliceSessionToClose = aliceSession;
@@ -1021,12 +1021,12 @@
 
         // Relog alice to simulate a new device
         [MXSDKOptions sharedInstance].enableCryptoWhenStartingMXSession = YES;
-        [matrixSDKTestsData relogUserSession:aliceSession withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *aliceSession2) {
+        [matrixSDKTestsData relogUserSession:self session:aliceSession withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *aliceSession2) {
             [MXSDKOptions sharedInstance].enableCryptoWhenStartingMXSession = NO;
 
             // Relog bob to simulate a new device
             [MXSDKOptions sharedInstance].enableCryptoWhenStartingMXSession = YES;
-            [matrixSDKTestsData relogUserSession:bobSession withPassword:MXTESTS_BOB_PWD onComplete:^(MXSession *bobSession2) {
+            [matrixSDKTestsData relogUserSession:self session:bobSession withPassword:MXTESTS_BOB_PWD onComplete:^(MXSession *bobSession2) {
                 [MXSDKOptions sharedInstance].enableCryptoWhenStartingMXSession = NO;
 
                 aliceSessionToClose = aliceSession2;
@@ -2109,7 +2109,7 @@
 
                                     // Relog bob to simulate a new device
                                     [MXSDKOptions sharedInstance].enableCryptoWhenStartingMXSession = YES;
-                                    [matrixSDKTestsData relogUserSession:bobSession withPassword:MXTESTS_BOB_PWD onComplete:^(MXSession *bobSession2) {
+                                    [matrixSDKTestsData relogUserSession:self session:bobSession withPassword:MXTESTS_BOB_PWD onComplete:^(MXSession *bobSession2) {
 
                                         [MXSDKOptions sharedInstance].enableCryptoWhenStartingMXSession = NO;
 
@@ -2192,7 +2192,7 @@
 
             // - Alice adds a new device
             [MXSDKOptions sharedInstance].enableCryptoWhenStartingMXSession = YES;
-            [matrixSDKTestsData relogUserSession:aliceSession withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *aliceSession2) {
+            [matrixSDKTestsData relogUserSession:self session:aliceSession withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *aliceSession2) {
                 [MXSDKOptions sharedInstance].enableCryptoWhenStartingMXSession = NO;
 
                 aliceSessionToClose = aliceSession2;
@@ -2291,7 +2291,7 @@
 
                         // Relog bob to simulate a new device
                         [MXSDKOptions sharedInstance].enableCryptoWhenStartingMXSession = YES;
-                        [matrixSDKTestsData relogUserSession:bobSession withPassword:MXTESTS_BOB_PWD onComplete:^(MXSession *newBobSession) {
+                        [matrixSDKTestsData relogUserSession:self session:bobSession withPassword:MXTESTS_BOB_PWD onComplete:^(MXSession *newBobSession) {
 
                             aliceSessionToClose = aliceSession;
                             bobSessionToClose = newBobSession;
@@ -2723,7 +2723,7 @@
         // 3 - Recreate a second MXSession, aliceSession2, for Alice with a new device
         // Relog alice to simulate a new device
         [MXSDKOptions sharedInstance].enableCryptoWhenStartingMXSession = YES;
-        [matrixSDKTestsData relogUserSessionWithNewDevice:aliceSession withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *aliceSession2) {
+        [matrixSDKTestsData relogUserSessionWithNewDevice:self session:aliceSession withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *aliceSession2) {
             [MXSDKOptions sharedInstance].enableCryptoWhenStartingMXSession = NO;
 
             aliceSessionToClose = aliceSession2;

--- a/MatrixSDKTests/MXEventTimelineTests.m
+++ b/MatrixSDKTests/MXEventTimelineTests.m
@@ -59,13 +59,13 @@ NSString *theInitialEventMessage = @"The initial timelime event";
         mxSession = mxSession2;
 
         // Add 20 messages to the room
-        [matrixSDKTestsData for:mxSession.matrixRestClient andRoom:room.roomId sendMessages:20 success:^{
+        [matrixSDKTestsData for:mxSession.matrixRestClient andRoom:room.roomId sendMessages:20 testCase:testCase success:^{
 
             // Add a text message that will be used as initial event
             [room sendTextMessage:theInitialEventMessage success:^(NSString *eventId) {
 
                 // Add 20 more messages
-                [matrixSDKTestsData for:mxSession.matrixRestClient andRoom:room.roomId sendMessages:20 success:^{
+                [matrixSDKTestsData for:mxSession.matrixRestClient andRoom:room.roomId sendMessages:20 testCase:testCase success:^{
 
                     readyToTest(room, expectation, eventId);
 

--- a/MatrixSDKTests/MXLazyLoadingTests.m
+++ b/MatrixSDKTests/MXLazyLoadingTests.m
@@ -98,7 +98,7 @@ Common initial conditions:
                     [roomFromBobPOV inviteUser:@"@dave:localhost:8480" success:^{
 
                         //  - Alice sends 50 messages
-                        [matrixSDKTestsData for:aliceRestClient andRoom:roomId sendMessages:50 success:^{
+                        [matrixSDKTestsData for:aliceRestClient andRoom:roomId sendMessages:50 testCase:self success:^{
 
                             // - Bob sends a message
                             [roomFromBobPOV sendTextMessage:bobMessage success:^(NSString *eventId) {
@@ -106,7 +106,7 @@ Common initial conditions:
                                 bobMessageEventId = eventId;
 
                                 // - Alice sends 50 messages
-                                [matrixSDKTestsData for:aliceRestClient andRoom:roomId sendMessages:50 success:^{
+                                [matrixSDKTestsData for:aliceRestClient andRoom:roomId sendMessages:50 testCase:self success:^{
 
                                     // - Alice makes an initial /sync
                                     MXSession *aliceSession = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
@@ -599,7 +599,7 @@ Common initial conditions:
 
 
                                                 // - Eve0 sends 20 messages
-                                                [matrixSDKTestsData for:eve0Session.matrixRestClient andRoom:roomId sendMessages:20 success:^{
+                                                [matrixSDKTestsData for:eve0Session.matrixRestClient andRoom:roomId sendMessages:20 testCase:self success:^{
 
                                                     // - Resume Alice MXSession
                                                     [aliceSession resume:^{
@@ -826,7 +826,7 @@ Common initial conditions:
         [aliceSession.matrixRestClient leaveRoom:roomId success:^{
 
             // - Bob sends 50 messages
-            [matrixSDKTestsData for:bobSession.matrixRestClient andRoom:roomId sendMessages:50 success:^{
+            [matrixSDKTestsData for:bobSession.matrixRestClient andRoom:roomId sendMessages:50 testCase:self success:^{
 
                 // - Resume Alice MXSession
                 [aliceSession resume:^{
@@ -1150,7 +1150,7 @@ Common initial conditions:
         [aliceSession pause];
 
         //  - Bob sends 50 messages
-        [matrixSDKTestsData for:bobSession.matrixRestClient andRoom:roomId sendMessages:50 success:^{
+        [matrixSDKTestsData for:bobSession.matrixRestClient andRoom:roomId sendMessages:50 testCase:self success:^{
 
             // - Alice resumes (there will a limited /sync)
             [aliceSession resume:^{

--- a/MatrixSDKTests/MXRestClientNoAuthAPITests.m
+++ b/MatrixSDKTests/MXRestClientNoAuthAPITests.m
@@ -60,7 +60,7 @@
 - (void)createTestAccount:(void (^)(void))onReady
 {
     // Register the user
-    [mxRestClient registerWithLoginType:kMXLoginFlowTypeDummy username:MXTESTS_USER password:MXTESTS_PWD success:^(MXCredentials *credentials) {
+    MXHTTPOperation *operation = [mxRestClient registerWithLoginType:kMXLoginFlowTypeDummy username:MXTESTS_USER password:MXTESTS_PWD success:^(MXCredentials *credentials) {
 
         onReady();
 
@@ -76,6 +76,7 @@
             XCTFail(@"Cannot create the test account");
         }
     }];
+    operation.maxRetriesTime = 1;
 }
 
 - (void)testInit
@@ -172,7 +173,7 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"asyncTest"];
 
     // Provide nil as username, the HS will provide one for us
-    [mxRestClient registerWithLoginType:kMXLoginFlowTypeDummy username:nil password:MXTESTS_PWD success:^(MXCredentials *credentials) {
+    MXHTTPOperation *operation = [mxRestClient registerWithLoginType:kMXLoginFlowTypeDummy username:nil password:MXTESTS_PWD success:^(MXCredentials *credentials) {
 
         XCTAssertNotNil(credentials);
         XCTAssertNotNil(credentials.homeServer);
@@ -185,6 +186,7 @@
         XCTFail(@"The request should not fail - NSError: %@", error);
         [expectation fulfill];
     }];
+    operation.maxRetriesTime = 1;
 
     [self waitForExpectationsWithTimeout:10 handler:nil];
 }
@@ -196,7 +198,7 @@
     [self createTestAccount:^{
 
         // Register the same user
-        [mxRestClient registerWithLoginType:kMXLoginFlowTypeDummy username:MXTESTS_USER password:MXTESTS_PWD success:^(MXCredentials *credentials) {
+        MXHTTPOperation *operation = [mxRestClient registerWithLoginType:kMXLoginFlowTypeDummy username:MXTESTS_USER password:MXTESTS_PWD success:^(MXCredentials *credentials) {
 
             XCTFail(@"The request should fail (User already exists)");
 
@@ -212,6 +214,7 @@
 
             [expectation fulfill];
         }];
+        operation.maxRetriesTime = 1;
     }];
 
     [self waitForExpectationsWithTimeout:10 handler:nil];

--- a/MatrixSDKTests/MXRestClientNoAuthAPITests.m
+++ b/MatrixSDKTests/MXRestClientNoAuthAPITests.m
@@ -76,7 +76,7 @@
             XCTFail(@"Cannot create the test account");
         }
     }];
-    operation.maxRetriesTime = 1;
+    operation.maxNumberOfTries = 1;
 }
 
 - (void)testInit
@@ -186,7 +186,7 @@
         XCTFail(@"The request should not fail - NSError: %@", error);
         [expectation fulfill];
     }];
-    operation.maxRetriesTime = 1;
+    operation.maxNumberOfTries = 1;
 
     [self waitForExpectationsWithTimeout:10 handler:nil];
 }
@@ -214,7 +214,7 @@
 
             [expectation fulfill];
         }];
-        operation.maxRetriesTime = 1;
+        operation.maxNumberOfTries = 1;
     }];
 
     [self waitForExpectationsWithTimeout:10 handler:nil];
@@ -474,7 +474,7 @@
 
     client.completionQueue = dispatch_queue_create("aQueueFromAnotherThread", DISPATCH_QUEUE_SERIAL);
 
-    [client publicRoomsOnServer:nil limit:-1 since:nil filter:nil thirdPartyInstanceId:nil includeAllNetworks:NO success:^(MXPublicRoomsResponse *publicRoomsResponse) {
+    MXHTTPOperation *operation = [client publicRoomsOnServer:nil limit:-1 since:nil filter:nil thirdPartyInstanceId:nil includeAllNetworks:NO success:^(MXPublicRoomsResponse *publicRoomsResponse) {
 
         XCTAssertFalse([[NSThread currentThread] isMainThread]);
         XCTAssertEqual(dispatch_get_current_queue(), client.completionQueue);
@@ -485,6 +485,7 @@
         XCTFail(@"The request should not fail - NSError: %@", error);
         [expectation fulfill];
     }];
+    operation.maxNumberOfTries = 1;
 
     [self waitForExpectationsWithTimeout:10 handler:nil];
 }

--- a/MatrixSDKTests/MXRestClientTests.m
+++ b/MatrixSDKTests/MXRestClientTests.m
@@ -1426,7 +1426,7 @@
     [matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
         
         // Add 50 messages to the room
-        [matrixSDKTestsData for:bobRestClient andRoom:roomId sendMessages:20 success:^{
+        [matrixSDKTestsData for:bobRestClient andRoom:roomId sendMessages:20 testCase:self success:^{
             
             MXRoomEventFilter *roomEventFilter = [[MXRoomEventFilter alloc] init];
             roomEventFilter.rooms = @[roomId];

--- a/MatrixSDKTests/MXRoomSummaryTests.m
+++ b/MatrixSDKTests/MXRoomSummaryTests.m
@@ -312,7 +312,7 @@ NSString *uisiString = @"The sender's device has not sent us the keys for this m
         NSString *roomId = room.roomId;
 
         // Add more messages than a single pagination can retrieve
-        [matrixSDKTestsData for:bobRestClient andRoom:roomId sendMessages:80 success:^{
+        [matrixSDKTestsData for:bobRestClient andRoom:roomId sendMessages:80 testCase:self success:^{
 
             MXRoomSummary *summary = [mxSession roomSummaryWithRoomId:roomId];
             XCTAssert(summary);

--- a/MatrixSDKTests/MXRoomSummaryTrustTests.m
+++ b/MatrixSDKTests/MXRoomSummaryTrustTests.m
@@ -133,7 +133,7 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
     // - Have Alice with 2 devices (Alice1 and Alice2) and Bob. All trusted via cross-signing
     [matrixSDKTestsE2EData doTestWithBobAndAliceWithTwoDevicesAllTrusted:self readyToTest:^(MXSession *aliceSession1, MXSession *aliceSession2, MXSession *bobSession1, NSString *roomId, XCTestExpectation *expectation) {
         
-        [matrixSDKTestsE2EData loginUserOnANewDevice:bobSession1.matrixRestClient.credentials withPassword:MXTESTS_BOB_PWD onComplete:^(MXSession *bobSession2) {
+        [matrixSDKTestsE2EData loginUserOnANewDevice:self credentials:bobSession1.matrixRestClient.credentials withPassword:MXTESTS_BOB_PWD onComplete:^(MXSession *bobSession2) {
             
             dispatch_after(dispatch_time(DISPATCH_TIME_NOW, kMXRoomSummaryTrustComputationDelayMs * NSEC_PER_MSEC), dispatch_get_main_queue(), ^{
                 
@@ -177,7 +177,7 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
             XCTAssertEqual(trust.trustedDevicesProgress.fractionCompleted, 1);
             
             // - Bob signs in on a new device
-            [matrixSDKTestsE2EData loginUserOnANewDevice:bobSession1.matrixRestClient.credentials withPassword:MXTESTS_BOB_PWD onComplete:^(MXSession *bobSession2) {
+            [matrixSDKTestsE2EData loginUserOnANewDevice:self credentials:bobSession1.matrixRestClient.credentials withPassword:MXTESTS_BOB_PWD onComplete:^(MXSession *bobSession2) {
             }];
             
             // -> Alice must be notified there is no more 100% of trust in this room
@@ -207,7 +207,7 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
     // - Have Alice with 2 devices (Alice1 and Alice2) and Bob. All trusted via cross-signing
     [matrixSDKTestsE2EData doTestWithBobAndAliceWithTwoDevicesAllTrusted:self readyToTest:^(MXSession *aliceSession1, MXSession *aliceSession2, MXSession *bobSession1, NSString *roomId, XCTestExpectation *expectation) {
         
-        [matrixSDKTestsE2EData loginUserOnANewDevice:bobSession1.matrixRestClient.credentials withPassword:MXTESTS_BOB_PWD onComplete:^(MXSession *bobSession2) {
+        [matrixSDKTestsE2EData loginUserOnANewDevice:self credentials:bobSession1.matrixRestClient.credentials withPassword:MXTESTS_BOB_PWD onComplete:^(MXSession *bobSession2) {
             
             dispatch_after(dispatch_time(DISPATCH_TIME_NOW, kMXRoomSummaryTrustComputationDelayMs * NSEC_PER_MSEC), dispatch_get_main_queue(), ^{
                 

--- a/MatrixSDKTests/MXSelfSignedHomeserverTests.m
+++ b/MatrixSDKTests/MXSelfSignedHomeserverTests.m
@@ -67,7 +67,7 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"asyncTest"];
 
     __block BOOL certificateCheckAsked = NO;
-    [matrixSDKTestsData getHttpsBobCredentials:^{
+    [matrixSDKTestsData getHttpsBobCredentials:self readyToTest:^{
 
         XCTAssert(certificateCheckAsked, @"We must have been asked to check the certificate");
         XCTAssertNotNil(matrixSDKTestsData.bobCredentials);
@@ -90,7 +90,7 @@
 {
     XCTestExpectation *expectation = [self expectationWithDescription:@"asyncTest"];
 
-    [matrixSDKTestsData getHttpsBobCredentials:^{
+    [matrixSDKTestsData getHttpsBobCredentials:self readyToTest:^{
 
         MXRestClient *mxRestClient = [[MXRestClient alloc] initWithCredentials:matrixSDKTestsData.bobCredentials andOnUnrecognizedCertificateBlock:^BOOL(NSData *certificate) {
 

--- a/MatrixSDKTests/MXStoreTests.m
+++ b/MatrixSDKTests/MXStoreTests.m
@@ -115,7 +115,7 @@
 
     [matrixSDKTestsData doMXRestClientTestWithBobAndAliceInARoom:testCase readyToTest:^(MXRestClient *bobRestClient, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation2) {
 
-        [matrixSDKTestsData for:bobRestClient andRoom:roomId sendMessages:5 success:^{
+        [matrixSDKTestsData for:bobRestClient andRoom:roomId sendMessages:5 testCase:testCase success:^{
 
             if (!expectation)
             {

--- a/MatrixSDKTests/MatrixSDKTestsData.h
+++ b/MatrixSDKTests/MatrixSDKTestsData.h
@@ -148,12 +148,18 @@ onUnrecognizedCertificateBlock:(MXHTTPClientOnUnrecognizedCertificate)onUnrecogn
 - (void)breakTestCase:(XCTestCase*)testCase reason:(NSString *)reason, ...;
 
 // Logout the user on the server and log the user in with a new device
-- (void)relogUserSession:(MXSession*)session withPassword:(NSString*)password onComplete:(void (^)(MXSession *newSession))onComplete;
+- (void)relogUserSession:(XCTestCase*)testCase
+                 session:(MXSession*)session
+            withPassword:(NSString*)password
+              onComplete:(void (^)(MXSession *newSession))onComplete;
 
 // Close the current session by erasing the crypto to store  and log the user in with a new device
-- (void)relogUserSessionWithNewDevice:(MXSession*)session withPassword:(NSString*)password onComplete:(void (^)(MXSession *newSession))onComplete;
+- (void)relogUserSessionWithNewDevice:(XCTestCase*)testCase
+                              session:(MXSession*)session
+                         withPassword:(NSString*)password
+                           onComplete:(void (^)(MXSession *newSession))onComplete;
 
-- (void)for:(MXRestClient *)mxRestClient2 andRoom:(NSString*)roomId sendMessages:(NSUInteger)messagesCount success:(void (^)(void))success;
+- (void)for:(MXRestClient *)mxRestClient2 andRoom:(NSString*)roomId sendMessages:(NSUInteger)messagesCount testCase:(XCTestCase*)testCase success:(void (^)(void))success;
 
 
 #pragma mark Reference keeping

--- a/MatrixSDKTests/MatrixSDKTestsData.h
+++ b/MatrixSDKTests/MatrixSDKTestsData.h
@@ -45,7 +45,8 @@ FOUNDATION_EXPORT NSString * const kMXTestsAliceAvatarURL;
 
 // Get credentials asynchronously
 // The user will be created if needed
-- (void)getBobCredentials:(void (^)(void))success;
+- (void)getBobCredentials:(XCTestCase*)testCase
+              readyToTest:(void (^)(void))readyToTest;
 
 // Prepare a test with a MXRestClient for mxBob so that we can make test on it
 - (void)doMXRestClientTestWithBob:(XCTestCase*)testCase
@@ -128,8 +129,11 @@ FOUNDATION_EXPORT NSString * const kMXTestsAliceAvatarURL;
 
 
 #pragma mark - HTTPS mxBob
-- (void)getHttpsBobCredentials:(void (^)(void))success;
-- (void)getHttpsBobCredentials:(void (^)(void))success onUnrecognizedCertificateBlock:(MXHTTPClientOnUnrecognizedCertificate)onUnrecognizedCertBlock;
+- (void)getHttpsBobCredentials:(XCTestCase*)testCase
+                   readyToTest:(void (^)(void))readyToTest;
+- (void)getHttpsBobCredentials:(XCTestCase*)testCase
+                   readyToTest:(void (^)(void))readyToTest
+onUnrecognizedCertificateBlock:(MXHTTPClientOnUnrecognizedCertificate)onUnrecognizedCertBlock;
 
 - (void)doHttpsMXRestClientTestWithBob:(XCTestCase*)testCase
                            readyToTest:(void (^)(MXRestClient *bobRestClient, XCTestExpectation *expectation))readyToTest;
@@ -138,6 +142,11 @@ FOUNDATION_EXPORT NSString * const kMXTestsAliceAvatarURL;
 
 
 #pragma mark - tools
+
+// Stop the given test with a failure reason.
+// This method stop the execution of the test.
+- (void)breakTestCase:(XCTestCase*)testCase reason:(NSString *)reason, ...;
+
 // Logout the user on the server and log the user in with a new device
 - (void)relogUserSession:(MXSession*)session withPassword:(NSString*)password onComplete:(void (^)(MXSession *newSession))onComplete;
 

--- a/MatrixSDKTests/MatrixSDKTestsData.m
+++ b/MatrixSDKTests/MatrixSDKTestsData.m
@@ -82,7 +82,7 @@ NSString * const kMXTestsAliceAvatarURL = @"mxc://matrix.org/kciiXusgZFKuNLIfLqm
         [self retain:mxRestClient];
 
         // First, try register the user
-        [mxRestClient registerWithLoginType:kMXLoginFlowTypeDummy username:bobUniqueUser password:MXTESTS_BOB_PWD success:^(MXCredentials *credentials) {
+        MXHTTPOperation *operation = [mxRestClient registerWithLoginType:kMXLoginFlowTypeDummy username:bobUniqueUser password:MXTESTS_BOB_PWD success:^(MXCredentials *credentials) {
 
             _bobCredentials = credentials;
             success();
@@ -107,6 +107,7 @@ NSString * const kMXTestsAliceAvatarURL = @"mxc://matrix.org/kciiXusgZFKuNLIfLqm
                 NSAssert(NO, @"Cannot create mxBOB account. Make sure the homeserver at %@ is running", mxRestClient.homeserver);
             }
         }];
+        operation.maxRetriesTime = 1;
     }
 }
 
@@ -463,7 +464,7 @@ NSString * const kMXTestsAliceAvatarURL = @"mxc://matrix.org/kciiXusgZFKuNLIfLqm
         [self retain:mxRestClient];
 
         // First, try register the user
-        [mxRestClient registerWithLoginType:kMXLoginFlowTypeDummy username:aliceUniqueUser password:MXTESTS_ALICE_PWD success:^(MXCredentials *credentials) {
+        MXHTTPOperation *operation = [mxRestClient registerWithLoginType:kMXLoginFlowTypeDummy username:aliceUniqueUser password:MXTESTS_ALICE_PWD success:^(MXCredentials *credentials) {
             
             _aliceCredentials = credentials;
             success();
@@ -488,6 +489,7 @@ NSString * const kMXTestsAliceAvatarURL = @"mxc://matrix.org/kciiXusgZFKuNLIfLqm
                 NSAssert(NO, @"Cannot create mxAlice account");
             }
         }];
+        operation.maxRetriesTime = 1;
     }
 }
 
@@ -696,7 +698,7 @@ NSString * const kMXTestsAliceAvatarURL = @"mxc://matrix.org/kciiXusgZFKuNLIfLqm
 
     // First, register a new random user
     NSString *anUniqueUser = [NSString stringWithFormat:@"%@", [[NSUUID UUID] UUIDString]];
-    [aUserRestClient registerWithLoginType:kMXLoginFlowTypeDummy username:anUniqueUser password:@"123456" success:^(MXCredentials *credentials) {
+    MXHTTPOperation *operation = [aUserRestClient registerWithLoginType:kMXLoginFlowTypeDummy username:anUniqueUser password:@"123456" success:^(MXCredentials *credentials) {
 
         aUserRestClient = [[MXRestClient alloc] initWithCredentials:credentials andOnUnrecognizedCertificateBlock:nil];
         [self retain:aUserRestClient];
@@ -715,6 +717,7 @@ NSString * const kMXTestsAliceAvatarURL = @"mxc://matrix.org/kciiXusgZFKuNLIfLqm
     } failure:^(NSError *error) {
         NSAssert(NO, @"Cannot set up intial test conditions - error: %@", error);
     }];
+    operation.maxRetriesTime = 1;
 }
 
 
@@ -743,7 +746,7 @@ NSString * const kMXTestsAliceAvatarURL = @"mxc://matrix.org/kciiXusgZFKuNLIfLqm
         [self retain:mxRestClient];
 
         // First, try register the user
-        [mxRestClient registerWithLoginType:kMXLoginFlowTypeDummy username:bobUniqueUser password:MXTESTS_BOB_PWD success:^(MXCredentials *credentials) {
+        MXHTTPOperation *operation = [mxRestClient registerWithLoginType:kMXLoginFlowTypeDummy username:bobUniqueUser password:MXTESTS_BOB_PWD success:^(MXCredentials *credentials) {
 
             _bobCredentials = credentials;
             success();
@@ -768,6 +771,7 @@ NSString * const kMXTestsAliceAvatarURL = @"mxc://matrix.org/kciiXusgZFKuNLIfLqm
                 NSAssert(NO, @"Cannot create mxBOB account. Make sure the homeserver at %@ is running", mxRestClient.homeserver);
             }
         }];
+        operation.maxRetriesTime = 1;
     }
 }
 

--- a/MatrixSDKTests/MatrixSDKTestsData.m
+++ b/MatrixSDKTests/MatrixSDKTestsData.m
@@ -108,7 +108,7 @@ NSString * const kMXTestsAliceAvatarURL = @"mxc://matrix.org/kciiXusgZFKuNLIfLqm
                 [self breakTestCase:testCase reason:@"Cannot create mxBOB account. Make sure the homeserver at %@ is running", mxRestClient.homeserver];
             }
         }];
-        operation.maxRetriesTime = 1;
+        operation.maxNumberOfTries = 1;
     }
 }
 
@@ -492,7 +492,7 @@ NSString * const kMXTestsAliceAvatarURL = @"mxc://matrix.org/kciiXusgZFKuNLIfLqm
                 [self breakTestCase:testCase reason:@"Cannot create mxAlice account"];
             }
         }];
-        operation.maxRetriesTime = 1;
+        operation.maxNumberOfTries = 1;
     }
 }
 
@@ -721,7 +721,7 @@ NSString * const kMXTestsAliceAvatarURL = @"mxc://matrix.org/kciiXusgZFKuNLIfLqm
     } failure:^(NSError *error) {
         [self breakTestCase:testCase reason:@"Cannot set up intial test conditions - error: %@", error];
     }];
-    operation.maxRetriesTime = 1;
+    operation.maxNumberOfTries = 1;
 }
 
 
@@ -778,7 +778,7 @@ onUnrecognizedCertificateBlock:(MXHTTPClientOnUnrecognizedCertificate)onUnrecogn
                 [self breakTestCase:testCase reason:@"Cannot create mxBOB account. Make sure the homeserver at %@ is running", mxRestClient.homeserver];
             }
         }];
-        operation.maxRetriesTime = 1;
+        operation.maxNumberOfTries = 1;
     }
 }
 

--- a/MatrixSDKTests/MatrixSDKTestsE2EData.h
+++ b/MatrixSDKTests/MatrixSDKTestsE2EData.h
@@ -80,7 +80,10 @@
                           warnOnUnknowDevices:(BOOL)warnOnUnknowDevices
                                   readyToTest:(void (^)(MXSession *aliceSession, MXSession *bobSession, MXSession *samSession, NSString *roomId, XCTestExpectation *expectation))readyToTest;
 
-- (void)loginUserOnANewDevice:(MXCredentials*)credentials withPassword:(NSString*)password onComplete:(void (^)(MXSession *newSession))onComplete;
+- (void)loginUserOnANewDevice:(XCTestCase*)testCase
+                  credentials:(MXCredentials*)credentials
+                 withPassword:(NSString*)password
+                   onComplete:(void (^)(MXSession *newSession))onComplete;
 
 
 #pragma mark - Cross-signing

--- a/MatrixSDKTests/MatrixSDKTestsE2EData.m
+++ b/MatrixSDKTests/MatrixSDKTestsE2EData.m
@@ -289,7 +289,10 @@
     }];
 }
 
-- (void)loginUserOnANewDevice:(MXCredentials*)credentials withPassword:(NSString*)password onComplete:(void (^)(MXSession *newSession))onComplete
+- (void)loginUserOnANewDevice:(XCTestCase*)testCase
+                  credentials:(MXCredentials*)credentials
+                 withPassword:(NSString*)password
+                   onComplete:(void (^)(MXSession *newSession))onComplete
 {
     [MXSDKOptions sharedInstance].enableCryptoWhenStartingMXSession = YES;
     
@@ -311,11 +314,11 @@
             onComplete(newSession);
             
         } failure:^(NSError *error) {
-            NSAssert(NO, @"Cannot set up intial test conditions - error: %@", error);
+            [matrixSDKTestsData breakTestCase:testCase reason:@"Cannot set up intial test conditions - error: %@", error];
         }];
         
     } failure:^(NSError *error) {
-        NSAssert(NO, @"Cannot log %@ in again. Error: %@", credentials.userId , error);
+        [matrixSDKTestsData breakTestCase:testCase reason:@"Cannot log %@ in again. Error: %@", credentials.userId , error];
     }];
 }
 
@@ -343,7 +346,7 @@
          [aliceSession1.crypto.crossSigning setupWithPassword:MXTESTS_ALICE_PWD success:^{
              [bobSession.crypto.crossSigning setupWithPassword:MXTESTS_BOB_PWD success:^{
                  
-                 [self loginUserOnANewDevice:aliceSession1.matrixRestClient.credentials withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *aliceSession2) {
+                 [self loginUserOnANewDevice:self credentials:aliceSession1.matrixRestClient.credentials withPassword:MXTESTS_ALICE_PWD onComplete:^(MXSession *aliceSession2) {
                      
                      NSString *aliceUserId = aliceSession1.matrixRestClient.credentials.userId;
                      NSString *bobUserId = bobSession.matrixRestClient.credentials.userId;

--- a/MatrixSDKTests/MatrixSDKTestsE2EData.m
+++ b/MatrixSDKTests/MatrixSDKTestsE2EData.m
@@ -97,11 +97,11 @@
                 readyToTest(aliceSession, room.roomId, expectation);
 
             } failure:^(NSError *error) {
-                NSAssert(NO, @"Cannot enable encryption in room - error: %@", error);
+                [matrixSDKTestsData breakTestCase:testCase reason:@"Cannot enable encryption in room - error: %@", error];
             }];
 
         } failure:^(NSError *error) {
-            NSAssert(NO, @"Cannot create a room - error: %@", error);
+            [matrixSDKTestsData breakTestCase:testCase reason:@"Cannot create a room - error: %@", error];
         }];
         
     }];
@@ -145,13 +145,13 @@
                     readyToTest(aliceSession, bobSession, room.roomId, expectation);
 
                 } failure:^(NSError *error) {
-                    NSAssert(NO, @"Cannot join a room - error: %@", error);
+                    [matrixSDKTestsData breakTestCase:testCase reason:@"Cannot join a room - error: %@", error];
                 }];
             }];
 
             [room inviteUser:bobSession.myUser.userId success:nil failure:^(NSError *error) {
                 [[NSNotificationCenter defaultCenter] removeObserver:observer];
-                NSAssert(NO, @"Cannot invite Bob (%@) - error: %@", bobSession.myUser.userId, error);
+                [matrixSDKTestsData breakTestCase:testCase reason:@"Cannot invite Bob (%@) - error: %@", bobSession.myUser.userId, error];
             }];
 
         }];
@@ -190,7 +190,7 @@
             [room inviteUser:bobSession.myUser.userId success:^{
                 readyToTest(aliceSession, bobSession, room.roomId, expectation);
             } failure:^(NSError *error) {
-                NSAssert(NO, @"Cannot invite Bob (%@) - error: %@", bobSession.myUser.userId, error);
+                [matrixSDKTestsData breakTestCase:testCase reason:@"Cannot invite Bob (%@) - error: %@", bobSession.myUser.userId, error];
             }];
             
         }];
@@ -237,7 +237,7 @@
             } failure:nil];
 
         } failure:^(NSError *error) {
-            NSAssert(NO, @"Cannot set up intial test conditions - error: %@", error);
+            [matrixSDKTestsData breakTestCase:testCase reason:@"Cannot set up intial test conditions - error: %@", error];
         }];
 
     }];
@@ -276,13 +276,13 @@
                     readyToTest(aliceSession, bobSession, samSession, room.roomId, expectation);
 
                 } failure:^(NSError *error) {
-                    NSAssert(NO, @"Cannot join a room - error: %@", error);
+                    [matrixSDKTestsData breakTestCase:testCase reason:@"Cannot join a room - error: %@", error];
                 }];
             }];
 
             [room inviteUser:samSession.myUser.userId success:nil failure:^(NSError *error) {
                 [[NSNotificationCenter defaultCenter] removeObserver:observer];
-                NSAssert(NO, @"Cannot invite Alice - error: %@", error);
+                [matrixSDKTestsData breakTestCase:testCase reason:@"Cannot invite Alice - error: %@", error];
             }];
 
         }];
@@ -369,37 +369,37 @@
                                          });
                                          
                                      } failure:^(NSError *error) {
-                                         NSAssert(NO, @"Cannot set up intial test conditions - error: %@", error);
+                                         [matrixSDKTestsData breakTestCase:testCase reason:@"Cannot set up intial test conditions - error: %@", error];
                                          [expectation fulfill];
                                      }];
                                      
                                  } failure:^(NSError *error) {
-                                     NSAssert(NO, @"Cannot set up intial test conditions - error: %@", error);
+                                     [matrixSDKTestsData breakTestCase:testCase reason:@"Cannot set up intial test conditions - error: %@", error];
                                      [expectation fulfill];
                                  }];
                                  
                              } failure:^(NSError *error) {
-                                 NSAssert(NO, @"Cannot set up intial test conditions - error: %@", error);
+                                 [matrixSDKTestsData breakTestCase:testCase reason:@"Cannot set up intial test conditions - error: %@", error];
                                  [expectation fulfill];
                              }];
                          } failure:^(NSError *error) {
-                             NSAssert(NO, @"Cannot set up intial test conditions - error: %@", error);
+                             [matrixSDKTestsData breakTestCase:testCase reason:@"Cannot set up intial test conditions - error: %@", error];
                              [expectation fulfill];
                          }];
                          
                      } failure:^(NSError *error) {
-                         NSAssert(NO, @"Cannot set up intial test conditions - error: %@", error);
+                         [matrixSDKTestsData breakTestCase:testCase reason:@"Cannot set up intial test conditions - error: %@", error];
                          [expectation fulfill];
                      }];
                  }];
                  
              } failure:^(NSError *error) {
-                 NSAssert(NO, @"Cannot set up intial test conditions - error: %@", error);
+                 [matrixSDKTestsData breakTestCase:testCase reason:@"Cannot set up intial test conditions - error: %@", error];
                  [expectation fulfill];
              }];
              
          } failure:^(NSError *error) {
-             NSAssert(NO, @"Cannot set up intial test conditions - error: %@", error);
+             [matrixSDKTestsData breakTestCase:testCase reason:@"Cannot set up intial test conditions - error: %@", error];
              [expectation fulfill];
          }];
      }];

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -68,10 +68,14 @@ platform :ios do
 
     opts = {
       :clean => true,
-      :scheme => "MatrixSDK",
+      :scheme => "MatrixSDK-macOS",
       :workspace => "MatrixSDK.xcworkspace",
       :configuration => "Debug",
       :code_coverage => true,
+      # Test result configuration
+      :result_bundle => true,
+      :output_directory => "./build/test",
+      :open_report => !is_ci?
     }
     scan(opts)
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -77,7 +77,12 @@ platform :ios do
       :output_directory => "./build/test",
       :open_report => !is_ci?
     }
-    scan(opts)
+    begin
+      scan(opts)
+    ensure
+      xcresult = "../#{opts[:output_directory]}/#{opts[:scheme]}.xcresult"
+      sh("zip", "-r", "#{xcresult}.zip", xcresult)
+    end
   end
 
   #### Private ####

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -80,8 +80,10 @@ platform :ios do
     begin
       scan(opts)
     ensure
-      xcresult = "../#{opts[:output_directory]}/#{opts[:scheme]}.xcresult"
-      sh("zip", "-r", "#{xcresult}.zip", xcresult)
+      Dir.chdir("../#{opts[:output_directory]}") do
+        xcresult = "#{opts[:scheme]}.xcresult"
+        sh("zip", "-r", "#{xcresult}.zip", xcresult)
+      end
     end
   end
 


### PR DESCRIPTION
Commits can be reviewed separately.

Changes and explanation:
 * Fix "fastlane ios test" and generate html report
Available at build/test/report.html. Other available artefacts: MatrixSDK-macOS.xcresult and report.junit

![image](https://user-images.githubusercontent.com/8418515/89294930-808ab580-d660-11ea-8d71-ed69c7ef07da.png)


 * Make tests fail instantly if no local synapse is running
In order to save CI time

 * Do not use anymore NSAssert in tests
If there is a crash when running tests that will be for a good reason. Plus it avoids xcode to rerun crashed tests 7 times.


