### PR TITLE
MXLoginSSOIdentityProvider: Add new `brand` field as described in MSC2858

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changes to be released in next version
  * 
 
 🙌 Improvements
- * 
+ * MXLoginSSOIdentityProvider: Add new `brand` field as described in MSC2858 (vector-im/element-ios/issues/3980).
 
 🐛 Bugfix
  * 

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -1074,6 +1074,8 @@
 		B14EF3632397E90400758AF0 /* MXScanRealmFileProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = B146D4C621A5A44E00D8C2C6 /* MXScanRealmFileProvider.h */; };
 		B14EF3642397E90400758AF0 /* MXRoom.h in Headers */ = {isa = PBXBuildFile; fileRef = 320DFDCA19DD99B60068622A /* MXRoom.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B14EF3652397E90400758AF0 /* MXServiceTerms.h in Headers */ = {isa = PBXBuildFile; fileRef = 3294FD9C22F321B0007F1E60 /* MXServiceTerms.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B165B81125C3307E003CF7F7 /* MXLoginSSOIdentityProviderBrand.h in Headers */ = {isa = PBXBuildFile; fileRef = B165B81025C3307E003CF7F7 /* MXLoginSSOIdentityProviderBrand.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B165B81225C3307E003CF7F7 /* MXLoginSSOIdentityProviderBrand.h in Headers */ = {isa = PBXBuildFile; fileRef = B165B81025C3307E003CF7F7 /* MXLoginSSOIdentityProviderBrand.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B17285792100C8EA0052C51E /* MXSendReplyEventStringsLocalizable.h in Headers */ = {isa = PBXBuildFile; fileRef = B17285782100C88A0052C51E /* MXSendReplyEventStringsLocalizable.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B172857C2100D4F60052C51E /* MXSendReplyEventDefaultStringLocalizations.h in Headers */ = {isa = PBXBuildFile; fileRef = B172857A2100D4F60052C51E /* MXSendReplyEventDefaultStringLocalizations.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B172857D2100D4F60052C51E /* MXSendReplyEventDefaultStringLocalizations.m in Sources */ = {isa = PBXBuildFile; fileRef = B172857B2100D4F60052C51E /* MXSendReplyEventDefaultStringLocalizations.m */; };
@@ -1850,6 +1852,7 @@
 		B14EECE42577F76100448735 /* MXLoginSSOFlow.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXLoginSSOFlow.m; sourceTree = "<group>"; };
 		B14EECED2578FE3F00448735 /* MXAuthenticationSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXAuthenticationSessionTests.swift; sourceTree = "<group>"; };
 		B14EF36B2397E90400758AF0 /* MatrixSDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MatrixSDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B165B81025C3307E003CF7F7 /* MXLoginSSOIdentityProviderBrand.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXLoginSSOIdentityProviderBrand.h; sourceTree = "<group>"; };
 		B17285782100C88A0052C51E /* MXSendReplyEventStringsLocalizable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MXSendReplyEventStringsLocalizable.h; path = ../MXSendReplyEventStringsLocalizable.h; sourceTree = "<group>"; };
 		B172857A2100D4F60052C51E /* MXSendReplyEventDefaultStringLocalizations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MXSendReplyEventDefaultStringLocalizations.h; path = ../MXSendReplyEventDefaultStringLocalizations.h; sourceTree = "<group>"; };
 		B172857B2100D4F60052C51E /* MXSendReplyEventDefaultStringLocalizations.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = MXSendReplyEventDefaultStringLocalizations.m; path = ../MXSendReplyEventDefaultStringLocalizations.m; sourceTree = "<group>"; };
@@ -3308,6 +3311,7 @@
 		B14EECD42577DE4400448735 /* Login */ = {
 			isa = PBXGroup;
 			children = (
+				B165B81025C3307E003CF7F7 /* MXLoginSSOIdentityProviderBrand.h */,
 				B14EECD52577DE7A00448735 /* MXLoginSSOIdentityProvider.h */,
 				B14EECD62577DE7A00448735 /* MXLoginSSOIdentityProvider.m */,
 				B14EECE32577F76100448735 /* MXLoginSSOFlow.h */,
@@ -3608,6 +3612,7 @@
 				3A108A7E25810C96005EEBE9 /* MXKeyData.h in Headers */,
 				327A5F4D239805F600ED6329 /* MXKeyVerificationStart.h in Headers */,
 				B124BBCC256453C90028996D /* MXMembershipTransitionState.h in Headers */,
+				B165B81125C3307E003CF7F7 /* MXLoginSSOIdentityProviderBrand.h in Headers */,
 				324DD2BF246D658500377005 /* MXHkdfSha256.h in Headers */,
 				32792BD42295A86600F4FC9D /* MXAggregatedReactionsUpdater.h in Headers */,
 				B146D4D621A5A44E00D8C2C6 /* MXScanRealmInMemoryProvider.h in Headers */,
@@ -3984,6 +3989,7 @@
 				B14EF3422397E90400758AF0 /* MXPeekingRoomSummary.h in Headers */,
 				B14EF3432397E90400758AF0 /* MXEventTimeline.h in Headers */,
 				B14EF3442397E90400758AF0 /* NSArray+MatrixSDK.h in Headers */,
+				B165B81225C3307E003CF7F7 /* MXLoginSSOIdentityProviderBrand.h in Headers */,
 				324DD2C6246E638B00377005 /* MXAesHmacSha2.h in Headers */,
 				B14EF3452397E90400758AF0 /* MXReplyEventParser.h in Headers */,
 				323F878E25553D84009E9E67 /* MXTaskProfile.h in Headers */,

--- a/MatrixSDK/JSONModels/Login/MXLoginSSOIdentityProvider.h
+++ b/MatrixSDK/JSONModels/Login/MXLoginSSOIdentityProvider.h
@@ -35,6 +35,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) NSString *name;
 
 /**
+ The brand field is optional. It allows the client to style the login button to suit a particular brand.
+ */
+@property (nonatomic, readonly, nullable) NSString *brand;
+
+/**
  The icon field is an optional field that points to an icon representing the identity provider. If present then it must be an HTTPS URL to an image resource.
  */
 @property (nonatomic, readonly, nullable) NSString *icon;

--- a/MatrixSDK/JSONModels/Login/MXLoginSSOIdentityProvider.m
+++ b/MatrixSDK/JSONModels/Login/MXLoginSSOIdentityProvider.m
@@ -21,6 +21,7 @@
 @property (nonatomic, readwrite) NSString *identifier;
 @property (nonatomic, readwrite) NSString *name;
 @property (nonatomic, readwrite, nullable) NSString *icon;
+@property (nonatomic, readwrite, nullable) NSString *brand;
 
 @end
 
@@ -43,6 +44,7 @@
         identityProvider.identifier = identifier;
         identityProvider.name = name;
         MXJSONModelSetString(identityProvider.icon, JSONDictionary[@"icon"]);
+        MXJSONModelSetString(identityProvider.brand, JSONDictionary[@"brand"]);
     }
     
     return identityProvider;

--- a/MatrixSDK/JSONModels/Login/MXLoginSSOIdentityProviderBrand.h
+++ b/MatrixSDK/JSONModels/Login/MXLoginSSOIdentityProviderBrand.h
@@ -1,0 +1,27 @@
+// 
+// Copyright 2021 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+/// MXLoginSSOIdentityProviderBrand identifies known identity provider brands as described in MSC2858 (see https://github.com/matrix-org/matrix-doc/pull/2858).
+/// Server implementations are free to add additional brands, though they should be mindful of clients which do not recognise any given brand.
+/// Clients are free to implement any set of brands they wish, including all or any of the bellow, but are expected to apply a sensible unbranded fallback for any brand they do not recognise/support.
+typedef NSString * MXLoginSSOIdentityProviderBrand NS_STRING_ENUM;
+
+static MXLoginSSOIdentityProviderBrand const MXLoginSSOIdentityProviderBrandGitlab = @"org.matrix.gitlab";
+static MXLoginSSOIdentityProviderBrand const MXLoginSSOIdentityProviderBrandGithub = @"org.matrix.github";
+static MXLoginSSOIdentityProviderBrand const MXLoginSSOIdentityProviderBrandApple = @"org.matrix.apple";
+static MXLoginSSOIdentityProviderBrand const MXLoginSSOIdentityProviderBrandGoogle = @"org.matrix.google";
+static MXLoginSSOIdentityProviderBrand const MXLoginSSOIdentityProviderBrandFacebook = @"org.matrix.facebook";
+static MXLoginSSOIdentityProviderBrand const MXLoginSSOIdentityProviderBrandTwitter = @"org.matrix.twitter";

--- a/MatrixSDK/JSONModels/Login/MXLoginSSOIdentityProviderBrand.h
+++ b/MatrixSDK/JSONModels/Login/MXLoginSSOIdentityProviderBrand.h
@@ -17,7 +17,7 @@
 /// MXLoginSSOIdentityProviderBrand identifies known identity provider brands as described in MSC2858 (see https://github.com/matrix-org/matrix-doc/pull/2858).
 /// Server implementations are free to add additional brands, though they should be mindful of clients which do not recognise any given brand.
 /// Clients are free to implement any set of brands they wish, including all or any of the bellow, but are expected to apply a sensible unbranded fallback for any brand they do not recognise/support.
-typedef NSString * MXLoginSSOIdentityProviderBrand NS_STRING_ENUM;
+typedef NSString *const MXLoginSSOIdentityProviderBrand NS_TYPED_EXTENSIBLE_ENUM;
 
 static MXLoginSSOIdentityProviderBrand const MXLoginSSOIdentityProviderBrandGitlab = @"org.matrix.gitlab";
 static MXLoginSSOIdentityProviderBrand const MXLoginSSOIdentityProviderBrandGithub = @"org.matrix.github";


### PR DESCRIPTION
Part of vector-im/element-ios/issues/3980