### PR TITLE
Workaround for users we did not send keys to 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Changes to be released in next version
 
 🐛 Bugfix
  * MXBackgroundSyncService: Clear the bg sync crypto db if needed (vector-im/element-ios/issues/3956).
+ * MXCrypto: Add a workaround when the megolm key is not shared to all members (vector-im/element-ios/issues/3907).
 
 ⚠️ API Changes
  * 

--- a/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmEncryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmEncryption.m
@@ -456,7 +456,10 @@
     if (!deviceInfo)
     {
         NSLog(@"[MXMegolmEncryption] reshareKey: ERROR: Unknown device");
-        failure(nil);
+        NSError *error = [NSError errorWithDomain:MXEncryptingErrorDomain
+                                             code:MXEncryptingErrorUnknownDeviceCode
+                                         userInfo:nil];
+        failure(error);
         return nil;
     }
     
@@ -465,8 +468,11 @@
     NSNumber *chainIndex = [obSessionInfo.sharedWithDevices objectForDevice:deviceId forUser:userId];
     if (!chainIndex)
     {
-        NSLog(@"[MXMegolmEncryption] reshareKey: ERROR: Never share megolm with this device");
-        failure(nil);
+        NSLog(@"[MXMegolmEncryption] reshareKey: ERROR: Never shared megolm key with this device");
+        NSError *error = [NSError errorWithDomain:MXEncryptingErrorDomain
+                                             code:MXEncryptingErrorReshareNotAllowedCode
+                                         userInfo:nil];
+        failure(error);
         return nil;
     }
 

--- a/MatrixSDK/Crypto/Data/MXCryptoConstants.h
+++ b/MatrixSDK/Crypto/Data/MXCryptoConstants.h
@@ -41,7 +41,8 @@ FOUNDATION_EXPORT NSString *const MXEncryptingErrorDomain;
 typedef enum : NSUInteger
 {
     // Note: The list of unknown devices is passed into the MXEncryptingErrorUnknownDeviceDevicesKey key in userInfo
-    MXEncryptingErrorUnknownDeviceCode
+    MXEncryptingErrorUnknownDeviceCode,
+    MXEncryptingErrorReshareNotAllowedCode
 } MXEncryptingErrorCode;
 
 FOUNDATION_EXPORT NSString* const MXEncryptingErrorUnknownDeviceReason;


### PR DESCRIPTION
The workaround for https://github.com/vector-im/element-ios/issues/3807 is explained in the [code](https://github.com/matrix-org/matrix-ios-sdk/compare/3807_keys_not_sent_workaround?expand=1#diff-71ce6c0d14f35842c13b559fe3fb8d8b1854546a30be98b476b5407146ec83aaR281)

I added more logs in the lazy loading of room members to check if the root issue is not there. 