### PR TITLE
MXCrossSigning: Trust cross-signing because we locally trust the devie that created it

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Changes to be released in next version
 
 🐛 Bugfix
  * Tests: Fix testMXDeviceListDidUpdateUsersDevicesNotification.
+ * MXCrossSigning: Trust cross-signing because we locally trust the device that created it.
 
 ⚠️ API Changes
  * 

--- a/MatrixSDK/Crypto/CrossSigning/MXCrossSigning.m
+++ b/MatrixSDK/Crypto/CrossSigning/MXCrossSigning.m
@@ -729,7 +729,7 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
             if ([key.type isEqualToString:kMXKeyEd25519Type])
             {
                 MXDeviceInfo *device = [self.crypto.store deviceWithDeviceId:key.keyId forUser:myUserId];
-                if (device && device.trustLevel.isVerified)
+                if (device && device.trustLevel.isLocallyVerified)
                 {
                     // Check signature validity
                     NSError *error;


### PR DESCRIPTION
And not because this device is verified by cross-signing, which is already true.

The new test shows the issue by resetting the cross-signing from another device

![image](https://user-images.githubusercontent.com/8418515/95956197-41b27200-0dfe-11eb-9d2c-5e24385d8606.png)
