### PR TITLE
Release 0.16.9

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,30 @@
+Changes to be released in next version
+=================================================
+
+Features:
+ * 
+
+Improvements:
+ * 
+
+Bugfix:
+ * 
+
+API Change:
+ * 
+
+Translations:
+ * 
+
+Others:
+ * 
+
+Build:
+ * 
+
+Test:
+ * 
+
 Changes in 0.16.8 (2020-07-28)
 ================================================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-Changes to be released in next version
+Changes in 0.16.9 (2020-08-05)
 =================================================
 
 Features:

--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "MatrixSDK"
-  s.version      = "0.16.8"
+  s.version      = "0.16.9"
   s.summary      = "The iOS SDK to build apps compatible with Matrix (https://www.matrix.org)"
 
   s.description  = <<-DESC

--- a/MatrixSDK.xcodeproj/xcshareddata/xcschemes/MatrixSDK-iOS.xcscheme
+++ b/MatrixSDK.xcodeproj/xcshareddata/xcschemes/MatrixSDK-iOS.xcscheme
@@ -40,8 +40,17 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      codeCoverageEnabled = "YES"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "32C6F92C19DD814400EA4E9C"
+            BuildableName = "MatrixSDK.framework"
+            BlueprintName = "MatrixSDK-iOS"
+            ReferencedContainer = "container:MatrixSDK.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -54,17 +63,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "32C6F92C19DD814400EA4E9C"
-            BuildableName = "MatrixSDK.framework"
-            BlueprintName = "MatrixSDK-iOS"
-            ReferencedContainer = "container:MatrixSDK.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -85,8 +83,6 @@
             ReferencedContainer = "container:MatrixSDK.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/MatrixSDK/MatrixSDKVersion.m
+++ b/MatrixSDK/MatrixSDKVersion.m
@@ -16,4 +16,4 @@
 
 #import <Foundation/Foundation.h>
 
-NSString *const MatrixSDKVersion = @"0.16.8";
+NSString *const MatrixSDKVersion = @"0.16.9";

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -80,6 +80,8 @@ platform :ios do
 
   desc "Just build the provided :scheme / :destination (without doing any xcarchive)"
   private_lane :build_scheme do |options|
+    cocoapods
+
     gym(
       workspace: "MatrixSDK.xcworkspace",
       scheme: options[:scheme],

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -17,73 +17,96 @@ platform :ios do
   #### Pod ####
 
   desc "Lint all podspecs"
-  lane :lint_pods do  	
-  	lint_pod_MatrixSDK
-  	lint_pod_SwiftMatrixSDK
+  lane :lint_pods do
+    lint_pod_MatrixSDK
+    lint_pod_SwiftMatrixSDK
   end
 
   desc "Lint MatrixSDK podspec"
-  lane :lint_pod_MatrixSDK do  	
-  	custom_pod_lib_lint(podspec: "../MatrixSDK.podspec", parameters: ['--allow-warnings'])
+  lane :lint_pod_MatrixSDK do
+    custom_pod_lib_lint(podspec: "../MatrixSDK.podspec", parameters: ["--allow-warnings", "--verbose"])
   end
 
   desc "Lint SwiftMatrixSDK podspec"
-  lane :lint_pod_SwiftMatrixSDK do  	
-  	custom_pod_lib_lint(podspec: "../SwiftMatrixSDK.podspec", parameters: ['--allow-warnings'])    
+  lane :lint_pod_SwiftMatrixSDK do
+    custom_pod_lib_lint(podspec: "../SwiftMatrixSDK.podspec", parameters: ["--allow-warnings", "--verbose"])
   end
 
   desc "Push all pods"
-  lane :push_pods do  	
-  	push_pod_MatrixSDK
-  	push_pod_SwiftMatrixSDK
+  lane :push_pods do
+    push_pod_MatrixSDK
+    push_pod_SwiftMatrixSDK
   end
 
   desc "Push MatrixSDK pod"
-    lane :push_pod_MatrixSDK do  	
-  	pod_push(path: "MatrixSDK.podspec", allow_warnings: true)
+  lane :push_pod_MatrixSDK do
+    pod_push(path: "MatrixSDK.podspec", allow_warnings: true)
   end
 
   desc "Push SwiftMatrixSDK pod"
-    lane :push_pod_SwiftMatrixSDK do  	
-  	pod_push(path: "SwiftMatrixSDK.podspec", allow_warnings: true)
+  lane :push_pod_SwiftMatrixSDK do
+    pod_push(path: "SwiftMatrixSDK.podspec", allow_warnings: true)
+  end
+
+  #### Build ####
+
+  desc "Ensure the iOS framework builds"
+  lane :build_ios do
+    build_scheme(scheme: "MatrixSDK-iOS", destination: "generic/platform=iOS Simulator")
+  end
+
+  desc "Ensure the macOS framework builds"
+  lane :build_macos do
+    build_scheme(scheme: "MatrixSDK-macOS", destination: "generic/platform=macOS")
   end
 
   #### Tests ####
 
-  desc "Run integration tests (Be sure to set up the homeserver before like described here https://github.com/matrix-org/matrix-ios-sdk#tests)"  
-  lane :test do	
-  	cocoapods
-  	      
+  desc "Run integration tests (Be sure to set up the homeserver before like described here https://github.com/matrix-org/matrix-ios-sdk#tests)"
+  lane :test do
+    cocoapods
+
     opts = {
       :clean => true,
-      :scheme =>  'MatrixSDK',
-      :workspace => 'MatrixSDK.xcworkspace',
-      :configuration => 'Debug',      
-      :code_coverage => true
+      :scheme => "MatrixSDK",
+      :workspace => "MatrixSDK.xcworkspace",
+      :configuration => "Debug",
+      :code_coverage => true,
     }
     scan(opts)
   end
 
   #### Private ####
-  
+
+  desc "Just build the provided :scheme / :destination (without doing any xcarchive)"
+  private_lane :build_scheme do |options|
+    gym(
+      workspace: "MatrixSDK.xcworkspace",
+      scheme: options[:scheme],
+      skip_package_ipa: true,
+      skip_archive: true,
+      derived_data_path: "./DerivedData",
+      destination: options[:destination],
+    )
+  end
+
   desc "Returns bundle Cocoapods version"
   private_lane :cocoapods_version do
-  	sh('bundle exec pod --version', log: false)  	
+    sh("bundle exec pod --version", log: false)
   end
 
   desc "Pod lib lint with podspec parameter"
   private_lane :custom_pod_lib_lint do |options|
-  	
     puts "Lint pod " << options[:podspec] << " with Cocoapods version " << cocoapods_version
 
-  	command = []
-  	command << "bundle exec pod lib lint"
-  	command << options[:podspec]
+    command = []
+    command << "bundle exec pod lib lint"
+    command << options[:podspec]
 
     if options[:parameters]
-    	command.concat(options[:parameters])
-	end
+      command.concat(options[:parameters])
+    end
 
-	sh(command.join(' '))
+    sh(command.join(" "))
   end
 end


### PR DESCRIPTION
This PR prepares the release of MatrixSDK v0.16.9.

Notes:
- This PR targets `release/0.16.9/master`, which has been cut from `master`.
- It includes changes to the `Podfile`, but _not_ the corresponding changes to `Podfile.lock`, as `pod install` hasn't yet been run.
  This is because the `Podfile` targets future versions of dependencies yet to be released, so `pod install` wouldn't be able to find them yet.
- When the CI runs its checks, it will temporarily point to the pending release branches of those dependencies beforehand
- It is only during `release:finish` that `pod update` will be run -- updating the `Podfile.lock`
to use the now officially released dependencies -- before ultimately merging `release/0.16.9/master` into `master` to tag the release.

---

➡️  Once this PR is merged, you will need to first ensure that the products this one depends on are fully released,
   then run `bundle exec rake release:finish` to close this release.

💡 If you want to review _only_ the changes made since the release branch was cut from `develop`,
   you can [check those here](https://github.com/matrix-org/matrix-ios-sdk/compare/develop...release/0.16.9/release)
