### PR TITLE
MXSession: Fix a race condition that prevented MXSession from actually being paused

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,8 @@ Changes to be released in next version
  *
 
 🐛 Bugfix
- * 
+ * MXSession: Fix a race conditions that prevented MXSession from actually being paused.
+ * MXSession: Make sure the resume method call its completion callback.
 
 ⚠️ API Changes
  * MXRoomSummary: Add a property to indicate room membership transition state.

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -660,7 +660,7 @@ typedef void (^MXOnResumeDone)(void);
 
 - (void)startWithSyncFilterId:(NSString *)syncFilterId onServerSyncDone:(void (^)(void))onServerSyncDone failure:(void (^)(NSError *))failure
 {
-    [self handleSyncResponseIfRequiredWithCompletion:^{
+    [self handleBackgroundSyncCacheIfRequiredWithCompletion:^{
         [self _startWithSyncFilterId:syncFilterId onServerSyncDone:onServerSyncDone failure:failure];
     }];
 }
@@ -867,7 +867,7 @@ typedef void (^MXOnResumeDone)(void);
 
 - (void)resume:(void (^)(void))resumeDone
 {
-    [self handleSyncResponseIfRequiredWithCompletion:^{
+    [self handleBackgroundSyncCacheIfRequiredWithCompletion:^{
         [self _resume:resumeDone];
     }];
 }
@@ -1653,9 +1653,9 @@ typedef void (^MXOnResumeDone)(void);
     return roomsInSyncResponse;
 }
 
-- (void)handleSyncResponseIfRequiredWithCompletion:(void (^)(void))completion
+- (void)handleBackgroundSyncCacheIfRequiredWithCompletion:(void (^)(void))completion
 {
-    NSLog(@"[MXSession] handleSyncResponseIfRequired. state %tu", _state);
+    NSLog(@"[MXSession] handleBackgroundSyncCacheIfRequired: state %tu", _state);
     
     MXSyncResponseFileStore *syncResponseStore = [[MXSyncResponseFileStore alloc] init];
     [syncResponseStore openWithCredentials:self.credentials];
@@ -1665,7 +1665,7 @@ typedef void (^MXOnResumeDone)(void);
         NSString *eventStreamToken = _store.eventStreamToken;
         if ([syncResponseStorePrevBatch isEqualToString:eventStreamToken])
         {
-            NSLog(@"[MXSession] handleSyncResponseIfRequired. Handle sync response from stream token %@", eventStreamToken);
+            NSLog(@"[MXSession] handleBackgroundSyncCacheIfRequired: Handle cache from stream token %@", eventStreamToken);
             
             //  sync response really continues from where the session left
             [self handleSyncResponse:syncResponseStore.syncResponse
@@ -1680,7 +1680,7 @@ typedef void (^MXOnResumeDone)(void);
         }
         else
         {
-            NSLog(@"[MXSession] handleSyncResponseIfRequired. Ignore sync response: MXSession stream token: %@. MXBackgroundSyncService stream token: %@", eventStreamToken, syncResponseStorePrevBatch);
+            NSLog(@"[MXSession] handleBackgroundSyncCacheIfRequired: Ignore cache: MXSession stream token: %@. MXBackgroundSyncService cache stream token: %@", eventStreamToken, syncResponseStorePrevBatch);
             
             //  this sync response will break the continuity in session, ignore & remove it
             [syncResponseStore deleteData];

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -1661,9 +1661,11 @@ typedef void (^MXOnResumeDone)(void);
     [syncResponseStore openWithCredentials:self.credentials];
     if (syncResponseStore.syncResponse)
     {
-        if ([syncResponseStore.prevBatch isEqualToString:_store.eventStreamToken])
+        NSString *syncResponseStorePrevBatch = syncResponseStore.prevBatch;
+        NSString *eventStreamToken = _store.eventStreamToken;
+        if ([syncResponseStorePrevBatch isEqualToString:eventStreamToken])
         {
-            NSLog(@"[MXSession] handleSyncResponseIfRequired. Handle sync response");
+            NSLog(@"[MXSession] handleSyncResponseIfRequired. Handle sync response from stream token %@", eventStreamToken);
             
             //  sync response really continues from where the session left
             [self handleSyncResponse:syncResponseStore.syncResponse
@@ -1678,7 +1680,7 @@ typedef void (^MXOnResumeDone)(void);
         }
         else
         {
-            NSLog(@"[MXSession] handleSyncResponseIfRequired. Ignore sync response");
+            NSLog(@"[MXSession] handleSyncResponseIfRequired. Ignore sync response: MXSession stream token: %@. MXBackgroundSyncService stream token: %@", eventStreamToken, syncResponseStorePrevBatch);
             
             //  this sync response will break the continuity in session, ignore & remove it
             [syncResponseStore deleteData];

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -272,6 +272,8 @@ typedef void (^MXOnResumeDone)(void);
 {
     if (_state != state)
     {
+        NSLog(@"[MXSession] setState: %@ (was %@)", @(state), @(_state));
+        
         _state = state;
 
         if (_state != MXSessionStateSyncError)
@@ -872,7 +874,7 @@ typedef void (^MXOnResumeDone)(void);
 
 - (void)_resume:(void (^)(void))resumeDone
 {
-    NSLog(@"[MXSession] resume the event stream from state %tu", _state);
+    NSLog(@"[MXSession] _resume: resume the event stream from state %tu", _state);
     
     if (self.backgroundTask.isRunning)
     {
@@ -899,6 +901,12 @@ typedef void (^MXOnResumeDone)(void);
     for (MXPeekingRoom *peekingRoom in peekingRooms)
     {
         [peekingRoom resume];
+    }
+    
+    if (!onResumeDone && resumeDone)
+    {
+        NSLog(@"[MXSession] _resume: the event stream is already running. Nothing to resume");
+        resumeDone();
     }
 }
 
@@ -1287,7 +1295,7 @@ typedef void (^MXOnResumeDone)(void);
                 }
             }
 
-            if (self.state != MXSessionStatePauseRequested)
+            if (self.state != MXSessionStatePauseRequested && self.state != MXSessionStatePaused)
             {
                 // The event stream is running by now
                 [self setState:MXSessionStateRunning];


### PR DESCRIPTION
The bug is not related to the bg sync service but its impact is much more visible. Having the MXSession still running in parallel of the bg sync service is definitely not great.

The rest is the commit message:
The bug exists since lazy loading implementation and the a-synchronousness it added. 

When the race appears, the session does not pause which leads to bg kills on iOS (https://github.com/vector-im/element-ios/issues/3761).

This commit fixes also the resume operation that never returned if the app was in running state (which was the case with the race condition).
