### PR TITLE
MXUIKitBackgroundTask: Avoid thread switching when creating a background task

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,11 +5,12 @@ Changes to be released in next version
  * 
 
 🙌 Improvements
- * 
+ * MXUIKitApplicationStateService: Add this service to track UIKit application state.
 
 🐛 Bugfix
  * MXBackgroundSyncService: Fix `m.buddy` to-device event crashes (vector-im/element-ios/issues/3889).
  * MXBackgroundSyncService: Fix app deadlock created between the app process and the notification service extension process (vector-im/element-ios/issues/3906).
+ * MXUIKitBackgroundTask: Avoid thread switching when creating a background task to keep threading model (vector-im/element-ios/issues/3917).
 
 ⚠️ API Changes
  * MXLoginSSOFlow: Use unstable identity providers field while the MSC2858 is not approved.

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -202,6 +202,8 @@
 		324DD2C7246E638B00377005 /* MXAesHmacSha2.m in Sources */ = {isa = PBXBuildFile; fileRef = 324DD2C4246E638B00377005 /* MXAesHmacSha2.m */; };
 		324DD2C8246E638B00377005 /* MXAesHmacSha2.m in Sources */ = {isa = PBXBuildFile; fileRef = 324DD2C4246E638B00377005 /* MXAesHmacSha2.m */; };
 		3250E7CB220C913900736CB5 /* MXCryptoTools.m in Sources */ = {isa = PBXBuildFile; fileRef = 3250E7C9220C913900736CB5 /* MXCryptoTools.m */; };
+		3251D41F25AF01D7001E6E77 /* MXUIKitApplicationStateService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3251D41E25AF01D7001E6E77 /* MXUIKitApplicationStateService.swift */; };
+		3251D42025AF01D7001E6E77 /* MXUIKitApplicationStateService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3251D41E25AF01D7001E6E77 /* MXUIKitApplicationStateService.swift */; };
 		3252DCAE224BE5D40032264F /* MXKeyVerificationManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 3252DCAC224BE5D40032264F /* MXKeyVerificationManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3252DCAF224BE5D40032264F /* MXKeyVerificationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 3252DCAD224BE5D40032264F /* MXKeyVerificationManager.m */; };
 		3252DCB6224BEA610032264F /* MXKeyVerificationTransaction.h in Headers */ = {isa = PBXBuildFile; fileRef = 3252DCB5224BEA610032264F /* MXKeyVerificationTransaction.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1431,6 +1433,7 @@
 		324DD2C4246E638B00377005 /* MXAesHmacSha2.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXAesHmacSha2.m; sourceTree = "<group>"; };
 		3250E7C8220C913900736CB5 /* MXCryptoTools.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXCryptoTools.h; sourceTree = "<group>"; };
 		3250E7C9220C913900736CB5 /* MXCryptoTools.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXCryptoTools.m; sourceTree = "<group>"; };
+		3251D41E25AF01D7001E6E77 /* MXUIKitApplicationStateService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXUIKitApplicationStateService.swift; sourceTree = "<group>"; };
 		3252DCAC224BE5D40032264F /* MXKeyVerificationManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXKeyVerificationManager.h; sourceTree = "<group>"; };
 		3252DCAD224BE5D40032264F /* MXKeyVerificationManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXKeyVerificationManager.m; sourceTree = "<group>"; };
 		3252DCB5224BEA610032264F /* MXKeyVerificationTransaction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXKeyVerificationTransaction.h; sourceTree = "<group>"; };
@@ -2135,6 +2138,7 @@
 				32A9E8211EF4026E0081358A /* MXBackgroundModeHandler.h */,
 				32A9E8221EF4026E0081358A /* MXUIKitBackgroundModeHandler.h */,
 				32A9E8231EF4026E0081358A /* MXUIKitBackgroundModeHandler.m */,
+				3251D41E25AF01D7001E6E77 /* MXUIKitApplicationStateService.swift */,
 				32A9770221626E5C00919CC0 /* MXServerNotices.h */,
 				32A9770321626E5C00919CC0 /* MXServerNotices.m */,
 				B11976FD236B27220001EC86 /* MXBackgroundTask.h */,
@@ -4313,6 +4317,7 @@
 				B182B08823167A640057972E /* MXIdentityServerHashDetails.m in Sources */,
 				324DD2A2246AE1EF00377005 /* MXEncryptedSecretContent.m in Sources */,
 				329FB1761A0A3A1600A5E88E /* MXRoomMember.m in Sources */,
+				3251D41F25AF01D7001E6E77 /* MXUIKitApplicationStateService.swift in Sources */,
 				B1136965230AC9D900E2B2FA /* MXIdentityService.m in Sources */,
 				B11BD44922CB56790064D8B0 /* MXReplyEventParser.m in Sources */,
 				323360701A403A0D0071A488 /* MXFileStore.m in Sources */,
@@ -4800,6 +4805,7 @@
 				B14EF2582397E90400758AF0 /* MXFilterObject.m in Sources */,
 				8EC511072568216B00EC4E5B /* MXTaggedEventInfo.m in Sources */,
 				B14EF2592397E90400758AF0 /* MXHTTPClient.m in Sources */,
+				3251D42025AF01D7001E6E77 /* MXUIKitApplicationStateService.swift in Sources */,
 				B19A30A72404257700FB6F35 /* MXQRCodeKeyVerificationStart.m in Sources */,
 				B14EF25A2397E90400758AF0 /* MXEnumConstants.m in Sources */,
 				B14EF25B2397E90400758AF0 /* MXSession.m in Sources */,

--- a/MatrixSDK/Utils/MXBackgroundModeHandler.h
+++ b/MatrixSDK/Utils/MXBackgroundModeHandler.h
@@ -31,7 +31,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @protocol MXBackgroundModeHandler <NSObject>
 
-- (id<MXBackgroundTask>)startBackgroundTaskWithName:(NSString *)name expirationHandler:(nullable MXBackgroundTaskExpirationHandler)expirationHandler;
+- (nullable id<MXBackgroundTask>)startBackgroundTaskWithName:(NSString *)name
+                                           expirationHandler:(nullable MXBackgroundTaskExpirationHandler)expirationHandler;
 
 @end
 

--- a/MatrixSDK/Utils/MXUIKitApplicationStateService.swift
+++ b/MatrixSDK/Utils/MXUIKitApplicationStateService.swift
@@ -1,0 +1,116 @@
+// 
+// Copyright 2021 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if os(iOS)
+
+import Foundation
+import UIKit
+
+@objcMembers
+/// This class provide allows to get current UIApplication.State of the app from any thread.
+/// It is only useful because UIApplication.shared.applicationState can be called only from the main thread.
+public class MXUIKitApplicationStateService: NSObject {
+    
+    //  MARK: - Properties
+    
+    private(set) public var applicationState: UIApplication.State
+    
+    public var backgroundTimeRemaining: TimeInterval {
+        get {
+            self.sharedApplication?.backgroundTimeRemaining ?? 0
+        }
+    }
+    
+    
+    //  MARK: - Static Method
+    
+    static public func readableApplicationState(applicationState: UIApplication.State) -> NSString {
+        switch applicationState {
+            case .active:
+                return "active"
+            case .inactive:
+                return "inactive"
+            case .background:
+                return "background"
+            @unknown default:
+                return "unknown"
+        }
+    }
+    
+    static public func readableEstimatedBackgroundTimeRemaining(backgroundTimeRemaining: TimeInterval) -> NSString {
+        if backgroundTimeRemaining == .greatestFiniteMagnitude {
+            return "undetermined"
+        }
+        else {
+            return NSString(format: "%.0f seconds", backgroundTimeRemaining)
+        }
+    }
+    
+    
+    //  MARK: - Method Overrides
+    
+    public override init() {
+        applicationState = .inactive
+        super.init()
+        
+        // Assume the service is created on the main tread
+        applicationState = self.sharedApplicationState
+
+        registerApplicationStateChangeNotifications()
+    }
+    
+    
+    //  MARK: - Private
+    
+    private func registerApplicationStateChangeNotifications() {
+        let notificationCenter = NotificationCenter.default
+        notificationCenter.addObserver(self, selector: #selector(applicationStateDidChange), name: UIApplication.didEnterBackgroundNotification, object: nil)
+        notificationCenter.addObserver(self, selector: #selector(applicationStateDidChange), name: UIApplication.willEnterForegroundNotification, object: nil)
+        notificationCenter.addObserver(self, selector: #selector(applicationStateDidChange), name: UIApplication.didFinishLaunchingNotification, object: nil)
+        notificationCenter.addObserver(self, selector: #selector(applicationStateDidChange), name: UIApplication.didBecomeActiveNotification, object: nil)
+        notificationCenter.addObserver(self, selector: #selector(applicationStateDidChange), name: UIApplication.willResignActiveNotification, object: nil)
+    }
+    
+    @objc private func applicationStateDidChange() {
+        // We are on the main tread. We can safely use UIApplication.shared.applicationState
+        let newApplicationState = self.sharedApplicationState
+        
+        if newApplicationState != applicationState {
+            let applicationStateString = MXUIKitApplicationStateService.readableApplicationState(applicationState: applicationState)
+            let newApplicationStateString = MXUIKitApplicationStateService.readableApplicationState(applicationState: newApplicationState)
+            NSLog("[MXUIKitApplicationStateService] applicationStateDidChange: from \(applicationStateString) to \(newApplicationStateString)")
+            
+            applicationState = newApplicationState
+        }
+    }
+    
+    private var sharedApplication: UIApplication? {
+        get {
+            // We cannot use UIApplication.shared from app extensions
+            // TODO: Move UIKit related code to a dedicated cocoapod sub spec
+            UIApplication.perform(NSSelectorFromString("sharedApplication")).takeUnretainedValue() as? UIApplication
+        }
+    }
+    
+    private var sharedApplicationState: UIApplication.State {
+        get {
+            // Can be only called from the main thread
+            self.sharedApplication?.applicationState ?? .inactive
+        }
+    }
+}
+
+#endif

--- a/MatrixSDK/Utils/MXUIKitApplicationStateService.swift
+++ b/MatrixSDK/Utils/MXUIKitApplicationStateService.swift
@@ -66,7 +66,8 @@ public class MXUIKitApplicationStateService: NSObject {
         applicationState = .inactive
         super.init()
         
-        // Assume the service is created on the main tread
+        // The service must be created on the main tread
+        assert(Thread.isMainThread, "[MXUIKitApplicationStateService] initialized on non-main thread.")
         applicationState = self.sharedApplicationState
 
         registerApplicationStateChangeNotifications()

--- a/MatrixSDK/Utils/MXUIKitApplicationStateService.swift
+++ b/MatrixSDK/Utils/MXUIKitApplicationStateService.swift
@@ -99,9 +99,15 @@ public class MXUIKitApplicationStateService: NSObject {
     
     private var sharedApplication: UIApplication? {
         get {
+            let selector = NSSelectorFromString("sharedApplication")
+            
             // We cannot use UIApplication.shared from app extensions
             // TODO: Move UIKit related code to a dedicated cocoapod sub spec
-            UIApplication.perform(NSSelectorFromString("sharedApplication")).takeUnretainedValue() as? UIApplication
+            guard UIApplication.responds(to: selector) else {
+                return nil
+            }
+            
+            return UIApplication.perform(selector)?.takeUnretainedValue() as? UIApplication
         }
     }
     

--- a/MatrixSDK/Utils/MXUIKitBackgroundModeHandler.m
+++ b/MatrixSDK/Utils/MXUIKitBackgroundModeHandler.m
@@ -21,14 +21,67 @@
 
 #import <UIKit/UIKit.h>
 #import "MXUIKitBackgroundTask.h"
+#import "MatrixSDKSwiftHeader.h"
+
+
+/**
+ Time threshold to be able to start a background task. So, if application's `backgroundTimeRemaining` returns less than this value, the task won't be started at all and expirationHandler will be called immediately.
+ @note This value only considered if the application is in background state.
+ @see -[UIApplication backgroundTimeRemaining]
+ */
+static const NSTimeInterval BackgroundTimeRemainingThresholdToStartTasks = 5.0;
+
+
+@interface MXUIKitBackgroundModeHandler ()
+{
+    MXUIKitApplicationStateService *applicationStateService;
+}
+@end
+
 
 @implementation MXUIKitBackgroundModeHandler
 
+- (instancetype)init
+{
+    self = [super init];
+    if (self)
+    {
+        applicationStateService = [MXUIKitApplicationStateService new];
+    }
+    return self;
+}
+
+
 #pragma mark - MXBackgroundModeHandler
 
-- (id<MXBackgroundTask>)startBackgroundTaskWithName:(NSString *)name expirationHandler:(nullable MXBackgroundTaskExpirationHandler)expirationHandler
+- (nullable id<MXBackgroundTask>)startBackgroundTaskWithName:(NSString *)name
+                                           expirationHandler:(nullable MXBackgroundTaskExpirationHandler)expirationHandler
 {
-    return [[MXUIKitBackgroundTask alloc] initAndStartWithName:name expirationHandler:expirationHandler];;
+    //  application is in background and not enough time to start this task
+    if (applicationStateService.applicationState == UIApplicationStateBackground &&
+        applicationStateService.backgroundTimeRemaining < BackgroundTimeRemainingThresholdToStartTasks)
+    {
+        NSLog(@"[MXBackgroundTask] Do not start background task - %@, as not enough time exists", name);
+        
+        //  call expiration handler immediately
+        if (expirationHandler)
+        {
+            expirationHandler();
+        }
+        return nil;
+    }
+    
+    id<MXBackgroundTask> backgroundTask = [[MXUIKitBackgroundTask alloc] initAndStartWithName:name expirationHandler:expirationHandler];
+    
+    if (backgroundTask)
+    {
+        NSString *readableAppState = [MXUIKitApplicationStateService readableApplicationStateWithApplicationState:applicationStateService.applicationState];
+        NSString *readableBackgroundTimeRemaining = [MXUIKitApplicationStateService readableEstimatedBackgroundTimeRemainingWithBackgroundTimeRemaining:applicationStateService.backgroundTimeRemaining];
+        
+        NSLog(@"[MXBackgroundTask] Background task %@ started with app state: %@ and estimated background time remaining: %@", backgroundTask.name, readableAppState, readableBackgroundTimeRemaining);
+    }
+
+    return backgroundTask;
 }
 
 @end

--- a/MatrixSDK/Utils/MXUIKitBackgroundTask.h
+++ b/MatrixSDK/Utils/MXUIKitBackgroundTask.h
@@ -26,8 +26,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MXUIKitBackgroundTask : NSObject<MXBackgroundTask>
 
-- (instancetype)initAndStartWithName:(NSString*)name
-                   expirationHandler:(nullable MXBackgroundTaskExpirationHandler)expirationHandler;
+- (nullable instancetype)initAndStartWithName:(NSString*)name
+                            expirationHandler:(nullable MXBackgroundTaskExpirationHandler)expirationHandler;
 
 @end
 


### PR DESCRIPTION
to keep threading model as it was before

Fix vector-im/element-ios/issues/3917.