### PR TITLE
Release 0.17.5

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-Changes to be released in next version
+Changes in 0.17.5 (2020-12-02)
 =================================================
 
 ✨ Features
@@ -21,6 +21,9 @@ Changes to be released in next version
 
 Others
  * 
+
+Improvements:
+
 
 Changes in 0.17.4 (2020-12-02)
 =================================================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,27 @@
+Changes to be released in next version
+=================================================
+
+✨ Features
+ * 
+
+🙌 Improvements
+ * 
+
+🐛 Bugfix
+ * 
+
+⚠️ API Changes
+ * 
+
+🗣 Translations
+ * 
+    
+🧱 Build
+ * 
+
+Others
+ * 
+
 Changes in 0.17.4 (2020-12-02)
 =================================================
 

--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "MatrixSDK"
-  s.version      = "0.17.4"
+  s.version      = "0.17.5"
   s.summary      = "The iOS SDK to build apps compatible with Matrix (https://www.matrix.org)"
 
   s.description  = <<-DESC

--- a/MatrixSDK/MatrixSDKVersion.m
+++ b/MatrixSDK/MatrixSDKVersion.m
@@ -16,4 +16,4 @@
 
 #import <Foundation/Foundation.h>
 
-NSString *const MatrixSDKVersion = @"0.17.4";
+NSString *const MatrixSDKVersion = @"0.17.5";


### PR DESCRIPTION
This PR prepares the release of MatrixSDK v0.17.5.

Notes:
- This PR targets `release/0.17.5/master`, which has been cut from `master`.
- It includes changes to the `Podfile`, but _not_ the corresponding changes to `Podfile.lock`, as `pod install` hasn't yet been run.
  This is because the `Podfile` targets future versions of dependencies yet to be released, so `pod install` wouldn't be able to find them yet.
- When the CI runs its checks, it will temporarily point to the pending release branches of those dependencies beforehand
- It is only during `release:finish` that `pod update` will be run -- updating the `Podfile.lock`
to use the now officially released dependencies -- before ultimately merging `release/0.17.5/master` into `master` to tag the release.

---

➡️  Once this PR is merged, you will need to first ensure that the products this one depends on are fully released,
   then run `bundle exec rake release:finish` to close this release.

💡 If you want to review _only_ the changes made since the release branch was cut from `develop`,
   you can [check those here](https://github.com/matrix-org/matrix-ios-sdk/compare/develop...release/0.17.5/release)
