### PR TITLE
MXCrypto: Reset OTKs when some IDs are already used

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ Changes to be released in next version
 🐛 Bugfix
  * MXCrypto: Reset OTKs when some IDs are already used (https://github.com/vector-im/element-ios/issues/3721).
  * MXCrypto: Send MXCrossSigningMyUserDidSignInOnNewDeviceNotification and MXDeviceListDidUpdateUsersDevicesNotification on the main thread.
-
+ * MXCrossSigning: Do not send MXCrossSigningMyUserDidSignInOnNewDeviceNotification again if the device has been verified from another thread.
+ 
 ⚠️ API Changes
  * 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Changes to be released in next version
 
 🐛 Bugfix
  * MXCrypto: Reset OTKs when some IDs are already used (https://github.com/vector-im/element-ios/issues/3721).
+ * MXCrypto: Send MXCrossSigningMyUserDidSignInOnNewDeviceNotification on the main thread.
 
 ⚠️ API Changes
  * 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,7 @@ Changes to be released in next version
 
 🐛 Bugfix
  * MXCrypto: Reset OTKs when some IDs are already used (https://github.com/vector-im/element-ios/issues/3721).
- * MXCrypto: Send MXCrossSigningMyUserDidSignInOnNewDeviceNotification on the main thread.
+ * MXCrypto: Send MXCrossSigningMyUserDidSignInOnNewDeviceNotification and MXDeviceListDidUpdateUsersDevicesNotification on the main thread.
 
 ⚠️ API Changes
  * 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changes to be released in next version
  * MXCrypto: Add hasKeysToDecryptEvent method.
 
 🐛 Bugfix
- * 
+ * MXCrypto: Reset OTKs when some IDs are already used (https://github.com/vector-im/element-ios/issues/3721).
 
 ⚠️ API Changes
  * 

--- a/MatrixSDK/Crypto/Algorithms/Olm/MXOlmDecryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Olm/MXOlmDecryption.m
@@ -327,7 +327,7 @@
     NSString *sessionId = [olmDevice createInboundSession:theirDeviceIdentityKey messageType:messageType cipherText:messageBody payload:&payload];
     if (!sessionId)
     {
-        NSLog(@"[MXOlmDecryption] decryptMessage: Error decrypting non-prekey message with existing sessions");
+        NSLog(@"[MXOlmDecryption] decryptMessage: Cannot create new inbound Olm session. Error decrypting non-prekey message with existing sessions");
         return nil;
     }
 

--- a/MatrixSDK/Crypto/CrossSigning/MXCrossSigning.m
+++ b/MatrixSDK/Crypto/CrossSigning/MXCrossSigning.m
@@ -823,7 +823,9 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
         {
             NSDictionary *userInfo = @{ MXCrossSigningNotificationDeviceIdsKey: newDeviceIds };
             
-            [[NSNotificationCenter defaultCenter] postNotificationName:MXCrossSigningMyUserDidSignInOnNewDeviceNotification object:self userInfo:userInfo];
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [[NSNotificationCenter defaultCenter] postNotificationName:MXCrossSigningMyUserDidSignInOnNewDeviceNotification object:self userInfo:userInfo];
+            });
         }
     }
 }

--- a/MatrixSDK/Crypto/CrossSigning/MXCrossSigning.m
+++ b/MatrixSDK/Crypto/CrossSigning/MXCrossSigning.m
@@ -813,7 +813,8 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
         
         for (MXDeviceInfo *deviceInfo in myUserDevices)
         {
-            if (deviceInfo.trustLevel.localVerificationStatus == MXDeviceUnknown)
+            if (!deviceInfo.trustLevel.isVerified
+                && deviceInfo.trustLevel.localVerificationStatus == MXDeviceUnknown)
             {
                 [newDeviceIds addObject:deviceInfo.deviceId];
             }

--- a/MatrixSDK/Crypto/Data/MXDeviceListOperationsPool.m
+++ b/MatrixSDK/Crypto/Data/MXDeviceListOperationsPool.m
@@ -219,8 +219,10 @@
         
         if (updatedUsersDevices.count)
         {
-            // Post notification using MXCrypto instance as MXDeviceListOperationsPool is an internal class.
-            [[NSNotificationCenter defaultCenter] postNotificationName:MXDeviceListDidUpdateUsersDevicesNotification object:self->crypto userInfo:updatedUsersDevices];
+            dispatch_async(dispatch_get_main_queue(), ^{
+                // Post notification using MXCrypto instance as MXDeviceListOperationsPool is an internal class.
+                [[NSNotificationCenter defaultCenter] postNotificationName:MXDeviceListDidUpdateUsersDevicesNotification object:self->crypto userInfo:updatedUsersDevices];
+            });
         }
         
         // Delay

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -83,10 +83,6 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     // Listener on memberships changes
     id roomMembershipEventsListener;
 
-    // For dev
-    // @TODO: could be removed
-    NSDictionary *lastPublishedOneTimeKeys;
-
     // The one-time keys count sent by /sync
     // -1 means the information was not sent by the server
     NSUInteger oneTimeKeyCount;
@@ -274,7 +270,6 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
             NSLog(@"[MXCrypto]    - device id  : %@", self.store.deviceId);
             NSLog(@"[MXCrypto]    - ed25519    : %@", self.olmDevice.deviceEd25519Key);
             NSLog(@"[MXCrypto]    - curve25519 : %@", self.olmDevice.deviceCurve25519Key);
-            //NSLog(@"   - oneTimeKeys: %@", lastPublishedOneTimeKeys);
             NSLog(@"[MXCrypto] ");
             NSLog(@"[MXCrypto] Store: %@", self.store);
             NSLog(@"[MXCrypto] ");
@@ -2699,7 +2694,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
             // We first find how many keys the server has for us.
             NSUInteger keyCount = [keysUploadResponse oneTimeKeyCountsForAlgorithm:@"signed_curve25519"];
 
-            NSLog(@"[MXCrypto] maybeUploadOneTimeKeys: %tu one-time keys on the homeserver", self->oneTimeKeyCount);
+            NSLog(@"[MXCrypto] maybeUploadOneTimeKeys: %@ one-time keys on the homeserver", @(keyCount));
 
             if ([self generateOneTimeKeys:keyCount])
             {
@@ -2833,7 +2828,6 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     return [_matrixRestClient uploadKeys:nil oneTimeKeys:oneTimeJson forDevice:_myDevice.deviceId success:^(MXKeysUploadResponse *keysUploadResponse) {
         MXStrongifyAndReturnIfNil(self);
 
-        self->lastPublishedOneTimeKeys = oneTimeKeys;
         [self.olmDevice markOneTimeKeysAsPublished];
         success(keysUploadResponse);
 


### PR DESCRIPTION
This is a mitigation for vector-im/element-ios#3721. 
But it does not fix the root issue.

This is how this PR behaves on the [steps to reproduce](https://github.com/vector-im/element-ios/issues/3721#issuecomment-705400377):
```
2020-10-08 09:16:22.890670+0200 Riot[31404:1330203] [MXHTTPClient] #12 - POST _matrix/client/r0/keys/upload/SYNBAYVHFQ completed in 196ms
2020-10-08 09:16:22.891049+0200 Riot[31404:1330203] [MXHTTPClient] Request 0x6000002a2ec0 failed for path: _matrix/client/r0/keys/upload/SYNBAYVHFQ - HTTP code: 400. Error: Error Domain=com.alamofire.error.serialization.response Code=-1011 "Request failed: bad request (400)" UserInfo={NSLocalizedDescription=Request failed: bad request (400), NSErrorFailingURLKey=https://matrix-client.matrix.org/_matrix/client/r0/keys/upload/SYNBAYVHFQ, com.alamofire.serialization.response.error.data={length = 531, bytes = 0x7b226572 72636f64 65223a22 4d5f554e ... 4167277d 7d7d227d }, com.alamofire.serialization.response.error.response=<NSHTTPURLResponse: 0x600001d17e40> { URL: https://matrix-client.matrix.org/_matrix/client/r0/keys/upload/SYNBAYVHFQ } { Status Code: 400, Headers {
2020-10-08 09:16:22.891735+0200 Riot[31404:1330449] [MXCrypto] uploadOneTimeKeys fails.
2020-10-08 09:16:22.891984+0200 Riot[31404:1330449] [MXCrypto] generateAndUploadOneTimeKeys: Failed to publish one-time keys. Error: Error Domain=org.matrix.sdk Code=6 "One time key signed_curve25519:AAAAAQ already exists. Old key: {"key":"mbMSl5/v4ZUOYa4K3WjIdpB/vCEh/gjB4FhSWOq3IAA","signatures":{"@superman:matrix.org":{"ed25519:SYNBAYVHFQ":"CteVb3rbYFQ4qxAqg3YsU7EaUN6tSmZK+OssNU8At0UCD/vQuLuxh21jalNGpn9HvtTNz10Qsw/X5gTYmXVbDQ"}}}; new key: {'key': 'XiwFps8Lz/+VWflVk/1O7P6gz/2q2Z118drmjnzjrTA', 'signatures': {'@superman:matrix.org': {'ed25519:SYNBAYVHFQ': 'BRYhdAJRlE3luwP//29pyuX3DxhJw8WxextbPY6Wg8eL+NMaDQnYixSpLLxuj5AdmnzZhgKxERs3SxsMV+NtAg'}}}" UserInfo={errcode=M_UNKNOWN, httpResponse=<NSHTTPURLResponse: 0x600001d17e40> { URL: https://matrix-client.matrix.org/_matrix/client/r0/keys/upload/SYNBAYVHFQ } { Status Code: 400, Headers {
2020-10-08 09:16:22.896053+0200 Riot[31404:1330449] [MXCrypto] uploadOneTimeKeys: Reset local OTKs because the server does not like them
2020-10-08 09:16:22.896735+0200 Riot[31404:1330449] [MXCrypto] uploadOneTimeKeys: Upload 1 keys
2020-10-08 09:16:22.896911+0200 Riot[31404:1330449] [MXHTTPClient] #13 - POST _matrix/client/r0/keys/upload/SYNBAYVHFQ
2020-10-08 09:16:23.101934+0200 Riot[31404:1330203] [MXHTTPClient] #13 - POST _matrix/client/r0/keys/upload/SYNBAYVHFQ completed in 205ms
2020-10-08 09:16:23.669519+0200 Riot[31404:1330203] [MXHTTPClient] #5 - POST _matrix/client/r0/keys/upload/SYNBAYVHFQ completed in 1992ms
2020-10-08 09:16:23.669972+0200 Riot[31404:1330449] [MXCrypto] uploadDeviceKeys done for @superman:matrix.org:
```

We detect the problem and we retry with new OTKs

