### PR TITLE
Background Sync: Use autoreleasepool to limit RAM usage

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,10 +5,10 @@ Changes to be released in next version
  * 
 
 🙌 Improvements
- * 
+ * MXMemory: New utility class to track memory usage.
 
 🐛 Bugfix
- * 
+ * Background Sync: Use autoreleasepool to limit RAM usage (vector-im/element-ios/issues/3957).
 
 ⚠️ API Changes
  * 
@@ -30,7 +30,6 @@ Changes in 0.17.10 (2021-01-27)
 
 🙌 Improvements
  * MXRealmCryptoStore: New implementation of deleteStoreWithCredentials that does not need to open the realm DB.
- * MXMemory: New utility class to track memory usage.
 
 🐛 Bugfix
  * MXBackgroundSyncService: Clear the bg sync crypto db if needed (vector-im/element-ios/issues/3956).

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changes to be released in next version
 
 🙌 Improvements
  * MXRealmCryptoStore: New implementation of deleteStoreWithCredentials that does not need to open the realm DB.
+ * MXMemory: New utility class to track memory usage.
 
 🐛 Bugfix
  * MXBackgroundSyncService: Clear the bg sync crypto db if needed (vector-im/element-ios/issues/3956).

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,7 +34,7 @@ Changes in 0.17.10 (2021-01-27)
 
 🐛 Bugfix
  * MXBackgroundSyncService: Clear the bg sync crypto db if needed (vector-im/element-ios/issues/3956).
- * MXCrypto: Add a workaround when the megolm key is not shared to all members (vector-im/element-ios/issues/3907).
+ * MXCrypto: Add a workaround when the megolm key is not shared to all members (vector-im/element-ios/issues/3807).
 
 ⚠️ API Changes
  * 

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -141,6 +141,8 @@
 		3245A7511AF7B2930001D8A7 /* MXCall.m in Sources */ = {isa = PBXBuildFile; fileRef = 3245A74D1AF7B2930001D8A7 /* MXCall.m */; };
 		3245A7521AF7B2930001D8A7 /* MXCallManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 3245A74E1AF7B2930001D8A7 /* MXCallManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3245A7531AF7B2930001D8A7 /* MXCallManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 3245A74F1AF7B2930001D8A7 /* MXCallManager.m */; };
+		324676EC25C15F4600EA855B /* MXMemory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 324676EB25C15F4600EA855B /* MXMemory.swift */; };
+		324676ED25C15F4600EA855B /* MXMemory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 324676EB25C15F4600EA855B /* MXMemory.swift */; };
 		3246BDC51A1A0789000A7D62 /* MXRoomStateDynamicTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3246BDC41A1A0789000A7D62 /* MXRoomStateDynamicTests.m */; };
 		32481A841C03572900782AD3 /* MXRoomAccountData.h in Headers */ = {isa = PBXBuildFile; fileRef = 32481A821C03572900782AD3 /* MXRoomAccountData.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		32481A851C03572900782AD3 /* MXRoomAccountData.m in Sources */ = {isa = PBXBuildFile; fileRef = 32481A831C03572900782AD3 /* MXRoomAccountData.m */; };
@@ -1409,6 +1411,7 @@
 		3245A74D1AF7B2930001D8A7 /* MXCall.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXCall.m; sourceTree = "<group>"; };
 		3245A74E1AF7B2930001D8A7 /* MXCallManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXCallManager.h; sourceTree = "<group>"; };
 		3245A74F1AF7B2930001D8A7 /* MXCallManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXCallManager.m; sourceTree = "<group>"; };
+		324676EB25C15F4600EA855B /* MXMemory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXMemory.swift; sourceTree = "<group>"; };
 		3246BDC41A1A0789000A7D62 /* MXRoomStateDynamicTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXRoomStateDynamicTests.m; sourceTree = "<group>"; };
 		32481A821C03572900782AD3 /* MXRoomAccountData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXRoomAccountData.h; sourceTree = "<group>"; };
 		32481A831C03572900782AD3 /* MXRoomAccountData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXRoomAccountData.m; sourceTree = "<group>"; };
@@ -2142,6 +2145,7 @@
 				329FB1781A0A74B100A5E88E /* MXTools.m */,
 				327E37B41A974F75007F026F /* MXLogger.h */,
 				327E37B51A974F75007F026F /* MXLogger.m */,
+				324676EB25C15F4600EA855B /* MXMemory.swift */,
 				32322A491E575F65005DD155 /* MXAllowedCertificates.h */,
 				32322A4A1E575F65005DD155 /* MXAllowedCertificates.m */,
 				C6FE1EEF1E65C4F7008587E4 /* MXAnalyticsDelegate.h */,
@@ -4387,6 +4391,7 @@
 				324AAC72239913AD00380A66 /* MXKeyVerificationRequestByDMJSONModel.m in Sources */,
 				C6B40F521F2A35BE00C42C72 /* MXRoomState.swift in Sources */,
 				B19A30C62404268600FB6F35 /* MXQRCodeDataBuilder.m in Sources */,
+				324676EC25C15F4600EA855B /* MXMemory.swift in Sources */,
 				32549AF723F2E2790002576B /* MXKeyVerificationReady.m in Sources */,
 				B11BD45522CB583E0064D8B0 /* MXReplyEventBodyParts.m in Sources */,
 				32F945F51FAB83D900622468 /* MXIncomingRoomKeyRequestCancellation.m in Sources */,
@@ -4860,6 +4865,7 @@
 				B14EF26D2397E90400758AF0 /* NSData+MatrixSDK.m in Sources */,
 				EC383BB22540688E002FBBE6 /* MXBackgroundStore.swift in Sources */,
 				B14EF26E2397E90400758AF0 /* MXFileRoomStore.m in Sources */,
+				324676ED25C15F4600EA855B /* MXMemory.swift in Sources */,
 				3A108AA525810FE5005EEBE9 /* MXRawDataKey.m in Sources */,
 				324DD29C246AD2B500377005 /* MXSecretStorage.m in Sources */,
 				B14EF26F2397E90400758AF0 /* MXUser.m in Sources */,

--- a/MatrixSDK/Background/Store/SyncResponseFileStore/MXSyncResponseFileStore.swift
+++ b/MatrixSDK/Background/Store/SyncResponseFileStore/MXSyncResponseFileStore.swift
@@ -137,7 +137,9 @@ extension MXSyncResponseFileStore: MXSyncResponseStore {
     
     public var syncResponse: MXSyncResponse? {
         get {
-            return readData()?.syncResponse
+            autoreleasepool {
+                return readData()?.syncResponse
+            }
         } set {
             autoreleasepool {
                 let data = readData() ?? MXSyncResponseStoreModel()

--- a/MatrixSDK/Background/Store/SyncResponseFileStore/MXSyncResponseFileStore.swift
+++ b/MatrixSDK/Background/Store/SyncResponseFileStore/MXSyncResponseFileStore.swift
@@ -70,15 +70,22 @@ public class MXSyncResponseFileStore: NSObject {
         fileOperationQueue.sync {
             fileContents = try? String(contentsOf: filePath,
                                        encoding: Constants.fileEncoding)
-            NSLog("[MXSyncResponseFileStore] readData: File read lasted \(stopwatch.readable())")
+            NSLog("[MXSyncResponseFileStore] readData: File read of \(fileContents?.count ?? 0) bytes lasted \(stopwatch.readable()). Free memory: \(MXMemory.formattedMemoryAvailable())")
+            
         }
+        
+        stopwatch.reset()
         guard let jsonString = fileContents else {
             return nil
         }
         guard let json = MXTools.deserialiseJSONString(jsonString) as? [AnyHashable: Any] else {
             return nil
         }
-        return MXSyncResponseStoreModel(fromJSON: json)
+        
+        let model = MXSyncResponseStoreModel(fromJSON: json)
+        
+        NSLog("[MXSyncResponseFileStore] readData: Consersion to model lasted \(stopwatch.readable()). Free memory: \(MXMemory.formattedMemoryAvailable())")
+        return model
     }
     
     private func saveData(_ data: MXSyncResponseStoreModel?) {
@@ -97,7 +104,7 @@ public class MXSyncResponseFileStore: NSObject {
             try? data.jsonString()?.write(to: self.filePath,
                                           atomically: true,
                                           encoding: Constants.fileEncoding)
-            NSLog("[MXSyncResponseFileStore] saveData: File write lasted \(stopwatch.readable())")
+            NSLog("[MXSyncResponseFileStore] saveData: File write lasted \(stopwatch.readable()). Free memory: \(MXMemory.formattedMemoryAvailable())")
         }
     }
     

--- a/MatrixSDK/Background/Store/SyncResponseFileStore/MXSyncResponseFileStore.swift
+++ b/MatrixSDK/Background/Store/SyncResponseFileStore/MXSyncResponseFileStore.swift
@@ -59,33 +59,35 @@ public class MXSyncResponseFileStore: NSObject {
     }
     
     private func readData() -> MXSyncResponseStoreModel? {
-        guard let filePath = filePath else {
-            return nil
-        }
-        
-        let stopwatch = MXStopwatch()
-        
-        var fileContents: String?
-        
-        fileOperationQueue.sync {
-            fileContents = try? String(contentsOf: filePath,
-                                       encoding: Constants.fileEncoding)
-            NSLog("[MXSyncResponseFileStore] readData: File read of \(fileContents?.count ?? 0) bytes lasted \(stopwatch.readable()). Free memory: \(MXMemory.formattedMemoryAvailable())")
+        autoreleasepool {
+            guard let filePath = filePath else {
+                return nil
+            }
             
+            let stopwatch = MXStopwatch()
+            
+            var fileContents: String?
+            
+            fileOperationQueue.sync {
+                fileContents = try? String(contentsOf: filePath,
+                                           encoding: Constants.fileEncoding)
+                NSLog("[MXSyncResponseFileStore] readData: File read of \(fileContents?.count ?? 0) bytes lasted \(stopwatch.readable()). Free memory: \(MXMemory.formattedMemoryAvailable())")
+                
+            }
+            
+            stopwatch.reset()
+            guard let jsonString = fileContents else {
+                return nil
+            }
+            guard let json = MXTools.deserialiseJSONString(jsonString) as? [AnyHashable: Any] else {
+                return nil
+            }
+            
+            let model = MXSyncResponseStoreModel(fromJSON: json)
+            
+            NSLog("[MXSyncResponseFileStore] readData: Consersion to model lasted \(stopwatch.readable()). Free memory: \(MXMemory.formattedMemoryAvailable())")
+            return model
         }
-        
-        stopwatch.reset()
-        guard let jsonString = fileContents else {
-            return nil
-        }
-        guard let json = MXTools.deserialiseJSONString(jsonString) as? [AnyHashable: Any] else {
-            return nil
-        }
-        
-        let model = MXSyncResponseStoreModel(fromJSON: json)
-        
-        NSLog("[MXSyncResponseFileStore] readData: Consersion to model lasted \(stopwatch.readable()). Free memory: \(MXMemory.formattedMemoryAvailable())")
-        return model
     }
     
     private func saveData(_ data: MXSyncResponseStoreModel?) {
@@ -121,11 +123,15 @@ extension MXSyncResponseFileStore: MXSyncResponseStore {
     
     public var prevBatch: String? {
         get {
-            return readData()?.prevBatch
+            autoreleasepool {
+                return readData()?.prevBatch
+            }
         } set {
-            let data = readData() ?? MXSyncResponseStoreModel()
-            data.prevBatch = newValue
-            saveData(data)
+            autoreleasepool {
+                let data = readData() ?? MXSyncResponseStoreModel()
+                data.prevBatch = newValue
+                saveData(data)
+            }
         }
     }
     
@@ -133,9 +139,11 @@ extension MXSyncResponseFileStore: MXSyncResponseStore {
         get {
             return readData()?.syncResponse
         } set {
-            let data = readData() ?? MXSyncResponseStoreModel()
-            data.syncResponse = newValue
-            saveData(data)
+            autoreleasepool {
+                let data = readData() ?? MXSyncResponseStoreModel()
+                data.syncResponse = newValue
+                saveData(data)
+            }
         }
     }
     

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -433,7 +433,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
                 NSString *algorithm;
                 id<MXEncrypting> alg = self->roomEncryptors[room.roomId];
 
-                NSLog(@"[MXCrypto] encryptEventContent: with %@", roomState.encryptionAlgorithm);
+                NSLog(@"[MXCrypto] encryptEventContent: with %@ for %@ users", roomState.encryptionAlgorithm, @(userIds.count));
 
                 if (!alg)
                 {

--- a/MatrixSDK/Utils/MXMemory.swift
+++ b/MatrixSDK/Utils/MXMemory.swift
@@ -73,10 +73,10 @@ public class MXMemory: NSObject {
     
     public static func formattedMemoryAvailable() -> String {
         guard #available(iOS 13.0, *) else {
-            return "Unknown MB"
+            return "Unsupported on this OS"
         }
         
-        let freeBytes = MXTools.memoryAvailable()
+        let freeBytes = self.memoryAvailable()
         let freeMB = Double(freeBytes) / 1024 / 1024
         guard let formattedStr = numberFormatter.string(from: NSNumber(value: freeMB)) else {
             return ""

--- a/MatrixSDK/Utils/MXMemory.swift
+++ b/MatrixSDK/Utils/MXMemory.swift
@@ -18,7 +18,7 @@ import Foundation
 
 /// Util class to log memory footprint and allocate memory for debugging purposes.
 @objcMembers
-class MXMemory: NSObject {
+public class MXMemory: NSObject {
     
     /// Memory formatter, uses exact 2 fraction digits and no grouping
     private static var numberFormatter: NumberFormatter {
@@ -57,7 +57,7 @@ class MXMemory: NSObject {
     
     /// Formatted memory footprint for debugging purposes
     /// - Returns: Memory footprint in MBs as a readable string
-    static func formattedMemoryFootprint() -> String {
+    public static func formattedMemoryFootprint() -> String {
         let usedBytes = UInt64(self.memoryFootprint() ?? 0)
         let usedMB = Double(usedBytes) / 1024 / 1024
         guard let formattedStr = numberFormatter.string(from: NSNumber(value: usedMB)) else {
@@ -68,7 +68,7 @@ class MXMemory: NSObject {
     
     /// Allocates some memory
     /// - Parameter numberOfBytes: Amount of memory to be allocated, in number of bytes
-    static func allocateMemoryOfSize(numberOfBytes: Int) {
+    public static func allocateMemoryOfSize(numberOfBytes: Int) {
         var buffer = [UInt8](repeating: 0, count: numberOfBytes)
         for i in 0 ..< numberOfBytes {
             buffer[i] = UInt8(i % 7)

--- a/MatrixSDK/Utils/MXMemory.swift
+++ b/MatrixSDK/Utils/MXMemory.swift
@@ -66,6 +66,24 @@ public class MXMemory: NSObject {
         return "\(formattedStr) MB"
     }
     
+    public static func memoryAvailable() -> UInt {
+        // We need some ObjC to get the value
+        return MXTools.memoryAvailable()
+    }
+    
+    public static func formattedMemoryAvailable() -> String {
+        guard #available(iOS 13.0, *) else {
+            return "Unknown MB"
+        }
+        
+        let freeBytes = MXTools.memoryAvailable()
+        let freeMB = Double(freeBytes) / 1024 / 1024
+        guard let formattedStr = numberFormatter.string(from: NSNumber(value: freeMB)) else {
+            return ""
+        }
+        return "\(formattedStr) MB"
+    }
+    
     /// Allocates some memory
     /// - Parameter numberOfBytes: Amount of memory to be allocated, in number of bytes
     public static func allocateMemoryOfSize(numberOfBytes: Int) {

--- a/MatrixSDK/Utils/MXMemory.swift
+++ b/MatrixSDK/Utils/MXMemory.swift
@@ -1,0 +1,77 @@
+/*
+ Copyright 2021 The Matrix.org Foundation C.I.C
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import Foundation
+
+/// Util class to log memory footprint and allocate memory for debugging purposes.
+@objcMembers
+class MXMemory: NSObject {
+    
+    /// Memory formatter, uses exact 2 fraction digits and no grouping
+    private static var numberFormatter: NumberFormatter {
+        let formatter = NumberFormatter()
+        formatter.alwaysShowsDecimalSeparator = true
+        formatter.decimalSeparator = "."
+        formatter.groupingSeparator = ""
+        formatter.maximumFractionDigits = 2
+        formatter.minimumFractionDigits = 2
+        return formatter
+    }
+    
+    /// Details: https://developer.apple.com/forums/thread/105088
+    /// - Returns: Current memory footprint
+    private static func memoryFootprint() -> Float? {
+        //  The `TASK_VM_INFO_COUNT` and `TASK_VM_INFO_REV1_COUNT` macros are too
+        //  complex for the Swift C importer, so we have to define them ourselves.
+        let TASK_VM_INFO_COUNT = mach_msg_type_number_t(MemoryLayout<task_vm_info_data_t>.size / MemoryLayout<integer_t>.size)
+        guard let offset = MemoryLayout.offset(of: \task_vm_info_data_t.min_address) else {
+            return nil
+        }
+        let TASK_VM_INFO_REV1_COUNT = mach_msg_type_number_t(offset / MemoryLayout<integer_t>.size)
+        var info = task_vm_info_data_t()
+        var count = TASK_VM_INFO_COUNT
+        let kr = withUnsafeMutablePointer(to: &info) { infoPtr in
+            infoPtr.withMemoryRebound(to: integer_t.self, capacity: Int(count)) { intPtr in
+                task_info(mach_task_self_, task_flavor_t(TASK_VM_INFO), intPtr, &count)
+            }
+        }
+        guard kr == KERN_SUCCESS, count >= TASK_VM_INFO_REV1_COUNT else {
+            return nil
+        }
+        
+        return Float(info.phys_footprint)
+    }
+    
+    /// Formatted memory footprint for debugging purposes
+    /// - Returns: Memory footprint in MBs as a readable string
+    static func formattedMemoryFootprint() -> String {
+        let usedBytes = UInt64(self.memoryFootprint() ?? 0)
+        let usedMB = Double(usedBytes) / 1024 / 1024
+        guard let formattedStr = numberFormatter.string(from: NSNumber(value: usedMB)) else {
+            return ""
+        }
+        return "\(formattedStr) MB"
+    }
+    
+    /// Allocates some memory
+    /// - Parameter numberOfBytes: Amount of memory to be allocated, in number of bytes
+    static func allocateMemoryOfSize(numberOfBytes: Int) {
+        var buffer = [UInt8](repeating: 0, count: numberOfBytes)
+        for i in 0 ..< numberOfBytes {
+            buffer[i] = UInt8(i % 7)
+        }
+    }
+}

--- a/MatrixSDK/Utils/MXTools.h
+++ b/MatrixSDK/Utils/MXTools.h
@@ -291,6 +291,19 @@ FOUNDATION_EXPORT NSString *const kMXToolsRegexStringForMatrixGroupIdentifier;
     typeof(var) var = weak##var
 
 
+#pragma mark - OS
+
+/**
+ Return the available memory.
+ 
+ @discussion
+ Available only for iOS from iOS13.
+ 
+ @return free memory in bytes.
+ */
++ (NSUInteger)memoryAvailable;
+
+
 #pragma mark - Unit testing
 
 /**

--- a/MatrixSDK/Utils/MXTools.m
+++ b/MatrixSDK/Utils/MXTools.m
@@ -23,6 +23,10 @@
 #import <MobileCoreServices/MobileCoreServices.h>
 #endif
 
+#if defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
+#import <os/proc.h>
+#endif
+
 #pragma mark - Constant definition
 NSString *const kMXToolsRegexStringForEmailAddress              = @"[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,}";
 
@@ -751,6 +755,18 @@ static NSMutableDictionary *fileExtensionByContentType = nil;
     NSData *jsonData = [jsonString dataUsingEncoding:NSUTF8StringEncoding];
     return [NSJSONSerialization JSONObjectWithData:jsonData options:0 error:nil];
 }
+
+
+#pragma mark - OS
+
++ (NSUInteger)memoryAvailable
+{
+#if defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
+    return os_proc_available_memory();
+#endif
+    return 0;
+}
+
 
 + (BOOL)isRunningUnitTests
 {


### PR DESCRIPTION
This change will make out of memory issues described at https://github.com/vector-im/element-ios/issues/3957#issuecomment-769076459 happen a bit later.

We need to have another implementation of the store for big accounts letting their app in background.

With a bg sync store of 2MB, I can get notifications and I have 4MB memory left (out of 24MB available). 

MXMemory was moved from element codebase.