### PR TITLE
MXFileStore: Make loadMetaData more robust

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Features:
 
 Improvements:
  * MXPushData: Implement JSONDictionary (vector-im/riot-ios/issues/3577).
+ * MXFileStore: Make loadMetaData more robust.
 
 Bugfix:
  * 

--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
@@ -1374,16 +1374,22 @@ static NSUInteger preloadOptions;
 - (void)loadMetaData
 {
     NSString *metaDataFile = [storePath stringByAppendingPathComponent:kMXFileStoreMedaDataFile];
-
+    
     @try
     {
         metaData = [NSKeyedUnarchiver unarchiveObjectWithFile:metaDataFile];
     }
     @catch (NSException *exception)
     {
-        NSLog(@"[MXFileStore] Warning: MXFileStore metadata has been corrupted");
+        NSLog(@"[MXFileStore] loadMetaData: Warning: MXFileStore metadata has been corrupted");
     }
-
+    
+    if (metaData && ![metaData isKindOfClass:MXFileStoreMetaData.class])
+    {
+        NSLog(@"[MXFileStore] loadMetaData: Warning: Bad MXFileStore metadata type: %@", metaData);
+        metaData = nil;
+    }
+    
     if (metaData.eventStreamToken)
     {
         [super setEventStreamToken:metaData.eventStreamToken];
@@ -1391,7 +1397,7 @@ static NSUInteger preloadOptions;
     }
     else
     {
-        NSLog(@"[MXFileStore] event stream token is missing");
+        NSLog(@"[MXFileStore] loadMetaData: event stream token is missing");
         [self deleteAllData];
     }
 }


### PR DESCRIPTION
This commit does not fix a corruption that we can have on the meta data file, probably due to a race condition. But it detects when the corruption happens and resets the store and everything.
