### PR TITLE
MXOlmDevice: Make usage of libolm data process-safe

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changes to be released in next version
  * 
 
 🐛 Bugfix
- * 
+ * MXOlmDevice: Make use of OLMAccount atomic (vector-im/element-ios/3817).
 
 ⚠️ API Changes
  * 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changes to be released in next version
  * 
 
 🐛 Bugfix
- * MXOlmDevice: Make use of OLMAccount atomic (vector-im/element-ios/3817).
+ * MXOlmDevice: Make usage of libolm data process-safe (vector-im/element-ios/3817).
 
 ⚠️ API Changes
  * 

--- a/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmEncryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmEncryption.m
@@ -405,9 +405,8 @@
                     // message because of the lack of keys, but there's not
                     // much point in that really; it will mostly serve to clog
                     // up to_device inboxes.
-                    //
-                    // ensureOlmSessionsForUsers has already done the logging,
-                    // so just skip it.
+                    
+                    NSLog(@"[MXMegolmEncryption] shareKey: Cannot share key with device %@:%@. No one time key", userId, deviceID);
                     continue;
                 }
 

--- a/MatrixSDK/Crypto/Data/Store/MXCryptoStore.h
+++ b/MatrixSDK/Crypto/Data/Store/MXCryptoStore.h
@@ -89,14 +89,30 @@
 - (NSString*)deviceId;
 
 /**
- Store the end to end account for the logged-in user.
+ Store the user olm account for this device.
+ 
+ This method MUST be used only on setup to store a new olm account.
  */
 - (void)storeAccount:(OLMAccount*)account;
 
 /**
- * Load the end to end account for the logged-in user.
+ The user olm account for this device.
+ 
+ This is safe to use the returned for read-only olm operation.
  */
 - (OLMAccount*)account;
+
+/**
+ Perform an action that will advance the olm account state.
+ 
+ Some cryptographic operations update the internal state of the olm account. They must be executed
+ into this method to make those operations atomic. This method stores the new olm account state
+ when the block retuns,
+ The implementation must call the block before returning. It must be multi-thread and multi-process safe.
+ 
+ @param block the block where olm operations can be safely called.
+ */
+- (void)performAccountOperationWithBlock:(void (^)(OLMAccount *olmAccount))block;
 
 /**
  Store the sync token corresponding to the device list.

--- a/MatrixSDK/Crypto/Data/Store/MXCryptoStore.h
+++ b/MatrixSDK/Crypto/Data/Store/MXCryptoStore.h
@@ -93,7 +93,7 @@
  
  This method MUST be used only on setup to store a new olm account.
  */
-- (void)storeAccount:(OLMAccount*)account;
+- (void)setAccount:(OLMAccount*)account;
 
 /**
  The user olm account for this device.

--- a/MatrixSDK/Crypto/Data/Store/MXCryptoStore.h
+++ b/MatrixSDK/Crypto/Data/Store/MXCryptoStore.h
@@ -285,6 +285,17 @@
 - (MXOlmInboundGroupSession*)inboundGroupSessionWithId:(NSString*)sessionId andSenderKey:(NSString*)senderKey;
 
 /**
+ Perform an action that will advance the passed end-to-end group session.
+ 
+ See performAccountOperationWithBlock for more details.
+ 
+ @param sessionId the session identifier.
+ @param senderKey the base64-encoded curve25519 key of the sender.
+ @param block the block where olm session operations can be safely made.
+ */
+- (void)performSessionOperationWithGroupSessionWithId:(NSString*)sessionId senderKey:(NSString*)senderKey block:(void (^)(MXOlmInboundGroupSession *inboundGroupSession))block;
+
+/**
  Retrieve all inbound group sessions.
  
  @return the list of all inbound group sessions.

--- a/MatrixSDK/Crypto/Data/Store/MXCryptoStore.h
+++ b/MatrixSDK/Crypto/Data/Store/MXCryptoStore.h
@@ -110,7 +110,7 @@
  when the block retuns,
  The implementation must call the block before returning. It must be multi-thread and multi-process safe.
  
- @param block the block where olm operations can be safely called.
+ @param block the block where olm operations can be safely made.
  */
 - (void)performAccountOperationWithBlock:(void (^)(OLMAccount *olmAccount))block;
 
@@ -230,7 +230,7 @@
 - (NSString*)algorithmForRoom:(NSString*)roomId;
 
 /**
- Store a session between the logged-in user and another device.
+ Store a session between this device and another device.
 
  @param deviceKey the public key of the other device.
  @param session the end-to-end session.
@@ -238,16 +238,28 @@
 - (void)storeSession:(MXOlmSession*)session forDevice:(NSString*)deviceKey;
 
 /**
- Retrieve an end-to-end session between the logged-in user and another
- device.
+ Retrieve an end-to-end session between this device and another device.
 
  @param deviceKey the public key of the other device.
- @return a array of end-to-end sessions sorted by the last updated first.
+ @param sessionId the session id.
+ 
+ @return the end-to-end session.
  */
 - (MXOlmSession*)sessionWithDevice:(NSString*)deviceKey andSessionId:(NSString*)sessionId;
 
 /**
- Retrieve all end-to-end sessions between the logged-in user and another
+ Perform an action that will advance the passed end-to-end session.
+ 
+ See performAccountOperationWithBlock for more details.
+ 
+ @param deviceKey the public key of the other device.
+ @param sessionId the session id.
+ @param block the block where olm session operations can be safely made.
+ */
+- (void)performSessionOperationWithDevice:(NSString*)deviceKey andSessionId:(NSString*)sessionId block:(void (^)(MXOlmSession *mxOlmSession))block;
+
+/**
+ Retrieve all end-to-end sessions between this device and another
  device sorted by `lastReceivedMessageTs`, the most recent(higest value) first.
 
  @param deviceKey the public key of the other device.

--- a/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
+++ b/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
@@ -385,7 +385,7 @@ RLM_ARRAY_TYPE(MXRealmSecret)
     return account.deviceId;
 }
 
-- (void)storeAccount:(OLMAccount*)olmAccount
+- (void)setAccount:(OLMAccount*)olmAccount
 {
     NSDate *startDate = [NSDate date];
 

--- a/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
+++ b/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
@@ -395,7 +395,7 @@ RLM_ARRAY_TYPE(MXRealmSecret)
         account.olmAccountData = [NSKeyedArchiver archivedDataWithRootObject:olmAccount];
     }];
 
-    NSLog(@"[MXRealmCryptoStore] storeAccount in %.0fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+    NSLog(@"[MXRealmCryptoStore] storeAccount in %.3fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 }
 
 - (OLMAccount*)account
@@ -439,7 +439,7 @@ RLM_ARRAY_TYPE(MXRealmSecret)
         block(nil);
     }
     
-    NSLog(@"[MXRealmCryptoStore] performAccountOperationWithBlock done in %.0fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+    NSLog(@"[MXRealmCryptoStore] performAccountOperationWithBlock done in %.3fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 }
 
 - (void)storeDeviceSyncToken:(NSString*)deviceSyncToken
@@ -491,7 +491,7 @@ RLM_ARRAY_TYPE(MXRealmSecret)
 
     }];
 
-    NSLog(@"[MXRealmCryptoStore] storeDeviceForUser in %.0fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+    NSLog(@"[MXRealmCryptoStore] storeDeviceForUser in %.3fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 }
 
 - (MXDeviceInfo*)deviceWithDeviceId:(NSString*)deviceId forUser:(NSString*)userID
@@ -552,7 +552,7 @@ RLM_ARRAY_TYPE(MXRealmSecret)
         }
     }];
 
-    NSLog(@"[MXRealmCryptoStore] storeDevicesForUser (count: %tu) in %.0fms", devices.count, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+    NSLog(@"[MXRealmCryptoStore] storeDevicesForUser (count: %tu) in %.3fms", devices.count, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 }
 
 - (NSDictionary<NSString*, MXDeviceInfo*>*)devicesForUser:(NSString*)userID
@@ -673,7 +673,7 @@ RLM_ARRAY_TYPE(MXRealmSecret)
         }
     }];
 
-    NSLog(@"[MXRealmCryptoStore] storeAlgorithmForRoom (%@) in %.0fms", (isNew?@"NEW":@"UPDATE"), [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+    NSLog(@"[MXRealmCryptoStore] storeAlgorithmForRoom (%@) in %.3fms", (isNew?@"NEW":@"UPDATE"), [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 }
 
 - (NSString*)algorithmForRoom:(NSString*)roomId
@@ -706,7 +706,7 @@ RLM_ARRAY_TYPE(MXRealmSecret)
         }
     }];
 
-    NSLog(@"[MXRealmCryptoStore] storeBlacklistUnverifiedDevicesInRoom (%@) in %.0fms", (isNew?@"NEW":@"UPDATE"), [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+    NSLog(@"[MXRealmCryptoStore] storeBlacklistUnverifiedDevicesInRoom (%@) in %.3fms", (isNew?@"NEW":@"UPDATE"), [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 }
 
 - (BOOL)blacklistUnverifiedDevicesInRoom:(NSString *)roomId
@@ -749,7 +749,7 @@ RLM_ARRAY_TYPE(MXRealmSecret)
         }
     }];
 
-    NSLog(@"[MXRealmCryptoStore] storeSession (%@) in %.0fms", (isNew?@"NEW":@"UPDATE"), [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+    NSLog(@"[MXRealmCryptoStore] storeSession (%@) in %.3fms", (isNew?@"NEW":@"UPDATE"), [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 }
 
 - (MXOlmSession*)sessionWithDevice:(NSString*)deviceKey andSessionId:(NSString*)sessionId
@@ -792,13 +792,13 @@ RLM_ARRAY_TYPE(MXRealmSecret)
     }
     else
     {
-        NSLog(@"[MXRealmCryptoStore] performSessionOperationWithDevice. Error: olm session not found");
+        NSLog(@"[MXRealmCryptoStore] performSessionOperationWithDevice. Error: olm session %@ not found", sessionId);
         block(nil);
     }
     
     [realm commitWriteTransaction];
     
-    NSLog(@"[MXRealmCryptoStore] performSessionOperationWithDevice done in %.0fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+    NSLog(@"[MXRealmCryptoStore] performSessionOperationWithDevice done in %.3fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 }
 
 - (NSArray<MXOlmSession*>*)sessionsWithDevice:(NSString*)deviceKey;
@@ -866,7 +866,7 @@ RLM_ARRAY_TYPE(MXRealmSecret)
     }];
 
 
-    NSLog(@"[MXRealmCryptoStore] storeInboundGroupSessions: store %@ keys (%@ new) in %.0fms", @(sessions.count), @(newCount), [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+    NSLog(@"[MXRealmCryptoStore] storeInboundGroupSessions: store %@ keys (%@ new) in %.3fms", @(sessions.count), @(newCount), [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 }
 
 - (MXOlmInboundGroupSession*)inboundGroupSessionWithId:(NSString*)sessionId andSenderKey:(NSString*)senderKey
@@ -915,18 +915,18 @@ RLM_ARRAY_TYPE(MXRealmSecret)
         }
         else
         {
-            NSLog(@"[MXRealmCryptoStore] performSessionOperationWithGroupSessionWithId. Error: Cannot build MXOlmInboundGroupSession");
+            NSLog(@"[MXRealmCryptoStore] performSessionOperationWithGroupSessionWithId. Error: Cannot build MXOlmInboundGroupSession for megolm session %@", sessionId);
             block(nil);
         }    }
     else
     {
-        NSLog(@"[MXRealmCryptoStore] performSessionOperationWithGroupSessionWithId. Error: megolm session not found");
+        NSLog(@"[MXRealmCryptoStore] performSessionOperationWithGroupSessionWithId. Error: megolm session %@ not found", sessionId);
         block(nil);
     }
     
     [realm commitWriteTransaction];
     
-    NSLog(@"[MXRealmCryptoStore] performSessionOperationWithGroupSessionWithId done in %.0fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+    NSLog(@"[MXRealmCryptoStore] performSessionOperationWithGroupSessionWithId done in %.3fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 }
 
 - (NSArray<MXOlmInboundGroupSession *> *)inboundGroupSessions

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -2187,17 +2187,17 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 
         if (sessionId)
         {
-            NSLog(@"[MXCrypto] Started new sessionid %@ for device %@ (theirOneTimeKey: %@)", sessionId, deviceInfo, oneTimeKey.value);
+            NSLog(@"[MXCrypto] verifyKeyAndStartSession: Started new olm session id %@ for device %@ (theirOneTimeKey: %@)", sessionId, deviceInfo, oneTimeKey.value);
         }
         else
         {
             // Possibly a bad key
-            NSLog(@"[MXCrypto] Error starting session with device %@:%@", userId, deviceId);
+            NSLog(@"[MXCrypto] verifyKeyAndStartSession: Error starting olm session with device %@:%@", userId, deviceId);
         }
     }
     else
     {
-        NSLog(@"[MXCrypto] Unable to verify signature on one-time key for device %@:%@. Error: %@", userId, deviceId, error.localizedFailureReason);
+        NSLog(@"[MXCrypto] verifyKeyAndStartSession: Unable to verify signature on one-time key for device %@:%@. Error: %@", userId, deviceId, error.localizedFailureReason);
     }
 
     return sessionId;

--- a/MatrixSDK/Crypto/MXOlmDevice.m
+++ b/MatrixSDK/Crypto/MXOlmDevice.m
@@ -77,7 +77,7 @@
             // Else, create it
             olmAccount = [[OLMAccount alloc] initNewAccount];
 
-            [store storeAccount:olmAccount];
+            [store setAccount:olmAccount];
         }
         else
         {


### PR DESCRIPTION
Closes https://github.com/vector-im/element-ios/issues/3817.

by making olm operations atomic.

Commits can be reviewed one by one. I started to make OlmAccount atomic. Then, OlmSession and OlmInboundGroupSession.