### PR TITLE
MX3PidAddManager: Use a non empty client_secret to discover /account/3pid/add flows

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Changes to be released in next version
 🐛 Bugfix
  * MXBackgroundSyncService: Clear the bg sync crypto db if needed (vector-im/element-ios/issues/3956).
  * MXCrypto: Add a workaround when the megolm key is not shared to all members (vector-im/element-ios/issues/3907).
+ * MX3PidAddManager: Use a non empty client_secret to discover /account/3pid/add flows (vector-im/element-ios/issues/3966).
 
 ⚠️ API Changes
  * 

--- a/MatrixSDK/ThreePidAdd/MX3PidAddManager.m
+++ b/MatrixSDK/ThreePidAdd/MX3PidAddManager.m
@@ -59,7 +59,7 @@ NSString *const MX3PidAddManagerErrorDomain = @"org.matrix.sdk.MX3PidAddManagerE
 {
     // Trigger a random request to the API
     // If authentication is required, it will provide the flow in the error response
-    return [self->mxSession.matrixRestClient add3PIDOnlyWithSessionId:@"" clientSecret:@"" authParams:nil success:^{
+    return [self->mxSession.matrixRestClient add3PIDOnlyWithSessionId:@"" clientSecret:[MXTools generateSecret] authParams:nil success:^{
         // This should not happen
         success(nil);
     } failure:^(NSError *error) {


### PR DESCRIPTION
fix vector-im/element-ios/issues/3966

We need it because Synapse now checks that it is not empty. We can use any non empty strings.

The proper fix will be to use the same client_secret  (and sid) from the beginning of the authentication. But this will be done later with https://github.com/vector-im/element-ios/issues/3970.

