### PR TITLE
Added MXKeyProvider to share encryption keys between application and Kit

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@ Changes to be released in next version
 =================================================
 
 ✨ Features
- * 
+ * Added MXKeyProvider to enable data encryption using keys given by client application (#3866)
 
 🙌 Improvements
  * MXTaggedEvents: Expose "m.tagged_events" according to [MSC2437](https://github.com/matrix-org/matrix-doc/pull/2437).

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -564,6 +564,7 @@
 		3A108AA525810FE5005EEBE9 /* MXRawDataKey.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A108AA125810FE5005EEBE9 /* MXRawDataKey.m */; };
 		3A108AB725812995005EEBE9 /* MXKeyProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A108AB625812995005EEBE9 /* MXKeyProvider.m */; };
 		3A108AB825812995005EEBE9 /* MXKeyProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A108AB625812995005EEBE9 /* MXKeyProvider.m */; };
+		3A108E6725826F52005EEBE9 /* MXKeyProviderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A108E6625826F52005EEBE9 /* MXKeyProviderTests.m */; };
 		3A23A73F256D322C00B9D00F /* MXAes.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A23A73D256D322C00B9D00F /* MXAes.m */; };
 		3A23A740256D322C00B9D00F /* MXAes.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A23A73D256D322C00B9D00F /* MXAes.m */; };
 		3A23A741256D322C00B9D00F /* MXAes.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A23A73E256D322C00B9D00F /* MXAes.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1742,6 +1743,7 @@
 		3A108AA025810FE5005EEBE9 /* MXRawDataKey.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXRawDataKey.h; sourceTree = "<group>"; };
 		3A108AA125810FE5005EEBE9 /* MXRawDataKey.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXRawDataKey.m; sourceTree = "<group>"; };
 		3A108AB625812995005EEBE9 /* MXKeyProvider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXKeyProvider.m; sourceTree = "<group>"; };
+		3A108E6625826F52005EEBE9 /* MXKeyProviderTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXKeyProviderTests.m; sourceTree = "<group>"; };
 		3A23A73D256D322C00B9D00F /* MXAes.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXAes.m; sourceTree = "<group>"; };
 		3A23A73E256D322C00B9D00F /* MXAes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXAes.h; sourceTree = "<group>"; };
 		3AE97790256FC190003883EF /* MXAesTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXAesTests.m; sourceTree = "<group>"; };
@@ -2961,6 +2963,7 @@
 				32CEEF3C23AD134A0039BA98 /* MXCrossSigningTests.m */,
 				ECAE7AEB24ED75F1002FA813 /* HTTPAdditionalHeadersTests.m */,
 				3AE97790256FC190003883EF /* MXAesTests.m */,
+				3A108E6625826F52005EEBE9 /* MXKeyProviderTests.m */,
 				B14EECED2578FE3F00448735 /* MXAuthenticationSessionTests.swift */,
 				EC383BC12542F251002FBBE6 /* MatrixSDKTests-Bridging-Header.h */,
 			);
@@ -4556,6 +4559,7 @@
 				3295719A1B024D2B00ABB3BA /* MXMockCallStackCall.m in Sources */,
 				324DD2BB246C3ADE00377005 /* MXCryptoSecretStorageTests.m in Sources */,
 				B19A30D82404335D00FB6F35 /* MXQRCodeDataTests.m in Sources */,
+				3A108E6725826F52005EEBE9 /* MXKeyProviderTests.m in Sources */,
 				B11BD45C22CB8ABC0064D8B0 /* MXReplyEventParserTests.m in Sources */,
 				ECAE7AEC24ED75F1002FA813 /* HTTPAdditionalHeadersTests.m in Sources */,
 				32AF9292241112850008A0FD /* MXCryptoSecretShareTests.m in Sources */,

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -552,6 +552,22 @@
 		32FE41371D0AB7070060835E /* MXEnumConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 32FE41351D0AB7070060835E /* MXEnumConstants.m */; };
 		32FFB4F0217E146A00C96002 /* MXRecoveryKey.h in Headers */ = {isa = PBXBuildFile; fileRef = 32FFB4EE217E146A00C96002 /* MXRecoveryKey.h */; };
 		32FFB4F1217E146A00C96002 /* MXRecoveryKey.m in Sources */ = {isa = PBXBuildFile; fileRef = 32FFB4EF217E146A00C96002 /* MXRecoveryKey.m */; };
+		3A108A3A2580E9C2005EEBE9 /* MXKeyProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A108A392580E9C2005EEBE9 /* MXKeyProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3A108A3B2580E9C2005EEBE9 /* MXKeyProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A108A392580E9C2005EEBE9 /* MXKeyProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3A108A7E25810C96005EEBE9 /* MXKeyData.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A108A7C25810C96005EEBE9 /* MXKeyData.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3A108A7F25810C96005EEBE9 /* MXKeyData.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A108A7C25810C96005EEBE9 /* MXKeyData.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3A108A8025810C96005EEBE9 /* MXKeyData.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A108A7D25810C96005EEBE9 /* MXKeyData.m */; };
+		3A108A8125810C96005EEBE9 /* MXKeyData.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A108A7D25810C96005EEBE9 /* MXKeyData.m */; };
+		3A108A9825810F62005EEBE9 /* MXAesKeyData.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A108A9625810F62005EEBE9 /* MXAesKeyData.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3A108A9925810F62005EEBE9 /* MXAesKeyData.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A108A9625810F62005EEBE9 /* MXAesKeyData.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3A108A9A25810F62005EEBE9 /* MXAesKeyData.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A108A9725810F62005EEBE9 /* MXAesKeyData.m */; };
+		3A108A9B25810F62005EEBE9 /* MXAesKeyData.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A108A9725810F62005EEBE9 /* MXAesKeyData.m */; };
+		3A108AA225810FE5005EEBE9 /* MXRawDataKey.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A108AA025810FE5005EEBE9 /* MXRawDataKey.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3A108AA325810FE5005EEBE9 /* MXRawDataKey.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A108AA025810FE5005EEBE9 /* MXRawDataKey.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3A108AA425810FE5005EEBE9 /* MXRawDataKey.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A108AA125810FE5005EEBE9 /* MXRawDataKey.m */; };
+		3A108AA525810FE5005EEBE9 /* MXRawDataKey.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A108AA125810FE5005EEBE9 /* MXRawDataKey.m */; };
+		3A108AB725812995005EEBE9 /* MXKeyProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A108AB625812995005EEBE9 /* MXKeyProvider.m */; };
+		3A108AB825812995005EEBE9 /* MXKeyProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A108AB625812995005EEBE9 /* MXKeyProvider.m */; };
 		3A23A73F256D322C00B9D00F /* MXAes.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A23A73D256D322C00B9D00F /* MXAes.m */; };
 		3A23A740256D322C00B9D00F /* MXAes.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A23A73D256D322C00B9D00F /* MXAes.m */; };
 		3A23A741256D322C00B9D00F /* MXAes.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A23A73E256D322C00B9D00F /* MXAes.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1706,6 +1722,14 @@
 		32FFB4EE217E146A00C96002 /* MXRecoveryKey.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXRecoveryKey.h; sourceTree = "<group>"; };
 		32FFB4EF217E146A00C96002 /* MXRecoveryKey.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXRecoveryKey.m; sourceTree = "<group>"; };
 		373B3662A92DBDD847639FA2 /* Pods-SDK-MatrixSDKTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SDK-MatrixSDKTests.debug.xcconfig"; path = "Target Support Files/Pods-SDK-MatrixSDKTests/Pods-SDK-MatrixSDKTests.debug.xcconfig"; sourceTree = "<group>"; };
+		3A108A392580E9C2005EEBE9 /* MXKeyProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXKeyProvider.h; sourceTree = "<group>"; };
+		3A108A7C25810C96005EEBE9 /* MXKeyData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXKeyData.h; sourceTree = "<group>"; };
+		3A108A7D25810C96005EEBE9 /* MXKeyData.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXKeyData.m; sourceTree = "<group>"; };
+		3A108A9625810F62005EEBE9 /* MXAesKeyData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXAesKeyData.h; sourceTree = "<group>"; };
+		3A108A9725810F62005EEBE9 /* MXAesKeyData.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXAesKeyData.m; sourceTree = "<group>"; };
+		3A108AA025810FE5005EEBE9 /* MXRawDataKey.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXRawDataKey.h; sourceTree = "<group>"; };
+		3A108AA125810FE5005EEBE9 /* MXRawDataKey.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXRawDataKey.m; sourceTree = "<group>"; };
+		3A108AB625812995005EEBE9 /* MXKeyProvider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXKeyProvider.m; sourceTree = "<group>"; };
 		3A23A73D256D322C00B9D00F /* MXAes.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXAes.m; sourceTree = "<group>"; };
 		3A23A73E256D322C00B9D00F /* MXAes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXAes.h; sourceTree = "<group>"; };
 		3AE97790256FC190003883EF /* MXAesTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXAesTests.m; sourceTree = "<group>"; };
@@ -2133,6 +2157,7 @@
 				32A1513B1DAF768D00400192 /* Data */,
 				32BBAE642178E99100D85F46 /* KeyBackup */,
 				32FA10B21FA1C28100E54233 /* KeySharing */,
+				3A108A382580E979005EEBE9 /* KeyProvider */,
 				32C78B64256CFC4D008130B1 /* Migration */,
 				32F00AB82488E14300131741 /* Recovery */,
 				324DD296246AD25E00377005 /* SecretStorage */,
@@ -3051,6 +3076,21 @@
 			path = Data;
 			sourceTree = "<group>";
 		};
+		3A108A382580E979005EEBE9 /* KeyProvider */ = {
+			isa = PBXGroup;
+			children = (
+				3A108A392580E9C2005EEBE9 /* MXKeyProvider.h */,
+				3A108AB625812995005EEBE9 /* MXKeyProvider.m */,
+				3A108A7C25810C96005EEBE9 /* MXKeyData.h */,
+				3A108A7D25810C96005EEBE9 /* MXKeyData.m */,
+				3A108A9625810F62005EEBE9 /* MXAesKeyData.h */,
+				3A108A9725810F62005EEBE9 /* MXAesKeyData.m */,
+				3A108AA025810FE5005EEBE9 /* MXRawDataKey.h */,
+				3A108AA125810FE5005EEBE9 /* MXRawDataKey.m */,
+			);
+			path = KeyProvider;
+			sourceTree = "<group>";
+		};
 		916911E77039455CC9D0900C /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -3348,6 +3388,7 @@
 				B17982F52119E4A2001FD722 /* MXRoomCreateContent.h in Headers */,
 				32792BDC2296B90A00F4FC9D /* MXAggregatedEditsUpdater.h in Headers */,
 				327E9AEF2289C61100A98BC1 /* MXAggregations.h in Headers */,
+				3A108A3A2580E9C2005EEBE9 /* MXKeyProvider.h in Headers */,
 				32DC15CF1A8CF7AE006F9AD3 /* MXPushRuleConditionChecker.h in Headers */,
 				3294FD9F22F321B0007F1E60 /* MXServiceTermsRestClient.h in Headers */,
 				32954019216385F100E300FC /* MXServerNoticeContent.h in Headers */,
@@ -3456,6 +3497,7 @@
 				320B3934239FA56900BE2C06 /* MXKeyVerificationByDMRequest.h in Headers */,
 				324DD2A6246AE81300377005 /* MXSecretStorageKeyContent.h in Headers */,
 				3281E8B919E42DFE00976E1A /* MXJSONModels.h in Headers */,
+				3A108AA225810FE5005EEBE9 /* MXRawDataKey.h in Headers */,
 				8EC511042568216B00EC4E5B /* MXTaggedEventInfo.h in Headers */,
 				B19A30D424042F2700FB6F35 /* MXSelfVerifyingMasterKeyNotTrustedQRCodeData.h in Headers */,
 				323F3F9420D3F0C700D26D6A /* MXRoomEventFilter.h in Headers */,
@@ -3463,6 +3505,7 @@
 				B19A30BC2404268600FB6F35 /* MXQRCodeDataCoder.h in Headers */,
 				325D1C261DFECE0D0070B8BF /* MXCrypto_Private.h in Headers */,
 				B10AFB4322A970060092E6AF /* MXEventReplace.h in Headers */,
+				3A108A7E25810C96005EEBE9 /* MXKeyData.h in Headers */,
 				327A5F4D239805F600ED6329 /* MXKeyVerificationStart.h in Headers */,
 				B124BBCC256453C90028996D /* MXMembershipTransitionState.h in Headers */,
 				324DD2BF246D658500377005 /* MXHkdfSha256.h in Headers */,
@@ -3510,6 +3553,7 @@
 				B146D4D521A5A44E00D8C2C6 /* MXScanRealmProvider.h in Headers */,
 				32CEEF4323AD2A6C0039BA98 /* MXCrossSigningKey.h in Headers */,
 				327E9ABC2284521C00A98BC1 /* MXEventUnsignedData.h in Headers */,
+				3A108A9825810F62005EEBE9 /* MXAesKeyData.h in Headers */,
 				B10AFB4722AA8A8E0092E6AF /* MXEventEditsListener.h in Headers */,
 				3287164F23C4C11F00D720CA /* MXKeyVerificationManager_Private.h in Headers */,
 				32F634AB1FC5E3480054EF49 /* MXEventDecryptionResult.h in Headers */,
@@ -3636,6 +3680,7 @@
 				32581DE923C8C0C900832EAA /* MXUserTrustLevel.h in Headers */,
 				B14EF2A82397E90400758AF0 /* MXServiceTermsRestClient.h in Headers */,
 				B14EF2A92397E90400758AF0 /* MXServerNoticeContent.h in Headers */,
+				3A108A7F25810C96005EEBE9 /* MXKeyData.h in Headers */,
 				B14EF2AA2397E90400758AF0 /* MXOlmDecryption.h in Headers */,
 				B14EF2AB2397E90400758AF0 /* MXUIKitBackgroundTask.h in Headers */,
 				B14EF2AC2397E90400758AF0 /* MXMemoryStore.h in Headers */,
@@ -3649,6 +3694,7 @@
 				B14EF2B32397E90400758AF0 /* MXRoomFilter.h in Headers */,
 				B14EF2B42397E90400758AF0 /* MXAntivirusScanStatus.h in Headers */,
 				324DD2A7246AE81300377005 /* MXSecretStorageKeyContent.h in Headers */,
+				3A108AA325810FE5005EEBE9 /* MXRawDataKey.h in Headers */,
 				B14EF2B52397E90400758AF0 /* MXDeviceListOperationsPool.h in Headers */,
 				B14EF2B62397E90400758AF0 /* MXJSONModel.h in Headers */,
 				B14EF2B72397E90400758AF0 /* MXCryptoStore.h in Headers */,
@@ -3734,6 +3780,7 @@
 				B14EF2F12397E90400758AF0 /* MXRealmEventScanMapper.h in Headers */,
 				B14EF2F22397E90400758AF0 /* MXEventScan.h in Headers */,
 				B14EF2F32397E90400758AF0 /* MXRealmMediaScanMapper.h in Headers */,
+				3A108A3B2580E9C2005EEBE9 /* MXKeyProvider.h in Headers */,
 				B14EF2F42397E90400758AF0 /* NSData+MatrixSDK.h in Headers */,
 				B14EF2F52397E90400758AF0 /* MXSDKOptions.h in Headers */,
 				B14EECD82577DE7A00448735 /* MXLoginSSOIdentityProvider.h in Headers */,
@@ -3834,6 +3881,7 @@
 				B14EF33F2397E90400758AF0 /* (null) in Headers */,
 				B14EF3402397E90400758AF0 /* MXKeyBackupVersionTrust.h in Headers */,
 				320B3935239FA56900BE2C06 /* MXKeyVerificationByDMRequest.h in Headers */,
+				3A108A9925810F62005EEBE9 /* MXAesKeyData.h in Headers */,
 				B14EF3412397E90400758AF0 /* MXOutgoingRoomKeyRequestManager.h in Headers */,
 				B14EF3422397E90400758AF0 /* MXPeekingRoomSummary.h in Headers */,
 				B14EF3432397E90400758AF0 /* MXEventTimeline.h in Headers */,
@@ -4257,6 +4305,7 @@
 				327137281A24D50A00DB6757 /* MXMyUser.m in Sources */,
 				C6F935881E5B3BE600FC34BF /* MX3PID.swift in Sources */,
 				B146D47821A5950800D8C2C6 /* MXMediaScan.m in Sources */,
+				3A108AA425810FE5005EEBE9 /* MXRawDataKey.m in Sources */,
 				C6F9358A1E5B3BE600FC34BF /* MXEvent.swift in Sources */,
 				B146D48021A59E2400D8C2C6 /* MXEventScan.m in Sources */,
 				329E808D224E2E1B00A48C3A /* MXOutgoingSASTransaction.m in Sources */,
@@ -4299,6 +4348,7 @@
 				32A31BC920D401FC005916C7 /* MXRoomFilter.m in Sources */,
 				32A151471DAF7C0C00400192 /* MXDeviceInfo.m in Sources */,
 				321CFDEB22525DEE004D31DF /* MXIncomingSASTransaction.m in Sources */,
+				3A108A8025810C96005EEBE9 /* MXKeyData.m in Sources */,
 				32A1515C1DB525DA00400192 /* NSObject+sortedKeys.m in Sources */,
 				32792BD52295A86600F4FC9D /* MXAggregatedReactionsUpdater.m in Sources */,
 				32618E7C20EFA45B00E1D2EA /* MXRoomMembers.m in Sources */,
@@ -4363,6 +4413,7 @@
 				B14EECD92577DE7A00448735 /* MXLoginSSOIdentityProvider.m in Sources */,
 				322691371E5EFF8700966A6E /* MXDeviceListOperationsPool.m in Sources */,
 				C6F935801E5B3ACA00FC34BF /* MXResponse.swift in Sources */,
+				3A108AB725812995005EEBE9 /* MXKeyProvider.m in Sources */,
 				32BA86B02152A79E008F277E /* MXRoomNameDefaultStringLocalizations.m in Sources */,
 				B19A30D624042F2700FB6F35 /* MXSelfVerifyingMasterKeyNotTrustedQRCodeData.m in Sources */,
 				32F9FA7E1DBA0CF0009D98A6 /* MXDecryptionResult.m in Sources */,
@@ -4388,6 +4439,7 @@
 				32999DE422DCD1AD004FF987 /* MXPusherData.m in Sources */,
 				322A51C81D9BBD3C00C8536D /* MXOlmDevice.m in Sources */,
 				32442FB221EDD21300D2411B /* MXKeyBackupPassword.m in Sources */,
+				3A108A9A25810F62005EEBE9 /* MXAesKeyData.m in Sources */,
 				329FB17A1A0A74B100A5E88E /* MXTools.m in Sources */,
 				329D3E631E251027002E2F1E /* MXRoomSummaryUpdater.m in Sources */,
 				B146D4D821A5A44E00D8C2C6 /* MXScanRealmInMemoryProvider.m in Sources */,
@@ -4527,6 +4579,7 @@
 				B14EF1F62397E90400758AF0 /* MXEventReplace.m in Sources */,
 				B14EF1F72397E90400758AF0 /* MXLoginTerms.m in Sources */,
 				B14EF1F82397E90400758AF0 /* MXReplyEventParts.m in Sources */,
+				3A108A8125810C96005EEBE9 /* MXKeyData.m in Sources */,
 				B14EF1F92397E90400758AF0 /* MXReactionRelation.m in Sources */,
 				B19A30BB2404268600FB6F35 /* MXQRCodeData.m in Sources */,
 				B14EF1FA2397E90400758AF0 /* MXQueuedEncryption.m in Sources */,
@@ -4683,6 +4736,7 @@
 				B14EF26C2397E90400758AF0 /* MXRoom.m in Sources */,
 				B14EF26D2397E90400758AF0 /* NSData+MatrixSDK.m in Sources */,
 				B14EF26E2397E90400758AF0 /* MXFileRoomStore.m in Sources */,
+				3A108AA525810FE5005EEBE9 /* MXRawDataKey.m in Sources */,
 				324DD29C246AD2B500377005 /* MXSecretStorage.m in Sources */,
 				B14EF26F2397E90400758AF0 /* MXUser.m in Sources */,
 				324AAC772399140D00380A66 /* MXKeyVerificationDone.m in Sources */,
@@ -4707,6 +4761,7 @@
 				B14EF27F2397E90400758AF0 /* MXRoomPredecessorInfo.m in Sources */,
 				B14EF2802397E90400758AF0 /* MXServiceTerms.m in Sources */,
 				B14EF2812397E90400758AF0 /* MXNotificationCenter.m in Sources */,
+				3A108AB825812995005EEBE9 /* MXKeyProvider.m in Sources */,
 				B14EF2822397E90400758AF0 /* MXDeviceList.m in Sources */,
 				320B3937239FA56900BE2C06 /* MXKeyVerificationByDMRequest.m in Sources */,
 				B14EF2832397E90400758AF0 /* MXRoomCreateContent.m in Sources */,
@@ -4723,6 +4778,7 @@
 				B14EF2882397E90400758AF0 /* MXOlmDevice.m in Sources */,
 				B14766BA23D9D9420091F721 /* MXUsersTrustLevelSummary.m in Sources */,
 				B14EF2892397E90400758AF0 /* MXKeyBackupPassword.m in Sources */,
+				3A108A9B25810F62005EEBE9 /* MXAesKeyData.m in Sources */,
 				B14EF28A2397E90400758AF0 /* MXTools.m in Sources */,
 				B14EF28B2397E90400758AF0 /* MXRoomSummaryUpdater.m in Sources */,
 				B14EF28C2397E90400758AF0 /* MXScanRealmInMemoryProvider.m in Sources */,

--- a/MatrixSDK/Crypto/KeyProvider/MXAesKeyData.h
+++ b/MatrixSDK/Crypto/KeyProvider/MXAesKeyData.h
@@ -1,0 +1,33 @@
+// 
+// Copyright 2020 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import <MatrixSDK/MatrixSDK.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MXAesKeyData : MXKeyData
+
+@property (nonatomic, readonly, nonnull) NSData *iv;
+
+@property (nonatomic, readonly, nonnull) NSData *key;
+
++ (instancetype) dataWithIv: (NSData *)iv key: (NSData *)key;
+
+- (instancetype) initWithIv: (NSData *)iv key: (NSData *)key;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixSDK/Crypto/KeyProvider/MXAesKeyData.h
+++ b/MatrixSDK/Crypto/KeyProvider/MXAesKeyData.h
@@ -18,14 +18,33 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/// Data class for AES keys
 @interface MXAesKeyData : MXKeyData
 
+/// Initialisation Vector data (can be generated using MXAes::iv)
 @property (nonatomic, readonly, nonnull) NSData *iv;
 
+/// Basically the AES Key
 @property (nonatomic, readonly, nonnull) NSData *key;
 
+/**
+ Convenience constructor
+ 
+ @param iv Initialisation Vector data (can be generated using MXAes::iv)
+ @param key the AES Key
+ 
+ @return a new instance of MXAesKeyData initialised with the given IV and key
+ */
 + (instancetype) dataWithIv: (NSData *)iv key: (NSData *)key;
 
+/**
+ default initialiser
+ 
+ @param iv Initialisation Vector data (can be generated using MXAes::iv)
+ @param key the AES Key
+ 
+ @return the instance of MXAesKeyData initialised with the given IV and key
+ */
 - (instancetype) initWithIv: (NSData *)iv key: (NSData *)key;
 
 @end

--- a/MatrixSDK/Crypto/KeyProvider/MXAesKeyData.m
+++ b/MatrixSDK/Crypto/KeyProvider/MXAesKeyData.m
@@ -1,0 +1,48 @@
+// 
+// Copyright 2020 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import "MXAesKeyData.h"
+
+@interface MXAesKeyData()
+
+@property (nonatomic, strong) NSData *iv;
+
+@property (nonatomic, strong) NSData *key;
+
+@end
+
+@implementation MXAesKeyData
+
++ (MXAesKeyData *) dataWithIv: (NSData *)iv key: (NSData *)key {
+    return [[MXAesKeyData alloc] initWithIv:iv key:key];
+}
+
+- (instancetype) initWithIv: (NSData *)iv key: (NSData *)key {
+    self = [super init];
+    
+    if (self) {
+        self.iv = iv;
+        self.key = key;
+    }
+    
+    return self;
+}
+
+- (MXKeyType)type {
+    return kAes;
+}
+
+@end

--- a/MatrixSDK/Crypto/KeyProvider/MXAesKeyData.m
+++ b/MatrixSDK/Crypto/KeyProvider/MXAesKeyData.m
@@ -26,14 +26,17 @@
 
 @implementation MXAesKeyData
 
-+ (MXAesKeyData *) dataWithIv: (NSData *)iv key: (NSData *)key {
++ (MXAesKeyData *) dataWithIv: (NSData *)iv key: (NSData *)key
+{
     return [[MXAesKeyData alloc] initWithIv:iv key:key];
 }
 
-- (instancetype) initWithIv: (NSData *)iv key: (NSData *)key {
+- (instancetype) initWithIv: (NSData *)iv key: (NSData *)key
+{
     self = [super init];
     
-    if (self) {
+    if (self)
+    {
         self.iv = iv;
         self.key = key;
     }
@@ -41,7 +44,8 @@
     return self;
 }
 
-- (MXKeyType)type {
+- (MXKeyType)type
+{
     return kAes;
 }
 

--- a/MatrixSDK/Crypto/KeyProvider/MXKeyData.h
+++ b/MatrixSDK/Crypto/KeyProvider/MXKeyData.h
@@ -16,15 +16,21 @@
 
 #import <Foundation/Foundation.h>
 
-typedef NS_ENUM(NSUInteger, MXKeyType) {
+/// Different type of Key Data
+typedef NS_ENUM(NSUInteger, MXKeyType)
+{
+    /// Key is based on a single raw data
     kRawData = 1,
+    /// AES Key based on an IV and a KEY
     kAes
 };
 
 NS_ASSUME_NONNULL_BEGIN
 
+/// Base class for Key Data returned by the MXKeyProviderDelegate.
 @interface MXKeyData : NSObject
 
+/// Type of the key
 @property (nonatomic, readonly) MXKeyType type;
 
 @end

--- a/MatrixSDK/Crypto/KeyProvider/MXKeyData.h
+++ b/MatrixSDK/Crypto/KeyProvider/MXKeyData.h
@@ -1,0 +1,32 @@
+// 
+// Copyright 2020 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+typedef NS_ENUM(NSUInteger, MXKeyType) {
+    kRawData = 1,
+    kAes
+};
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MXKeyData : NSObject
+
+@property (nonatomic, readonly) MXKeyType type;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixSDK/Crypto/KeyProvider/MXKeyData.m
+++ b/MatrixSDK/Crypto/KeyProvider/MXKeyData.m
@@ -1,0 +1,21 @@
+// 
+// Copyright 2020 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import "MXKeyData.h"
+
+@implementation MXKeyData
+
+@end

--- a/MatrixSDK/Crypto/KeyProvider/MXKeyProvider.h
+++ b/MatrixSDK/Crypto/KeyProvider/MXKeyProvider.h
@@ -19,6 +19,8 @@
 #ifndef KeyProvider_h
 #define KeyProvider_h
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// This delegate will be in charged to effectively give the encryption keys configured in the application
 @protocol MXKeyProviderDelegate <NSObject>
 
@@ -29,7 +31,7 @@
  
  @return YES if encryption should be enabled. No otherwise
  */
-- (BOOL)isEncryptionAvailableForDataOfType:(nonnull NSString *)dataType;
+- (BOOL)isEncryptionAvailableForDataOfType:(NSString *)dataType;
 
 /**
  check if the delegate is ready to give the ecryption keys
@@ -38,7 +40,7 @@
 
  @return YES a encryption key is ready. NO otherwise
  */
-- (BOOL)hasKeyForDataOfType:(nonnull NSString *)dataType;
+- (BOOL)hasKeyForDataOfType:(NSString *)dataType;
 
 /**
  return the key data for a dedicated type of data
@@ -47,7 +49,7 @@
 
  @return the encryption data if ready. Nil otherwise
  */
-- (nullable MXKeyData *)keyDataForDataOfType:(nonnull NSString *)dataType;
+- (nullable MXKeyData *)keyDataForDataOfType:(NSString *)dataType;
 
 @end
 
@@ -61,7 +63,7 @@
 @interface MXKeyProvider : NSObject
 
 /// Shared instance of the provider
-+ (nonnull instancetype)sharedInstance;
++ (instancetype)sharedInstance;
 
 /// Set the delegate if you want to enable encryption and provide encryption keys
 @property (nonatomic, strong, nullable) id<MXKeyProviderDelegate> delegate;
@@ -87,7 +89,7 @@
  
  @throw exception if data is mandatory and the delegate is not ready or if the type of the key is not valid
  */
-- (nullable MXKeyData *)requestKeyForDataOfType:(nonnull NSString *)dataType
+- (nullable MXKeyData *)requestKeyForDataOfType:(NSString *)dataType
                                     isMandatory:(BOOL)isMandatory
                                 expectedKeyType:(MXKeyType)keyType;
 
@@ -98,7 +100,7 @@
  
  @return YES if encryption should be enabled. No otherwise
  */
-- (BOOL)isEncryptionAvailableForDataOfType:(nonnull NSString *)dataType;
+- (BOOL)isEncryptionAvailableForDataOfType:(NSString *)dataType;
 
 /**
  check if the delegate is ready to give the ecryption keys
@@ -110,7 +112,7 @@
  
  @throw exception if data is mandatory and the delegate is not ready
  */
-- (BOOL)hasKeyForDataOfType:(nonnull NSString *)dataType
+- (BOOL)hasKeyForDataOfType:(NSString *)dataType
                 isMandatory:(BOOL)isMandatory;
 
 /**
@@ -124,10 +126,12 @@
  
  @throw exception if data is mandatory and the delegate is not ready or if the type of the key is not valid
   */
-- (nonnull MXKeyData *)keyDataForDataOfType:(nonnull NSString *)dataType
-                                isMandatory:(BOOL)isMandatory
-                            expectedKeyType:(MXKeyType)keyType;
+- (MXKeyData *)keyDataForDataOfType:(NSString *)dataType
+                        isMandatory:(BOOL)isMandatory
+                    expectedKeyType:(MXKeyType)keyType;
 
 @end
+
+NS_ASSUME_NONNULL_END
 
 #endif /* KeyProvider_h */

--- a/MatrixSDK/Crypto/KeyProvider/MXKeyProvider.h
+++ b/MatrixSDK/Crypto/KeyProvider/MXKeyProvider.h
@@ -19,36 +19,114 @@
 #ifndef KeyProvider_h
 #define KeyProvider_h
 
-typedef NS_ENUM(NSUInteger, MXDataType) {
-    kContactsType = 1,
-    kAccountType
-};
-
+/// This delegate will be in charged to effectively give the encryption keys configured in the application
 @protocol MXKeyProviderDelegate <NSObject>
 
-/// check if data of specific type can be encrypted
-- (BOOL)enableEncryptionForDataOfType:(MXDataType)dataType;
+/**
+ check if data of specific type can be encrypted
+ 
+ @param dataType type of the data to be encrypted
+ 
+ @return YES if encryption should be enabled. No otherwise
+ */
+- (BOOL)isEncryptionAvailableForDataOfType:(nonnull NSString *)dataType;
 
-/// check if the delegate is ready to give the ecryption keys
-- (BOOL)hasKeyForDataOfType:(MXDataType)dataType;
+/**
+ check if the delegate is ready to give the ecryption keys
+ 
+ @param dataType type of the data to be encrypted
 
-- (nullable MXKeyData *)keyDataForDataOfType:(MXDataType)dataType;
+ @return YES a encryption key is ready. NO otherwise
+ */
+- (BOOL)hasKeyForDataOfType:(nonnull NSString *)dataType;
+
+/**
+ return the key data for a dedicated type of data
+ 
+ @param dataType type of the data to be encrypted
+
+ @return the encryption data if ready. Nil otherwise
+ */
+- (nullable MXKeyData *)keyDataForDataOfType:(nonnull NSString *)dataType;
 
 @end
 
+/**
+ Provider of all keys needed by a client of the SDK
+ 
+ This class is used by the Matrix SDK and the Matrix Kit to retrieve encryption keyx initialised by the client application.
+ The encryption becomes effective by setting the delegate of the MXKeyProvider::sharedInstance. The delegate will
+ be in charge to enable / disable encryption and provide the requested keys accordingly.
+ */
 @interface MXKeyProvider : NSObject
 
+/// Shared instance of the provider
 + (nonnull instancetype)sharedInstance;
 
+/// Set the delegate if you want to enable encryption and provide encryption keys
 @property (nonatomic, strong, nullable) id<MXKeyProviderDelegate> delegate;
 
-- (nullable MXKeyData *)requestKeyForDataOfType:(MXDataType)dataType;
+/**
+ @brief return a key if encryption is needed and key is available.
+ 
+ basically:
+ @code
+     if ([self isEncryptionAvailableForDataOfType:dataType] && [self hasKeyForDataOfType:dataType isMandatory:isMandatory]) {
+         return [self keyDataForDataOfType:dataType isMandatory:isMandatory expectedKeyType:keyType];
+     }
+     return nil;
+ @endcode
+ 
+ @param dataType user defined type of the data to be encrypted
+ @param isMandatory set it to YES if you want excpetion to be raised if the key is not available with delegate set and encryption available.
+ @param expectedKeyType expected type of the key. Exception if types don't match.
+ 
+ @see isEncryptionAvailableForDataOfType:
+ 
+ @return the encryption data if needed and ready. Nil otherwise
+ 
+ @throw exception if data is mandatory and the delegate is not ready or if the type of the key is not valid
+ */
+- (nullable MXKeyData *)requestKeyForDataOfType:(nonnull NSString *)dataType
+                                    isMandatory:(BOOL)isMandatory
+                                expectedKeyType:(MXKeyType)keyType;
 
-- (BOOL)isEncryptionAvailableForDataOfType:(MXDataType)dataType;
+/**
+ check if data of specific type can be encrypted
+ 
+ @param dataType type of the data to be encrypted
+ 
+ @return YES if encryption should be enabled. No otherwise
+ */
+- (BOOL)isEncryptionAvailableForDataOfType:(nonnull NSString *)dataType;
 
-- (BOOL)hasKeyForDataOfType:(MXDataType)dataType;
+/**
+ check if the delegate is ready to give the ecryption keys
+ 
+ @param dataType type of the data to be encrypted
+ @param isMandatory set it to YES if you want excpetion to be raised if the key is not available with delegate set and encryption available.
 
-- (nonnull MXKeyData *)keyDataForDataOfType:(MXDataType)dataType;
+ @return YES a encryption key is ready. NO otherwise
+ 
+ @throw exception if data is mandatory and the delegate is not ready
+ */
+- (BOOL)hasKeyForDataOfType:(nonnull NSString *)dataType
+                isMandatory:(BOOL)isMandatory;
+
+/**
+ return the key data for a dedicated type of data
+ 
+ @param dataType type of the data to be encrypted
+ @param isMandatory set it to YES if you want excpetion to be raised if the key is not available with delegate set and encryption available.
+ @param expectedKeyType expected type of the key. Exception if types don't match.
+
+ @return the encryption data if ready. Nil otherwise
+ 
+ @throw exception if data is mandatory and the delegate is not ready or if the type of the key is not valid
+  */
+- (nonnull MXKeyData *)keyDataForDataOfType:(nonnull NSString *)dataType
+                                isMandatory:(BOOL)isMandatory
+                            expectedKeyType:(MXKeyType)keyType;
 
 @end
 

--- a/MatrixSDK/Crypto/KeyProvider/MXKeyProvider.h
+++ b/MatrixSDK/Crypto/KeyProvider/MXKeyProvider.h
@@ -1,0 +1,55 @@
+// 
+// Copyright 2020 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import "MXKeyData.h"
+
+#ifndef KeyProvider_h
+#define KeyProvider_h
+
+typedef NS_ENUM(NSUInteger, MXDataType) {
+    kContactsType = 1,
+    kAccountType
+};
+
+@protocol MXKeyProviderDelegate <NSObject>
+
+/// check if data of specific type can be encrypted
+- (BOOL)enableEncryptionForDataOfType:(MXDataType)dataType;
+
+/// check if the delegate is ready to give the ecryption keys
+- (BOOL)hasKeyForDataOfType:(MXDataType)dataType;
+
+- (nullable MXKeyData *)keyDataForDataOfType:(MXDataType)dataType;
+
+@end
+
+@interface MXKeyProvider : NSObject
+
++ (nonnull instancetype)sharedInstance;
+
+@property (nonatomic, strong, nullable) id<MXKeyProviderDelegate> delegate;
+
+- (nullable MXKeyData *)requestKeyForDataOfType:(MXDataType)dataType;
+
+- (BOOL)isEncryptionAvailableForDataOfType:(MXDataType)dataType;
+
+- (BOOL)hasKeyForDataOfType:(MXDataType)dataType;
+
+- (nonnull MXKeyData *)keyDataForDataOfType:(MXDataType)dataType;
+
+@end
+
+#endif /* KeyProvider_h */

--- a/MatrixSDK/Crypto/KeyProvider/MXKeyProvider.m
+++ b/MatrixSDK/Crypto/KeyProvider/MXKeyProvider.m
@@ -1,0 +1,135 @@
+// 
+// Copyright 2020 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import "MXKeyProvider.h"
+
+static MXKeyProvider *sharedInstance = nil;
+static NSDictionary* configurationsForDataType = nil;
+
+@interface MXKeyConfig: NSObject
+
++ (instancetype) configWithMandatory: (BOOL)isMandatory keyType: (MXKeyType)keyType;
+
+- (instancetype) initWithMandatory: (BOOL)isMandatory keyType: (MXKeyType)keyType;
+
+@property (nonatomic) BOOL isMandatory;
+
+@property (nonatomic) MXKeyType keyType;
+
+@end
+
+
+@implementation MXKeyProvider
+
++ (instancetype)sharedInstance
+{
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sharedInstance = [[self alloc] init];
+        
+        configurationsForDataType =
+        @{
+            @(kContactsType) : [MXKeyConfig configWithMandatory:NO keyType:kAes],
+            @(kAccountType) : [MXKeyConfig configWithMandatory:YES keyType:kAes],
+        };
+        
+    });
+    return sharedInstance;
+}
+
+- (nullable MXKeyData *)requestKeyForDataOfType:(MXDataType)dataType {
+    if ([self isEncryptionAvailableForDataOfType:dataType]
+        && [self hasKeyForDataOfType:dataType])
+    {
+        return [self keyDataForDataOfType:dataType];
+    }
+    
+    return nil;
+}
+
+- (BOOL)isEncryptionAvailableForDataOfType:(MXDataType)dataType
+{
+    return self.delegate && [self.delegate enableEncryptionForDataOfType:dataType];
+}
+
+- (BOOL)hasKeyForDataOfType:(MXDataType)dataType
+{
+    BOOL keyAvailable = [self.delegate hasKeyForDataOfType:dataType];
+    
+    MXKeyConfig *config = [self configForDataOfType:dataType];
+    
+    if (!keyAvailable && config.isMandatory)
+    {
+        [NSException raise:@"MandatoryKey" format:@"Mandatory Key not available for data of type %lu", dataType];
+    }
+    
+    return keyAvailable;
+}
+
+- (nonnull MXKeyData *)keyDataForDataOfType:(MXDataType)dataType
+{
+    MXKeyData *keyData = [self.delegate keyDataForDataOfType:dataType];
+    MXKeyConfig *config = [configurationsForDataType objectForKey:@(dataType)];
+    
+    if (!keyData && config.isMandatory)
+    {
+        [NSException raise:@"MandatoryKey" format:@"No key value for mandatory Key (date type : %lu)", dataType];
+    }
+
+    if (keyData.type != config.keyType)
+    {
+        [NSException raise:@"KeyType" format:@"Wrong key type (%lu expected %lu) for data of type : %lu", keyData.type, config.keyType, dataType];
+    }
+
+    return keyData;
+}
+
+#pragma mark private methods
+
+- (MXKeyConfig *) configForDataOfType:(MXDataType)dataType
+{
+    MXKeyConfig *config = [configurationsForDataType objectForKey:@(dataType)];
+    
+    if (!config)
+    {
+        [NSException raise:@"MissingConfigurationForDataType" format:@"Missing configuration for data of type %lu", dataType];
+    }
+    
+    return config;
+}
+
+@end
+
+@implementation MXKeyConfig
+
++ (instancetype)configWithMandatory:(BOOL)isMandatory keyType: (MXKeyType)keyType
+{
+    return [[MXKeyConfig alloc] initWithMandatory:isMandatory keyType:keyType];
+}
+
+- (instancetype)initWithMandatory:(BOOL)isMandatory keyType: (MXKeyType)keyType
+{
+    self = [super init];
+    
+    if (self) {
+        self.isMandatory = isMandatory;
+        self.keyType = keyType;
+    }
+    
+    return self;
+}
+
+@end

--- a/MatrixSDK/Crypto/KeyProvider/MXRawDataKey.h
+++ b/MatrixSDK/Crypto/KeyProvider/MXRawDataKey.h
@@ -18,12 +18,28 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/// Data class for basic raw data keys
 @interface MXRawDataKey : MXKeyData
 
+/// Basicaly the key
 @property (nonatomic, readonly, nonnull) NSData *key;
 
+/**
+ Convenience constructor
+ 
+ @param key the raw data Key
+ 
+ @return a new instance of MXRawDataKey initialised with the given key
+ */
 + (instancetype) dataWithKey: (NSData *)key;
 
+/**
+ Default initialiser
+ 
+ @param key the raw data Key
+ 
+ @return the instance of MXRawDataKey initialised with the given key
+ */
 - (instancetype) initWithKey: (NSData *)key;
 
 @end

--- a/MatrixSDK/Crypto/KeyProvider/MXRawDataKey.h
+++ b/MatrixSDK/Crypto/KeyProvider/MXRawDataKey.h
@@ -1,0 +1,31 @@
+// 
+// Copyright 2020 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import <MatrixSDK/MatrixSDK.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MXRawDataKey : MXKeyData
+
+@property (nonatomic, readonly, nonnull) NSData *key;
+
++ (instancetype) dataWithKey: (NSData *)key;
+
+- (instancetype) initWithKey: (NSData *)key;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixSDK/Crypto/KeyProvider/MXRawDataKey.m
+++ b/MatrixSDK/Crypto/KeyProvider/MXRawDataKey.m
@@ -24,11 +24,13 @@
 
 @implementation MXRawDataKey
 
-+ (MXRawDataKey *) dataWithKey: (NSData *)key {
++ (MXRawDataKey *) dataWithKey: (NSData *)key
+{
     return [[MXRawDataKey alloc] initWithKey: key];
 }
 
-- (instancetype) initWithKey: (NSData *)key {
+- (instancetype) initWithKey: (NSData *)key
+{
     self = [super init];
     
     if (self)
@@ -39,7 +41,8 @@
     return self;
 }
 
-- (MXKeyType)type {
+- (MXKeyType)type
+{
     return kRawData;
 }
 

--- a/MatrixSDK/Crypto/KeyProvider/MXRawDataKey.m
+++ b/MatrixSDK/Crypto/KeyProvider/MXRawDataKey.m
@@ -1,0 +1,46 @@
+// 
+// Copyright 2020 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import "MXRawDataKey.h"
+
+@interface MXRawDataKey()
+
+@property (nonatomic, strong) NSData *key;
+
+@end
+
+@implementation MXRawDataKey
+
++ (MXRawDataKey *) dataWithKey: (NSData *)key {
+    return [[MXRawDataKey alloc] initWithKey: key];
+}
+
+- (instancetype) initWithKey: (NSData *)key {
+    self = [super init];
+    
+    if (self)
+    {
+        self.key = key;
+    }
+    
+    return self;
+}
+
+- (MXKeyType)type {
+    return kRawData;
+}
+
+@end

--- a/MatrixSDK/MatrixSDK.h
+++ b/MatrixSDK/MatrixSDK.h
@@ -102,3 +102,7 @@ FOUNDATION_EXPORT NSString *MatrixSDKVersion;
 #import "MXMediaScan.h"
 
 #import "MXLoginSSOFlow.h"
+
+#import "MXKeyProvider.h"
+#import "MXAesKeyData.h"
+#import "MXRawDataKey.h"

--- a/MatrixSDKTests/MXKeyProviderTests.m
+++ b/MatrixSDKTests/MXKeyProviderTests.m
@@ -1,0 +1,125 @@
+// 
+// Copyright 2020 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import <XCTest/XCTest.h>
+#import "MXKeyProvider.h"
+#import "MXAesKeyData.h"
+#import "MXRawDataKey.h"
+
+@interface MXKeyProviderTests : XCTestCase <MXKeyProviderDelegate>
+
+@property (nonatomic) BOOL isEncryptionAvailable;
+@property (nonatomic, strong, nullable) MXKeyData *currentKey;
+
+@end
+
+@implementation MXKeyProviderTests
+
+- (void)setUp {
+    self.isEncryptionAvailable = YES;
+    NSData *iv = [@"baB6pgMP9erqSaKF" dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *aesKey = [@"6fXK17pQFUrFqOnxt3wrqz8RHkQUT9vQ" dataUsingEncoding:NSUTF8StringEncoding];
+    self.currentKey = [MXAesKeyData dataWithIv:iv key:aesKey];
+    [MXKeyProvider sharedInstance].delegate = self;
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+}
+
+- (void)testNoDelegateSet {
+    [MXKeyProvider sharedInstance].delegate = nil;
+    
+    @try {
+        MXKeyData *key = [[MXKeyProvider sharedInstance] requestKeyForDataOfType:@"MXKeyProviderTests" isMandatory:YES expectedKeyType:kAes];
+        XCTAssertNil(key);
+        
+        key = [[MXKeyProvider sharedInstance] requestKeyForDataOfType:@"MXKeyProviderTests" isMandatory:NO expectedKeyType:kAes];
+        XCTAssertNil(key);
+        
+        key = [[MXKeyProvider sharedInstance] requestKeyForDataOfType:@"MXKeyProviderTests" isMandatory:YES expectedKeyType:kRawData];
+        XCTAssertNil(key);
+    } @catch (NSException *exception) {
+        XCTFail(@"Unexpected exception raised: %@", exception);
+    }
+}
+
+- (void)testEncryptionNotAvailable {
+    self.isEncryptionAvailable = NO;
+    
+    @try {
+        MXKeyData *key = [[MXKeyProvider sharedInstance] requestKeyForDataOfType:@"MXKeyProviderTests" isMandatory:YES expectedKeyType:kAes];
+        XCTAssertNil(key);
+        
+        key = [[MXKeyProvider sharedInstance] requestKeyForDataOfType:@"MXKeyProviderTests" isMandatory:NO expectedKeyType:kAes];
+        XCTAssertNil(key);
+        
+        key = [[MXKeyProvider sharedInstance] requestKeyForDataOfType:@"MXKeyProviderTests" isMandatory:YES expectedKeyType:kRawData];
+        XCTAssertNil(key);
+    } @catch (NSException *exception) {
+        XCTFail(@"Unexpected exception raised: %@", exception);
+    }
+}
+
+- (void)testAllSet {
+    @try {
+        MXKeyData *key = [[MXKeyProvider sharedInstance] requestKeyForDataOfType:@"MXKeyProviderTests" isMandatory:YES expectedKeyType:kAes];
+        XCTAssert(key == self.currentKey);
+    } @catch (NSException *exception) {
+        XCTFail(@"Unexpected exception raised: %@", exception);
+    }
+}
+
+- (void)testKeyNotAvailable {
+    self.currentKey = nil;
+    
+    @try {
+        MXKeyData *key = [[MXKeyProvider sharedInstance] requestKeyForDataOfType:@"MXKeyProviderTests" isMandatory:NO expectedKeyType:kAes];
+        XCTAssertNil(key);
+    } @catch (NSException *exception) {
+        XCTFail(@"Unexpected exception raised (key not mandatory): %@", exception);
+    }
+    
+    @try {
+        [[MXKeyProvider sharedInstance] requestKeyForDataOfType:@"MXKeyProviderTests" isMandatory:YES expectedKeyType:kAes];
+        XCTFail(@"Exception should be raised as the key is mandatory but not set yet.");
+    } @catch (NSException *exception) {
+    }
+}
+
+- (void)testInvalidKeyType {
+    @try {
+        [[MXKeyProvider sharedInstance] requestKeyForDataOfType:@"MXKeyProviderTests" isMandatory:NO expectedKeyType:kRawData];
+        XCTFail(@"Exception should be raised as the key type does not match.");
+    } @catch (NSException *exception) {
+    }
+}
+
+#pragma mark - MXKeyProviderDelegate
+
+- (BOOL)isEncryptionAvailableForDataOfType:(nonnull NSString *)dataType {
+    return self.isEncryptionAvailable;
+}
+
+- (BOOL)hasKeyForDataOfType:(nonnull NSString *)dataType {
+    return self.currentKey != nil;
+}
+
+- (nullable MXKeyData *)keyDataForDataOfType:(nonnull NSString *)dataType {
+    return self.currentKey;
+}
+
+@end


### PR DESCRIPTION
part of the fix for https://github.com/vector-im/element-ios/issues/3866