### PR TITLE
MXBackgroundSyncService: Clear the bg sync crypto db if needed 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,10 +5,10 @@ Changes to be released in next version
  * 
 
 🙌 Improvements
- * 
+ * MXRealmCryptoStore: New implementation of deleteStoreWithCredentials that does not need to open the realm DB.
 
 🐛 Bugfix
- * 
+ * MXBackgroundSyncService: Clear the bg sync crypto db if needed (vector-im/element-ios/issues/3956).
 
 ⚠️ API Changes
  * 

--- a/MatrixSDK/Background/MXBackgroundCryptoStore.h
+++ b/MatrixSDK/Background/MXBackgroundCryptoStore.h
@@ -29,6 +29,15 @@ NS_ASSUME_NONNULL_BEGIN
 @interface MXBackgroundCryptoStore : NSObject <MXCryptoStore>
 
 /**
+ Create the store for the passed credentials.
+ 
+ @param credentials the credentials of the account.
+ @param resetBackgroundCryptoStore if YES, clear the separate DB.
+ @return the store.
+ */
+- (instancetype)initWithCredentials:(MXCredentials *)theCredentials resetBackgroundCryptoStore:(BOOL)resetBackgroundCryptoStore;
+
+/**
  Reset the intermediate store.
  */
 - (void)reset;

--- a/MatrixSDK/Background/MXBackgroundCryptoStore.m
+++ b/MatrixSDK/Background/MXBackgroundCryptoStore.m
@@ -40,7 +40,7 @@ NSString *const MXBackgroundCryptoStoreUserIdSuffix = @":bgCryptoStore";
 
 @implementation MXBackgroundCryptoStore
 
-- (instancetype)initWithCredentials:(MXCredentials *)theCredentials
+- (instancetype)initWithCredentials:(MXCredentials *)theCredentials resetBackgroundCryptoStore:(BOOL)resetBackgroundCryptoStore
 {
     self = [super init];
     if (self)
@@ -59,8 +59,16 @@ NSString *const MXBackgroundCryptoStoreUserIdSuffix = @":bgCryptoStore";
         }
         
         MXCredentials *bgCredentials = [MXBackgroundCryptoStore credentialForBgCryptoStoreWithCredentials:credentials];
+        
+        if (resetBackgroundCryptoStore)
+        {
+            NSLog(@"[MXBackgroundCryptoStore] initWithCredentials: Delete existing bgCryptoStore if any");
+            [MXRealmCryptoStore deleteStoreWithCredentials:bgCredentials];
+        }
+        
         if ([MXRealmCryptoStore hasDataForCredentials:bgCredentials])
         {
+            NSLog(@"[MXBackgroundCryptoStore] initWithCredentials: Reuse existing bgCryptoStore");
             bgCryptoStore = [[MXRealmCryptoStore alloc] initWithCredentials:bgCredentials];
         }
         else
@@ -90,6 +98,12 @@ NSString *const MXBackgroundCryptoStoreUserIdSuffix = @":bgCryptoStore";
         
         [self->bgCryptoStore open:onComplete failure:failure];
     } failure:failure];
+}
+
+- (instancetype)initWithCredentials:(MXCredentials *)theCredentials
+{
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+    return nil;
 }
 
 + (BOOL)hasDataForCredentials:(MXCredentials*)credentials

--- a/MatrixSDK/Background/MXBackgroundCryptoStore.m
+++ b/MatrixSDK/Background/MXBackgroundCryptoStore.m
@@ -47,7 +47,16 @@ NSString *const MXBackgroundCryptoStoreUserIdSuffix = @":bgCryptoStore";
     {
         credentials = theCredentials;
         
-        cryptoStore = [[MXRealmCryptoStore alloc] initWithCredentials:credentials];
+        if ([MXRealmCryptoStore hasDataForCredentials:credentials])
+        {
+            cryptoStore = [[MXRealmCryptoStore alloc] initWithCredentials:credentials];
+        }
+        else
+        {
+            // Should never happen
+            NSLog(@"[MXBackgroundCryptoStore] initWithCredentials: Warning: createStoreWithCredentials: %@:%@", credentials.userId, credentials.deviceId);
+            cryptoStore = [MXRealmCryptoStore createStoreWithCredentials:credentials];
+        }
         
         MXCredentials *bgCredentials = [MXBackgroundCryptoStore credentialForBgCryptoStoreWithCredentials:credentials];
         if ([MXRealmCryptoStore hasDataForCredentials:bgCredentials])
@@ -85,25 +94,14 @@ NSString *const MXBackgroundCryptoStoreUserIdSuffix = @":bgCryptoStore";
 
 + (BOOL)hasDataForCredentials:(MXCredentials*)credentials
 {
-    // Should be always YES
-    return [MXRealmCryptoStore hasDataForCredentials:credentials];
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+    return NO;
 }
 
 + (instancetype)createStoreWithCredentials:(MXCredentials*)credentials
 {
-    // Should never happen
-    NSLog(@"[MXBackgroundCryptoStore] createStoreWithCredentials: %@:%@", credentials.userId, credentials.deviceId);
-    
-    MXRealmCryptoStore *cryptoStore = [MXRealmCryptoStore createStoreWithCredentials:credentials];
-    
-    MXCredentials *bgCredentials = [MXBackgroundCryptoStore credentialForBgCryptoStoreWithCredentials:credentials];
-    MXRealmCryptoStore *bgCryptoStore = [MXRealmCryptoStore createStoreWithCredentials:bgCredentials];
-    
-    MXBackgroundCryptoStore *store = [MXBackgroundCryptoStore new];
-    store->cryptoStore = cryptoStore;
-    store->bgCryptoStore = bgCryptoStore;
-    
-    return store;
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+    return nil;
 }
 
 

--- a/MatrixSDK/Background/MXBackgroundSyncService.swift
+++ b/MatrixSDK/Background/MXBackgroundSyncService.swift
@@ -59,7 +59,9 @@ public enum MXBackgroundSyncServiceError: Error {
         restClient = MXRestClient(credentials: credentials, unrecognizedCertificateHandler: nil)
         restClient.completionQueue = processingQueue
         store = MXBackgroundStore(withCredentials: credentials)
-        cryptoStore = MXBackgroundCryptoStore(credentials: credentials)
+        // We can flush any crypto data if our sync response store is empty
+        let resetBackgroundCryptoStore = syncResponseStore.syncResponse == nil
+        cryptoStore = MXBackgroundCryptoStore(credentials: credentials, resetBackgroundCryptoStore: resetBackgroundCryptoStore)
         olmDevice = MXOlmDevice(store: cryptoStore)
         pushRulesManager = MXBackgroundPushRulesManager(withCredentials: credentials)
         if let accountData = syncResponseStore.syncResponse?.accountData {

--- a/MatrixSDK/Background/MXBackgroundSyncService.swift
+++ b/MatrixSDK/Background/MXBackgroundSyncService.swift
@@ -59,11 +59,7 @@ public enum MXBackgroundSyncServiceError: Error {
         restClient = MXRestClient(credentials: credentials, unrecognizedCertificateHandler: nil)
         restClient.completionQueue = processingQueue
         store = MXBackgroundStore(withCredentials: credentials)
-        if MXRealmCryptoStore.hasData(for: credentials) {
-            cryptoStore = MXBackgroundCryptoStore(credentials: credentials)
-        } else {
-            cryptoStore = MXBackgroundCryptoStore.createStore(with: credentials)
-        }
+        cryptoStore = MXBackgroundCryptoStore(credentials: credentials)
         olmDevice = MXOlmDevice(store: cryptoStore)
         pushRulesManager = MXBackgroundPushRulesManager(withCredentials: credentials)
         if let accountData = syncResponseStore.syncResponse?.accountData {

--- a/MatrixSDK/Background/MXBackgroundSyncService.swift
+++ b/MatrixSDK/Background/MXBackgroundSyncService.swift
@@ -258,9 +258,6 @@ public enum MXBackgroundSyncServiceError: Error {
     private func launchBackgroundSync(forEventId eventId: String,
                                       roomId: String,
                                       completion: @escaping (MXResponse<MXEvent>) -> Void) {
-        
-        // Check local stores on every request so that we use up-to-data data from the MXSession store
-        updateBackgroundServiceStoresIfNeeded()
             
         guard let eventStreamToken = syncResponseStore.syncResponse?.nextBatch ?? store.eventStreamToken else {
             NSLog("[MXBackgroundSyncService] launchBackgroundSync: Do not sync because event streaming not started yet.")

--- a/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
+++ b/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
@@ -1440,43 +1440,10 @@ RLM_ARRAY_TYPE(MXRealmSecret)
         
         config.fileURL = realmFileURL;
         
-        // Check whether an existing db file has to be be moved from the default folder to the shared container.
-        if ([NSFileManager.defaultManager fileExistsAtPath:[defaultRealmFileURL path]])
+        // Make sure the full path exists before giving it to Realm
+        if (![NSFileManager.defaultManager fileExistsAtPath:realmFileFolderURL.path])
         {
-            if (![NSFileManager.defaultManager fileExistsAtPath:[realmFileURL path]])
-            {
-                // Move this db file in the container directory associated with the application group identifier.
-                NSLog(@"[MXRealmCryptoStore] Move the db file to the application group container");
-                
-                if (![NSFileManager.defaultManager fileExistsAtPath:realmFileFolderURL.path])
-                {
-                    [[NSFileManager defaultManager] createDirectoryAtPath:realmFileFolderURL.path withIntermediateDirectories:YES attributes:nil error:nil];
-                }
-                
-                NSError *fileManagerError = nil;
-                
-                [NSFileManager.defaultManager moveItemAtURL:defaultRealmFileURL toURL:realmFileURL error:&fileManagerError];
-                
-                if (fileManagerError)
-                {
-                    NSLog(@"[MXRealmCryptoStore] Move db file failed (%@)", fileManagerError);
-                    // Keep using the old file
-                    config.fileURL = defaultRealmFileURL;
-                }
-            }
-            else
-            {
-                // Remove the residual db file.
-                [NSFileManager.defaultManager removeItemAtURL:defaultRealmFileURL error:nil];
-            }
-        }
-        else
-        {
-            // Make sure the full exists before giving it to Realm 
-            if (![NSFileManager.defaultManager fileExistsAtPath:realmFileFolderURL.path])
-            {
-                [[NSFileManager defaultManager] createDirectoryAtPath:realmFileFolderURL.path withIntermediateDirectories:YES attributes:nil error:nil];
-            }
+            [[NSFileManager defaultManager] createDirectoryAtPath:realmFileFolderURL.path withIntermediateDirectories:YES attributes:nil error:nil];
         }
     }
     else

--- a/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
+++ b/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
@@ -346,6 +346,7 @@ RLM_ARRAY_TYPE(MXRealmSecret)
     if (![RLMRealm fileExistsForConfiguration:config])
     {
         NSLog(@"[MXRealmCryptoStore] deleteStore: Realm db does not exist");
+        return;
     }
     
     NSError *error;

--- a/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
+++ b/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
@@ -1732,7 +1732,7 @@ RLM_ARRAY_TYPE(MXRealmSecret)
         // Use the shared db file URL.
         NSURL *sharedContainerURL = [[NSFileManager defaultManager] containerURLForSecurityApplicationGroupIdentifier:applicationGroupIdentifier];
         NSURL *realmFileFolderURL = [sharedContainerURL URLByAppendingPathComponent:kMXRealmCryptoStoreFolder];
-        realmFileURL = [[realmFileFolderURL URLByAppendingPathComponent:userId] URLByAppendingPathExtension:@"realm"];
+        realmFileURL = [[realmFileFolderURL URLByAppendingPathComponent:realmFile] URLByAppendingPathExtension:@"realm"];
     }
     else
     {

--- a/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
+++ b/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
@@ -334,14 +334,16 @@ RLM_ARRAY_TYPE(MXRealmSecret)
 }
 
 + (void)deleteStoreWithCredentials:(MXCredentials*)credentials
-{
+{    
     NSLog(@"[MXRealmCryptoStore] deleteStore for %@:%@", credentials.userId, credentials.deviceId);
+    NSURL *realmFileURL = [self realmFileURLForUserWithUserId:credentials.userId andDevice:credentials.deviceId];
 
-    RLMRealm *realm = [MXRealmCryptoStore realmForUser:credentials.userId andDevice:credentials.deviceId];
-
-    [realm transactionWithBlock:^{
-        [realm deleteAllObjects];
-    }];
+    NSError *error;
+    [[NSFileManager defaultManager] removeItemAtPath:realmFileURL.path error:&error];
+    if (error)
+    {
+        NSLog(@"[MXRealmCryptoStore] deleteStore: Error: %@", error);
+    }
 }
 
 - (instancetype)initWithCredentials:(MXCredentials *)credentials

--- a/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
+++ b/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
@@ -334,12 +334,15 @@ RLM_ARRAY_TYPE(MXRealmSecret)
 }
 
 + (void)deleteStoreWithCredentials:(MXCredentials*)credentials
-{    
+{
     NSLog(@"[MXRealmCryptoStore] deleteStore for %@:%@", credentials.userId, credentials.deviceId);
-    NSURL *realmFileURL = [self realmFileURLForUserWithUserId:credentials.userId andDevice:credentials.deviceId];
 
+    RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
+    NSURL *realmFileURL = [self realmFileURLForUserWithUserId:credentials.userId andDevice:credentials.deviceId];
+    config.fileURL = realmFileURL;
+    
     NSError *error;
-    [[NSFileManager defaultManager] removeItemAtPath:realmFileURL.path error:&error];
+    [RLMRealm deleteFilesForConfiguration:config error:&error];
     if (error)
     {
         NSLog(@"[MXRealmCryptoStore] deleteStore: Error: %@", error);


### PR DESCRIPTION
so that we will be able to even clear corrupted db. This should fix vector-im/element-ios#3956.

It does not prevent the corruption (even Realm does not know how it can happen) but the app and the NSE will auto fix themselves. The user will just need to open the app. 
Opening the app will clear the background sync cache. On the next push, the bg sync service will detect that the bg sync cache is empty, it will then clear the realm db. Any corrupted db issue is solved.
Some notifications will not be able to decrypt but messages will be readable within the app.

This required some changes in `MXRealmCryptoStore` to delete the db without opening it.