### PR TITLE
MXRestClient: Fix uploadKeys method that was using the /keys/upload/ in a bad way

### DIFF
--- a/MatrixSDK/Contrib/Swift/MXRestClient.swift
+++ b/MatrixSDK/Contrib/Swift/MXRestClient.swift
@@ -1727,14 +1727,13 @@ public extension MXRestClient {
      - parameters:
         - deviceKeys: the device keys to send.
         - oneTimeKeys: the one-time keys to send.
-        - deviceId: the explicit device_id to use for upload (pass `nil` to use the same as that used during auth).
         - completion: A block object called when the operation completes.
         - response: Provides information about the keys on success.
      
      - returns: a `MXHTTPOperation` instance.
      */
     @nonobjc @discardableResult func uploadKeys(_ deviceKeys: [String: Any], oneTimeKeys: [String: Any], forDevice deviceId: String? = nil, completion: @escaping (_ response: MXResponse<MXKeysUploadResponse>) -> Void) -> MXHTTPOperation {
-        return __uploadKeys(deviceKeys, oneTimeKeys: oneTimeKeys, forDevice: deviceId, success: currySuccess(completion), failure: curryFailure(completion))
+        return __uploadKeys(deviceKeys, oneTimeKeys: oneTimeKeys, success: currySuccess(completion), failure: curryFailure(completion))
     }
     
     /**

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -2638,7 +2638,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 
     // For now, we set the device id explicitly, as we may not be using the
     // same one as used in login.
-    return [_matrixRestClient uploadKeys:_myDevice.JSONDictionary oneTimeKeys:nil forDevice:_myDevice.deviceId success:success failure:failure];
+    return [_matrixRestClient uploadKeys:_myDevice.JSONDictionary oneTimeKeys:nil success:success failure:failure];
 }
 
 /**
@@ -2883,7 +2883,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     // For now, we set the device id explicitly, as we may not be using the
     // same one as used in login.
     MXWeakify(self);
-    return [_matrixRestClient uploadKeys:nil oneTimeKeys:oneTimeJson forDevice:_myDevice.deviceId success:^(MXKeysUploadResponse *keysUploadResponse) {
+    return [_matrixRestClient uploadKeys:nil oneTimeKeys:oneTimeJson success:^(MXKeysUploadResponse *keysUploadResponse) {
         MXStrongifyAndReturnIfNil(self);
 
         [self.olmDevice markOneTimeKeysAsPublished];
@@ -2898,7 +2898,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 // Ask the server how many keys we have
 - (MXHTTPOperation *)publishedOneTimeKeysCount:(void (^)(NSUInteger publishedKeyCount))success failure:(void (^)(NSError *))failure
 {
-    return [_matrixRestClient uploadKeys:_myDevice.JSONDictionary oneTimeKeys:nil forDevice:_myDevice.deviceId success:^(MXKeysUploadResponse *keysUploadResponse) {
+    return [_matrixRestClient uploadKeys:_myDevice.JSONDictionary oneTimeKeys:nil success:^(MXKeysUploadResponse *keysUploadResponse) {
         
         NSUInteger publishedkeyCount = [keysUploadResponse oneTimeKeyCountsForAlgorithm:@"signed_curve25519"];
         

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -2088,8 +2088,6 @@ typedef MXHTTPOperation* (^MXRestClientIdentityServerAccessTokenHandler)(void (^
 
  @param deviceKeys the device keys to send.
  @param oneTimeKeys the one-time keys to send.
- @param deviceId the explicit device_id to use for upload
-        (default is to use the same as that used during auth).
 
  @param success A block object called when the operation succeeds.
  @param failure A block object called when the operation fails.
@@ -2097,7 +2095,6 @@ typedef MXHTTPOperation* (^MXRestClientIdentityServerAccessTokenHandler)(void (^
  @return a MXHTTPOperation instance.
  */
 - (MXHTTPOperation*)uploadKeys:(NSDictionary*)deviceKeys oneTimeKeys:(NSDictionary*)oneTimeKeys
-                     forDevice:(NSString*)deviceId
                        success:(void (^)(MXKeysUploadResponse *keysUploadResponse))success
                        failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -3946,17 +3946,10 @@ MXAuthAction;
 
 #pragma mark - Crypto
 - (MXHTTPOperation*)uploadKeys:(NSDictionary*)deviceKeys oneTimeKeys:(NSDictionary*)oneTimeKeys
-                     forDevice:(NSString*)deviceId
                        success:(void (^)(MXKeysUploadResponse *keysUploadResponse))success
                        failure:(void (^)(NSError *error))failure
 {
     NSString *path = [NSString stringWithFormat:@"%@/keys/upload", kMXAPIPrefixPathR0];
-    if (deviceId)
-    {
-        path = [NSString stringWithFormat:@"%@/%@",
-                path,
-                [MXTools encodeURIComponent:deviceId]];
-    }
 
     NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
     if (deviceKeys)

--- a/MatrixSDKTests/MXRestClientTests.m
+++ b/MatrixSDKTests/MXRestClientTests.m
@@ -1577,7 +1577,7 @@
                               };
 
         // Upload the device keys
-        [bobRestClient uploadKeys:nil oneTimeKeys:otks forDevice:@"dev1" success:^(MXKeysUploadResponse *keysUploadResponse) {
+        [bobRestClient uploadKeys:nil oneTimeKeys:otks success:^(MXKeysUploadResponse *keysUploadResponse) {
 
             XCTAssert(keysUploadResponse.oneTimeKeyCounts);
             XCTAssertEqual(keysUploadResponse.oneTimeKeyCounts.count, 1, @"There is no yet one-time keys");
@@ -1618,18 +1618,18 @@
                                };
 
         // Upload the device keys
-        [bobRestClient uploadKeys:nil oneTimeKeys:otks forDevice:@"dev1" success:^(MXKeysUploadResponse *keysUploadResponse) {
+        [bobRestClient uploadKeys:nil oneTimeKeys:otks success:^(MXKeysUploadResponse *keysUploadResponse) {
 
             [matrixSDKTestsData doMXRestClientTestWithAlice:nil readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation2) {
 
                 MXUsersDevicesMap<NSString *> *usersDevicesKeyTypesMap = [[MXUsersDevicesMap alloc] init];
-                [usersDevicesKeyTypesMap setObject:@"curve25519" forUser:bobRestClient.credentials.userId andDevice:@"dev1"];
+                [usersDevicesKeyTypesMap setObject:@"curve25519" forUser:bobRestClient.credentials.userId andDevice:bobRestClient.credentials.deviceId];
 
                 [aliceRestClient claimOneTimeKeysForUsersDevices:usersDevicesKeyTypesMap success:^(MXKeysClaimResponse *keysClaimResponse) {
 
                     XCTAssertEqual(keysClaimResponse.oneTimeKeys.map.count, 1);
 
-                    MXKey *bobOtk = [keysClaimResponse.oneTimeKeys objectForDevice:@"dev1" forUser:bobRestClient.credentials.userId];
+                    MXKey *bobOtk = [keysClaimResponse.oneTimeKeys objectForDevice:bobRestClient.credentials.deviceId forUser:bobRestClient.credentials.userId];
                     XCTAssert(bobOtk);
 
                     // Test MXKey


### PR DESCRIPTION
Fix vector-im/element-ios/issues/3737

The CS API does not take a deviceId parameter.

Tests are still happy:
![image](https://user-images.githubusercontent.com/8418515/101923019-26ca6700-3bcf-11eb-8e20-53009bf9aa2c.png)
