### PR TITLE
MXBackgroundSyncService: Keep its stores in sync with MXSession store

### DIFF
--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -333,7 +333,7 @@
 		328DDEC11A07E57E008C7DC8 /* MXJSONModelTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 328DDEC01A07E57E008C7DC8 /* MXJSONModelTests.m */; };
 		3290293424CB10D000DA7BB6 /* MatrixSDKVersion.m in Sources */ = {isa = PBXBuildFile; fileRef = 3290293324CB10D000DA7BB6 /* MatrixSDKVersion.m */; };
 		3290293524CB10D000DA7BB6 /* MatrixSDKVersion.m in Sources */ = {isa = PBXBuildFile; fileRef = 3290293324CB10D000DA7BB6 /* MatrixSDKVersion.m */; };
-		3291D4D41A68FFEB00C3BA41 /* MXFileRoomStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 3291D4D21A68FFEB00C3BA41 /* MXFileRoomStore.h */; };
+		3291D4D41A68FFEB00C3BA41 /* MXFileRoomStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 3291D4D21A68FFEB00C3BA41 /* MXFileRoomStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3291D4D51A68FFEB00C3BA41 /* MXFileRoomStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 3291D4D31A68FFEB00C3BA41 /* MXFileRoomStore.m */; };
 		3291DC8323DF52E10009732F /* MXRoomCreationParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 3291DC8123DF52E10009732F /* MXRoomCreationParameters.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3291DC8423DF52E20009732F /* MXRoomCreationParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 3291DC8123DF52E10009732F /* MXRoomCreationParameters.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -876,7 +876,7 @@
 		B14EF2CB2397E90400758AF0 /* MXCallAudioSessionConfigurator.h in Headers */ = {isa = PBXBuildFile; fileRef = 92634B7E1EF2A37A00DB9F60 /* MXCallAudioSessionConfigurator.h */; };
 		B14EF2CC2397E90400758AF0 /* MXMatrixVersions.h in Headers */ = {isa = PBXBuildFile; fileRef = 323F8862212D4E470001C73C /* MXMatrixVersions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B14EF2CD2397E90400758AF0 /* MXRealmEventScanStore.h in Headers */ = {isa = PBXBuildFile; fileRef = B146D4F821A5BF7100D8C2C6 /* MXRealmEventScanStore.h */; };
-		B14EF2CE2397E90400758AF0 /* MXFileRoomStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 3291D4D21A68FFEB00C3BA41 /* MXFileRoomStore.h */; };
+		B14EF2CE2397E90400758AF0 /* MXFileRoomStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 3291D4D21A68FFEB00C3BA41 /* MXFileRoomStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B14EF2D02397E90400758AF0 /* MXWellknownIntegrations.h in Headers */ = {isa = PBXBuildFile; fileRef = 32CF439B2371AF9500907C56 /* MXWellknownIntegrations.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B14EF2D12397E90400758AF0 /* MXEventsEnumeratorOnArray.h in Headers */ = {isa = PBXBuildFile; fileRef = 320BBF3F1D6C81550079890E /* MXEventsEnumeratorOnArray.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B14EF2D22397E90400758AF0 /* MXReplyEventParts.h in Headers */ = {isa = PBXBuildFile; fileRef = B11BD44A22CB56E80064D8B0 /* MXReplyEventParts.h */; settings = {ATTRIBUTES = (Public, ); }; };

--- a/MatrixSDK/Background/MXBackgroundStore.swift
+++ b/MatrixSDK/Background/MXBackgroundStore.swift
@@ -87,6 +87,13 @@ class MXBackgroundStore: NSObject, MXStore {
         }
     }
     
+    func event(withEventId eventId: String, inRoom roomId: String) -> MXEvent? {
+        // TODO
+        
+        NSLog("[MXBackgroundStore] eventWithEventId: \(eventId): TODO")
+        return nil
+    }
+    
     
     //  MARK: - Stubs
     
@@ -103,10 +110,6 @@ class MXBackgroundStore: NSObject, MXStore {
     
     func eventExists(withEventId eventId: String, inRoom roomId: String) -> Bool {
         return false
-    }
-    
-    func event(withEventId eventId: String, inRoom roomId: String) -> MXEvent? {
-        return nil
     }
     
     func deleteAllMessages(inRoom roomId: String) {

--- a/MatrixSDK/Background/MXBackgroundStore.swift
+++ b/MatrixSDK/Background/MXBackgroundStore.swift
@@ -24,57 +24,29 @@ enum MXBackgroundStoreErrorCode: Int {
     case userIDMissing = 1001   // User ID is missing in credentials
 }
 
-/// Fake memory store implementation. Uses some real values from an MXFileStore instance.
-class MXBackgroundStore: MXMemoryStore {
+/// Minimalist MXStore implementation. It uses some real values from an MXFileStore instance.
+class MXBackgroundStore: NSObject, MXStore {
 
-    //  In-memory value for eventStreamToken. Will be used as eventStreamToken if provided.
-    private var lastStoredEventStreamToken: String?
-    private var credentials: MXCredentials
     //  real store
     private var fileStore: MXFileStore
-    private var myUser: MXUser?
     
     init(withCredentials credentials: MXCredentials) {
-        self.credentials = credentials
         fileStore = MXFileStore(credentials: credentials)
         //  load real eventStreamToken
         fileStore.loadMetaData()
     }
     
-    override func open(with credentials: MXCredentials, onComplete: (() -> Void)?, failure: ((Error?) -> Void)? = nil) {
-        super.open(with: credentials, onComplete: {
-            guard let userId = credentials.userId else {
-                failure?(NSError(domain: MXBackgroundStoreErrorDomain,
-                                 code: MXBackgroundStoreErrorCode.userIDMissing.rawValue,
-                                 userInfo: nil))
-                return
-            }
-            //  load session user before calling onComplete
-            self.fileStore.asyncUsers(withUserIds: [userId], success: { (users) in
-                if let user = users.first {
-                    self.myUser = user
-                }
-                onComplete?()
-            }, failure: failure)
-        }, failure: failure)
-    }
-    
     //  Return real eventStreamToken, to be able to launch a meaningful background sync
-    override var eventStreamToken: String? {
+    var eventStreamToken: String? {
         get {
-            //  if more up-to-date token exists, use it
-            if let token = lastStoredEventStreamToken {
-                return token
-            }
             return fileStore.eventStreamToken
         } set {
-            //  store new token values in memory, and return these values in future reads
-            lastStoredEventStreamToken = newValue
+            //  no-op
         }
     }
     
     //  Return real userAccountData, to be able to use push rules
-    override var userAccountData: [AnyHashable : Any]? {
+    var userAccountData: [AnyHashable : Any]? {
         get {
             return fileStore.userAccountData
         } set {
@@ -83,45 +55,153 @@ class MXBackgroundStore: MXMemoryStore {
     }
     
     //  This store should act like as a permanent one
-    override var isPermanent: Bool {
+    var isPermanent: Bool {
         return true
     }
     
     //  Some mandatory methods to implement to be permanent
-    override func storeState(forRoom roomId: String, stateEvents: [MXEvent]) {
+    func storeState(forRoom roomId: String, stateEvents: [MXEvent]) {
         //  no-op
     }
     
     //  Fetch real room state
-    override func state(ofRoom roomId: String, success: @escaping ([MXEvent]) -> Void, failure: ((Error) -> Void)? = nil) {
+    func state(ofRoom roomId: String, success: @escaping ([MXEvent]) -> Void, failure: ((Error) -> Void)? = nil) {
         fileStore.state(ofRoom: roomId, success: success, failure: failure)
     }
     
     //  Fetch real soom summary
-    override func summary(ofRoom roomId: String) -> MXRoomSummary? {
+    func summary(ofRoom roomId: String) -> MXRoomSummary? {
         return fileStore.summary(ofRoom: roomId)
     }
     
     //  Fetch real room account data
-    override func accountData(ofRoom roomId: String) -> MXRoomAccountData? {
+    func accountData(ofRoom roomId: String) -> MXRoomAccountData? {
         return fileStore.accountData(ofRoom: roomId)
     }
     
-    //  Override and return a user to be stored on session.myUser
-    override func user(withUserId userId: String) -> MXUser? {
-        if userId == credentials.userId, let myUser = myUser {
-            //  if asking for session user and myUser is set, return that
-            return myUser
-        }
-        return MXUser(userId: userId)
-    }
-    
-    override var syncFilterId: String? {
+    var syncFilterId: String? {
         get {
             return fileStore.syncFilterId
         } set {
             //  no-op
         }
+    }
+    
+    
+    //  MARK: - Stubs
+    
+    /// Following operations should be not required
+    
+    func open(with credentials: MXCredentials, onComplete: (() -> Void)?, failure: ((Error?) -> Void)? = nil) {
+    }
+    
+    func storeEvent(forRoom roomId: String, event: MXEvent, direction: __MXTimelineDirection) {
+    }
+    
+    func replace(_ event: MXEvent, inRoom roomId: String) {
+    }
+    
+    func eventExists(withEventId eventId: String, inRoom roomId: String) -> Bool {
+        return false
+    }
+    
+    func event(withEventId eventId: String, inRoom roomId: String) -> MXEvent? {
+        return nil
+    }
+    
+    func deleteAllMessages(inRoom roomId: String) {
+    }
+    
+    func deleteRoom(_ roomId: String) {
+    }
+    
+    func deleteAllData() {
+    }
+    
+    func storePaginationToken(ofRoom roomId: String, andToken token: String) {
+    }
+    
+    func paginationToken(ofRoom roomId: String) -> String? {
+        return nil
+    }
+    
+    func storeHasReachedHomeServerPaginationEnd(forRoom roomId: String, andValue value: Bool) {
+    }
+    
+    func hasReachedHomeServerPaginationEnd(forRoom roomId: String) -> Bool {
+        return true
+    }
+    
+    func storeHasLoadedAllRoomMembers(forRoom roomId: String, andValue value: Bool) {
+    }
+    
+    func hasLoadedAllRoomMembers(forRoom roomId: String) -> Bool {
+        return false
+    }
+    
+    func messagesEnumerator(forRoom roomId: String) -> MXEventsEnumerator {
+        return MXEventsEnumeratorOnArray(messages: [])
+    }
+    
+    func messagesEnumerator(forRoom roomId: String, withTypeIn types: [Any]?) -> MXEventsEnumerator {
+        return MXEventsEnumeratorOnArray(messages: [])
+    }
+    
+    func relations(forEvent eventId: String, inRoom roomId: String, relationType: String) -> [MXEvent] {
+        return []
+    }
+    
+    func store(_ user: MXUser) {
+    }
+    
+    func users() -> [MXUser]? {
+        return nil
+    }
+    
+    func user(withUserId userId: String) -> MXUser? {
+        return nil
+    }
+    
+    func store(_ group: MXGroup) {
+    }
+    
+    func groups() -> [MXGroup]? {
+        return nil
+    }
+    
+    func group(withGroupId groupId: String) -> MXGroup? {
+        return nil
+    }
+    
+    func deleteGroup(_ groupId: String) {
+    }
+    
+    func storePartialTextMessage(forRoom roomId: String, partialTextMessage: String) {
+    }
+    
+    func partialTextMessage(ofRoom roomId: String) -> String? {
+        return nil
+    }
+    
+    func getEventReceipts(_ roomId: String, eventId: String, sorted sort: Bool) -> [MXReceiptData]? {
+        return nil
+    }
+    
+    func storeReceipt(_ receipt: MXReceiptData, inRoom roomId: String) -> Bool {
+        return false
+    }
+    
+    func getReceiptInRoom(_ roomId: String, forUserId userId: String) -> MXReceiptData? {
+        return nil
+    }
+    
+    func localUnreadEventCount(_ roomId: String, withTypeIn types: [Any]?) -> UInt {
+        return 0
+    }
+    
+    var homeserverWellknown: MXWellKnown?
+    
+    func storeHomeserverWellknown(_ homeserverWellknown: MXWellKnown) {
     }
     
 }

--- a/MatrixSDK/Background/MXBackgroundStore.swift
+++ b/MatrixSDK/Background/MXBackgroundStore.swift
@@ -59,7 +59,7 @@ class MXBackgroundStore: NSObject, MXStore {
     
     //  This store should act like as a permanent one
     var isPermanent: Bool {
-        return true
+        return false
     }
     
     //  Some mandatory methods to implement to be permanent

--- a/MatrixSDK/Background/MXBackgroundStore.swift
+++ b/MatrixSDK/Background/MXBackgroundStore.swift
@@ -57,7 +57,6 @@ class MXBackgroundStore: NSObject, MXStore {
         }
     }
     
-    //  This store should act like as a permanent one
     var isPermanent: Bool {
         return false
     }

--- a/MatrixSDK/Background/MXBackgroundStore.swift
+++ b/MatrixSDK/Background/MXBackgroundStore.swift
@@ -30,6 +30,9 @@ class MXBackgroundStore: NSObject, MXStore {
     //  real store
     private var fileStore: MXFileStore
     
+    // Room stores cache
+    private var roomsStore: [String: MXFileRoomStore] = [:]
+    
     init(withCredentials credentials: MXCredentials) {
         fileStore = MXFileStore(credentials: credentials)
         //  load real eventStreamToken
@@ -88,10 +91,31 @@ class MXBackgroundStore: NSObject, MXStore {
     }
     
     func event(withEventId eventId: String, inRoom roomId: String) -> MXEvent? {
-        // TODO
+        guard let roomStore = roomStore(forRoom: roomId) else {
+            return nil
+        }
         
-        NSLog("[MXBackgroundStore] eventWithEventId: \(eventId): TODO")
-        return nil
+        let event = roomStore.event(withEventId: eventId)
+        
+        NSLog("[MXBackgroundStore] eventWithEventId: \(eventId) \(event == nil ? "not " : "" )found")
+        return event
+    }
+    
+    
+    //  MARK: - Private
+    private func roomStore(forRoom roomId: String) -> MXFileRoomStore? {
+        // Use the cached instance if available
+        if let roomStore = roomsStore[roomId] {
+            return roomStore
+        }
+        
+        guard let roomStore = fileStore.roomStore(forRoom: roomId) else {
+            NSLog("[MXBackgroundStore] roomStore: Unknown room id: \(roomId)")
+            return nil
+        }
+        
+        roomsStore[roomId] = roomStore
+        return roomStore
     }
     
     

--- a/MatrixSDK/Background/MXBackgroundSyncService.swift
+++ b/MatrixSDK/Background/MXBackgroundSyncService.swift
@@ -246,10 +246,10 @@ public enum MXBackgroundSyncServiceError: Error {
                             //  handle encryption for this event
                             handleEncryption(forEvent: event)
                             
-                        case .failure(_):
+                        case .failure(let error):
                             NSLog("[MXBackgroundSyncService] fetchEvent: Failed to fetch event \(eventId)")
                             Queues.dispatchQueue.async {
-                                completion(.failure(MXBackgroundSyncServiceError.unknown))
+                                completion(.failure(error))
                             }
                     }
                 }

--- a/MatrixSDK/Background/MXBackgroundSyncService.swift
+++ b/MatrixSDK/Background/MXBackgroundSyncService.swift
@@ -211,7 +211,7 @@ public enum MXBackgroundSyncServiceError: Error {
         } else {
             //  do not call the /event api and just check if the event exists in the store
             let event = syncResponseStore.event(withEventId: eventId, inRoom: roomId)
-                ?? store.event(withEventId: eventId, inRoom: roomId)    // TODO: MXBackgroundStore does not support it
+                ?? store.event(withEventId: eventId, inRoom: roomId)
             
             if let event = event {
                 NSLog("[MXBackgroundSyncService] fetchEvent: We have the event in stores.")

--- a/MatrixSDK/Background/MXBackgroundSyncService.swift
+++ b/MatrixSDK/Background/MXBackgroundSyncService.swift
@@ -538,7 +538,7 @@ public enum MXBackgroundSyncServiceError: Error {
         if (eventStreamToken != upToDateEventStreamToken) {
             // MXSession continued to work in parallel with the background sync service
             // MXSession has updated its stream token. We need to use t
-            NSLog("[MXBackgroundSyncService] resetBackgroundServiceStoresIfNeeded: Update MXBackgroundStore. Its event stream token (\(String(describing: eventStreamToken))) does not match current MXStore.eventStreamToken (\(String(describing: upToDateEventStreamToken)))")
+            NSLog("[MXBackgroundSyncService] updateBackgroundServiceStoresIfNeeded: Update MXBackgroundStore. Its event stream token (\(String(describing: eventStreamToken))) does not match current MXStore.eventStreamToken (\(String(describing: upToDateEventStreamToken)))")
             store = upToDateStore
             
             // syncResponseStore has obsolete data. Reset it

--- a/MatrixSDK/Background/MXBackgroundSyncService.swift
+++ b/MatrixSDK/Background/MXBackgroundSyncService.swift
@@ -59,7 +59,6 @@ public enum MXBackgroundSyncServiceError: Error {
         restClient = MXRestClient(credentials: credentials, unrecognizedCertificateHandler: nil)
         restClient.completionQueue = processingQueue
         store = MXBackgroundStore(withCredentials: credentials)
-        store.open(with: credentials, onComplete: nil, failure: nil)
         if MXRealmCryptoStore.hasData(for: credentials) {
             cryptoStore = MXRealmCryptoStore(credentials: credentials)
         } else {
@@ -206,7 +205,8 @@ public enum MXBackgroundSyncServiceError: Error {
             handleEncryption(forEvent: cachedEvent)
         } else {
             //  do not call the /event api and just check if the event exists in the store
-            let event = syncResponseStore.event(withEventId: eventId, inRoom: roomId) ?? store.event(withEventId: eventId, inRoom: roomId)
+            let event = syncResponseStore.event(withEventId: eventId, inRoom: roomId)
+                ?? store.event(withEventId: eventId, inRoom: roomId)    // TODO: MXBackgroundStore does not support it
             
             if let event = event {
                 NSLog("[MXBackgroundSyncService] fetchEvent: We have the event in stores.")

--- a/MatrixSDK/Background/MXBackgroundSyncService.swift
+++ b/MatrixSDK/Background/MXBackgroundSyncService.swift
@@ -129,10 +129,9 @@ public enum MXBackgroundSyncServiceError: Error {
     /// - Returns: Push rule matching the event.
     public func pushRule(matching event: MXEvent, roomState: MXRoomState) -> MXPushRule? {
         guard let currentUserId = credentials.userId else { return nil }
-        let currentUser = store.user(withUserId: currentUserId)
         return pushRulesManager.pushRule(matching: event,
                                          roomState: roomState,
-                                         currentUserDisplayName: currentUser?.displayname)
+                                         currentUserDisplayName:  roomState.members.member(withUserId: currentUserId)?.displayname)
     }
     
     //  MARK: - Private

--- a/MatrixSDK/Background/MXBackgroundSyncService.swift
+++ b/MatrixSDK/Background/MXBackgroundSyncService.swift
@@ -542,7 +542,7 @@ public enum MXBackgroundSyncServiceError: Error {
             store = upToDateStore
             
             // syncResponseStore has obsolete data. Reset it
-            NSLog("[MXBackgroundSyncService] resetBackgroundServiceStoresIfNeeded: Reset MXSyncResponseStore. Its prevBatch was token \(String(describing: syncResponseStore.prevBatch))")
+            NSLog("[MXBackgroundSyncService] updateBackgroundServiceStoresIfNeeded: Reset MXSyncResponseStore. Its prevBatch was token \(String(describing: syncResponseStore.prevBatch))")
             syncResponseStore.deleteData()
         }
     }

--- a/MatrixSDK/Background/MXBackgroundSyncService.swift
+++ b/MatrixSDK/Background/MXBackgroundSyncService.swift
@@ -234,6 +234,10 @@ public enum MXBackgroundSyncServiceError: Error {
     private func launchBackgroundSync(forEventId eventId: String,
                                       roomId: String,
                                       completion: @escaping (MXResponse<MXEvent>) -> Void) {
+        
+        // Check local stores on every request so that we use up-to-data data from the MXSession store
+        updateBackgroundServiceStoresIfNeeded()
+            
         guard let eventStreamToken = syncResponseStore.syncResponse?.nextBatch ?? store.eventStreamToken else {
             NSLog("[MXBackgroundSyncService] launchBackgroundSync: Do not sync because event streaming not started yet.")
             Queues.dispatchQueue.async {

--- a/MatrixSDK/Background/MXBackgroundSyncService.swift
+++ b/MatrixSDK/Background/MXBackgroundSyncService.swift
@@ -210,7 +210,10 @@ public enum MXBackgroundSyncServiceError: Error {
         } else {
             //  do not call the /event api and just check if the event exists in the store
             let event = syncResponseStore.event(withEventId: eventId, inRoom: roomId)
-                ?? store.event(withEventId: eventId, inRoom: roomId)
+                // Disable read access to MXSession store because it consumes too much RAM
+                // and RAM is limited when running an app extension
+                // TODO: Find a way to reuse MXSession store data
+                //?? store.event(withEventId: eventId, inRoom: roomId)
             
             if let event = event {
                 NSLog("[MXBackgroundSyncService] fetchEvent: We have the event in stores.")

--- a/MatrixSDK/Background/Store/SyncResponseFileStore/MXSyncResponseFileStore.swift
+++ b/MatrixSDK/Background/Store/SyncResponseFileStore/MXSyncResponseFileStore.swift
@@ -154,6 +154,9 @@ extension MXSyncResponseFileStore: MXSyncResponseStore {
         
         let result = allEvents.first(where: { eventId == $0.eventId })
         result?.roomId = roomId
+        
+        NSLog("[MXSyncResponseFileStore] eventWithEventId: \(eventId) \(result == nil ? "not " : "" )found")
+        
         return result
     }
     

--- a/MatrixSDK/Data/MXRoomMembers.m
+++ b/MatrixSDK/Data/MXRoomMembers.m
@@ -22,8 +22,8 @@
 
 @interface MXRoomMembers ()
 {
-    __weak MXSession *mxSession;
-    __weak MXRoomState *state;
+    MXSession *mxSession;
+    MXRoomState *state;
 
     /**
      Members ordered by userId.

--- a/MatrixSDK/Data/MXRoomMembers.m
+++ b/MatrixSDK/Data/MXRoomMembers.m
@@ -22,8 +22,8 @@
 
 @interface MXRoomMembers ()
 {
-    MXSession *mxSession;
-    MXRoomState *state;
+    __weak MXSession *mxSession;
+    __weak MXRoomState *state;
 
     /**
      Members ordered by userId.

--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.h
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.h
@@ -2,6 +2,7 @@
  Copyright 2014 OpenMarket Ltd
  Copyright 2017 Vector Creations Ltd
  Copyright 2018 New Vector Ltd
+ Copyright 2020 The Matrix.org Foundation C.I.C
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -17,6 +18,8 @@
  */
 
 #import "MXMemoryStore.h"
+
+#import "MXFileRoomStore.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -163,10 +166,21 @@ typedef NS_OPTIONS(NSInteger, MXFileStorePreloadOptions)
                        success:(void (^)(MXRoomAccountData * _Nonnull roomAccountData))success
                        failure:(nullable void (^)(NSError * _Nonnull error))failure;
 
+
+#pragma mark - Sync API (Do not use them on the main thread)
+
 /**
  Load metadata for the store. Sets eventStreamToken.
  */
 - (void)loadMetaData;
+
+/**
+ Get the room store for a given room.
+ 
+ @param roomId the room id.
+ @return the store.
+ */
+- (nullable MXFileRoomStore *)roomStoreForRoom:(NSString*)roomId;
 
 @end
 

--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
@@ -2,6 +2,7 @@
  Copyright 2014 OpenMarket Ltd
  Copyright 2017 Vector Creations Ltd
  Copyright 2018 New Vector Ltd
+ Copyright 2020 The Matrix.org Foundation C.I.C
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -1950,6 +1951,27 @@ static NSUInteger preloadOptions;
         });
     });
 }
+
+
+#pragma mark - Sync API (Do not use them on the main thread)
+
+- (MXFileRoomStore *)roomStoreForRoom:(NSString*)roomId
+{
+    NSString *roomFile = [self messagesFileForRoom:roomId forBackup:NO];
+    
+    MXFileRoomStore *roomStore;
+    @try
+    {
+        roomStore = [NSKeyedUnarchiver unarchiveObjectWithFile:roomFile];
+    }
+    @catch (NSException *exception)
+    {
+        NSLog(@"[MXFileStore] roomStoreForRoom = Warning: MXFileRoomStore file for room %@ seems corrupted", roomId);
+    }
+    
+    return roomStore;
+}
+
 
 #pragma mark - Tools
 /**

--- a/MatrixSDKTests/MXBackgroundSyncServiceTests.swift
+++ b/MatrixSDKTests/MXBackgroundSyncServiceTests.swift
@@ -592,7 +592,6 @@ class MXBackgroundSyncServiceTests: XCTestCase {
     // - Bob uses the MXBackgroundSyncService again
     // -> MXBackgroundSyncService should have detected that the MXSession ran in parallel.
     //    It must have reset its cache. syncResponseStore.prevBatch must not be the same
-    // -> MXSyncResponseFileStore must be in sync with MXSession store
     func testWithMXSessionRunningInParallel() {
         
         // - Alice and Bob are in an encrypted room
@@ -632,8 +631,6 @@ class MXBackgroundSyncServiceTests: XCTestCase {
                             syncResponseStore.open(withCredentials: bobCredentials)
                             let syncResponseStorePrevBatch = syncResponseStore.prevBatch
                             
-                            let bobSessionStartEventStreamToken2 = bobSession!.store.eventStreamToken
-                            
                             // - Alice sends a message. This make bob MXSession update its sync token
                             room.sendTextMessage(Constants.messageText, localEcho: &localEcho) { _ in }
                             
@@ -649,9 +646,6 @@ class MXBackgroundSyncServiceTests: XCTestCase {
                                     syncResponseStore.open(withCredentials: bobCredentials)
                                     
                                     XCTAssertNotEqual(syncResponseStorePrevBatch, syncResponseStore.prevBatch)
-                                    
-                                    // -> MXSyncResponseFileStore must be in sync with MXSession store
-                                    XCTAssertNotEqual(bobSessionStartEventStreamToken2, syncResponseStore.prevBatch)
 
                                     expectation?.fulfill()
                                 }

--- a/MatrixSDKTests/MXBackgroundSyncServiceTests.swift
+++ b/MatrixSDKTests/MXBackgroundSyncServiceTests.swift
@@ -612,8 +612,6 @@ class MXBackgroundSyncServiceTests: XCTestCase {
                 return
             }
             
-            let bobSessionStartEventStreamToken1 = bobSession!.store.eventStreamToken
-                
             // - Alice sends a message
             var localEcho: MXEvent?
             room.sendTextMessage(Constants.messageText, localEcho: &localEcho) { (response) in
@@ -633,10 +631,6 @@ class MXBackgroundSyncServiceTests: XCTestCase {
                             let syncResponseStore = MXSyncResponseFileStore()
                             syncResponseStore.open(withCredentials: bobCredentials)
                             let syncResponseStorePrevBatch = syncResponseStore.prevBatch
-                            
-                            // Test check
-                            // MXSyncResponseFileStore should point to the same sync token as MXSession store
-                            XCTAssertNotEqual(bobSessionStartEventStreamToken1, syncResponseStorePrevBatch)
                             
                             let bobSessionStartEventStreamToken2 = bobSession!.store.eventStreamToken
                             


### PR DESCRIPTION
In real life, the same `MXBackgroundSyncService` instance runs for hours.  `MXSession` can run in parallel with it.

Here, we make sure that `MXBackgroundSyncService` uses the latest data stored by `MXSession`, instead of using obsolete data we have in memory.
Else `MXSession` will consider `MXBackgroundSyncService` data obsolete on its next startup or resume, making `MXBackgroundSyncService` previous work useless.

MXBackgroundStore.event(withEventId:) was not working. It should work now.