### PR TITLE
Pods: Update Realm to 10.1.4 to be able to `pod lib lint` using Xcode 12.2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changes to be released in next version
 
 🙌 Improvements
  * Pods: Update JitsiMeetSDK to 2.11.0 to be able to build using Xcode 12.2 (vector-im/element-ios/issues/3808).
+ * Pods: Update Realm to 10.1.4 to be able to `pod lib lint` using Xcode 12.2 (vector-im/element-ios/issues/3808).
 
 🐛 Bugfix
  * 

--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -37,7 +37,7 @@ Pod::Spec.new do |s|
 
       # Requirements for e2e encryption
       ss.dependency 'OLMKit', '~> 3.1.0'
-      ss.dependency 'Realm', '10.1.2'
+      ss.dependency 'Realm', '10.1.4'
       ss.dependency 'libbase58', '~> 0.1.4'
   end
 

--- a/Podfile
+++ b/Podfile
@@ -8,7 +8,7 @@ abstract_target 'MatrixSDK' do
     pod 'OLMKit', '~> 3.1.0', :inhibit_warnings => true
     #pod 'OLMKit', :path => '../olm/OLMKit.podspec'
     
-    pod 'Realm', '10.1.2'
+    pod 'Realm', '10.1.4'
     pod 'libbase58', '~> 0.1.4'
     
     target 'MatrixSDK-iOS' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -34,9 +34,9 @@ PODS:
     - OLMKit/olmcpp (= 3.1.0)
   - OLMKit/olmc (3.1.0)
   - OLMKit/olmcpp (3.1.0)
-  - Realm (10.1.2):
-    - Realm/Headers (= 10.1.2)
-  - Realm/Headers (10.1.2)
+  - Realm (10.1.4):
+    - Realm/Headers (= 10.1.4)
+  - Realm/Headers (10.1.4)
 
 DEPENDENCIES:
   - AFNetworking (~> 4.0.0)
@@ -44,7 +44,7 @@ DEPENDENCIES:
   - libbase58 (~> 0.1.4)
   - OHHTTPStubs (~> 9.0.0)
   - OLMKit (~> 3.1.0)
-  - Realm (= 10.1.2)
+  - Realm (= 10.1.4)
 
 SPEC REPOS:
   trunk:
@@ -61,8 +61,8 @@ SPEC CHECKSUMS:
   libbase58: 7c040313537b8c44b6e2d15586af8e21f7354efd
   OHHTTPStubs: cb29d2a9d09a828ecb93349a2b0c64f99e0db89f
   OLMKit: 4ee0159d63feeb86d836fdcfefe418e163511639
-  Realm: 031fdd4be7094d01b43af1a5e49766ab644bb800
+  Realm: 80f4fb2971ccb9adc27a47d0955ae8e533a7030b
 
-PODFILE CHECKSUM: bafcfe1874b5534acdc9d6c00d60eb962dfcb647
+PODFILE CHECKSUM: 94b04346b278bff5535960219bf37af5c5a33442
 
 COCOAPODS: 1.10.0


### PR DESCRIPTION
Another update required for vector-im/element-ios/issues/3808.