### PR TITLE
MXBackgroundSyncService: Fix app deadlock 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Changes to be released in next version
 
 🐛 Bugfix
  * MXBackgroundSyncService: Fix `m.buddy` to-device event crashes (vector-im/element-ios/issues/3889).
+ * MXBackgroundSyncService: Fix app deadlock created between the app process and the notification service extension process (vector-im/element-ios/issues/3906).
 
 ⚠️ API Changes
  * MXLoginSSOFlow: Use unstable identity providers field while the MSC2858 is not approved.

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -89,6 +89,10 @@
 		322691361E5EFF8700966A6E /* MXDeviceListOperationsPool.h in Headers */ = {isa = PBXBuildFile; fileRef = 322691341E5EFF8700966A6E /* MXDeviceListOperationsPool.h */; };
 		322691371E5EFF8700966A6E /* MXDeviceListOperationsPool.m in Sources */ = {isa = PBXBuildFile; fileRef = 322691351E5EFF8700966A6E /* MXDeviceListOperationsPool.m */; };
 		3226DC3819DEED3B00866530 /* MatrixSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 32C6F92D19DD814400EA4E9C /* MatrixSDK.framework */; };
+		3229535125A5F7220012FCF0 /* MXBackgroundCryptoStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 3229534F25A5F7220012FCF0 /* MXBackgroundCryptoStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3229535225A5F7220012FCF0 /* MXBackgroundCryptoStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 3229534F25A5F7220012FCF0 /* MXBackgroundCryptoStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3229535325A5F7220012FCF0 /* MXBackgroundCryptoStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 3229535025A5F7220012FCF0 /* MXBackgroundCryptoStore.m */; };
+		3229535425A5F7220012FCF0 /* MXBackgroundCryptoStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 3229535025A5F7220012FCF0 /* MXBackgroundCryptoStore.m */; };
 		322A51B61D9AB15900C8536D /* MXCrypto.h in Headers */ = {isa = PBXBuildFile; fileRef = 322A51B41D9AB15900C8536D /* MXCrypto.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		322A51B71D9AB15900C8536D /* MXCrypto.m in Sources */ = {isa = PBXBuildFile; fileRef = 322A51B51D9AB15900C8536D /* MXCrypto.m */; };
 		322A51C31D9AC8FE00C8536D /* MXCryptoAlgorithms.h in Headers */ = {isa = PBXBuildFile; fileRef = 322A51C11D9AC8FE00C8536D /* MXCryptoAlgorithms.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1350,6 +1354,8 @@
 		322691311E5EF77D00966A6E /* MXDeviceListOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXDeviceListOperation.m; sourceTree = "<group>"; };
 		322691341E5EFF8700966A6E /* MXDeviceListOperationsPool.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MXDeviceListOperationsPool.h; path = MatrixSDK/Crypto/Data/MXDeviceListOperationsPool.h; sourceTree = SOURCE_ROOT; };
 		322691351E5EFF8700966A6E /* MXDeviceListOperationsPool.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MXDeviceListOperationsPool.m; path = MatrixSDK/Crypto/Data/MXDeviceListOperationsPool.m; sourceTree = SOURCE_ROOT; };
+		3229534F25A5F7220012FCF0 /* MXBackgroundCryptoStore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXBackgroundCryptoStore.h; sourceTree = "<group>"; };
+		3229535025A5F7220012FCF0 /* MXBackgroundCryptoStore.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXBackgroundCryptoStore.m; sourceTree = "<group>"; };
 		322A51B41D9AB15900C8536D /* MXCrypto.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXCrypto.h; sourceTree = "<group>"; };
 		322A51B51D9AB15900C8536D /* MXCrypto.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXCrypto.m; sourceTree = "<group>"; };
 		322A51C11D9AC8FE00C8536D /* MXCryptoAlgorithms.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXCryptoAlgorithms.h; sourceTree = "<group>"; };
@@ -3374,6 +3380,8 @@
 				EC383BA1253DE4B1002FBBE6 /* MXBackgroundSyncService.swift */,
 				EC383BB52540E15E002FBBE6 /* MXBackgroundPushRulesManager.swift */,
 				EC383BAB254030DF002FBBE6 /* MXBackgroundStore.swift */,
+				3229534F25A5F7220012FCF0 /* MXBackgroundCryptoStore.h */,
+				3229535025A5F7220012FCF0 /* MXBackgroundCryptoStore.m */,
 				EC383BA9253DE733002FBBE6 /* NSDictionary.swift */,
 				EC383BB82542DC0D002FBBE6 /* NSArray.swift */,
 				EC383BA3253DE6C0002FBBE6 /* Store */,
@@ -3633,6 +3641,7 @@
 				327187851DA7D0220071C818 /* MXOlmDecryption.h in Headers */,
 				322A51C71D9BBD3C00C8536D /* MXOlmDevice.h in Headers */,
 				3252DCAE224BE5D40032264F /* MXKeyVerificationManager.h in Headers */,
+				3229535125A5F7220012FCF0 /* MXBackgroundCryptoStore.h in Headers */,
 				3265CB381A14C43E00E24B2F /* MXRoomState.h in Headers */,
 				322360521A8E610500A3CA81 /* MXPushRuleDisplayNameCondtionChecker.h in Headers */,
 				B1DDC9D62418098200D208E3 /* MXIncomingSASTransaction_Private.h in Headers */,
@@ -3785,6 +3794,7 @@
 				B14EF2BC2397E90400758AF0 /* MXAggregatedReactions.h in Headers */,
 				32AF9280240EA0190008A0FD /* MXSecretShareManager.h in Headers */,
 				B14EF2BD2397E90400758AF0 /* MXAggregationPaginatedResponse.h in Headers */,
+				3229535225A5F7220012FCF0 /* MXBackgroundCryptoStore.h in Headers */,
 				B14EF2BE2397E90400758AF0 /* MXEvent.h in Headers */,
 				B14EF2BF2397E90400758AF0 /* MXRoomThirdPartyInvite.h in Headers */,
 				B14EF2C02397E90400758AF0 /* MXRoomNameStringsLocalizable.h in Headers */,
@@ -4389,6 +4399,7 @@
 				B11BD45A22CB58850064D8B0 /* MXReplyEventFormattedBodyParts.m in Sources */,
 				32CE6FB91A409B1F00317F1E /* MXFileStoreMetaData.m in Sources */,
 				3264DB921CEC528D00B99881 /* MXAccountData.m in Sources */,
+				3229535325A5F7220012FCF0 /* MXBackgroundCryptoStore.m in Sources */,
 				3213301A228B010C0070BA9B /* MXRealmReactionCount.m in Sources */,
 				3250E7CB220C913900736CB5 /* MXCryptoTools.m in Sources */,
 				322691331E5EF77D00966A6E /* MXDeviceListOperation.m in Sources */,
@@ -4843,6 +4854,7 @@
 				B14EF27E2397E90400758AF0 /* MXCrypto.m in Sources */,
 				B14EF27F2397E90400758AF0 /* MXRoomPredecessorInfo.m in Sources */,
 				B14EF2802397E90400758AF0 /* MXServiceTerms.m in Sources */,
+				3229535425A5F7220012FCF0 /* MXBackgroundCryptoStore.m in Sources */,
 				B14EF2812397E90400758AF0 /* MXNotificationCenter.m in Sources */,
 				3A108AB825812995005EEBE9 /* MXKeyProvider.m in Sources */,
 				B14EF2822397E90400758AF0 /* MXDeviceList.m in Sources */,

--- a/MatrixSDK.xcodeproj/xcshareddata/IDETemplateMacros.plist
+++ b/MatrixSDK.xcodeproj/xcshareddata/IDETemplateMacros.plist
@@ -4,7 +4,7 @@
 <dict>
     <key>FILEHEADER</key>
     <string> 
-// Copyright 2020 The Matrix.org Foundation C.I.C
+// Copyright 2021 The Matrix.org Foundation C.I.C
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MatrixSDK/Background/MXBackgroundCryptoStore.h
+++ b/MatrixSDK/Background/MXBackgroundCryptoStore.h
@@ -28,6 +28,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MXBackgroundCryptoStore : NSObject <MXCryptoStore>
 
+/**
+ Reset the intermediate store.
+ */
+- (void)reset;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/MatrixSDK/Background/MXBackgroundCryptoStore.h
+++ b/MatrixSDK/Background/MXBackgroundCryptoStore.h
@@ -1,0 +1,33 @@
+// 
+// Copyright 2021 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "MXCryptoStore.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ The `MXBackgroundCryptoStore` implements a minimal set of the `MXCryptoStore` protocol for `MXBackgroundSyncService`
+ needs.
+ It ensures that DB write operations required by `MXBackgroundSyncService` are made on a separate DB.
+ This avoids to have deadlocks between the app process and an iOS notification extension service.
+ */
+@interface MXBackgroundCryptoStore : NSObject <MXCryptoStore>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixSDK/Background/MXBackgroundCryptoStore.m
+++ b/MatrixSDK/Background/MXBackgroundCryptoStore.m
@@ -16,6 +16,8 @@
 
 #import "MXBackgroundCryptoStore.h"
 
+#import <OLMKit/OLMKit.h>
+
 #import "MXRealmCryptoStore.h"
 #import "MXTools.h"
 
@@ -90,6 +92,8 @@ NSString *const MXBackgroundCryptoStoreUserIdSuffix = @":bgCryptoStore";
 + (instancetype)createStoreWithCredentials:(MXCredentials*)credentials
 {
     // Should never happen
+    NSLog(@"[MXBackgroundCryptoStore] createStoreWithCredentials: %@:%@", credentials.userId, credentials.deviceId);
+    
     MXRealmCryptoStore *cryptoStore = [MXRealmCryptoStore createStoreWithCredentials:credentials];
     
     MXCredentials *bgCredentials = [MXBackgroundCryptoStore credentialForBgCryptoStoreWithCredentials:credentials];
@@ -113,6 +117,8 @@ NSString *const MXBackgroundCryptoStoreUserIdSuffix = @":bgCryptoStore";
 - (void)setAccount:(OLMAccount*)account
 {
     // Should never happen
+    NSLog(@"[MXBackgroundCryptoStore] setAccount: identityKeys: %@", account.identityKeys);
+    
     [cryptoStore setAccount:account];
     [bgCryptoStore setAccount:account];
 }
@@ -162,7 +168,14 @@ NSString *const MXBackgroundCryptoStoreUserIdSuffix = @":bgCryptoStore";
 
 - (NSArray<MXOlmSession*>*)sessionsWithDevice:(NSString*)deviceKey
 {
-    return [[cryptoStore sessionsWithDevice:deviceKey] arrayByAddingObjectsFromArray:[bgCryptoStore sessionsWithDevice:deviceKey]];
+    NSArray<MXOlmSession*> *bgSessions = [bgCryptoStore sessionsWithDevice:deviceKey] ?: @[];
+    NSArray<MXOlmSession*> *appSessions = [cryptoStore sessionsWithDevice:deviceKey] ?: @[];
+
+    NSMutableArray<MXOlmSession*> *sessions = [NSMutableArray array];
+    [sessions addObjectsFromArray:bgSessions];
+    [sessions addObjectsFromArray:appSessions];
+
+    return sessions;
 }
 
 - (void)storeSession:(MXOlmSession*)session forDevice:(NSString*)deviceKey

--- a/MatrixSDK/Background/MXBackgroundCryptoStore.m
+++ b/MatrixSDK/Background/MXBackgroundCryptoStore.m
@@ -24,6 +24,8 @@ NSString *const MXBackgroundCryptoStoreUserIdSuffix = @":bgCryptoStore";
 
 @interface MXBackgroundCryptoStore()
 {
+    MXCredentials *credentials;
+    
     // The MXRealmCryptoStore used by the app process
     // It is used in a read-only way.
     MXRealmCryptoStore *cryptoStore;
@@ -36,11 +38,13 @@ NSString *const MXBackgroundCryptoStoreUserIdSuffix = @":bgCryptoStore";
 
 @implementation MXBackgroundCryptoStore
 
-- (instancetype)initWithCredentials:(MXCredentials *)credentials
+- (instancetype)initWithCredentials:(MXCredentials *)theCredentials
 {
     self = [super init];
     if (self)
     {
+        credentials = theCredentials;
+        
         cryptoStore = [[MXRealmCryptoStore alloc] initWithCredentials:credentials];
         
         MXCredentials *bgCredentials = [MXBackgroundCryptoStore credentialForBgCryptoStoreWithCredentials:credentials];
@@ -55,6 +59,16 @@ NSString *const MXBackgroundCryptoStoreUserIdSuffix = @":bgCryptoStore";
         }
     }
     return self;
+}
+
+- (void)reset
+{
+    if (bgCryptoStore)
+    {
+        MXCredentials *bgCredentials = [MXBackgroundCryptoStore credentialForBgCryptoStoreWithCredentials:credentials];
+        [MXRealmCryptoStore deleteStoreWithCredentials:bgCredentials];
+        bgCryptoStore = [MXRealmCryptoStore createStoreWithCredentials:bgCredentials];
+    }
 }
 
 - (void)open:(void (^)(void))onComplete failure:(void (^)(NSError *error))failure

--- a/MatrixSDK/Background/MXBackgroundCryptoStore.m
+++ b/MatrixSDK/Background/MXBackgroundCryptoStore.m
@@ -1,0 +1,447 @@
+// 
+// Copyright 2021 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import "MXBackgroundCryptoStore.h"
+
+#import "MXRealmCryptoStore.h"
+#import "MXTools.h"
+
+NSString *const MXBackgroundCryptoStoreUserIdSuffix = @":bgCryptoStore";
+
+
+@interface MXBackgroundCryptoStore()
+{
+    // The MXRealmCryptoStore used by the app process
+    // It is used in a read-only way.
+    MXRealmCryptoStore *cryptoStore;
+    
+    // A MXRealmCryptoStore instance we use as an intermediate read-write cache for data (olm and megolm keys) that comes during background syncs.
+    // Write operations happen only in this instance.
+    MXRealmCryptoStore *bgCryptoStore;
+}
+@end
+
+@implementation MXBackgroundCryptoStore
+
+- (instancetype)initWithCredentials:(MXCredentials *)credentials
+{
+    self = [super init];
+    if (self)
+    {
+        cryptoStore = [[MXRealmCryptoStore alloc] initWithCredentials:credentials];
+        
+        MXCredentials *bgCredentials = [MXBackgroundCryptoStore credentialForBgCryptoStoreWithCredentials:credentials];
+        if ([MXRealmCryptoStore hasDataForCredentials:bgCredentials])
+        {
+            bgCryptoStore = [[MXRealmCryptoStore alloc] initWithCredentials:bgCredentials];
+        }
+        else
+        {
+            NSLog(@"[MXBackgroundCryptoStore] initWithCredentials: Create bgCryptoStore");
+            bgCryptoStore = [MXRealmCryptoStore createStoreWithCredentials:bgCredentials];
+        }
+    }
+    return self;
+}
+
+- (void)open:(void (^)(void))onComplete failure:(void (^)(NSError *error))failure
+{
+    MXWeakify(self);
+    [cryptoStore open:^{
+        MXStrongifyAndReturnIfNil(self);
+        
+        [self->bgCryptoStore open:onComplete failure:failure];
+    } failure:failure];
+}
+
++ (BOOL)hasDataForCredentials:(MXCredentials*)credentials
+{
+    // Should be always YES
+    return [MXRealmCryptoStore hasDataForCredentials:credentials];
+}
+
++ (instancetype)createStoreWithCredentials:(MXCredentials*)credentials
+{
+    // Should never happen
+    MXRealmCryptoStore *cryptoStore = [MXRealmCryptoStore createStoreWithCredentials:credentials];
+    
+    MXCredentials *bgCredentials = [MXBackgroundCryptoStore credentialForBgCryptoStoreWithCredentials:credentials];
+    MXRealmCryptoStore *bgCryptoStore = [MXRealmCryptoStore createStoreWithCredentials:bgCredentials];
+    
+    MXBackgroundCryptoStore *store = [MXBackgroundCryptoStore new];
+    store->cryptoStore = cryptoStore;
+    store->bgCryptoStore = bgCryptoStore;
+    
+    return store;
+}
+
+
+#pragma mark - libolm
+
+- (OLMAccount*)account
+{
+    return cryptoStore.account;
+}
+
+- (void)setAccount:(OLMAccount*)account
+{
+    // Should never happen
+    [cryptoStore setAccount:account];
+    [bgCryptoStore setAccount:account];
+}
+
+
+- (void)performAccountOperationWithBlock:(void (^)(OLMAccount *olmAccount))block
+{
+    // If needed, transfer data from cryptoStore to bgCryptoStore first
+    if (!bgCryptoStore.account)
+    {
+        NSLog(@"[MXBackgroundCryptoStore] performAccountOperationWithBlock: Transfer data from cryptoStore to bgCryptoStore");
+        [bgCryptoStore setAccount:cryptoStore.account];
+    }
+    
+    [bgCryptoStore performAccountOperationWithBlock:block];
+}
+
+
+#pragma mark - Olm
+
+- (void)performSessionOperationWithDevice:(NSString*)deviceKey andSessionId:(NSString*)sessionId block:(void (^)(MXOlmSession *mxOlmSession))block
+{
+    // If needed, transfer data from cryptoStore to bgCryptoStore first
+    MXOlmSession *olmSession = [bgCryptoStore sessionWithDevice:deviceKey andSessionId:sessionId];
+    if (!olmSession)
+    {
+        olmSession = [cryptoStore sessionWithDevice:deviceKey andSessionId:sessionId];
+        if (olmSession)
+        {
+            NSLog(@"[MXBackgroundCryptoStore] performSessionOperationWithDevice: Transfer data for %@ from cryptoStore to bgCryptoStore", sessionId);
+            [bgCryptoStore storeSession:olmSession forDevice:deviceKey];
+        }
+    }
+    
+    [bgCryptoStore performSessionOperationWithDevice:deviceKey andSessionId:sessionId block:block];
+}
+
+- (MXOlmSession*)sessionWithDevice:(NSString*)deviceKey andSessionId:(NSString*)sessionId
+{
+    MXOlmSession *olmSession = [bgCryptoStore sessionWithDevice:deviceKey andSessionId:sessionId];
+    if (!olmSession)
+    {
+        olmSession = [cryptoStore sessionWithDevice:deviceKey andSessionId:sessionId];
+    }
+    return olmSession;
+}
+
+- (NSArray<MXOlmSession*>*)sessionsWithDevice:(NSString*)deviceKey
+{
+    return [[cryptoStore sessionsWithDevice:deviceKey] arrayByAddingObjectsFromArray:[bgCryptoStore sessionsWithDevice:deviceKey]];
+}
+
+- (void)storeSession:(MXOlmSession*)session forDevice:(NSString*)deviceKey
+{
+    [bgCryptoStore storeSession:session forDevice:deviceKey];
+}
+
+
+#pragma mark - Megolm
+
+- (MXOlmInboundGroupSession*)inboundGroupSessionWithId:(NSString*)sessionId andSenderKey:(NSString*)senderKey
+{
+    MXOlmInboundGroupSession *inboundGroupSession = [bgCryptoStore inboundGroupSessionWithId:sessionId andSenderKey:senderKey];
+    if (!inboundGroupSession)
+    {
+        inboundGroupSession = [cryptoStore inboundGroupSessionWithId:sessionId andSenderKey:senderKey];
+    }
+    return inboundGroupSession;
+}
+
+- (void)storeInboundGroupSessions:(NSArray<MXOlmInboundGroupSession *>*)sessions
+{
+    [bgCryptoStore storeInboundGroupSessions:sessions];
+}
+
+- (void)performSessionOperationWithGroupSessionWithId:(NSString*)sessionId senderKey:(NSString*)senderKey block:(void (^)(MXOlmInboundGroupSession *inboundGroupSession))block
+{
+    // If needed, transfer data from cryptoStore to bgCryptoStore first
+    MXOlmInboundGroupSession *inboundGroupSession = [bgCryptoStore inboundGroupSessionWithId:sessionId andSenderKey:senderKey];
+    if (!inboundGroupSession)
+    {
+        inboundGroupSession = [cryptoStore inboundGroupSessionWithId:sessionId andSenderKey:senderKey];
+        if (inboundGroupSession)
+        {
+            NSLog(@"[MXBackgroundCryptoStore] performSessionOperationWithGroupSessionWithId: Transfer data for %@ from cryptoStore to bgCryptoStore", sessionId);
+            [bgCryptoStore storeInboundGroupSessions:@[inboundGroupSession]];
+        }
+    }
+    
+    [bgCryptoStore performSessionOperationWithGroupSessionWithId:sessionId senderKey:senderKey block:block];
+}
+
+
+#pragma mark - Private Methods
+
++ (MXCredentials*)credentialForBgCryptoStoreWithCredentials:(MXCredentials*)credentials
+{
+    MXCredentials *bgCredentials = [credentials copy];
+    bgCredentials.userId = [credentials.userId stringByAppendingString:MXBackgroundCryptoStoreUserIdSuffix];
+    
+    return bgCredentials;
+}
+
+
+#pragma mark - No-op
+
++ (void)deleteStoreWithCredentials:(MXCredentials*)credentials
+{
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+}
+
+- (void)storeDeviceId:(NSString*)deviceId
+{
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+}
+
+- (NSString*)deviceId
+{
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+    return nil;
+}
+
+- (void)storeDeviceSyncToken:(NSString*)deviceSyncToken
+{
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+}
+
+- (NSArray<MXOlmInboundGroupSession*> *)inboundGroupSessions
+{
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+    return nil;
+}
+
+- (NSString*)deviceSyncToken
+{
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+    return nil;
+}
+
+- (void)storeDeviceForUser:(NSString*)userId device:(MXDeviceInfo*)device
+{
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+}
+
+- (MXDeviceInfo*)deviceWithDeviceId:(NSString*)deviceId forUser:(NSString*)userId;
+{
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+    return nil;
+}
+
+- (MXDeviceInfo*)deviceWithIdentityKey:(NSString*)identityKey
+{
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+    return nil;
+}
+
+- (void)storeDevicesForUser:(NSString*)userId devices:(NSDictionary<NSString*, MXDeviceInfo*>*)devices
+{
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+}
+
+- (NSDictionary<NSString*, MXDeviceInfo*>*)devicesForUser:(NSString*)userId
+{
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+    return nil;
+}
+
+- (NSDictionary<NSString*, NSNumber*>*)deviceTrackingStatus
+{
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+    return nil;
+}
+
+- (void)storeDeviceTrackingStatus:(NSDictionary<NSString*, NSNumber*>*)statusMap
+{
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+}
+
+- (void)storeCrossSigningKeys:(MXCrossSigningInfo*)crossSigningInfo
+{
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+}
+
+- (MXCrossSigningInfo*)crossSigningKeysForUser:(NSString*)userId
+{
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+    return nil;
+}
+
+- (NSArray<MXCrossSigningInfo*> *)crossSigningKeys
+{
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+    return nil;
+}
+
+- (void)storeAlgorithmForRoom:(NSString*)roomId algorithm:(NSString*)algorithm
+{
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+}
+
+- (NSString*)algorithmForRoom:(NSString*)roomId
+{
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+    return nil;
+}
+
+-(NSString *)backupVersion
+{
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+    return nil;
+}
+
+- (void)setBackupVersion:(NSString *)backupVersion{
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+}
+
+- (void)resetBackupMarkers
+{
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+}
+
+- (void)markBackupDoneForInboundGroupSessions:(NSArray<MXOlmInboundGroupSession *>*)sessions
+{
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+}
+
+- (NSArray<MXOlmInboundGroupSession*>*)inboundGroupSessionsToBackup:(NSUInteger)limit
+{
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+    return nil;
+}
+
+- (NSUInteger)inboundGroupSessionsCount:(BOOL)onlyBackedUp
+{
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+    return 0;
+}
+
+- (MXOutgoingRoomKeyRequest*)outgoingRoomKeyRequestWithRequestBody:(NSDictionary *)requestBody
+{
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+    return nil;
+}
+
+- (MXOutgoingRoomKeyRequest*)outgoingRoomKeyRequestWithState:(MXRoomKeyRequestState)state
+{
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+    return nil;
+}
+
+- (NSArray<MXOutgoingRoomKeyRequest*> *)allOutgoingRoomKeyRequestsWithState:(MXRoomKeyRequestState)state
+{
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+    return nil;
+}
+
+- (void)storeOutgoingRoomKeyRequest:(MXOutgoingRoomKeyRequest*)request
+{
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+}
+
+- (void)updateOutgoingRoomKeyRequest:(MXOutgoingRoomKeyRequest*)request
+{
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+}
+
+- (void)deleteOutgoingRoomKeyRequestWithRequestId:(NSString*)requestId
+{
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+}
+
+- (void)storeIncomingRoomKeyRequest:(MXIncomingRoomKeyRequest*)request
+{
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+}
+
+- (void)deleteIncomingRoomKeyRequest:(NSString*)requestId fromUser:(NSString*)userId andDevice:(NSString*)deviceId
+{
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+}
+
+- (MXIncomingRoomKeyRequest*)incomingRoomKeyRequestWithRequestId:(NSString*)requestId fromUser:(NSString*)userId andDevice:(NSString*)deviceId
+{
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+    return nil;
+}
+
+- (MXUsersDevicesMap<NSArray<MXIncomingRoomKeyRequest *> *> *)incomingRoomKeyRequests
+{
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+    return nil;
+}
+
+- (void)storeSecret:(NSString*)secret withSecretId:(NSString*)secretId
+{
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+}
+
+- (NSString*)secretWithSecretId:(NSString*)secretId
+{
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+    return nil;
+}
+
+- (void)deleteSecretWithSecretId:(NSString*)secretId
+{
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+}
+
+- (BOOL)globalBlacklistUnverifiedDevices{
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+    return NO;
+}
+
+- (void)setGlobalBlacklistUnverifiedDevices:(BOOL)globalBlacklistUnverifiedDevices{
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+}
+
+- (BOOL)blacklistUnverifiedDevicesInRoom:(NSString *)roomId
+{
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+    return NO;
+}
+
+- (void)storeBlacklistUnverifiedDevicesInRoom:(NSString *)roomId blacklist:(BOOL)blacklist
+{
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+}
+
+- (void)removeInboundGroupSessionWithId:(NSString*)sessionId andSenderKey:(NSString*)senderKey
+{
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+}
+
+- (MXCryptoVersion)cryptoVersion
+{
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+    return MXCryptoVersionUndefined;
+}
+
+- (void)setCryptoVersion:(MXCryptoVersion)cryptoVersion
+{
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+}
+
+@end

--- a/MatrixSDK/Background/MXBackgroundSyncService.swift
+++ b/MatrixSDK/Background/MXBackgroundSyncService.swift
@@ -41,7 +41,7 @@ public enum MXBackgroundSyncServiceError: Error {
     private let credentials: MXCredentials
     private let syncResponseStore: MXSyncResponseStore
     private var store: MXStore
-    private let cryptoStore: MXCryptoStore
+    private let cryptoStore: MXBackgroundCryptoStore
     private let olmDevice: MXOlmDevice
     private let restClient: MXRestClient
     private var pushRulesManager: MXBackgroundPushRulesManager
@@ -60,9 +60,9 @@ public enum MXBackgroundSyncServiceError: Error {
         restClient.completionQueue = processingQueue
         store = MXBackgroundStore(withCredentials: credentials)
         if MXRealmCryptoStore.hasData(for: credentials) {
-            cryptoStore = MXRealmCryptoStore(credentials: credentials)
+            cryptoStore = MXBackgroundCryptoStore(credentials: credentials)
         } else {
-            cryptoStore = MXRealmCryptoStore.createStore(with: credentials)
+            cryptoStore = MXBackgroundCryptoStore.createStore(with: credentials)
         }
         olmDevice = MXOlmDevice(store: cryptoStore)
         pushRulesManager = MXBackgroundPushRulesManager(withCredentials: credentials)

--- a/MatrixSDK/Background/MXBackgroundSyncService.swift
+++ b/MatrixSDK/Background/MXBackgroundSyncService.swift
@@ -578,6 +578,9 @@ public enum MXBackgroundSyncServiceError: Error {
             // syncResponseStore has obsolete data. Reset it
             NSLog("[MXBackgroundSyncService] updateBackgroundServiceStoresIfNeeded: Reset MXSyncResponseStore. Its prevBatch was token \(String(describing: syncResponseStore.prevBatch))")
             syncResponseStore.deleteData()
+            
+            NSLog("[MXBackgroundSyncService] updateBackgroundServiceStoresIfNeeded: Reset MXBackgroundCryptoStore")
+            cryptoStore.reset()
         }
     }
     

--- a/MatrixSDK/Data/MXCredentials.h
+++ b/MatrixSDK/Data/MXCredentials.h
@@ -1,5 +1,6 @@
 /*
  Copyright 2019 New Vector Ltd
+ Copyright 2021 The Matrix.org Foundation C.I.C
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -24,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
  The `MXCredentials` class contains credentials to communicate with the Matrix
  Client-Server API.
  */
-@interface MXCredentials : NSObject
+@interface MXCredentials : NSObject <NSCopying>
 
 /**
  The homeserver url (ex: "https://matrix.org").

--- a/MatrixSDK/Data/MXCredentials.m
+++ b/MatrixSDK/Data/MXCredentials.m
@@ -1,5 +1,6 @@
 /*
  Copyright 2019 New Vector Ltd
+ Copyright 2021 The Matrix.org Foundation C.I.C
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -96,6 +97,25 @@
 - (NSString *)homeServerName
 {
     return [NSURL URLWithString:_homeServer].host;
+}
+
+
+#pragma mark - NSCopying
+
+- (id)copyWithZone:(NSZone *)zone
+{
+    MXCredentials *credentials = [[[self class] allocWithZone:zone] init];
+    
+    credentials.userId = [_userId copyWithZone:zone];
+    credentials.homeServer = [_homeServer copyWithZone:zone];
+    credentials.accessToken = [_accessToken copyWithZone:zone];
+    credentials.identityServer = [_identityServer copyWithZone:zone];
+    credentials.identityServerAccessToken = [_identityServerAccessToken copyWithZone:zone];
+    credentials.deviceId = [_deviceId copyWithZone:zone];
+    credentials.allowedCertificate = [_allowedCertificate copyWithZone:zone];
+    credentials.ignoredCertificate = [_ignoredCertificate copyWithZone:zone];
+
+    return credentials;
 }
 
 @end

--- a/MatrixSDK/JSONModels/MXEvent.m
+++ b/MatrixSDK/JSONModels/MXEvent.m
@@ -832,19 +832,29 @@ NSString *const kMXEventIdentifierKey = @"kMXEventIdentifierKey";
     _clearEvent = nil;
     if (decryptionResult.clearEvent)
     {
-        NSDictionary *clearEventJSON = decryptionResult.clearEvent;
-        if (clearEventJSON[@"content"][@"m.new_content"] && !_wireContent[@"m.relates_to"])
+        NSDictionary *clearEventJSON, *clearEventJSONContent;
+        MXJSONModelSetDictionary(clearEventJSON, decryptionResult.clearEvent);
+        MXJSONModelSetDictionary(clearEventJSONContent, clearEventJSON[@"content"]);
+
+        if (clearEventJSONContent[@"m.new_content"] && !_wireContent[@"m.relates_to"])
         {
             // If the event has been edited, use the new content
             // This can be done only on client side
             // TODO: Remove this with the coming update of MSC1849.
-            NSMutableDictionary *clearEventUpdatedJSON = [clearEventJSON mutableCopy];
-            clearEventUpdatedJSON[@"content"] = clearEventJSON[@"content"][@"m.new_content"];
-            clearEventJSON = clearEventUpdatedJSON;
+            NSDictionary *clearEventJSONNewContent;
+            MXJSONModelSetDictionary(clearEventJSONNewContent, clearEventJSONContent[@"m.new_content"]);
+            
+            if (clearEventJSONNewContent)
+            {
+                NSMutableDictionary *clearEventUpdatedJSON = [clearEventJSON mutableCopy];
+                clearEventUpdatedJSON[@"content"] = clearEventJSONNewContent;
+                clearEventJSON = clearEventUpdatedJSON;
+            }
         }
 
         NSDictionary *decryptionClearEventJSON;
-        NSDictionary *encryptedContentRelatesToJSON = _wireContent[@"m.relates_to"];
+        NSDictionary *encryptedContentRelatesToJSON;
+        MXJSONModelSetDictionary(clearEventJSONContent, _wireContent[@"m.relates_to"]);
         
         // Add "m.relates_to" data from e2e event to the unencrypted content event
         if (encryptedContentRelatesToJSON)

--- a/MatrixSDK/MatrixSDK.h
+++ b/MatrixSDK/MatrixSDK.h
@@ -120,3 +120,4 @@ FOUNDATION_EXPORT NSString *MatrixSDKVersion;
 #import "MXMegolmDecryption.h"
 #import "MXOlmDecryption.h"
 #import "MXSyncResponseStoreModel.h"
+#import "MXBackgroundCryptoStore.h"

--- a/MatrixSDKTests/MXBackgroundSyncServiceTests.swift
+++ b/MatrixSDKTests/MXBackgroundSyncServiceTests.swift
@@ -39,6 +39,15 @@ class MXBackgroundSyncServiceTests: XCTestCase {
         bgSyncService = nil
     }
     
+    
+    // Copy of private [MXBackgroundCryptoStore credentialForBgCryptoStoreWithCredentials:] method
+    func credentialForBgCryptoStore(withCredentials credentials: MXCredentials) -> MXCredentials {
+        let bgCredentials = credentials
+        bgCredentials.userId = bgCredentials.userId?.appending(":bgCryptoStore")
+        
+        return bgCredentials
+    }
+    
     // Nonimal test: Get an event from the background service
     // - Alice and Bob are in a room
     // - Bob stops their app
@@ -221,8 +230,10 @@ class MXBackgroundSyncServiceTests: XCTestCase {
     // - Alice sends a message
     // - Bob uses the MXBackgroundSyncService to fetch it
     // -> The message can be read and decypted from MXBackgroundSyncService
+    // -> Keys are stored in the intermediate MXBackgroundSyncService crypto store, not in the main crypto store
     // - Bob restarts their MXSession
     // -> The message is available from MXSession and no more from MXBackgroundSyncService
+    // -> Keys are stored in the main crypto store but no more in the intermediate MXBackgroundSyncService crypto store
     func testWithEncryptedEventRollingKeys() {
         
         let aliceStore = MXFileStore()
@@ -254,6 +265,7 @@ class MXBackgroundSyncServiceTests: XCTestCase {
                 
                 newAliceSession?.crypto.warnOnUnknowDevices = warnOnUnknownDevices
                 
+                // - Alice sends a message
                 var localEcho: MXEvent?
                 room.sendTextMessage(Constants.messageText, localEcho: &localEcho) { (response) in
                     switch response {
@@ -265,11 +277,13 @@ class MXBackgroundSyncServiceTests: XCTestCase {
                                 return
                             }
                             
+                            // - Bob uses the MXBackgroundSyncService to fetch it
                             self.bgSyncService = MXBackgroundSyncService(withCredentials: bobCredentials)
                             
                             self.bgSyncService?.event(withEventId: eventId, inRoom: roomId) { (response) in
                                 switch response {
                                     case .success(let event):
+                                        // -> The message can be read and decypted from MXBackgroundSyncService
                                         XCTAssertTrue(event.isEncrypted, "Event should be encrypted")
                                         XCTAssertNotNil(event.clear, "Event should be decrypted successfully")
                                         
@@ -282,12 +296,26 @@ class MXBackgroundSyncServiceTests: XCTestCase {
                                         syncResponseStore.open(withCredentials: bobCredentials)
                                         XCTAssertNotNil(syncResponseStore.event(withEventId: eventId, inRoom: roomId), "Event should be stored in sync response store")
                                         
+                                        // -> Keys are stored in the intermediate MXBackgroundSyncService crypto store, not in the main crypto store
+                                        let cryptoStore = MXRealmCryptoStore(credentials: bobCredentials)
+                                        let bgSyncServiceCryptoStore = MXRealmCryptoStore(credentials: self.credentialForBgCryptoStore(withCredentials: bobCredentials))
+                                        let sessionId = event.wireContent["session_id"] as! String
+                                        let senderKey = event.wireContent["sender_key"] as! String
+                                        XCTAssertNil(cryptoStore?.inboundGroupSession(withId: sessionId, andSenderKey: senderKey), "Key must not be yet stored in the main MXRealmCryptoStore")
+                                        XCTAssertNotNil(bgSyncServiceCryptoStore?.inboundGroupSession(withId: sessionId, andSenderKey: senderKey), "Key must be stored in the intermediate MXBackgroundService MXRealmCryptoStore")
+                                        
+                                        // - Bob restarts their MXSession
                                         let newBobSession = MXSession(matrixRestClient: MXRestClient(credentials: bobCredentials, unrecognizedCertificateHandler: nil))
                                         newBobSession?.setStore(bobStore, completion: { (_) in
                                             newBobSession?.start(withSyncFilterId: bobStore.syncFilterId, completion: { (_) in
+                                                // -> The message is available from MXSession and no more from MXBackgroundSyncService
                                                 XCTAssertNil(syncResponseStore.event(withEventId: eventId, inRoom: roomId), "Event should not be stored in sync response store anymore")
                                                 XCTAssertNotNil(bobStore.event(withEventId: eventId, inRoom: roomId), "Event should be in session store anymore")
                                                 expectation?.fulfill()
+                                                
+                                                // -> Keys are stored in the main crypto store but no more in the intermediate MXBackgroundSyncService crypto store
+                                                XCTAssertNotNil(cryptoStore?.inboundGroupSession(withId: sessionId, andSenderKey: senderKey), "Key must be now stored in the main MXRealmCryptoStore")
+                                                XCTAssertNil(bgSyncServiceCryptoStore?.inboundGroupSession(withId: sessionId, andSenderKey: senderKey), "Key must be no more stored in the intermediate MXBackgroundService MXRealmCryptoStore")
                                             })
                                         })
                                     case .failure(let error):


### PR DESCRIPTION
created between the app process and the notification service extension process

Fix vector-im/element-ios/issues/3906

The fix consists in having a separated MXCryptoStore DB where the NSE writes in. Thus, each MXCryptoStore DB is written by only one process. One process cannot be blocked anymore because another process is writing to the same DB.
 