### PR TITLE
Freeze MXResponse enum

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,7 @@ Changes to be released in next version
  * 
 
 ⚠️ API Changes
- * 
+ * MXResponse has been frozen for binary compatibility.
 
 🗣 Translations
  * 

--- a/MatrixSDK/Contrib/Swift/MXResponse.swift
+++ b/MatrixSDK/Contrib/Swift/MXResponse.swift
@@ -46,9 +46,10 @@ import Foundation
      }
  
  */
-public enum MXResponse<T> {
+@frozen public enum MXResponse<T> {
     case success(T)
     case failure(Error)
+    // Note: Additional cases break binary compatibility
     
     /// Indicates whether the API call was successful
     public var isSuccess: Bool {


### PR DESCRIPTION
When using [niochat/MatrixSDK](https://github.com/niochat/MatrixSDK) (or MatrixSDK.xcframework) any switch against `MXResponse` produces a warning that unknown cases are unhandled.

Hoping this change is welcome as I can't foresee any other cases that could be added to MXResponse?

Please let me know if there's any changes you would like.

Signed-off-by: Doug Earnshaw pixlwave@users.noreply.github.com

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request updates [CHANGES.rst](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CHANGES.rst)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)
