### PR TITLE
VoIP: Fix camera indicator when video call answered elsewhere

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,7 @@ Changes to be released in next version
  * VoIP: DTMF support in calls (vector-im/element-ios/issues/3929).
 
 🐛 Bugfix
- * 
+ * VoIP: Fix camera indicator when video call answered elsewhere (vector-im/element-ios/issues/3971).
 
 ⚠️ API Changes
  * 

--- a/MatrixSDK/VoIP/MXCall.m
+++ b/MatrixSDK/VoIP/MXCall.m
@@ -682,6 +682,9 @@ NSString *const kMXCallSupportsTransferringStatusDidChange = @"kMXCallSupportsTr
         [[MXSDKOptions sharedInstance].analyticsDelegate trackValue:@(_endReason)
                                                            category:kMXAnalyticsVoipCategory
                                                                name:kMXAnalyticsVoipNameCallEnded];
+        
+        // Terminate the call at the stack level
+        [callStackCall end];
     }
     else if (MXCallStateInviteSent == state)
     {


### PR DESCRIPTION
Fix vector-im/element-ios#3971