### PR TITLE
Release 0.17.2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,27 @@
+Changes to be released in next version
+=================================================
+
+✨ Features
+ * 
+
+🙌 Improvements
+ * 
+
+🐛 Bugfix
+ * 
+
+⚠️ API Changes
+ * 
+
+🗣 Translations
+ * 
+    
+🧱 Build
+ * 
+
+Others
+ * 
+
 Changes in 0.17.1 (2020-11-17)
 =================================================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,30 @@
-Changes in 0.17.0 (2020-11-13)
+Changes to be released in next version
+=================================================
+
+✨ Features
+ * 
+
+🙌 Improvements
+ * 
+
+🐛 Bugfix
+ * 
+
+⚠️ API Changes
+ * Update Realm to 10.2.1 and CocoaPods to 1.10.0.
+ * CocoaPods 1.10.0 is mandatory.
+
+🗣 Translations
+ * 
+    
+🧱 Build
+ * 
+
+Others
+ * 
+
+ 
+ Changes in 0.17.0 (2020-11-13)
 =================================================
 
 ✨ Features
@@ -16,8 +42,6 @@ Changes in 0.17.0 (2020-11-13)
 
 ⚠️ API Changes
  * Xcode 12 is now mandatory for using the JingleCallStack sub pod.
- * Update Realm to 10.2.1 and CocoaPods to 1.10.0.
- * CocoaPods 1.10.0 is mandatory.
 
 🗣 Translations
  * 
@@ -27,8 +51,6 @@ Changes in 0.17.0 (2020-11-13)
 
 Others
  * 
-
-Improvements:
 
 
 Changes in 0.16.20 (2020-10-27)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-Changes to be released in next version
+Changes in 0.17.2 (2020-11-17)
 =================================================
 
 ✨ Features
@@ -22,6 +22,9 @@ Changes to be released in next version
 
 Others
  * 
+
+Improvements:
+
 
 Changes in 0.17.1 (2020-11-17)
 =================================================

--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "MatrixSDK"
-  s.version      = "0.17.1"
+  s.version      = "0.17.2"
   s.summary      = "The iOS SDK to build apps compatible with Matrix (https://www.matrix.org)"
 
   s.description  = <<-DESC

--- a/MatrixSDK/MatrixSDKVersion.m
+++ b/MatrixSDK/MatrixSDKVersion.m
@@ -16,4 +16,4 @@
 
 #import <Foundation/Foundation.h>
 
-NSString *const MatrixSDKVersion = @"0.17.1";
+NSString *const MatrixSDKVersion = @"0.17.2";

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -34,9 +34,9 @@ PODS:
     - OLMKit/olmcpp (= 3.1.0)
   - OLMKit/olmc (3.1.0)
   - OLMKit/olmcpp (3.1.0)
-  - Realm (10.1.2):
-    - Realm/Headers (= 10.1.2)
-  - Realm/Headers (10.1.2)
+  - Realm (10.1.4):
+    - Realm/Headers (= 10.1.4)
+  - Realm/Headers (10.1.4)
 
 DEPENDENCIES:
   - AFNetworking (~> 4.0.0)
@@ -61,7 +61,7 @@ SPEC CHECKSUMS:
   libbase58: 7c040313537b8c44b6e2d15586af8e21f7354efd
   OHHTTPStubs: cb29d2a9d09a828ecb93349a2b0c64f99e0db89f
   OLMKit: 4ee0159d63feeb86d836fdcfefe418e163511639
-  Realm: 031fdd4be7094d01b43af1a5e49766ab644bb800
+  Realm: 80f4fb2971ccb9adc27a47d0955ae8e533a7030b
 
 PODFILE CHECKSUM: 0cfd720a37593162ffaf1195b92c369673639b45
 


### PR DESCRIPTION
This PR prepares the release of MatrixSDK v0.17.2.

Notes:
- This PR targets `release/0.17.2/master`, which has been cut from `master`.
- It includes changes to the `Podfile`, but _not_ the corresponding changes to `Podfile.lock`, as `pod install` hasn't yet been run.
  This is because the `Podfile` targets future versions of dependencies yet to be released, so `pod install` wouldn't be able to find them yet.
- When the CI runs its checks, it will temporarily point to the pending release branches of those dependencies beforehand
- It is only during `release:finish` that `pod update` will be run -- updating the `Podfile.lock`
to use the now officially released dependencies -- before ultimately merging `release/0.17.2/master` into `master` to tag the release.

---

➡️  Once this PR is merged, you will need to first ensure that the products this one depends on are fully released,
   then run `bundle exec rake release:finish` to close this release.

💡 If you want to review _only_ the changes made since the release branch was cut from `develop`,
   you can [check those here](https://github.com/matrix-org/matrix-ios-sdk/compare/develop...release/0.17.2/release)
