### PR TITLE
Pods: Update JitsiMeetSDK to 2.11.0 to be able to build using Xcode 12.2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changes to be released in next version
  * Added MXAes encryption helper class (vector-im/element-ios/issues/3833).
 
 🙌 Improvements
- *
+ * Pods: Update JitsiMeetSDK to 2.11.0 to be able to build using Xcode 12.2 (vector-im/element-ios/issues/3808).
 
 🐛 Bugfix
  * 

--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -54,7 +54,7 @@ Pod::Spec.new do |s|
     #ss.ios.dependency 'GoogleWebRTC', '~>1.1.21820'
     
     # Use WebRTC framework included in Jitsi Meet SDK
-    ss.ios.dependency 'JitsiMeetSDK', ' 2.10.2'
+    ss.ios.dependency 'JitsiMeetSDK', ' 2.11.0'
 
     # JitsiMeetSDK has not yet binaries for arm64 simulator
     ss.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }


### PR DESCRIPTION
fix vector-im/element-ios/issues/3808
