### PR TITLE
Cache realm for thread, instead of recreating it on every access

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Changes to be released in next version
  * MXMemory: New utility class to track memory usage.
  * MXRealmCryptoStore: Compact Realm DB only once, at the first usage.
  * MXLoginSSOIdentityProvider: Add new `brand` field as described in MSC2858 (vector-im/element-ios/issues/3980).
+ * MXRealmCryptoStore: Cache the Realm for the current thread.
 
 🐛 Bugfix
  * Background Sync: Use autoreleasepool to limit RAM usage (vector-im/element-ios/issues/3957).

--- a/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
+++ b/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
@@ -426,6 +426,7 @@ static void cleanup_id(void *ptr) {
 
 - (RLMRealm *)realm
 {
+    // Cache the store for this thread in a pthread_specific. Release it in the cleanup.
     static pthread_key_t realmKey;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{

--- a/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
+++ b/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
@@ -301,7 +301,7 @@ RLM_ARRAY_TYPE(MXRealmSecret)
 
 @interface MXRealmCryptoStore ()
 {
-    NSCache<NSThread *, RLMRealm*> *cachedRealms;
+    NSCache<NSThread *, RLMRealm *> *cachedRealms;
     NSString *userId;
     NSString *deviceId;
 }


### PR DESCRIPTION
In unscientific profiling (scrolling through a group chat of mine for about 5 seconds,) `+realmForUser:andDevice:` was crazy expensive. On my iMac Pro, it accounted for 534ms of CPU time. After this patch, it dropped to 21ms.

<img width="1751" alt="Screen Shot 2021-01-31 at 2 12 34 PM" src="https://user-images.githubusercontent.com/2466893/106395278-62173400-63cf-11eb-8160-99d7d3edf758.png">

<img width="1751" alt="Screen Shot 2021-01-31 at 2 15 01 PM" src="https://user-images.githubusercontent.com/2466893/106395282-67747e80-63cf-11eb-88bf-133c907fe99d.png">

Let me know!

Signed-off-by: Adlai Holler <adlai@icloud.com>
