### PR TITLE
Podspec: Fix arm64 simulator issue with JitsiMeetSDK

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Changes to be released in next version
 
 🐛 Bugfix
  * Podspec: Fix arm64 simulator issue with JitsiMeetSDK.
+ * Realm: Stick on 10.1.2 because the CI cannot build.
 
 ⚠️ API Changes
  * 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changes to be released in next version
  * 
 
 🐛 Bugfix
- * 
+ * Podspec: Fix arm64 simulator issue with JitsiMeetSDK.
 
 ⚠️ API Changes
  * 

--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -37,7 +37,7 @@ Pod::Spec.new do |s|
 
       # Requirements for e2e encryption
       ss.dependency 'OLMKit', '~> 3.1.0'
-      ss.dependency 'Realm', '~> 10.1.2'
+      ss.dependency 'Realm', '10.1.2'
       ss.dependency 'libbase58', '~> 0.1.4'
   end
 

--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -56,6 +56,9 @@ Pod::Spec.new do |s|
     # Use WebRTC framework included in Jitsi Meet SDK
     ss.ios.dependency 'JitsiMeetSDK', ' 2.10.2'
 
+    # JitsiMeetSDK has not yet binaries for arm64 simulator
+    ss.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+    ss.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
   end
 
   s.subspec 'SwiftSupport' do |ss|    

--- a/Podfile
+++ b/Podfile
@@ -8,7 +8,7 @@ abstract_target 'MatrixSDK' do
     pod 'OLMKit', '~> 3.1.0', :inhibit_warnings => true
     #pod 'OLMKit', :path => '../olm/OLMKit.podspec'
     
-    pod 'Realm', '~> 10.1.2'
+    pod 'Realm', '10.1.2'
     pod 'libbase58', '~> 0.1.4'
     
     target 'MatrixSDK-iOS' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -34,9 +34,9 @@ PODS:
     - OLMKit/olmcpp (= 3.1.0)
   - OLMKit/olmc (3.1.0)
   - OLMKit/olmcpp (3.1.0)
-  - Realm (10.1.4):
-    - Realm/Headers (= 10.1.4)
-  - Realm/Headers (10.1.4)
+  - Realm (10.1.2):
+    - Realm/Headers (= 10.1.2)
+  - Realm/Headers (10.1.2)
 
 DEPENDENCIES:
   - AFNetworking (~> 4.0.0)
@@ -44,7 +44,7 @@ DEPENDENCIES:
   - libbase58 (~> 0.1.4)
   - OHHTTPStubs (~> 9.0.0)
   - OLMKit (~> 3.1.0)
-  - Realm (~> 10.1.2)
+  - Realm (= 10.1.2)
 
 SPEC REPOS:
   trunk:
@@ -61,8 +61,8 @@ SPEC CHECKSUMS:
   libbase58: 7c040313537b8c44b6e2d15586af8e21f7354efd
   OHHTTPStubs: cb29d2a9d09a828ecb93349a2b0c64f99e0db89f
   OLMKit: 4ee0159d63feeb86d836fdcfefe418e163511639
-  Realm: 80f4fb2971ccb9adc27a47d0955ae8e533a7030b
+  Realm: 031fdd4be7094d01b43af1a5e49766ab644bb800
 
-PODFILE CHECKSUM: 0cfd720a37593162ffaf1195b92c369673639b45
+PODFILE CHECKSUM: bafcfe1874b5534acdc9d6c00d60eb962dfcb647
 
 COCOAPODS: 1.10.0


### PR DESCRIPTION
`pod lib lint` passed but not `pod trunk push`. The last one complained about the sub spec related to JitsiMeetSDK.

It seems that `pod lib lint` does not explicitly lint sub specs. 


To force the lint of guilty sub spec, I ran:
`pod lib lint --subspec=JingleCallStack --fail-fast --verbose --no-clean --allow-warnings`