### PR TITLE
MXThrottler: Dispatch the block on the correct queue

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Changes to be released in next version
 
 🐛 Bugfix
  * MXSession: Fix log for next stream token.
+ * MXThrottler: Dispatch the block on the correct queue. This will prevent unexpected loops (vector-im/element-ios/3778).
  * Update JitsiMeetSDK to 2.10.0 (vector-im/element-ios/3712).
 
 ⚠️ API Changes

--- a/MatrixSDK/Utils/MXThrottler.m
+++ b/MatrixSDK/Utils/MXThrottler.m
@@ -58,7 +58,11 @@ NSUInteger count = 0;
 - (void)throttle:(dispatch_block_t)block
 {
     // Cancel any existing work item if it has not yet executed
-    workItem = nil;
+    if (workItem)
+    {
+        NSLog(@"[MXThrottler] throttle: Cancel previous block");
+        workItem = nil;
+    }
     
     // Re-assign workItem with the new block task, resetting the previousRun time when it executes
     MXWeakify(self);
@@ -67,6 +71,7 @@ NSUInteger count = 0;
 
         self->previousRun = [NSDate new];
         block();
+        self->workItem = nil;
     };
     
     if (isTimerArmed)
@@ -82,13 +87,19 @@ NSUInteger count = 0;
     NSTimeInterval delay = [[NSDate new] timeIntervalSinceDate:previousRun] > _minimumDelay ? 0 : _minimumDelay;
     if (delay == 0)
     {
-        if (workItem)
-        {
-            workItem();
-        }
+        dispatch_async(_queue, ^{
+            MXStrongifyAndReturnIfNil(self);
+            
+            if (self->workItem)
+            {
+                self->workItem();
+            }
+        });
     }
     else
     {
+        NSLog(@"[MXThrottler] throttle: Delay block by %@s", @(delay));
+        
         isTimerArmed = YES;
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)), _queue, ^{
             MXStrongifyAndReturnIfNil(self);


### PR DESCRIPTION
This will prevent unexpected loop

Closes https://github.com/vector-im/element-ios/issues/3778
