### PR TITLE
Some room members count are wrong after clearing the cache

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Improvements:
  * 
 
 Bugfix:
- * 
+ * Some room members count are wrong after clearing the cache
 
 API Change:
  * 

--- a/MatrixSDK/Data/MXRoomState.m
+++ b/MatrixSDK/Data/MXRoomState.m
@@ -592,7 +592,7 @@
 
     stateCopy->_members = [_members copyWithZone:zone];
 
-    stateCopy->_membersCount = _membersCount;
+    stateCopy->_membersCount = [_membersCount copyWithZone:zone];
     
     stateCopy->roomAliases = [[NSMutableDictionary allocWithZone:zone] initWithDictionary:roomAliases];
 

--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
@@ -25,7 +25,7 @@
 #import "MXSDKOptions.h"
 #import "MXTools.h"
 
-static NSUInteger const kMXFileVersion = 66;
+static NSUInteger const kMXFileVersion = 67;
 
 static NSString *const kMXFileStoreFolder = @"MXFileStore";
 static NSString *const kMXFileStoreMedaDataFile = @"MXFileStore";


### PR DESCRIPTION
The bug was located in [MXRoomState copyWithZone:]. Indeed the item `membersCount` was not copied correctly whereas this is an instance of MXRoomMembersCount class.

The "back state" created thanks to the copy here: https://github.com/matrix-org/matrix-ios-sdk/blob/6027fd5b2b644f2ebeb1049cdb80a318d7db2273/MatrixSDK/Data/MXRoomState.m#L126 was using the same membersCount instance as the provided "live state". The content of this membersCount was updated in case of membership events in the back pagination. The live state was then corrupted.
According to my investigation, the corrupted state was not pushed to the store, except perhaps if new membership events were received in the live stream.