### PR TITLE
VoIP: Add New Event Types to Mapping

### DIFF
--- a/MatrixSDK/Utils/MXTools.m
+++ b/MatrixSDK/Utils/MXTools.m
@@ -110,6 +110,8 @@ NSCharacterSet *uriComponentCharset;
                                 kMXEventTypeStringCallHangup,
                                 kMXEventTypeStringCallReject,
                                 kMXEventTypeStringCallNegotiate,
+                                kMXEventTypeStringCallReplaces,
+                                kMXEventTypeStringCallRejectReplacement,
                                 kMXEventTypeStringSticker,
                                 kMXEventTypeStringRoomTombStone,
                                 kMXEventTypeStringKeyVerificationRequest,


### PR DESCRIPTION
Fixes `m.key.verification.start` events to be handled as `m.key.verification.request` events.