### PR TITLE
 SSSS: Use unpadded base64 for secrets data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Improvements:
 
 Bugfix:
  * MXBase64Tools: Make sure the SDK decode padded and unpadded base64 strings like other platforms (vector-im/riot-ios/issues/3667).
+ * SSSS: Use unpadded base64 for secrets data (vector-im/riot-ios/issues/3669).
 
 API Change:
  * 

--- a/MatrixSDK/Crypto/SecretStorage/MXSecretStorage.m
+++ b/MatrixSDK/Crypto/SecretStorage/MXSecretStorage.m
@@ -598,9 +598,9 @@ static NSString* const kSecretStorageZeroString = @"\0\0\0\0\0\0\0\0\0\0\0\0\0\0
     }
     
     MXEncryptedSecretContent *secretContent = [MXEncryptedSecretContent new];
-    secretContent.ciphertext = [MXBase64Tools base64FromData:cipher];
-    secretContent.mac = [MXBase64Tools base64FromData:hmac];
-    secretContent.iv = [MXBase64Tools base64FromData:iv];
+    secretContent.ciphertext = [MXBase64Tools unpaddedBase64FromData:cipher];
+    secretContent.mac = [MXBase64Tools unpaddedBase64FromData:hmac];
+    secretContent.iv = [MXBase64Tools unpaddedBase64FromData:iv];
     
     return secretContent;
 }


### PR DESCRIPTION
Fix vector-im/riot-ios/issues/3669

This changes will not affect other clients (web, android) or existing data. It is only driven by consistency across platforms.
