### PR TITLE
Pod: Update Jitsi a bit more to build with Xcode 12

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,9 +9,10 @@ Changes to be released in next version
 
 🐛 Bugfix
  * MXSession: Fix log for next stream token.
+ * Update JitsiMeetSDK to 2.10.0 (vector-im/element-ios/3712).
 
 ⚠️ API Changes
- * 
+ * Xcode 12 is now mandatory for using the JingleCallStack sub pod.
 
 🗣 Translations
  * 
@@ -31,13 +32,13 @@ Changes in 0.16.20 (2020-10-27)
 🙌 Improvements
  * Update GZIP to 1.3.0 (vector-im/element-ios/3570).
  * Update Realm to 5.4.8 (vector-im/element-ios/3570).
- * Update JitsiMeetSDK to 2.10.2 (vector-im/element-ios/3570).
+ * Update JitsiMeetSDK to 2.10.0 (vector-im/element-ios/3570).
 
 🐛 Bugfix
  * 
 
 ⚠️ API Changes
- * Xcode 12 is now mandatory for using the JingleCallStack sub pod.
+ * 
 
 🗣 Translations
  * 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,7 +13,7 @@ Changes to be released in next version
  * 
 
 ⚠️ API Changes
- * 
+ * Xcode 12 is now mandatory for using the JingleCallStack sub pod.
 
 🗣 Translations
  * 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,7 @@ Changes to be released in next version
 🙌 Improvements
  * Update GZIP to 1.3.0 (vector-im/element-ios/3570).
  * Update Realm to 5.4.8 (vector-im/element-ios/3570).
- * Update JitsiMeetSDK to 2.10.0 (vector-im/element-ios/3570).
+ * Update JitsiMeetSDK to 2.10.2 (vector-im/element-ios/3570).
 
 🐛 Bugfix
  * 

--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -54,7 +54,7 @@ Pod::Spec.new do |s|
     #ss.ios.dependency 'GoogleWebRTC', '~>1.1.21820'
     
     # Use WebRTC framework included in Jitsi Meet SDK
-    ss.ios.dependency 'JitsiMeetSDK', ' 2.10.0'
+    ss.ios.dependency 'JitsiMeetSDK', ' 2.10.2'
 
   end
 


### PR DESCRIPTION
I tested Jitsi and 1:1 calls on Xcode 12. They work as expected.

This is a WIP because EI does not build with Xcode 11.7 with this update.