### PR TITLE
MXSession: Make `handleBackgroundSyncCacheIfRequiredWithCompletion` public

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Changes to be released in next version
  * MXMemory: New utility class to track memory usage.
  * MXRealmCryptoStore: Compact Realm DB only once, at the first usage.
  * MXLoginSSOIdentityProvider: Add new `brand` field as described in MSC2858 (vector-im/element-ios/issues/3980).
+ * MXSession: Make `handleBackgroundSyncCacheIfRequiredWithCompletion` method public (vector-im/element-ios/issues/3986).
 
 🐛 Bugfix
  * Background Sync: Use autoreleasepool to limit RAM usage (vector-im/element-ios/issues/3957).

--- a/MatrixSDK/MXSession.h
+++ b/MatrixSDK/MXSession.h
@@ -573,6 +573,13 @@ typedef void (^MXOnBackgroundSyncFail)(NSError *error);
                failure:(MXOnBackgroundSyncFail)backgroundSyncfails NS_REFINED_FOR_SWIFT;
 
 /**
+ Handles sync response retrieved by the background sync service, if the cache is valid. Clears the cache after processing.
+ 
+ @param completion Completion block called when the session has been processed the cache, or when no valid cache exists.
+ */
+- (void)handleBackgroundSyncCacheIfRequiredWithCompletion:(void (^)(void))completion;
+
+/**
  Restart the session events stream.
  @return YES if the operation succeeds
  */


### PR DESCRIPTION
Part of vector-im/element-ios#3986