### PR TITLE
BugFix - MXRoomSummary: directUserId may be missing (null) for a direct chat if it was joined on another device.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changes to be released in next version
  * 
 
 🐛 Bugfix
- * 
+ * MXRoomSummary: directUserId may be missing (null) for a direct chat if it was joined on another device.
 
 ⚠️ API Changes
  * 

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -2420,6 +2420,14 @@ typedef void (^MXOnResumeDone)(void);
     {
         summary = [[MXRoomSummary alloc] initWithRoomId:room.roomId andMatrixSession:self];
         roomsSummaries[room.roomId] = summary;
+
+        // Update the summary if necessary
+        NSString *directUserId = [self directUserIdInRoom:room.roomId];
+        if (directUserId)
+        {
+            summary.directUserId = directUserId;
+            [summary save:YES];
+        }
     }
 
     if (notify)


### PR DESCRIPTION
I observed a direct chat for which the field directUserId was null in its room summary. NOK

This field of the room summaries is updated currently in 3 cases (at the sdk level during the sync):
- initial sync
- new invites in the server sync response
- an update of the direct chats (in the account data)

I remembered join this direct chat on a web client, I realized the room summary was not correctly updated on iOS because the room was not present in the rooms list when we processed the new direct chat list. Indeed the account data (in which are the directs) are handled before the joined room list...
In conclusion: directUserId is missing (null) for a direct chat after the sync if it was joined on another device whereas the ios session was offline.
