### PR TITLE
Use an array instead of dictionary when querying all device keys

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changes to be released in next version
  * MXTaggedEvents: Expose "m.tagged_events" according to [MSC2437](https://github.com/matrix-org/matrix-doc/pull/2437).
 
 🐛 Bugfix
- * 
+ * MXRestClient: Fix the format of the request body when querying device keys for users.
 
 ⚠️ API Changes
  * 

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -4025,7 +4025,7 @@ MXAuthAction;
     NSMutableDictionary *downloadQuery = [NSMutableDictionary dictionary];
     for (NSString *userID in userIds)
     {
-        downloadQuery[userID] = @{};
+        downloadQuery[userID] = @[];
     }
 
     NSMutableDictionary *parameters = [NSMutableDictionary dictionaryWithDictionary:@{


### PR DESCRIPTION
Fixes: https://github.com/vector-im/element-ios/issues/3539

This changes the format of the request to `POST /_matrix/client/r0/keys/query` from:

```jsonc
{
  ...
  "device_keys": {
    "@user:domain": {}
  },
  ...
```

to

```jsonc
{
  ...
  "device_keys": {
    "@user:domain": []  // changed to array
  },
  ...
```

which is spec compliant. Dendrite [will fail](https://github.com/matrix-org/complement/pull/20) these requests if a dictionary if provided instead of an array.

Given the above issue, I feel that there must be somewhere that Element iOS also requests `POST /_matrix/client/r0/keys/query` with user IDs *and* device IDs, but I could only find this code that requests keys for all devices. Therefore I might be missing something :slightly_smiling_face: 