### PR TITLE
MXRoomSummary: Fix crash when lastMessageData cannot be decrypted

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Changes to be released in next version
 
 🐛 Bugfix
  * MXRestClient: Fix the format of the request body when querying device keys for users (vector-im/element-ios#3539).
+ * MXRoomSummary: Fix crash when decoding lastMessageData (vector-im/element-ios/issues/3879).
 
 ⚠️ API Changes
  *

--- a/MatrixSDK/Data/MXRoomSummary.m
+++ b/MatrixSDK/Data/MXRoomSummary.m
@@ -844,7 +844,12 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
         {
             NSData *lastMessageEncryptedData = [aDecoder decodeObjectForKey:@"lastMessageEncryptedData"];
             NSData *lastMessageDataData = [self decrypt:lastMessageEncryptedData];
-            lastMessageData = [NSKeyedUnarchiver unarchiveObjectWithData:lastMessageDataData];
+            
+            //  Sanity check. If `decrypt` fails, returns nil and causes NSKeyedUnarchiver raise an exception.
+            if (lastMessageDataData)
+            {
+                lastMessageData = [NSKeyedUnarchiver unarchiveObjectWithData:lastMessageDataData];
+            }
         }
         else
         {


### PR DESCRIPTION
Fix https://github.com/vector-im/element-ios/issues/3879