### PR TITLE
MXEvent: Fix a regression on edits and replies in e2ee rooms

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changes to be released in next version
  * 
 
 🐛 Bugfix
- * 
+ * MXEvent: Fix a regression on edits and replies in e2ee rooms (vector-im/element-ios/issues/3944).
 
 ⚠️ API Changes
  * 

--- a/MatrixSDK/JSONModels/MXEvent.m
+++ b/MatrixSDK/JSONModels/MXEvent.m
@@ -854,7 +854,7 @@ NSString *const kMXEventIdentifierKey = @"kMXEventIdentifierKey";
 
         NSDictionary *decryptionClearEventJSON;
         NSDictionary *encryptedContentRelatesToJSON;
-        MXJSONModelSetDictionary(clearEventJSONContent, _wireContent[@"m.relates_to"]);
+        MXJSONModelSetDictionary(encryptedContentRelatesToJSON, _wireContent[@"m.relates_to"]);
         
         // Add "m.relates_to" data from e2e event to the unencrypted content event
         if (encryptedContentRelatesToJSON)


### PR DESCRIPTION
https://github.com/vector-im/element-ios/issues/3944

The regression came from this commit: https://github.com/matrix-org/matrix-ios-sdk/commit/ee85b4d2ae325d258a82a405480d293950cfe9d5#diff-7cdafc921212e01c6332371099d18fee873c8f1c1a5354520f71e6c623b7081eR857

Before:
<img width="364" alt="Screenshot 2021-01-18 at 12 23 58" src="https://user-images.githubusercontent.com/8418515/104909962-ec4fa900-5988-11eb-94b2-8b0b6863cfd2.png">

After:
<img width="363" alt="Screenshot 2021-01-18 at 12 24 41" src="https://user-images.githubusercontent.com/8418515/104909968-f1145d00-5988-11eb-80fe-483605633ab7.png">
