### PR TITLE
MXSession: Fix Well-known not read from the homeserver domain

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Improvements:
 Bugfix:
  * MXBase64Tools: Make sure the SDK decode padded and unpadded base64 strings like other platforms (vector-im/riot-ios/issues/3667).
  * SSSS: Use unpadded base64 for secrets data (vector-im/riot-ios/issues/3669).
+ * MXSession: Fix `refreshHomeserverWellknown` method not reading Well-Known from the homeserver domain (vector-im/element-ios/issues/3653).
 
 API Change:
  * 

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -3555,7 +3555,21 @@ typedef void (^MXOnResumeDone)(void);
     NSLog(@"[MXSession] refreshHomeserverWellknown");
     if (!autoDiscovery)
     {
-        autoDiscovery = [[MXAutoDiscovery alloc] initWithUrl:matrixRestClient.homeserver];
+        NSString *homeServerDomain;
+        
+        // Retrieve the domain from the user id as it can be different from the `MXRestClient.homeserver` that uses the client-server API endpoint domain.
+        NSString *userDomain = [MXTools serverNameInMatrixIdentifier:self.myUserId];
+        
+        if (userDomain)
+        {
+            homeServerDomain = userDomain;
+        }
+        else
+        {
+            homeServerDomain = matrixRestClient.homeserver;
+        }
+        
+        autoDiscovery = [[MXAutoDiscovery alloc] initWithUrl:homeServerDomain];
     }
 
     MXWeakify(self);


### PR DESCRIPTION
Fix vector-im/element-ios/issues/3653