### PR TITLE
MXLoginSSOFlow: Use unstable identity providers field while the MSC2858 is not approved

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,7 @@ Changes to be released in next version
  * 
 
 ⚠️ API Changes
- * 
+ * MXLoginSSOFlow: Use unstable identity providers field while the MSC2858 is not approved.
 
 🗣 Translations
  * 

--- a/MatrixSDK/JSONModels/Login/MXLoginSSOFlow.h
+++ b/MatrixSDK/JSONModels/Login/MXLoginSSOFlow.h
@@ -21,6 +21,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 extern NSString *const MXLoginSSOFlowIdentityProvidersKey;
+extern NSString *const MXLoginSSOFlowMSC2858IdentityProvidersKey; // Unstable key to use MSC2858 is not finalized.
 
 /**
  `MXLoginSSOFlow` represents a SSO login or a register flow supported by the home server (See MSC2858 https://github.com/matrix-org/matrix-doc/pull/2858).

--- a/MatrixSDK/JSONModels/Login/MXLoginSSOFlow.m
+++ b/MatrixSDK/JSONModels/Login/MXLoginSSOFlow.m
@@ -16,7 +16,8 @@
 
 #import "MXLoginSSOFlow.h"
 
-NSString *const MXLoginSSOFlowIdentityProvidersKey = @"org.matrix.msc2858.identity_providers";
+NSString *const MXLoginSSOFlowIdentityProvidersKey = @"identity_providers";
+NSString *const MXLoginSSOFlowMSC2858IdentityProvidersKey = @"org.matrix.msc2858.identity_providers";
 
 @interface MXLoginSSOFlow()
 
@@ -34,7 +35,8 @@ NSString *const MXLoginSSOFlowIdentityProvidersKey = @"org.matrix.msc2858.identi
     {
         NSArray *jsonIdentityProdivers;
         
-        MXJSONModelSetArray(jsonIdentityProdivers, JSONDictionary[MXLoginSSOFlowIdentityProvidersKey]);
+        // Use unstable MSC2858 field while MSC is not finalized
+        MXJSONModelSetArray(jsonIdentityProdivers, JSONDictionary[MXLoginSSOFlowMSC2858IdentityProvidersKey]);
         
         NSArray<MXLoginSSOIdentityProvider*> *identityProviders;
         

--- a/MatrixSDK/JSONModels/Login/MXLoginSSOFlow.m
+++ b/MatrixSDK/JSONModels/Login/MXLoginSSOFlow.m
@@ -16,7 +16,7 @@
 
 #import "MXLoginSSOFlow.h"
 
-NSString *const MXLoginSSOFlowIdentityProvidersKey = @"identity_providers";
+NSString *const MXLoginSSOFlowIdentityProvidersKey = @"org.matrix.msc2858.identity_providers";
 
 @interface MXLoginSSOFlow()
 

--- a/MatrixSDKTests/MXAuthenticationSessionTests.swift
+++ b/MatrixSDKTests/MXAuthenticationSessionTests.swift
@@ -39,7 +39,7 @@ class MXAuthenticationSessionTests: XCTestCase {
                 ],
                 ["type": "m.login.sso",
                  "stages": [],
-                 MXLoginSSOFlowIdentityProvidersKey: [
+                 MXLoginSSOFlowMSC2858IdentityProvidersKey: [
                     ["id": "gitlab",
                      "name": "GitLab"
                     ],

--- a/MatrixSDKTests/MXAuthenticationSessionTests.swift
+++ b/MatrixSDKTests/MXAuthenticationSessionTests.swift
@@ -39,7 +39,7 @@ class MXAuthenticationSessionTests: XCTestCase {
                 ],
                 ["type": "m.login.sso",
                  "stages": [],
-                 "identity_providers": [
+                 MXLoginSSOFlowIdentityProvidersKey: [
                     ["id": "gitlab",
                      "name": "GitLab"
                     ],


### PR DESCRIPTION
See https://github.com/matrix-org/matrix-doc/pull/2858/#discussion_r543567196 for more details.