### PR TITLE
MXBase64Tools: Make sure the SDK decode padded and unpadded base64 like other platforms

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Improvements:
  * 
 
 Bugfix:
- * 
+ * MXBase64Tools: Make sure the SDK decode padded and unpadded base64 strings like other platforms (vector-im/riot-ios/issues/3667).
 
 API Change:
  * 

--- a/MatrixSDK/Crypto/CrossSigning/MXCrossSigning.m
+++ b/MatrixSDK/Crypto/CrossSigning/MXCrossSigning.m
@@ -1026,7 +1026,7 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
 {
     OLMPkSigning *pkSigning;
     
-    NSData *privateKey = [MXBase64Tools dataFromUnpaddedBase64:base64PrivateKey];
+    NSData *privateKey = [MXBase64Tools dataFromBase64:base64PrivateKey];
     if (privateKey)
     {
         pkSigning = [self pkSigningFromPrivateKey:privateKey withExpectedPublicKey:expectedPublicKey];

--- a/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.m
+++ b/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.m
@@ -1289,7 +1289,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
 {
     BOOL isSecretValid = NO;
     
-    NSData *privateKey = [MXBase64Tools dataFromUnpaddedBase64:secret];
+    NSData *privateKey = [MXBase64Tools dataFromBase64:secret];
     NSString *pKDecryptionPublicKey = [self pkDecrytionPublicKeyFromPrivateKey:privateKey];
     if ([self checkPkDecryptionPublicKey:pKDecryptionPublicKey forKeyBackupVersion:keyBackupVersion])
     {
@@ -1432,7 +1432,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
         return nil;
     }
     
-    return [MXBase64Tools dataFromUnpaddedBase64:privateKeyBase64];
+    return [MXBase64Tools dataFromBase64:privateKeyBase64];
 }
 
 - (nullable OLMPkDecryption*)pkDecryptionFromCryptoStore

--- a/MatrixSDK/Crypto/SecretStorage/MXSecretStorage.m
+++ b/MatrixSDK/Crypto/SecretStorage/MXSecretStorage.m
@@ -331,7 +331,7 @@ static NSString* const kSecretStorageZeroString = @"\0\0\0\0\0\0\0\0\0\0\0\0\0\0
             }
             
             // Check secret input
-            NSData *secret = [MXBase64Tools dataFromUnpaddedBase64:unpaddedBase64Secret];
+            NSData *secret = [MXBase64Tools dataFromBase64:unpaddedBase64Secret];
             if (!secret)
             {
                 NSLog(@"[MXSecretStorage] storeSecret: ERROR: The secret string is not in unpadded Base64 format");

--- a/MatrixSDK/Crypto/Verification/Data/MXQRCodeDataBuilder.m
+++ b/MatrixSDK/Crypto/Verification/Data/MXQRCodeDataBuilder.m
@@ -122,7 +122,7 @@ static NSUInteger const kSharedSecretBytesCount = 8;
 
 - (BOOL)isKeyValid:(NSString*)key
 {
-    NSData *keyData = [MXBase64Tools dataFromUnpaddedBase64:key];
+    NSData *keyData = [MXBase64Tools dataFromBase64:key];
     return keyData.length == kKeyBytesCount;
 }
 

--- a/MatrixSDK/Crypto/Verification/Data/MXQRCodeDataCoder.m
+++ b/MatrixSDK/Crypto/Verification/Data/MXQRCodeDataCoder.m
@@ -263,11 +263,11 @@ static NSUInteger const kQRCodeFormatMinimumSharedSecretByteCount = 8;
     [qrCodeRawData appendData:transactionIDData];
     
     // the first key, as 32 bytes. The key to use depends on the mode field:
-    NSData *firstKeyData = [MXBase64Tools dataFromUnpaddedBase64:qrCodeDataCodable.firstKey];
+    NSData *firstKeyData = [MXBase64Tools dataFromBase64:qrCodeDataCodable.firstKey];
     [qrCodeRawData appendData:firstKeyData];
 
     // the second key, as 32 bytes. The key to use depends on the mode field:
-    NSData *secondKeyData = [MXBase64Tools dataFromUnpaddedBase64:qrCodeDataCodable.secondKey];
+    NSData *secondKeyData = [MXBase64Tools dataFromBase64:qrCodeDataCodable.secondKey];
     [qrCodeRawData appendData:secondKeyData];
 
     // a random shared secret

--- a/MatrixSDK/Crypto/Verification/Transactions/QRCode/MXQRCodeTransaction.m
+++ b/MatrixSDK/Crypto/Verification/Transactions/QRCode/MXQRCodeTransaction.m
@@ -171,7 +171,7 @@ NSString * const MXKeyVerificationMethodReciprocate = @"m.reciprocate.v1";
     }
     
     // Verify shared secret
-    NSData *startSharedSecretData = [MXBase64Tools dataFromUnpaddedBase64:start.sharedSecret];
+    NSData *startSharedSecretData = [MXBase64Tools dataFromBase64:start.sharedSecret];
     
     if (![startSharedSecretData isEqualToData:self.qrCodeData.sharedSecret])
     {

--- a/MatrixSDK/Utils/MXBase64Tools.h
+++ b/MatrixSDK/Utils/MXBase64Tools.h
@@ -34,11 +34,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Data
 
-+ (NSData *)dataFromUnpaddedBase64:(NSString *)unpaddedBase64;
-+ (NSString *)unpaddedBase64FromData:(NSData *)data;
-
+// The base64 string can be padded or unpadded
 + (NSData *)dataFromBase64:(NSString *)base64;
+
 + (NSString *)base64FromData:(NSData *)data;
++ (NSString *)unpaddedBase64FromData:(NSData *)data;
 
 @end
 

--- a/MatrixSDK/Utils/MXBase64Tools.m
+++ b/MatrixSDK/Utils/MXBase64Tools.m
@@ -58,27 +58,22 @@
 
 #pragma mark - Data
 
-+ (NSData *)dataFromUnpaddedBase64:(NSString *)unpaddedBase64
++ (NSData *)dataFromBase64:(NSString *)base64
 {
-    NSString *base64String = [[self class] padBase64:unpaddedBase64];
+    // Make sure we have a padded base64 string before calling NSData
+    NSString *base64String = [[self class] padBase64:base64];
     return [[NSData alloc] initWithBase64EncodedString:base64String options:NSDataBase64DecodingIgnoreUnknownCharacters];
+}
+
++ (NSString *)base64FromData:(NSData *)data
+{
+    return [data base64EncodedStringWithOptions:0];
 }
 
 + (NSString *)unpaddedBase64FromData:(NSData *)data
 {
     NSString *base64 = [[self class] base64FromData:data];
     return [[self class] base64ToUnpaddedBase64:base64];
-}
-
-
-+ (NSData *)dataFromBase64:(NSString *)base64
-{
-     return [[NSData alloc] initWithBase64EncodedString:base64 options:NSDataBase64DecodingIgnoreUnknownCharacters];
-}
-
-+ (NSString *)base64FromData:(NSData *)data
-{
-    return [data base64EncodedStringWithOptions:0];
 }
 
 @end

--- a/MatrixSDKTests/MXCryptoSecretStorageTests.m
+++ b/MatrixSDKTests/MXCryptoSecretStorageTests.m
@@ -90,9 +90,9 @@ UInt8 privateKeyBytes[] = {
         NSDictionary *MSKContent = @{
                                      @"encrypted": @{
                                              @"qkEmh7mHZBySbXqroxiz7fM18fJuXnnt": @{
-                                                     @"iv": @"RS18YsoaFkYcFrKYBC8w9g==",
-                                                     @"ciphertext": @"FCihoO5ztgLKcAzmGxKgoNbcKLYDMKVxuJkj9ElBsmj5+XbmV0vFQjezDH0=",
-                                                     @"mac": @"y3cULM3z/pQBTCDHM8RI+9HnTdDjvRoucr9iV7ZHk3E="
+                                                     @"iv": @"RS18YsoaFkYcFrKYBC8w9g",
+                                                     @"ciphertext": @"FCihoO5ztgLKcAzmGxKgoNbcKLYDMKVxuJkj9ElBsmj5+XbmV0vFQjezDH0",
+                                                     @"mac": @"y3cULM3z/pQBTCDHM8RI+9HnTdDjvRoucr9iV7ZHk3E"
                                                      }
                                              }
                                      };
@@ -101,7 +101,7 @@ UInt8 privateKeyBytes[] = {
                                      @"encrypted": @{
                                              @"qkEmh7mHZBySbXqroxiz7fM18fJuXnnt": @{
                                                      @"iv": @"fep37xQGPNRv5cR9HWBcEQ==",
-                                                     @"ciphertext": @"bepBSorZceMrAzGjWEiXUOP49BzZozuAODVj4XW9E1I+nhs6RqeYj0anhzQ=",
+                                                     @"ciphertext": @"bepBSorZceMrAzGjWEiXUOP49BzZozuAODVj4XW9E1I+nhs6RqeYj0anhzQ",
                                                      @"mac": @"o3GbngWeB8KLJ2GARo1jaYXFKnPXPWkvdAv4cQtgUB4="
                                                      }
                                              }
@@ -110,8 +110,8 @@ UInt8 privateKeyBytes[] = {
         NSDictionary *SSKContent = @{
                                      @"encrypted": @{
                                              @"qkEmh7mHZBySbXqroxiz7fM18fJuXnnt": @{
-                                                     @"iv": @"ty18XRmd7VReJDXpCsL3xA==",
-                                                     @"ciphertext": @"b3AVFOjzyHZvhGPu0uddu9DhIDQ2htUfDypTGag+Pweu8dF1pc7wdLoDgYc=",
+                                                     @"iv": @"ty18XRmd7VReJDXpCsL3xA",
+                                                     @"ciphertext": @"b3AVFOjzyHZvhGPu0uddu9DhIDQ2htUfDypTGag+Pweu8dF1pc7wdLoDgYc",
                                                      @"mac": @"53SKD7e3GvYWSznLEHudFctc1CSbtloid2EcAyAbxoQ="
                                                      }
                                              }
@@ -121,8 +121,8 @@ UInt8 privateKeyBytes[] = {
                                            @"encrypted": @{
                                                    @"qkEmh7mHZBySbXqroxiz7fM18fJuXnnt": @{
                                                            @"iv": @"AQRau/6+1sAFTlh+pHcraQ==",
-                                                           @"ciphertext": @"q0tVFMeU1XKn/V6oIfP5letoR6qTcTP2cwNrYNIb2lD4fYCGL0LyYmazsgI=",
-                                                           @"mac": @"sB61R0Tzrb0x0PyRZDJRe58DEo9SzTeEfO+1QCNQLzM="
+                                                           @"ciphertext": @"q0tVFMeU1XKn/V6oIfP5letoR6qTcTP2cwNrYNIb2lD4fYCGL0LyYmazsgI",
+                                                           @"mac": @"sB61R0Tzrb0x0PyRZDJRe58DEo9SzTeEfO+1QCNQLzM"
                                                            }
                                                    }
                                            };
@@ -431,7 +431,7 @@ UInt8 privateKeyBytes[] = {
             XCTAssertNotNil(unpaddedBase64Secret);
             
             // -> It should be the one created by matrix-js-sdk
-            NSData *key = [MXBase64Tools dataFromUnpaddedBase64:unpaddedBase64Secret];
+            NSData *key = [MXBase64Tools dataFromBase64:unpaddedBase64Secret];
             NSData *jsKey = [NSData dataWithBytes:jsSDKDataBackupKeyBytes length:sizeof(jsSDKDataBackupKeyBytes)];
             
             XCTAssertEqualObjects(key, jsKey);


### PR DESCRIPTION
Fix vector-im/element-ios/issues/3667
Fix vector-im/element-ios/issues/3668

We have now only one decoding method that manages padded and unpadded base64.

SDK tests are still happy.