### PR TITLE
Tools: Add MXProfiler to track performances

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Changes to be released in next version
 🙌 Improvements
  * MXAnalyticsDelegate: Make it fully agnostic on tracked data.
  * MXRealmCryptoStore: Compact DB files before getting out of memory error (vector-im/element-ios/3792).
+ * Tools: Add MXProfiler to track some performance.
 
 🐛 Bugfix
  * MXSession: Fix log for next stream token.

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -114,6 +114,18 @@
 		323EF7471C7CB4C7000DC98C /* MXEventTimelineTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 323EF7461C7CB4C7000DC98C /* MXEventTimelineTests.m */; };
 		323F3F9320D3F0C700D26D6A /* MXRoomEventFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 323F3F9120D3F0C700D26D6A /* MXRoomEventFilter.m */; };
 		323F3F9420D3F0C700D26D6A /* MXRoomEventFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 323F3F9220D3F0C700D26D6A /* MXRoomEventFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		323F8773255460B5009E9E67 /* MXProfiler.h in Headers */ = {isa = PBXBuildFile; fileRef = 323F8772255460B5009E9E67 /* MXProfiler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		323F8774255460B5009E9E67 /* MXProfiler.h in Headers */ = {isa = PBXBuildFile; fileRef = 323F8772255460B5009E9E67 /* MXProfiler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		323F877B25546170009E9E67 /* MXBaseProfiler.h in Headers */ = {isa = PBXBuildFile; fileRef = 323F877925546170009E9E67 /* MXBaseProfiler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		323F877C25546170009E9E67 /* MXBaseProfiler.h in Headers */ = {isa = PBXBuildFile; fileRef = 323F877925546170009E9E67 /* MXBaseProfiler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		323F877D25546170009E9E67 /* MXBaseProfiler.m in Sources */ = {isa = PBXBuildFile; fileRef = 323F877A25546170009E9E67 /* MXBaseProfiler.m */; };
+		323F877E25546170009E9E67 /* MXBaseProfiler.m in Sources */ = {isa = PBXBuildFile; fileRef = 323F877A25546170009E9E67 /* MXBaseProfiler.m */; };
+		323F878D25553D84009E9E67 /* MXTaskProfile.h in Headers */ = {isa = PBXBuildFile; fileRef = 323F878B25553D84009E9E67 /* MXTaskProfile.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		323F878E25553D84009E9E67 /* MXTaskProfile.h in Headers */ = {isa = PBXBuildFile; fileRef = 323F878B25553D84009E9E67 /* MXTaskProfile.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		323F878F25553D84009E9E67 /* MXTaskProfile.m in Sources */ = {isa = PBXBuildFile; fileRef = 323F878C25553D84009E9E67 /* MXTaskProfile.m */; };
+		323F879025553D84009E9E67 /* MXTaskProfile.m in Sources */ = {isa = PBXBuildFile; fileRef = 323F878C25553D84009E9E67 /* MXTaskProfile.m */; };
+		323F879625554FF2009E9E67 /* MXTaskProfile_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 323F879525554FF2009E9E67 /* MXTaskProfile_Private.h */; };
+		323F879725554FF2009E9E67 /* MXTaskProfile_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 323F879525554FF2009E9E67 /* MXTaskProfile_Private.h */; };
 		323F8864212D4E470001C73C /* MXMatrixVersions.h in Headers */ = {isa = PBXBuildFile; fileRef = 323F8862212D4E470001C73C /* MXMatrixVersions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		323F8865212D4E480001C73C /* MXMatrixVersions.m in Sources */ = {isa = PBXBuildFile; fileRef = 323F8863212D4E470001C73C /* MXMatrixVersions.m */; };
 		324095221AFA432F00D81C97 /* MXCallStackCall.h in Headers */ = {isa = PBXBuildFile; fileRef = 3240951E1AFA432F00D81C97 /* MXCallStackCall.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1301,6 +1313,12 @@
 		323EF7461C7CB4C7000DC98C /* MXEventTimelineTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXEventTimelineTests.m; sourceTree = "<group>"; };
 		323F3F9120D3F0C700D26D6A /* MXRoomEventFilter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXRoomEventFilter.m; sourceTree = "<group>"; };
 		323F3F9220D3F0C700D26D6A /* MXRoomEventFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXRoomEventFilter.h; sourceTree = "<group>"; };
+		323F8772255460B5009E9E67 /* MXProfiler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXProfiler.h; sourceTree = "<group>"; };
+		323F877925546170009E9E67 /* MXBaseProfiler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXBaseProfiler.h; sourceTree = "<group>"; };
+		323F877A25546170009E9E67 /* MXBaseProfiler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXBaseProfiler.m; sourceTree = "<group>"; };
+		323F878B25553D84009E9E67 /* MXTaskProfile.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXTaskProfile.h; sourceTree = "<group>"; };
+		323F878C25553D84009E9E67 /* MXTaskProfile.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXTaskProfile.m; sourceTree = "<group>"; };
+		323F879525554FF2009E9E67 /* MXTaskProfile_Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXTaskProfile_Private.h; sourceTree = "<group>"; };
 		323F8862212D4E470001C73C /* MXMatrixVersions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXMatrixVersions.h; sourceTree = "<group>"; };
 		323F8863212D4E470001C73C /* MXMatrixVersions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXMatrixVersions.m; sourceTree = "<group>"; };
 		3240951E1AFA432F00D81C97 /* MXCallStackCall.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXCallStackCall.h; sourceTree = "<group>"; };
@@ -1987,6 +2005,7 @@
 		320DFDD619DD99B60068622A /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				323F87712554607A009E9E67 /* Profiling */,
 				F08B8D591E014711006171A8 /* Categories */,
 				F03EF4F91DF014D9009DF592 /* Media */,
 				B146D46E21A5939000D8C2C6 /* Realm */,
@@ -2134,6 +2153,19 @@
 				32618E7020ED2DF500E1D2EA /* MXFilterJSONModel.m */,
 			);
 			path = Filters;
+			sourceTree = "<group>";
+		};
+		323F87712554607A009E9E67 /* Profiling */ = {
+			isa = PBXGroup;
+			children = (
+				323F8772255460B5009E9E67 /* MXProfiler.h */,
+				323F877925546170009E9E67 /* MXBaseProfiler.h */,
+				323F877A25546170009E9E67 /* MXBaseProfiler.m */,
+				323F878B25553D84009E9E67 /* MXTaskProfile.h */,
+				323F878C25553D84009E9E67 /* MXTaskProfile.m */,
+				323F879525554FF2009E9E67 /* MXTaskProfile_Private.h */,
+			);
+			path = Profiling;
 			sourceTree = "<group>";
 		};
 		3240951D1AFA432F00D81C97 /* CallStack */ = {
@@ -3245,6 +3277,7 @@
 				327E9AE72285A8C400A98BC1 /* MXAggregationPaginatedResponse.h in Headers */,
 				32CEEF4923B0A8170039BA98 /* MXCrossSigningTools.h in Headers */,
 				323E0C5B1A306D7A00A31D73 /* MXEvent.h in Headers */,
+				323F8773255460B5009E9E67 /* MXProfiler.h in Headers */,
 				327A5F4B239805F600ED6329 /* MXKeyVerificationCancel.h in Headers */,
 				327F8DB21C6112BA00581CA3 /* MXRoomThirdPartyInvite.h in Headers */,
 				32BA86AC21529E29008F277E /* MXRoomNameStringsLocalizable.h in Headers */,
@@ -3292,6 +3325,7 @@
 				3245A7501AF7B2930001D8A7 /* MXCall.h in Headers */,
 				02CAD43B217DD12F0074700B /* MXContentScanEncryptedBody.h in Headers */,
 				32D2CC0423422462002BD8CA /* MX3PidAddManager.h in Headers */,
+				323F877B25546170009E9E67 /* MXBaseProfiler.h in Headers */,
 				324DD2C5246E638B00377005 /* MXAesHmacSha2.h in Headers */,
 				3271877D1DA7CB2F0071C818 /* MXDecrypting.h in Headers */,
 				32114A851A262CE000FF2EC4 /* MXStore.h in Headers */,
@@ -3343,6 +3377,7 @@
 				B146D50221A5C6D700D8C2C6 /* MXScanManager.h in Headers */,
 				32A31BC420D3FFB0005916C7 /* MXFilter.h in Headers */,
 				3274538423FD69D600438328 /* MXKeyVerificationRequestByToDeviceJSONModel.h in Headers */,
+				323F878D25553D84009E9E67 /* MXTaskProfile.h in Headers */,
 				327A5F53239805F600ED6329 /* MXKeyVerificationAccept.h in Headers */,
 				32A151481DAF7C0C00400192 /* MXKey.h in Headers */,
 				32BBAE6D2178E99100D85F46 /* MXKeyBackupVersion.h in Headers */,
@@ -3360,6 +3395,7 @@
 				3275FD9521A6B46600B9C13D /* MXLoginTerms.h in Headers */,
 				32F945F81FAB83D900622468 /* MXIncomingRoomKeyRequestCancellation.h in Headers */,
 				02CAD438217DD12F0074700B /* MXContentScanResult.h in Headers */,
+				323F879625554FF2009E9E67 /* MXTaskProfile_Private.h in Headers */,
 				32618E7B20EFA45B00E1D2EA /* MXRoomMembers.h in Headers */,
 				3240969D1F9F751600DBA607 /* MXPushRuleSenderNotificationPermissionConditionChecker.h in Headers */,
 				329E808C224E2E1B00A48C3A /* MXOutgoingSASTransaction.h in Headers */,
@@ -3473,6 +3509,7 @@
 				324AAC812399143400380A66 /* MXKeyVerificationKey.h in Headers */,
 				B1798D0724091A0100308A8F /* MXBase64Tools.h in Headers */,
 				B14EF29D2397E90400758AF0 /* MXRealmEventScan.h in Headers */,
+				323F8774255460B5009E9E67 /* MXProfiler.h in Headers */,
 				32CEEF4423AD2A6C0039BA98 /* MXCrossSigningKey.h in Headers */,
 				B14EF29E2397E90400758AF0 /* MXMediaScanStoreDelegate.h in Headers */,
 				B14EF29F2397E90400758AF0 /* MXAllowedCertificates.h in Headers */,
@@ -3647,6 +3684,7 @@
 				32F00ABC2488E1CD00131741 /* MXRecoveryService.h in Headers */,
 				32CEEF4A23B0A8170039BA98 /* MXCrossSigningTools.h in Headers */,
 				B14EF3242397E90400758AF0 /* MXBugReportRestClient.h in Headers */,
+				323F877C25546170009E9E67 /* MXBaseProfiler.h in Headers */,
 				B14EF3252397E90400758AF0 /* MXRoomPowerLevels.h in Headers */,
 				B19A309F240424BD00FB6F35 /* MXQRCodeTransaction_Private.h in Headers */,
 				B14EF3262397E90400758AF0 /* MXEventScanStoreDelegate.h in Headers */,
@@ -3687,6 +3725,7 @@
 				B14EF3442397E90400758AF0 /* NSArray+MatrixSDK.h in Headers */,
 				324DD2C6246E638B00377005 /* MXAesHmacSha2.h in Headers */,
 				B14EF3452397E90400758AF0 /* MXReplyEventParser.h in Headers */,
+				323F878E25553D84009E9E67 /* MXTaskProfile.h in Headers */,
 				B14EF3462397E90400758AF0 /* MXIncomingSASTransaction.h in Headers */,
 				B14EF3472397E90400758AF0 /* MXCryptoAlgorithms.h in Headers */,
 				B14EF3482397E90400758AF0 /* MXIncomingRoomKeyRequest.h in Headers */,
@@ -3720,6 +3759,7 @@
 				32AF9285240EA2430008A0FD /* MXSecretShareRequest.h in Headers */,
 				B14EF3602397E90400758AF0 /* MXHTTPClient.h in Headers */,
 				B19A30C92404268600FB6F35 /* MXQRCodeDataBuilder.h in Headers */,
+				323F879725554FF2009E9E67 /* MXTaskProfile_Private.h in Headers */,
 				32F00AC12488FB3600131741 /* MXRecoveryService_Private.h in Headers */,
 				B14EF3612397E90400758AF0 /* MXMegolmBackupAuthData.h in Headers */,
 				B14EF3622397E90400758AF0 /* MXReactionCountChange.h in Headers */,
@@ -3998,6 +4038,7 @@
 				32A31BC520D3FFB0005916C7 /* MXFilter.m in Sources */,
 				32B76EA520FDE85100B095F6 /* MXRoomMembersCount.m in Sources */,
 				32CEEF4B23B0A8170039BA98 /* MXCrossSigningTools.m in Sources */,
+				323F877D25546170009E9E67 /* MXBaseProfiler.m in Sources */,
 				320B3936239FA56900BE2C06 /* MXKeyVerificationByDMRequest.m in Sources */,
 				B146D47121A5939100D8C2C6 /* MXRealmHelper.m in Sources */,
 				32261B8C23C74A230018F1E2 /* MXDeviceTrustLevel.m in Sources */,
@@ -4035,6 +4076,7 @@
 				323360701A403A0D0071A488 /* MXFileStore.m in Sources */,
 				B1136967230C1E8600E2B2FA /* MXIdentityService.swift in Sources */,
 				32A9770521626E5C00919CC0 /* MXServerNotices.m in Sources */,
+				323F878F25553D84009E9E67 /* MXTaskProfile.m in Sources */,
 				32D7767E1A27860600FC4AA2 /* MXMemoryStore.m in Sources */,
 				324DD2B8246C21C700377005 /* MXSecretStorageKeyCreationInfo.m in Sources */,
 				327E9AE82285A8C400A98BC1 /* MXAggregationPaginatedResponse.m in Sources */,
@@ -4526,6 +4568,7 @@
 				B14EF2792397E90400758AF0 /* MXEventListener.m in Sources */,
 				B14EF27A2397E90400758AF0 /* MXSessionEventListener.swift in Sources */,
 				B14EF27B2397E90400758AF0 /* MXOlmSessionResult.m in Sources */,
+				323F877E25546170009E9E67 /* MXBaseProfiler.m in Sources */,
 				B14EF27C2397E90400758AF0 /* MXRestClient.swift in Sources */,
 				32AF929A24115D8B0008A0FD /* MXPendingSecretShareRequest.m in Sources */,
 				B14EF27D2397E90400758AF0 /* MXKeyBackup.m in Sources */,
@@ -4536,6 +4579,7 @@
 				B14EF2822397E90400758AF0 /* MXDeviceList.m in Sources */,
 				320B3937239FA56900BE2C06 /* MXKeyVerificationByDMRequest.m in Sources */,
 				B14EF2832397E90400758AF0 /* MXRoomCreateContent.m in Sources */,
+				323F879025553D84009E9E67 /* MXTaskProfile.m in Sources */,
 				B14EF2842397E90400758AF0 /* MXUIKitBackgroundModeHandler.m in Sources */,
 				B14EF2852397E90400758AF0 /* (null) in Sources */,
 				32A9F8E1244720B10069C65B /* MXThrottler.m in Sources */,

--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
@@ -219,8 +219,9 @@ static NSUInteger preloadOptions;
 
             // If metaData is still defined, we can load rooms data
             if (self->metaData)
-            {
-                NSDate *startDate = [NSDate date];
+            {                
+                MXTaskProfile *taskProfile = [MXSDKOptions.sharedInstance.profiler startMeasuringTaskWithName:kMXAnalyticsStartupStorePreload category:kMXAnalyticsStartupCategory];
+                
                 NSLog(@"[MXFileStore] Start data loading from files");
 
                 [self loadRoomsMessages];
@@ -240,12 +241,9 @@ static NSUInteger preloadOptions;
                 [self loadUsers];
                 [self loadGroups];
 
-                NSTimeInterval duration = [[NSDate date] timeIntervalSinceDate:startDate];
-                NSLog(@"[MXFileStore] Data loaded from files in %.0fms", duration * 1000);
-
-                [[MXSDKOptions sharedInstance].analyticsDelegate trackDuration:duration
-                                                                      category:kMXAnalyticsStartupCategory
-                                                                          name:kMXAnalyticsStartupStorePreload];
+                taskProfile.units = self->roomStores.count;
+                [MXSDKOptions.sharedInstance.profiler stopMeasuringTaskWithProfile:taskProfile];
+                NSLog(@"[MXFileStore] Data loaded from files in %.0fms", taskProfile.duration * 1000);
             }
 
             // Else, if credentials is valid, create and store it

--- a/MatrixSDK/MXEnumConstants.h
+++ b/MatrixSDK/MXEnumConstants.h
@@ -241,6 +241,11 @@ FOUNDATION_EXPORT NSString *const kMXAnalyticsStartupMountData;
 // Duration of the the display of the app launch screen
 FOUNDATION_EXPORT NSString *const kMXAnalyticsStartupLaunchScreen;
 
+// Metrics related to the initial sync request
+FOUNDATION_EXPORT NSString *const kMXAnalyticsInitialSyncCategory;
+FOUNDATION_EXPORT NSString *const kMXAnalyticsInitialSyncRequest;
+FOUNDATION_EXPORT NSString *const kMXAnalyticsInitialSyncParsing;
+
 /**
  Overall stats category.
  */

--- a/MatrixSDK/MXEnumConstants.m
+++ b/MatrixSDK/MXEnumConstants.m
@@ -87,5 +87,9 @@ NSString *const kMXAnalyticsStartupStorePreload = @"storePreload";
 NSString *const kMXAnalyticsStartupMountData = @"mountData";
 NSString *const kMXAnalyticsStartupLaunchScreen = @"launchScreen";
 
+NSString *const kMXAnalyticsInitialSyncCategory = @"initialSync";
+NSString *const kMXAnalyticsInitialSyncRequest = @"request";
+NSString *const kMXAnalyticsInitialSyncParsing = @"parsing";
+
 NSString *const kMXAnalyticsStatsCategory = @"stats";
 NSString *const kMXAnalyticsStatsRooms = @"rooms";

--- a/MatrixSDK/MXSDKOptions.h
+++ b/MatrixSDK/MXSDKOptions.h
@@ -1,6 +1,7 @@
 /*
  Copyright 2015 OpenMarket Ltd
  Copyright 2017 Vector Creations Ltd
+ Copyright 2020 The Matrix.org Foundation C.I.C
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -16,7 +17,9 @@
  */
 
 #import <Foundation/Foundation.h>
+
 #import "MXAnalyticsDelegate.h"
+#import "MXProfiler.h"
 
 
 #pragma mark - Build time options
@@ -75,6 +78,13 @@ NS_ASSUME_NONNULL_BEGIN
  By default, nil.
  */
 @property (nonatomic, nullable) id<MXAnalyticsDelegate> analyticsDelegate;
+
+/**
+ The profiler.
+ 
+ By default, MXBaseProfiler.
+ */
+@property (nonatomic, nullable) id<MXProfiler> profiler;
 
 /**
  The version of the media cache at the application level.

--- a/MatrixSDK/MXSDKOptions.m
+++ b/MatrixSDK/MXSDKOptions.m
@@ -1,6 +1,7 @@
 /*
  Copyright 2015 OpenMarket Ltd
  Copyright 2017 Vector Creations Ltd
+ Copyright 2020 The Matrix.org Foundation C.I.C
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -16,6 +17,8 @@
  */
 
 #import "MXSDKOptions.h"
+
+#import "MXBaseProfiler.h"
 
 static MXSDKOptions *sharedOnceInstance = nil;
 
@@ -35,6 +38,7 @@ static MXSDKOptions *sharedOnceInstance = nil;
     self = [super init];
     if (self)
     {
+        _profiler = [MXBaseProfiler new];
         _disableIdenticonUseForUserAvatar = NO;
         _enableCryptoWhenStartingMXSession = NO;
         _enableKeyBackupWhenStartingMXCrypto = YES;

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -989,6 +989,9 @@ typedef void (^MXOnResumeDone)(void);
             wasfirstSync = YES;
             self->firstSyncDone = YES;
             
+            // Contextualise the profiling with the amount of received information
+            syncTaskProfile.units = syncResponse.rooms.join.count + syncResponse.rooms.invite.count + syncResponse.rooms.leave.count;
+            
             [MXSDKOptions.sharedInstance.profiler stopMeasuringTaskWithProfile:syncTaskProfile];
         }
 

--- a/MatrixSDK/Utils/Profiling/MXBaseProfiler.h
+++ b/MatrixSDK/Utils/Profiling/MXBaseProfiler.h
@@ -1,0 +1,33 @@
+// 
+// Copyright 2020 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "MXProfiler.h"
+#import "MXAnalyticsDelegate.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ A profiler that sends data to analytics.
+ */
+@interface MXBaseProfiler : NSObject <MXProfiler>
+
+@property (nonatomic, weak, nullable) id<MXAnalyticsDelegate> analytics;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixSDK/Utils/Profiling/MXBaseProfiler.m
+++ b/MatrixSDK/Utils/Profiling/MXBaseProfiler.m
@@ -1,0 +1,107 @@
+// 
+// Copyright 2020 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import "MXBaseProfiler.h"
+
+#import "MXTaskProfile_Private.h"
+
+@interface MXBaseProfiler ()
+{
+    NSMutableArray<MXTaskProfile *> *taskProfiles;
+}
+
+@end
+
+
+@implementation MXBaseProfiler
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self)
+    {
+        taskProfiles = [NSMutableArray array];
+    }
+    return self;
+}
+
+- (MXTaskProfile *)startMeasuringTaskWithName:(nonnull NSString *)name category:(nonnull NSString *)category
+{
+    MXTaskProfile *taskProfile = [[MXTaskProfile alloc] initWithName:name category:category];
+    
+    @synchronized (taskProfiles)
+    {
+        [taskProfiles addObject:taskProfile];
+    }
+    
+    return taskProfile;
+}
+
+- (void)stopMeasuringTaskWithProfile:(MXTaskProfile *)taskProfile
+{
+    [taskProfile markAsCompleted];
+    
+    NSLog(@"[MXBaseProfiler] Task %@ - %@ for %@ units completed in  %.3fms%@",
+          taskProfile.category,
+          taskProfile.name,
+          @(taskProfile.units),
+          taskProfile.duration,
+          taskProfile.paused ? @" (but it was paused)" : @"");
+          
+    // Do not send a task that was paused to analytics. Data is often not valid
+    if (!taskProfile.paused)
+    {
+        // TODO: Send units information (but Matomo does not support additional contextual data)
+        [self.analytics trackDuration:taskProfile.duration category:taskProfile.category name:taskProfile.name];
+    }
+    
+    @synchronized (taskProfiles)
+    {
+        [taskProfiles removeObject:taskProfile];
+    }
+}
+
+- (void)pause
+{
+    @synchronized (taskProfiles)
+    {
+        // Mark pending task has invalidated
+        for (MXTaskProfile *taskProfile in taskProfiles)
+        {
+            [taskProfile markAsPaused];
+        }
+    }
+}
+
+- (void)resume
+{
+    // Resume is not supported yet. It is hard to find an accurate implementation
+}
+
+#pragma mark - Private
+
+- (nullable MXTaskProfile*)taskProfileWithName:(NSString*)name category:(NSString*)category
+{
+    MXTaskProfile *taskProfile;
+    
+    @synchronized (taskProfiles)
+    {
+        taskProfile = [taskProfiles filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"name == %@ && category == %@", name, category]].firstObject;
+    }
+    return taskProfile;
+}
+
+@end

--- a/MatrixSDK/Utils/Profiling/MXBaseProfiler.m
+++ b/MatrixSDK/Utils/Profiling/MXBaseProfiler.m
@@ -54,7 +54,7 @@
 {
     [taskProfile markAsCompleted];
     
-    NSLog(@"[MXBaseProfiler] Task %@ - %@ for %@ units completed in  %.3fms%@",
+    NSLog(@"[MXBaseProfiler] Task %@ - %@ for %@ units completed in %.3fms%@",
           taskProfile.category,
           taskProfile.name,
           @(taskProfile.units),

--- a/MatrixSDK/Utils/Profiling/MXBaseProfiler.m
+++ b/MatrixSDK/Utils/Profiling/MXBaseProfiler.m
@@ -74,6 +74,15 @@
     }
 }
 
+- (void)cancelTaskProfile:(MXTaskProfile *)taskProfile;
+{
+    @synchronized (taskProfiles)
+    {
+        [taskProfiles removeObject:taskProfile];
+    }
+}
+
+
 - (void)pause
 {
     @synchronized (taskProfiles)

--- a/MatrixSDK/Utils/Profiling/MXBaseProfiler.m
+++ b/MatrixSDK/Utils/Profiling/MXBaseProfiler.m
@@ -58,7 +58,7 @@
           taskProfile.category,
           taskProfile.name,
           @(taskProfile.units),
-          taskProfile.duration,
+          taskProfile.duration * 1000,
           taskProfile.paused ? @" (but it was paused)" : @"");
           
     // Do not send a task that was paused to analytics. Data is often not valid

--- a/MatrixSDK/Utils/Profiling/MXProfiler.h
+++ b/MatrixSDK/Utils/Profiling/MXProfiler.h
@@ -1,0 +1,63 @@
+// 
+// Copyright 2020 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import "MXTaskProfile.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ Central point to collect profiling data.
+ */
+@protocol MXProfiler
+
+/**
+ Start measuring a task.
+ 
+ @param name the name of the task.
+ @param category the category the task belongs to.
+ */
+- (MXTaskProfile *)startMeasuringTaskWithName:(NSString*)name category:(NSString*)category;
+
+/**
+ Stop the clock for a task.
+ 
+ @param taskProfile the task.
+ */
+- (void)stopMeasuringTaskWithProfile:(MXTaskProfile *)taskProfile;
+
+/**
+ Retrieve the profile of a given task.
+ 
+ @param name the name of the task.
+ @param category the category the task belongs to.
+ */
+- (nullable MXTaskProfile*)taskProfileWithName:(NSString*)name category:(NSString*)category;
+
+
+/**
+ Call this pause method when the process is going to be suspended.
+ This affects time measurement.
+ */
+- (void)pause;
+
+/**
+ Call this resume method when the process is back.
+ */
+- (void)resume;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixSDK/Utils/Profiling/MXProfiler.h
+++ b/MatrixSDK/Utils/Profiling/MXProfiler.h
@@ -46,6 +46,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (nullable MXTaskProfile*)taskProfileWithName:(NSString*)name category:(NSString*)category;
 
+/**
+ Cancel a task profiling.
+ 
+ @param taskProfile the task.
+ */
+- (void)cancelTaskProfile:(MXTaskProfile *)taskProfile;
+
 
 /**
  Call this pause method when the process is going to be suspended.

--- a/MatrixSDK/Utils/Profiling/MXTaskProfile.h
+++ b/MatrixSDK/Utils/Profiling/MXTaskProfile.h
@@ -20,13 +20,18 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MXTaskProfile : NSObject
 
+// Task name
 @property (nonatomic, readonly) NSString *name;
+
+// Category to group related tasks
 @property (nonatomic, readonly) NSString *category;
 
+// Task timing
 @property (nonatomic, readonly) NSDate *startDate;
 @property (nonatomic, readonly, nullable) NSDate *endDate;
 @property (nonatomic, readonly) NSTimeInterval duration;
 
+// Number of items managed by the task
 @property (nonatomic) NSUInteger units;
 
 // YES, if the task was interrupted by a pause

--- a/MatrixSDK/Utils/Profiling/MXTaskProfile.h
+++ b/MatrixSDK/Utils/Profiling/MXTaskProfile.h
@@ -1,0 +1,38 @@
+// 
+// Copyright 2020 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MXTaskProfile : NSObject
+
+@property (nonatomic, readonly) NSString *name;
+@property (nonatomic, readonly) NSString *category;
+
+@property (nonatomic, readonly) NSDate *startDate;
+@property (nonatomic, readonly, nullable) NSDate *endDate;
+@property (nonatomic, readonly) NSTimeInterval duration;
+
+@property (nonatomic) NSUInteger units;
+
+// YES, if the task was interrupted by a pause
+@property (nonatomic, readonly) BOOL paused;
+
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixSDK/Utils/Profiling/MXTaskProfile.m
+++ b/MatrixSDK/Utils/Profiling/MXTaskProfile.m
@@ -1,0 +1,55 @@
+// 
+// Copyright 2020 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import "MXTaskProfile.h"
+
+@implementation MXTaskProfile
+
+- (instancetype)initWithName:(NSString *)name category:(NSString *)category
+{
+    self = [self init];
+    if (self)
+    {
+        _name = name;
+        _category = category;
+        _startDate = [NSDate date];
+        _paused = NO;
+        _units = 1;
+    }
+    return self;
+}
+
+- (void)markAsCompleted
+{
+    _endDate = [NSDate date];
+}
+
+- (void)markAsPaused
+{
+    _paused = YES;
+}
+
+- (NSTimeInterval)duration
+{
+    NSTimeInterval duration = 0;
+    if (_endDate)
+    {
+        duration = [_endDate timeIntervalSinceDate:_startDate];
+    }
+    return duration;;
+}
+
+@end

--- a/MatrixSDK/Utils/Profiling/MXTaskProfile.m
+++ b/MatrixSDK/Utils/Profiling/MXTaskProfile.m
@@ -49,7 +49,7 @@
     {
         duration = [_endDate timeIntervalSinceDate:_startDate];
     }
-    return duration;;
+    return duration;
 }
 
 @end

--- a/MatrixSDK/Utils/Profiling/MXTaskProfile_Private.h
+++ b/MatrixSDK/Utils/Profiling/MXTaskProfile_Private.h
@@ -1,0 +1,36 @@
+// 
+// Copyright 2020 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import "MXTaskProfile.h"
+
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ The `MXTaskProfile_Private` extension exposes internal operations.
+ */
+@interface MXTaskProfile ()
+
+- (instancetype)initWithName:(NSString *)name category:(NSString *)category;
+
+- (void)markAsCompleted;
+
+- (void)markAsPaused;
+
+@end
+
+NS_ASSUME_NONNULL_END
+


### PR DESCRIPTION
The default implementation, `MXBaseProfiler`, reports duration in logs and to the `MXAnalytics` interface.
Logs look like:
```
[MXBaseProfiler] Task startup - storePreload for 578 units completed in 1682.477ms
[MXBaseProfiler] Task startup - mountData for 578 units completed in 2267.157ms
[MXBaseProfiler] Task startup - launchScreen for 1 units completed in 2282.014ms
...
[MXBaseProfiler] Task startup - incrementalSync for 53 units completed in 481.103ms
[MXBaseProfiler] Task notifications - timelineDisplay for 1 units completed in 652.003ms
```
 
The app can call `MXProfiler.pause()` when it goes in background. This avoids to measure and to report bad durations.