### PR TITLE
MXCrypto: Create MXCryptoMigration to purge all one time keys because some may be bad

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,10 +5,11 @@ Changes to be released in next version
  * 
 
 🙌 Improvements
- * MXCrypto: Introduce MXCryptoVersion to track changes between MXCrypto module updates.
+ * MXCrypto: Introduce MXCryptoVersion and MXCryptoMigration to manage logical migration between MXCrypto module updates.
 
 🐛 Bugfix
  * MXOlmDevice: Make usage of libolm data process-safe (vector-im/element-ios/3817).
+ * MXCrypto: Use MXCryptoMigration to purge all one time keys because some may be bad (vector-im/element-ios/3818).
 
 ⚠️ API Changes
  * 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changes to be released in next version
  * 
 
 🙌 Improvements
- * 
+ * MXCrypto: Introduce MXCryptoVersion to track changes between MXCrypto module updates.
 
 🐛 Bugfix
  * MXOlmDevice: Make usage of libolm data process-safe (vector-im/element-ios/3817).

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -474,6 +474,12 @@
 		32C474C122AF7A2D00CFBCD2 /* MXReactionOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 32C474BF22AF7A2D00CFBCD2 /* MXReactionOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		32C474C222AF7A2D00CFBCD2 /* MXReactionOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 32C474C022AF7A2D00CFBCD2 /* MXReactionOperation.m */; };
 		32C6F93319DD814400EA4E9C /* MatrixSDK.h in Headers */ = {isa = PBXBuildFile; fileRef = 32C6F93219DD814400EA4E9C /* MatrixSDK.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		32C78B68256CFC4D008130B1 /* MXCryptoVersion.h in Headers */ = {isa = PBXBuildFile; fileRef = 32C78B65256CFC4D008130B1 /* MXCryptoVersion.h */; };
+		32C78B69256CFC4D008130B1 /* MXCryptoVersion.h in Headers */ = {isa = PBXBuildFile; fileRef = 32C78B65256CFC4D008130B1 /* MXCryptoVersion.h */; };
+		32C78B6A256CFC4D008130B1 /* MXCryptoMigration.m in Sources */ = {isa = PBXBuildFile; fileRef = 32C78B66256CFC4D008130B1 /* MXCryptoMigration.m */; };
+		32C78B6B256CFC4D008130B1 /* MXCryptoMigration.m in Sources */ = {isa = PBXBuildFile; fileRef = 32C78B66256CFC4D008130B1 /* MXCryptoMigration.m */; };
+		32C78B6C256CFC4D008130B1 /* MXCryptoMigration.h in Headers */ = {isa = PBXBuildFile; fileRef = 32C78B67256CFC4D008130B1 /* MXCryptoMigration.h */; };
+		32C78B6D256CFC4D008130B1 /* MXCryptoMigration.h in Headers */ = {isa = PBXBuildFile; fileRef = 32C78B67256CFC4D008130B1 /* MXCryptoMigration.h */; };
 		32C9B71823E81A1C00C6F30A /* MXCrossSigningVerificationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 32C9B71723E81A1C00C6F30A /* MXCrossSigningVerificationTests.m */; };
 		32C9B71923E81A1C00C6F30A /* MXCrossSigningVerificationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 32C9B71723E81A1C00C6F30A /* MXCrossSigningVerificationTests.m */; };
 		32CAB1071A91EA34008C5BB9 /* MXPushRuleRoomMemberCountConditionChecker.h in Headers */ = {isa = PBXBuildFile; fileRef = 32CAB1051A91EA34008C5BB9 /* MXPushRuleRoomMemberCountConditionChecker.h */; };
@@ -1606,6 +1612,9 @@
 		32C6F93219DD814400EA4E9C /* MatrixSDK.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MatrixSDK.h; sourceTree = "<group>"; };
 		32C6F93819DD814400EA4E9C /* MatrixSDKTests-iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "MatrixSDKTests-iOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		32C6F93B19DD814400EA4E9C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		32C78B65256CFC4D008130B1 /* MXCryptoVersion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXCryptoVersion.h; sourceTree = "<group>"; };
+		32C78B66256CFC4D008130B1 /* MXCryptoMigration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXCryptoMigration.m; sourceTree = "<group>"; };
+		32C78B67256CFC4D008130B1 /* MXCryptoMigration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXCryptoMigration.h; sourceTree = "<group>"; };
 		32C9B71723E81A1C00C6F30A /* MXCrossSigningVerificationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXCrossSigningVerificationTests.m; sourceTree = "<group>"; };
 		32CAB1051A91EA34008C5BB9 /* MXPushRuleRoomMemberCountConditionChecker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXPushRuleRoomMemberCountConditionChecker.h; sourceTree = "<group>"; };
 		32CAB1061A91EA34008C5BB9 /* MXPushRuleRoomMemberCountConditionChecker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXPushRuleRoomMemberCountConditionChecker.m; sourceTree = "<group>"; };
@@ -2082,6 +2091,7 @@
 				32A1513B1DAF768D00400192 /* Data */,
 				32BBAE642178E99100D85F46 /* KeyBackup */,
 				32FA10B21FA1C28100E54233 /* KeySharing */,
+				32C78B64256CFC4D008130B1 /* Migration */,
 				32F00AB82488E14300131741 /* Recovery */,
 				324DD296246AD25E00377005 /* SecretStorage */,
 				324BE4651E3FADB1008D99D4 /* Utils */,
@@ -2860,6 +2870,16 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
+		32C78B64256CFC4D008130B1 /* Migration */ = {
+			isa = PBXGroup;
+			children = (
+				32C78B65256CFC4D008130B1 /* MXCryptoVersion.h */,
+				32C78B66256CFC4D008130B1 /* MXCryptoMigration.m */,
+				32C78B67256CFC4D008130B1 /* MXCryptoMigration.h */,
+			);
+			path = Migration;
+			sourceTree = "<group>";
+		};
 		32CEEF3F23AD2A340039BA98 /* CrossSigning */ = {
 			isa = PBXGroup;
 			children = (
@@ -3344,10 +3364,12 @@
 				B146D4F021A5AF7F00D8C2C6 /* MXRealmEventScanMapper.h in Headers */,
 				B146D47F21A59E2400D8C2C6 /* MXEventScan.h in Headers */,
 				B146D4E121A5AEF200D8C2C6 /* MXRealmMediaScanMapper.h in Headers */,
+				32C78B6C256CFC4D008130B1 /* MXCryptoMigration.h in Headers */,
 				F08B8D5C1E014711006171A8 /* NSData+MatrixSDK.h in Headers */,
 				C60165381E3AA57900B92CFA /* MXSDKOptions.h in Headers */,
 				32CEEF4F23B0AB030039BA98 /* MXCrossSigning.h in Headers */,
 				EC619D9324DD834B00663A80 /* MXPushGatewayRestClient.h in Headers */,
+				32C78B68256CFC4D008130B1 /* MXCryptoVersion.h in Headers */,
 				320B3934239FA56900BE2C06 /* MXKeyVerificationByDMRequest.h in Headers */,
 				324DD2A6246AE81300377005 /* MXSecretStorageKeyContent.h in Headers */,
 				3281E8B919E42DFE00976E1A /* MXJSONModels.h in Headers */,
@@ -3632,6 +3654,7 @@
 				B14EF2FC2397E90400758AF0 /* MXAggregatedReactionsUpdater.h in Headers */,
 				B14EF2FD2397E90400758AF0 /* MXScanRealmInMemoryProvider.h in Headers */,
 				B14EF2FE2397E90400758AF0 /* MXReplyEventBodyParts.h in Headers */,
+				32C78B69256CFC4D008130B1 /* MXCryptoVersion.h in Headers */,
 				B14EF2FF2397E90400758AF0 /* MXSendReplyEventStringsLocalizable.h in Headers */,
 				B14EF3002397E90400758AF0 /* MXQueuedEncryption.h in Headers */,
 				324AAC822399143400380A66 /* MXKeyVerificationMac.h in Headers */,
@@ -3760,6 +3783,7 @@
 				B14EF3602397E90400758AF0 /* MXHTTPClient.h in Headers */,
 				B19A30C92404268600FB6F35 /* MXQRCodeDataBuilder.h in Headers */,
 				323F879725554FF2009E9E67 /* MXTaskProfile_Private.h in Headers */,
+				32C78B6D256CFC4D008130B1 /* MXCryptoMigration.h in Headers */,
 				32F00AC12488FB3600131741 /* MXRecoveryService_Private.h in Headers */,
 				B14EF3612397E90400758AF0 /* MXMegolmBackupAuthData.h in Headers */,
 				B14EF3622397E90400758AF0 /* MXReactionCountChange.h in Headers */,
@@ -4104,6 +4128,7 @@
 				32CEEF5123B0AB030039BA98 /* MXCrossSigning.m in Sources */,
 				32720D9F222EAA6F0086FFF5 /* MXAutoDiscovery.m in Sources */,
 				3297912923A93D4B00F7BB9B /* MXKeyVerification.m in Sources */,
+				32C78B6A256CFC4D008130B1 /* MXCryptoMigration.m in Sources */,
 				32D2CC0623422462002BD8CA /* MX3PidAddManager.m in Sources */,
 				92634B831EF2E3C400DB9F60 /* MXCallKitConfiguration.m in Sources */,
 				3265CB391A14C43E00E24B2F /* MXRoomState.m in Sources */,
@@ -4474,6 +4499,7 @@
 				B14EF22E2397E90400758AF0 /* MXCryptoTools.m in Sources */,
 				B14EF22F2397E90400758AF0 /* (null) in Sources */,
 				B14EF2302397E90400758AF0 /* MXDeviceListOperation.m in Sources */,
+				32C78B6B256CFC4D008130B1 /* MXCryptoMigration.m in Sources */,
 				B14EF2312397E90400758AF0 /* MX3PidAddSession.m in Sources */,
 				B14EF2322397E90400758AF0 /* MXBugReportRestClient.m in Sources */,
 				B14EF2332397E90400758AF0 /* MXRoomSummary.swift in Sources */,

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -480,6 +480,8 @@
 		32C78B6B256CFC4D008130B1 /* MXCryptoMigration.m in Sources */ = {isa = PBXBuildFile; fileRef = 32C78B66256CFC4D008130B1 /* MXCryptoMigration.m */; };
 		32C78B6C256CFC4D008130B1 /* MXCryptoMigration.h in Headers */ = {isa = PBXBuildFile; fileRef = 32C78B67256CFC4D008130B1 /* MXCryptoMigration.h */; };
 		32C78B6D256CFC4D008130B1 /* MXCryptoMigration.h in Headers */ = {isa = PBXBuildFile; fileRef = 32C78B67256CFC4D008130B1 /* MXCryptoMigration.h */; };
+		32C78BA7256D227D008130B1 /* MXCryptoMigrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 32C78BA6256D227D008130B1 /* MXCryptoMigrationTests.m */; };
+		32C78BA8256D227D008130B1 /* MXCryptoMigrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 32C78BA6256D227D008130B1 /* MXCryptoMigrationTests.m */; };
 		32C9B71823E81A1C00C6F30A /* MXCrossSigningVerificationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 32C9B71723E81A1C00C6F30A /* MXCrossSigningVerificationTests.m */; };
 		32C9B71923E81A1C00C6F30A /* MXCrossSigningVerificationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 32C9B71723E81A1C00C6F30A /* MXCrossSigningVerificationTests.m */; };
 		32CAB1071A91EA34008C5BB9 /* MXPushRuleRoomMemberCountConditionChecker.h in Headers */ = {isa = PBXBuildFile; fileRef = 32CAB1051A91EA34008C5BB9 /* MXPushRuleRoomMemberCountConditionChecker.h */; };
@@ -1615,6 +1617,7 @@
 		32C78B65256CFC4D008130B1 /* MXCryptoVersion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXCryptoVersion.h; sourceTree = "<group>"; };
 		32C78B66256CFC4D008130B1 /* MXCryptoMigration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXCryptoMigration.m; sourceTree = "<group>"; };
 		32C78B67256CFC4D008130B1 /* MXCryptoMigration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXCryptoMigration.h; sourceTree = "<group>"; };
+		32C78BA6256D227D008130B1 /* MXCryptoMigrationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXCryptoMigrationTests.m; sourceTree = "<group>"; };
 		32C9B71723E81A1C00C6F30A /* MXCrossSigningVerificationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXCrossSigningVerificationTests.m; sourceTree = "<group>"; };
 		32CAB1051A91EA34008C5BB9 /* MXPushRuleRoomMemberCountConditionChecker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXPushRuleRoomMemberCountConditionChecker.h; sourceTree = "<group>"; };
 		32CAB1061A91EA34008C5BB9 /* MXPushRuleRoomMemberCountConditionChecker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXPushRuleRoomMemberCountConditionChecker.m; sourceTree = "<group>"; };
@@ -2797,6 +2800,7 @@
 		32C6F93919DD814400EA4E9C /* MatrixSDKTests */ = {
 			isa = PBXGroup;
 			children = (
+				32C78BA6256D227D008130B1 /* MXCryptoMigrationTests.m */,
 				321EA11C24893A0400E35B02 /* MXCryptoRecoveryServiceTests.m */,
 				324DD2BA246C3ADE00377005 /* MXCryptoSecretStorageTests.m */,
 				B19A30AE240425D000FB6F35 /* MXQRCodeDataTests.m */,
@@ -4357,6 +4361,7 @@
 				32A27D1F19EC335300BAFADE /* MXRoomTests.m in Sources */,
 				32D8CAC219DEE6ED002AF8A0 /* MXRestClientNoAuthAPITests.m in Sources */,
 				32FCAB4D19E578860049C555 /* MXRestClientTests.m in Sources */,
+				32C78BA7256D227D008130B1 /* MXCryptoMigrationTests.m in Sources */,
 				32C03CB62123076F00D92712 /* DirectRoomTests.m in Sources */,
 				329FB17C1A0A963700A5E88E /* MXRoomMemberTests.m in Sources */,
 				3246BDC51A1A0789000A7D62 /* MXRoomStateDynamicTests.m in Sources */,
@@ -4683,6 +4688,7 @@
 				B1E09A352397FD7D0057C069 /* MXEventTests.m in Sources */,
 				B1E09A312397FD750057C069 /* MXSessionTests.m in Sources */,
 				B1E09A322397FD750057C069 /* MXRoomTests.m in Sources */,
+				32C78BA8256D227D008130B1 /* MXCryptoMigrationTests.m in Sources */,
 				B1E09A2F2397FD750057C069 /* MXErrorTests.m in Sources */,
 				B1E09A2A2397FD680057C069 /* MatrixSDKTestsData.m in Sources */,
 				B1E09A302397FD750057C069 /* MXHTTPClientTests.m in Sources */,

--- a/MatrixSDK/Crypto/Data/Store/MXCryptoStore.h
+++ b/MatrixSDK/Crypto/Data/Store/MXCryptoStore.h
@@ -25,6 +25,7 @@
 #import "MXCredentials.h"
 
 #import <OLMKit/OLMKit.h>
+#import "MXCryptoVersion.h"
 #import "MXOlmSession.h"
 #import "MXOlmInboundGroupSession.h"
 #import "MXDeviceInfo.h"
@@ -497,6 +498,17 @@
  @param senderKey the base64-encoded curve25519 key of the sender.
  */
 - (void)removeInboundGroupSessionWithId:(NSString*)sessionId andSenderKey:(NSString*)senderKey;
+
+
+#pragma mark - Versioning
+
+/**
+ The version of the crypto module implementation.
+ 
+ It is used to hanle logical migration between crypto module updates.
+ Must return MXCryptoVersionUndefined if not defined yet.
+ */
+@property (nonatomic) MXCryptoVersion cryptoVersion;
 
 @end
 

--- a/MatrixSDK/Crypto/Data/Store/MXCryptoStore.h
+++ b/MatrixSDK/Crypto/Data/Store/MXCryptoStore.h
@@ -505,7 +505,7 @@
 /**
  The version of the crypto module implementation.
  
- It is used to hanle logical migration between crypto module updates.
+ It is used to handle logical migration between crypto module updates.
  Must return MXCryptoVersionUndefined if not defined yet.
  */
 @property (nonatomic) MXCryptoVersion cryptoVersion;

--- a/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
+++ b/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
@@ -24,7 +24,7 @@
 #import "MXTools.h"
 #import "MXCryptoTools.h"
 
-NSUInteger const kMXRealmCryptoStoreVersion = 12;
+NSUInteger const kMXRealmCryptoStoreVersion = 13;
 
 static NSString *const kMXRealmCryptoStoreFolder = @"MXRealmCryptoStore";
 
@@ -141,6 +141,11 @@ RLM_ARRAY_TYPE(MXRealmOlmInboundGroupSession)
  The device id.
  */
 @property (nonatomic) NSString *deviceId;
+
+/**
+ The version of the crypto module implementation.
+ */
+@property (nonatomic) MXCryptoVersion cryptoVersion;
 
 /**
  The pickled OLMAccount object.
@@ -1249,6 +1254,24 @@ RLM_ARRAY_TYPE(MXRealmSecret)
     }];
 }
 
+
+#pragma mark - Versioning
+
+- (MXCryptoVersion)cryptoVersion
+{
+    MXRealmOlmAccount *account = self.accountInCurrentThread;
+    return account.cryptoVersion;
+}
+
+-(void)setCryptoVersion:(MXCryptoVersion)cryptoVersion
+{
+    MXRealmOlmAccount *account = self.accountInCurrentThread;
+    [account.realm transactionWithBlock:^{
+        account.cryptoVersion = cryptoVersion;
+    }];
+}
+
+
 #pragma mark - Private methods
 + (RLMRealm*)realmForUser:(NSString*)userId andDevice:(NSString*)deviceId
 {
@@ -1548,6 +1571,19 @@ RLM_ARRAY_TYPE(MXRealmSecret)
                                                   ];
                         }
                         newObject[@"deviceInfoData"] = [NSKeyedArchiver archivedDataWithRootObject:device];
+                    }];
+                }
+                    
+                case 12:
+                {
+                    NSLog(@"[MXRealmCryptoStore] Migration from schema #12 -> #13");
+                    
+                    // Ìntroduction of MXCryptoStore.cryptoVersion
+                    // Set the default value
+                    NSLog(@"[MXRealmCryptoStore]    Add new MXRealmOlmAccount.cryptoVersion. Set it to MXCryptoVersion1");
+                    
+                    [migration enumerateObjects:MXRealmOlmAccount.className block:^(RLMObject *oldObject, RLMObject *newObject) {
+                        newObject[@"cryptoVersion"] = @(MXCryptoVersion1);
                     }];
                 }
             }

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -264,7 +264,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
             MXStrongifyAndReturnIfNil(self);
             
             // We have no mandatory migration for now
-            // We can try again at the next MXCrypto start up
+            // We can try again at the next MXCrypto startup
             NSLog(@"[MXCrypto] start. Migration failed. Ignore it for now");
             self->cryptoMigration = nil;
             [self start:success failure:failure];

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -137,6 +137,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     dispatch_sync(cryptoQueue, ^{
 
         MXCryptoStoreClass *cryptoStore = [MXCryptoStoreClass createStoreWithCredentials:mxSession.matrixRestClient.credentials];
+        cryptoStore.cryptoVersion = MXCryptoVersionLast;
         crypto = [[MXCrypto alloc] initWithMatrixSession:mxSession cryptoQueue:cryptoQueue andStore:cryptoStore];
 
     });
@@ -188,6 +189,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 
             // Create it
             MXCryptoStoreClass *cryptoStore = [MXCryptoStoreClass createStoreWithCredentials:mxSession.matrixRestClient.credentials];
+            cryptoStore.cryptoVersion = MXCryptoVersionLast;
             MXCrypto *crypto = [[MXCrypto alloc] initWithMatrixSession:mxSession cryptoQueue:cryptoQueue andStore:cryptoStore];
 
             dispatch_async(dispatch_get_main_queue(), ^{

--- a/MatrixSDK/Crypto/MXCrypto_Private.h
+++ b/MatrixSDK/Crypto/MXCrypto_Private.h
@@ -161,6 +161,32 @@
 - (NSDictionary*)signObject:(NSDictionary*)object;
 
 
+#pragma mark - One Time keys
+
+/**
+ Retrieve the number of one time keys published on the homeserver.
+
+ @param success A block object called when the operation succeeds.
+                It provides the number of OTKs.
+ @param failure A block object called when the operation fails.
+ */
+- (MXHTTPOperation *)publishedOneTimeKeysCount:(void (^)(NSUInteger publishedKeyCount))success
+                                       failure:(void (^)(NSError *))failure;
+
+/**
+ Generate and publish enough one time keys on the homeserver.
+ 
+ @param keyCount the number of keys currently available on the homeserver.
+ @param retry YES to retry in case of server error.
+ @param success A block object called when the operation succeeds.
+ @param failure A block object called when the operation fails.
+ */
+- (MXHTTPOperation *)generateAndUploadOneTimeKeys:(NSUInteger)keyCount
+                                            retry:(BOOL)retry
+                                          success:(void (^)(void))success
+                                          failure:(void (^)(NSError *))failure;
+
+
 #pragma mark - import/export
 
 /**

--- a/MatrixSDK/Crypto/Migration/MXCryptoMigration.h
+++ b/MatrixSDK/Crypto/Migration/MXCryptoMigration.h
@@ -20,6 +20,14 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+
+FOUNDATION_EXPORT NSString *const MXCryptoMigrationErrorDomain;
+typedef NS_ENUM(NSInteger, MXCryptoMigrationErrorCode)
+{
+    MXCryptoMigrationCannotPurgeAllOneTimeKeysErrorCode,
+};
+
+
 /**
  The `MXCryptoMigration` class handles the migration logic between breaking changes in the implementation
  of the MXCrypto module.

--- a/MatrixSDK/Crypto/Migration/MXCryptoMigration.h
+++ b/MatrixSDK/Crypto/Migration/MXCryptoMigration.h
@@ -1,0 +1,51 @@
+// 
+// Copyright 2020 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+@class MXCrypto;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ The `MXCryptoMigration` class handles the migration logic between breaking changes in the implementation
+ of the MXCrypto module.
+ It helps to update data between version (MXCryptoVersion) changes.
+ */
+@interface MXCryptoMigration : NSObject
+
+- (instancetype)initWithCrypto:(MXCrypto *)crypto;
+
+/**
+ Indicate if the data must be updated.
+ 
+ @return YES if a migration should be done.
+ */
+- (BOOL)shouldMigrate;
+
+/**
+ Migrate the data to the latest version of the implmentation (MXCryptoVersionLast).
+ 
+ @param success A block object called when the operation succeeds.
+ @param failure A block object called when the operation fails.
+ */
+- (void)migrateWithSuccess:(void (^)(void))success
+                   failure:(void (^)(NSError *error))failure;
+
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixSDK/Crypto/Migration/MXCryptoMigration.h
+++ b/MatrixSDK/Crypto/Migration/MXCryptoMigration.h
@@ -45,7 +45,7 @@ typedef NS_ENUM(NSInteger, MXCryptoMigrationErrorCode)
 - (BOOL)shouldMigrate;
 
 /**
- Migrate the data to the latest version of the implmentation (MXCryptoVersionLast).
+ Migrate the data to the latest version of the implementation (MXCryptoVersionLast).
  
  @param success A block object called when the operation succeeds.
  @param failure A block object called when the operation fails.

--- a/MatrixSDK/Crypto/Migration/MXCryptoMigration.m
+++ b/MatrixSDK/Crypto/Migration/MXCryptoMigration.m
@@ -38,7 +38,6 @@ NSUInteger const kMXCryptoMigrationKeyPurgeRetryCountLimit = 10;
 @interface MXCryptoMigration ()
 {
     MXCrypto *crypto;
-    
     NSUInteger keyPurgeRetryCount;
 }
 
@@ -128,9 +127,9 @@ NSUInteger const kMXCryptoMigrationKeyPurgeRetryCountLimit = 10;
     }];
 }
 
-// Purge one time keys uploaded by this device
-// We purge them by claiming them.
-// A one time key can be used and claimed only one. Claiming one time key removes it from
+// Purge one time keys uploaded by this device. We purge them by claiming them.
+//
+// A one time key can be used and claimed only once. Claiming one time key removes it from
 // the published list of OTKs.
 - (void)purgePublishedOneTimeKeys:(void (^)(void))success failure:(void (^)(NSError *))failure
 {
@@ -210,6 +209,5 @@ NSUInteger const kMXCryptoMigrationKeyPurgeRetryCountLimit = 10;
         success(keyClaimed);
     });
 }
-
 
 @end

--- a/MatrixSDK/Crypto/Migration/MXCryptoMigration.m
+++ b/MatrixSDK/Crypto/Migration/MXCryptoMigration.m
@@ -105,7 +105,10 @@ NSUInteger const kMXCryptoMigrationKeyPurgeRetryCountLimit = 10;
     [self purgePublishedOneTimeKeys:^{
         MXStrongifyAndReturnIfNil(self);
         
-        // 2- Upload fresh and valid OTKs
+        // 2- Reset any pending local one time keys to start from a fresh set of OTKs
+        [self->crypto.olmDevice markOneTimeKeysAsPublished];
+        
+        // 3- Upload fresh and valid OTKs
         [self->crypto generateAndUploadOneTimeKeys:0 retry:YES success:^{
             
             // Migration is done

--- a/MatrixSDK/Crypto/Migration/MXCryptoMigration.m
+++ b/MatrixSDK/Crypto/Migration/MXCryptoMigration.m
@@ -37,7 +37,7 @@ NSUInteger const kMXCryptoMigrationKeyPurgeRetryCountLimit = 10;
 
 @interface MXCryptoMigration ()
 {
-    MXCrypto *crypto;
+    __weak MXCrypto *crypto;
     NSUInteger keyPurgeRetryCount;
 }
 

--- a/MatrixSDK/Crypto/Migration/MXCryptoMigration.m
+++ b/MatrixSDK/Crypto/Migration/MXCryptoMigration.m
@@ -1,0 +1,183 @@
+// 
+// Copyright 2020 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import "MXCryptoMigration.h"
+
+#import "MXCrypto_Private.h"
+#import "MXKey.h"
+#import "MXTools.h"
+
+
+#pragma mark - Constants definitions
+
+// The number of keys to purge (claim)
+NSUInteger const kMXCryptoMigrationKeyPurgeStepCount = 5;
+
+// In case of error, time to wait before processing the next purge batch
+NSTimeInterval const kMXCryptoMigrationKeyPurgeBatchPeriod = 0.5;
+
+
+@interface MXCryptoMigration ()
+{
+    MXCrypto *crypto;
+}
+
+@end
+
+
+@implementation MXCryptoMigration
+
+- (instancetype)initWithCrypto:(MXCrypto *)theCrypto
+{
+    self = [self init];
+    if (self)
+    {
+        crypto = theCrypto;
+    }
+    return self;
+}
+
+- (BOOL)shouldMigrate
+{
+    MXCryptoVersion lastUsedCryptoVersion = crypto.store.cryptoVersion;
+    BOOL shouldMigrate = lastUsedCryptoVersion < MXCryptoVersionLast;
+    
+    if (shouldMigrate)
+    {
+        NSLog(@"[MXCryptoMigration] shouldMigrate: YES from version %@ to %@", @(lastUsedCryptoVersion), @(MXCryptoVersionLast));
+    }
+    else
+    {
+        NSLog(@"[MXCryptoMigration] shouldMigrate: NO");
+    }
+    
+    return shouldMigrate;
+}
+
+- (void)migrateWithSuccess:(void (^)(void))success failure:(void (^)(NSError * _Nonnull))failure
+{
+    MXCryptoVersion lastUsedCryptoVersion = crypto.store.cryptoVersion;
+    NSLog(@"[MXCryptoMigration] migrate from version %@", @(lastUsedCryptoVersion));
+    
+    switch (lastUsedCryptoVersion)
+    {
+        case MXCryptoVersion1:
+            [self migrateToCryptoVersion2:success failure:failure];
+            break;
+            
+        default:
+            NSLog(@"[MXCryptoMigration] migrate. Error: Unsupported migration");
+            break;
+    }
+}
+
+
+#pragma mark - Private methods
+
+- (void)migrateToCryptoVersion2:(void (^)(void))success failure:(void (^)(NSError *))failure
+{
+    NSLog(@"[MXCryptoMigration] migrateToCryptoVersion2: start");
+    
+    // 1- Remove all one time keys already published on the server because some can be bad
+    // https://github.com/vector-im/element-ios/issues/3818
+    MXWeakify(self);
+    [self purgePublishedOneTimeKeys:^{
+        MXStrongifyAndReturnIfNil(self);
+        
+        // 2- Upload fresh and valid OTKs
+        [self->crypto generateAndUploadOneTimeKeys:0 retry:YES success:^{
+            
+            // Migration is done
+            NSLog(@"[MXCryptoMigration] migrateToCryptoVersion2: completed");
+            self->crypto.store.cryptoVersion = MXCryptoVersion2;
+            
+            success();
+            
+        } failure:failure];
+        
+    } failure:failure];
+}
+
+// Purge one time keys uploaded by this device
+// We purge them by claiming them.
+// A one time key can be used and claimed only one. Claiming one time key removes it from
+// the published list of OTKs.
+- (void)purgePublishedOneTimeKeys:(void (^)(void))success failure:(void (^)(NSError *))failure
+{
+    NSLog(@"[MXCryptoMigration] purgePublishedOneTimeKeys");
+    [crypto publishedOneTimeKeysCount:^(NSUInteger publishedKeyCount) {
+        
+        // Purge/Claim keys by batch
+        NSUInteger keysToClaim = MIN(kMXCryptoMigrationKeyPurgeStepCount, publishedKeyCount);
+        
+        [self claimOwnOneTimeKeys:keysToClaim success:^(NSUInteger keyClaimed) {
+            
+            NSLog(@"[MXCryptoMigration] purgePublishedOneTimeKeys: %@ out of %@ purged", @(keyClaimed), @(publishedKeyCount));
+            if (keyClaimed == publishedKeyCount)
+            {
+                NSLog(@"[MXCryptoMigration] purgePublishedOneTimeKeys: completed");
+                success();
+            }
+            else if (keyClaimed < keysToClaim)
+            {
+                NSLog(@"[MXCryptoMigration] purgePublishedOneTimeKeys: Delay the next batch because this batch was not 100%% successful");
+                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, kMXCryptoMigrationKeyPurgeBatchPeriod * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+                    [self purgePublishedOneTimeKeys:success failure:failure];
+                });
+            }
+            else
+            {
+                // Purge the next batch
+                [self purgePublishedOneTimeKeys:success failure:failure];
+            }
+            
+        } failure:failure];
+        
+    } failure:failure];
+}
+
+- (void)claimOwnOneTimeKeys:(NSUInteger)keyCount success:(void (^)(NSUInteger keyClaimed))success failure:(void (^)(NSError *))failure
+{
+    NSLog(@"[MXCryptoMigration] claimOwnOneTimeKeys: %@", @(keyCount));
+    
+    MXUsersDevicesMap<NSString*> *usersDevicesToClaim = [MXUsersDevicesMap new];
+    [usersDevicesToClaim setObject:kMXKeySignedCurve25519Type forUser:crypto.mxSession.myUserId andDevice:crypto.mxSession.myDeviceId];
+    
+    dispatch_group_t group = dispatch_group_create();
+    
+    __block NSUInteger keyClaimed = 0;
+    for (NSUInteger i = 0; i < keyCount; i++)
+    {
+        dispatch_group_enter(group);
+        [crypto.matrixRestClient claimOneTimeKeysForUsersDevices:usersDevicesToClaim success:^(MXKeysClaimResponse *keysClaimResponse) {
+            
+            keyClaimed++;
+            dispatch_group_leave(group);
+            
+        } failure:^(NSError *error) {
+            NSLog(@"[MXCryptoMigration] claimOwnOneTimeKeys: claimOneTimeKeysForUsersDevices failed. Error: %@", error);
+            dispatch_group_leave(group);
+        }];
+    }
+    
+    dispatch_group_notify(group, crypto.cryptoQueue, ^{
+        NSLog(@"[MXCryptoMigration] claimOwnOneTimeKeys: Successful claimed %@ (requested: %@) one time keys", @(keyClaimed), @(keyCount));
+        success(keyClaimed);
+    });
+}
+
+
+@end

--- a/MatrixSDK/Crypto/Migration/MXCryptoVersion.h
+++ b/MatrixSDK/Crypto/Migration/MXCryptoVersion.h
@@ -1,0 +1,42 @@
+// 
+// Copyright 2020 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#ifndef MXCryptoVersion_h
+#define MXCryptoVersion_h
+
+/**
+ Versions of the crypto module that require logical updates.
+ */
+typedef NS_ENUM(NSInteger, MXCryptoVersion)
+{
+    // Should never happen
+    MXCryptoVersionUndefined = 0,
+    
+    // The initial version we used for years
+    MXCryptoVersion1,
+    
+    // Version created to fix bad one time keys uploaded to the home server
+    // https://github.com/vector-im/element-ios/issues/3818
+    MXCryptoVersion2,
+    
+    // Keep it at the last position. It is used to compute MXCryptoVersionLast.
+    MXCryptoVersionCount,
+};
+
+// The current version of MXCrypto
+#define MXCryptoVersionLast (MXCryptoVersionCount - 1)
+
+#endif /* MXCryptoVersion_h */

--- a/MatrixSDKTests/MXCryptoMigrationTests.m
+++ b/MatrixSDKTests/MXCryptoMigrationTests.m
@@ -1,0 +1,152 @@
+// 
+// Copyright 2020 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "MXCryptoMigration.h"
+
+#import "MatrixSDKTestsData.h"
+#import "MatrixSDKTestsE2EData.h"
+#import "MXCrypto_Private.h"
+
+
+@interface MXCryptoMigration ()
+
+- (void)migrateToCryptoVersion2:(void (^)(void))success failure:(void (^)(NSError *))failure;
+- (void)claimOwnOneTimeKeys:(NSUInteger)keyCount success:(void (^)(NSUInteger keyClaimed))success failure:(void (^)(NSError *))failure;
+
+@end
+
+
+@interface MXCryptoMigrationTests : XCTestCase
+{
+    MatrixSDKTestsData *matrixSDKTestsData;
+    MatrixSDKTestsE2EData *matrixSDKTestsE2EData;
+}
+@end
+
+
+@implementation MXCryptoMigrationTests
+
+- (void)setUp
+{
+    [super setUp];
+    
+    matrixSDKTestsData = [[MatrixSDKTestsData alloc] init];
+    matrixSDKTestsE2EData = [[MatrixSDKTestsE2EData alloc] initWithMatrixSDKTestsData:matrixSDKTestsData];
+}
+
+- (void)tearDown
+{
+    matrixSDKTestsData = nil;
+    matrixSDKTestsE2EData = nil;
+    
+    [super tearDown];
+}
+
+/**
+ Test shouldMigrate.
+ 
+ - Have Alice
+ -> There is no need to migrate on a fresh login
+ */
+- (void)testShouldMigrate
+{
+    // - Have Alice
+    [matrixSDKTestsE2EData doE2ETestWithBobAndAlice:self readyToTest:^(MXSession *bobSession, MXSession *aliceSession, XCTestExpectation *expectation) {
+        
+        // -> There is no need to migrate on a fresh login
+        MXCryptoMigration *cryptoMigration = [[MXCryptoMigration alloc] initWithCrypto:aliceSession.crypto];
+        XCTAssertFalse([cryptoMigration shouldMigrate]);
+        
+        [expectation fulfill];
+    }];
+}
+
+/**
+ Test migration to testMigrationToMXCryptoVersion2 which purges all one time keys
+ 
+ - Alice and Bob are in a room
+ - Consume some one time keys to check later that the migration actually completes after having uploading 50 OTKs
+ - Bob does a migration
+ -> Bob must have 50 OTKs available
+ - Alice sends a message (it will use an olm session based one of those new OTKs)
+ -> Bob must be able to decrypt the message
+ */
+- (void)testMigrationToMXCryptoVersion2
+{
+    // - Alice and Bob are in a room
+    [matrixSDKTestsE2EData doE2ETestWithAliceAndBobInARoom:self cryptedBob:YES warnOnUnknowDevices:NO readyToTest:^(MXSession *aliceSession, MXSession *bobSession, NSString *roomId, XCTestExpectation *expectation) {
+        
+        MXCryptoMigration *bobCryptoMigration = [[MXCryptoMigration alloc] initWithCrypto:bobSession.crypto];
+        
+        // - Consume some one time keys to check later that the migration actually completes after having uploading 50 OTKs
+        [bobCryptoMigration claimOwnOneTimeKeys:3 success:^(NSUInteger keyClaimed) {
+            XCTAssertEqual(keyClaimed, 3);
+            
+            // - Bob does a migration
+            [bobCryptoMigration migrateToCryptoVersion2:^{
+                
+                // -> Bob must have 50 OTKs available
+                [bobSession.crypto publishedOneTimeKeysCount:^(NSUInteger publishedKeyCount) {
+                    
+                    XCTAssertEqual(publishedKeyCount, 50);
+                    
+                    // - Alice sends a message (it will use an olm session based one of those new OTKs)
+                    NSString *messageFromAlice = @"Hello I'm Alice!";
+                    
+                    MXRoom *roomFromBobPOV = [bobSession roomWithRoomId:roomId];
+                    MXRoom *roomFromAlicePOV = [aliceSession roomWithRoomId:roomId];
+                    
+                    XCTAssert(roomFromBobPOV.summary.isEncrypted);
+                    XCTAssert(roomFromAlicePOV.summary.isEncrypted);
+                    
+                    [roomFromBobPOV liveTimeline:^(MXEventTimeline *liveTimeline) {
+                        
+                        [liveTimeline listenToEventsOfTypes:@[kMXEventTypeStringRoomMessage] onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
+                            
+                            // -> Bob must be able to decrypt the message
+                            XCTAssertEqual(event.eventType, MXEventTypeRoomMessage);
+                            XCTAssertNil(event.decryptionError);
+                            
+                            [expectation fulfill];
+                        }];
+                    }];
+                    
+                    [roomFromAlicePOV sendTextMessage:messageFromAlice success:nil failure:^(NSError *error) {
+                        XCTFail(@"Cannot set up intial test conditions - error: %@", error);
+                        [expectation fulfill];
+                    }];
+                    
+                } failure:^(NSError *error) {
+                    XCTFail(@"The operation should not fail - NSError: %@", error);
+                    [expectation fulfill];
+                }];
+                
+            } failure:^(NSError *error) {
+                XCTFail(@"The operation should not fail - NSError: %@", error);
+                [expectation fulfill];
+            }];
+            
+        } failure:^(NSError *error) {
+            XCTFail(@"Cannot set up intial test conditions - error: %@", error);
+            [expectation fulfill];
+        }];
+
+    }];
+}
+
+@end

--- a/MatrixSDKTests/MXCryptoMigrationTests.m
+++ b/MatrixSDKTests/MXCryptoMigrationTests.m
@@ -68,8 +68,9 @@
     // - Have Alice
     [matrixSDKTestsE2EData doE2ETestWithBobAndAlice:self readyToTest:^(MXSession *bobSession, MXSession *aliceSession, XCTestExpectation *expectation) {
         
-        // -> There is no need to migrate on a fresh login
         MXCryptoMigration *cryptoMigration = [[MXCryptoMigration alloc] initWithCrypto:aliceSession.crypto];
+
+        // -> There is no need to migrate on a fresh login
         XCTAssertFalse([cryptoMigration shouldMigrate]);
         
         [expectation fulfill];
@@ -77,12 +78,12 @@
 }
 
 /**
- Test migration to testMigrationToMXCryptoVersion2 which purges all one time keys
+ Test migration to MXCryptoVersion2, which purges all published one time keys.
  
  - Alice and Bob are in a room
- - Consume some one time keys to check later that the migration actually completes after having uploading 50 OTKs
+ - Consume some one time keys to check later that the migration actually completes after having uploading the fresh 50 OTKs
  - Bob does a migration
- -> Bob must have 50 OTKs available
+ -> Bob must have 50 OTKs available again
  - Alice sends a message (it will use an olm session based one of those new OTKs)
  -> Bob must be able to decrypt the message
  */
@@ -93,14 +94,14 @@
         
         MXCryptoMigration *bobCryptoMigration = [[MXCryptoMigration alloc] initWithCrypto:bobSession.crypto];
         
-        // - Consume some one time keys to check later that the migration actually completes after having uploading 50 OTKs
+        // - Consume some one time keys to check later that the migration actually completes after having uploading the fresh 50 OTKs
         [bobCryptoMigration claimOwnOneTimeKeys:3 success:^(NSUInteger keyClaimed) {
             XCTAssertEqual(keyClaimed, 3);
             
             // - Bob does a migration
             [bobCryptoMigration migrateToCryptoVersion2:^{
                 
-                // -> Bob must have 50 OTKs available
+                // -> Bob must have 50 OTKs available again
                 [bobSession.crypto publishedOneTimeKeysCount:^(NSUInteger publishedKeyCount) {
                     
                     XCTAssertEqual(publishedKeyCount, 50);


### PR DESCRIPTION
Fix vector-im/element-ios/issues/3818.
