### PR TITLE
MXRealmCryptoStore: Make sure secrets in the DB are encrypted

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Changes to be released in next version
  * MXRoomState: Add creator user id property.
  * MXRoomSummary: Add creator user id property.
  * MXCrypto: Encrypt cached e2ee data using an external pickle key (vector-im/element-ios#3867).
+ * Crypto: Upgrade OLMKit(3.2.2).
 
 🐛 Bugfix
  * Fix calls from my own users (vector-im/element-ios/issues/4031).

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Changes to be released in next version
 🙌 Improvements
  * MXRoomState: Add creator user id property.
  * MXRoomSummary: Add creator user id property.
+ * MXCrypto: Encrypt cached e2ee data using an external pickle key (vector-im/element-ios#3867).
 
 🐛 Bugfix
  * Fix calls from my own users (vector-im/element-ios/issues/4031).

--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -37,7 +37,7 @@ Pod::Spec.new do |s|
       ss.dependency 'GZIP', '~> 1.3.0'
 
       # Requirements for e2e encryption
-      ss.dependency 'OLMKit', '~> 3.1.0'
+      ss.dependency 'OLMKit', '~> 3.2.2'
       ss.dependency 'Realm', '10.1.4'
       ss.dependency 'libbase58', '~> 0.1.4'
   end

--- a/MatrixSDK/Crypto/Data/MXCryptoConstants.h
+++ b/MatrixSDK/Crypto/Data/MXCryptoConstants.h
@@ -33,6 +33,11 @@ FOUNDATION_EXPORT NSString *const kMXCryptoMegolmAlgorithm;
  */
 FOUNDATION_EXPORT NSString *const kMXCryptoMegolmBackupAlgorithm;
 
+/**
+ MXKeyProvider identifier for a 32 bytes long key to pickle secrets managed by the olm library.
+ */
+FOUNDATION_EXPORT NSString *const MXCryptoOlmPickleKeyDataType;
+
 
 #pragma mark - Encrypting error
 

--- a/MatrixSDK/Crypto/Data/MXCryptoConstants.m
+++ b/MatrixSDK/Crypto/Data/MXCryptoConstants.m
@@ -20,6 +20,7 @@
 NSString *const kMXCryptoOlmAlgorithm           = @"m.olm.v1.curve25519-aes-sha2";
 NSString *const kMXCryptoMegolmAlgorithm        = @"m.megolm.v1.aes-sha2";
 NSString *const kMXCryptoMegolmBackupAlgorithm  = @"m.megolm_backup.v1.curve25519-aes-sha2";
+NSString *const MXCryptoOlmPickleKeyDataType    = @"org.matrix.sdk.olm.pickle.key";
 
 
 #pragma mark - Encrypting error

--- a/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
+++ b/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
@@ -1,13 +1,13 @@
 /*
  Copyright 2016 OpenMarket Ltd
  Copyright 2017 Vector Creations Ltd
-
+ 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
-
+ 
  http://www.apache.org/licenses/LICENSE-2.0
-
+ 
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -243,13 +243,13 @@ RLM_ARRAY_TYPE(MXRealmSharedOutboundSession)
 - (MXOutgoingRoomKeyRequest *)outgoingRoomKeyRequest
 {
     MXOutgoingRoomKeyRequest *outgoingRoomKeyRequest = [[MXOutgoingRoomKeyRequest alloc] init];
-
+    
     outgoingRoomKeyRequest.requestId = self.requestId;
     outgoingRoomKeyRequest.cancellationTxnId = self.cancellationTxnId;
     outgoingRoomKeyRequest.state = (MXRoomKeyRequestState)[self.state unsignedIntegerValue];
     outgoingRoomKeyRequest.recipients = [NSKeyedUnarchiver unarchiveObjectWithData:self.recipientsData];
     outgoingRoomKeyRequest.requestBody = [MXTools deserialiseJSONString:self.requestBodyString];
-
+    
     return outgoingRoomKeyRequest;
 }
 
@@ -270,12 +270,12 @@ RLM_ARRAY_TYPE(MXRealmSharedOutboundSession)
 - (MXIncomingRoomKeyRequest *)incomingRoomKeyRequest
 {
     MXIncomingRoomKeyRequest *incomingRoomKeyRequest = [[MXIncomingRoomKeyRequest alloc] init];
-
+    
     incomingRoomKeyRequest.requestId = self.requestId;
     incomingRoomKeyRequest.userId = self.userId;
     incomingRoomKeyRequest.deviceId = self.deviceId;
     incomingRoomKeyRequest.requestBody = [NSKeyedUnarchiver unarchiveObjectWithData:self.requestBodyData];
-
+    
     return incomingRoomKeyRequest;
 }
 
@@ -307,7 +307,7 @@ RLM_ARRAY_TYPE(MXRealmSecret)
 
 /**
  The realm on the current thread.
-
+ 
  As MXCryptoStore methods can be called from different threads, we need to load realm objects
  from the root. This is how Realm works in multi-threading environment.
  */
@@ -331,14 +331,14 @@ RLM_ARRAY_TYPE(MXRealmSecret)
 + (instancetype)createStoreWithCredentials:(MXCredentials*)credentials
 {
     NSLog(@"[MXRealmCryptoStore] createStore for %@:%@", credentials.userId, credentials.deviceId);
-
+    
     RLMRealm *realm = [MXRealmCryptoStore realmForUser:credentials.userId andDevice:credentials.deviceId];
-
+    
     MXRealmOlmAccount *account = [[MXRealmOlmAccount alloc] initWithValue:@{
-                                                                          @"userId" : credentials.userId,
-                                                                          }];
+        @"userId" : credentials.userId,
+    }];
     account.deviceId = credentials.deviceId;
-
+    
     [realm beginWriteTransaction];
     [realm addObject:account];
     [realm commitWriteTransaction];
@@ -389,13 +389,13 @@ RLM_ARRAY_TYPE(MXRealmSecret)
 - (instancetype)initWithCredentials:(MXCredentials *)credentials
 {
     NSLog(@"[MXRealmCryptoStore] initWithCredentials for %@:%@", credentials.userId, credentials.deviceId);
-
+    
     self = [super init];
     if (self)
     {
         userId = credentials.userId;
         deviceId = credentials.deviceId;
-
+        
         MXRealmOlmAccount *account = self.accountInCurrentThread;
         if (!account)
         {
@@ -411,7 +411,7 @@ RLM_ARRAY_TYPE(MXRealmSecret)
                 return [MXRealmCryptoStore createStoreWithCredentials:credentials];
             }
         }
-
+        
         NSLog(@"[MXRealmCryptoStore] Schema version: %llu", account.realm.configuration.schemaVersion);
     }
     return self;
@@ -435,7 +435,7 @@ RLM_ARRAY_TYPE(MXRealmSecret)
 - (void)storeDeviceId:(NSString*)deviceId
 {
     MXRealmOlmAccount *account = self.accountInCurrentThread;
-
+    
     [account.realm transactionWithBlock:^{
         account.deviceId = deviceId;
     }];
@@ -444,20 +444,20 @@ RLM_ARRAY_TYPE(MXRealmSecret)
 - (NSString*)deviceId
 {
     MXRealmOlmAccount *account = self.accountInCurrentThread;
-
+    
     return account.deviceId;
 }
 
 - (void)setAccount:(OLMAccount*)olmAccount
 {
     NSDate *startDate = [NSDate date];
-
+    
     MXRealmOlmAccount *account = self.accountInCurrentThread;
-
+    
     [account.realm transactionWithBlock:^{
         account.olmAccountData = [NSKeyedArchiver archivedDataWithRootObject:olmAccount];
     }];
-
+    
     NSLog(@"[MXRealmCryptoStore] storeAccount in %.3fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 }
 
@@ -522,28 +522,28 @@ RLM_ARRAY_TYPE(MXRealmSecret)
 - (void)storeDeviceForUser:(NSString*)userID device:(MXDeviceInfo*)device
 {
     NSDate *startDate = [NSDate date];
-
+    
     RLMRealm *realm = self.realm;
-
+    
     [realm transactionWithBlock:^{
-
+        
         MXRealmUser *realmUser = [MXRealmUser objectsInRealm:realm where:@"userId = %@", userID].firstObject;
         if (!realmUser)
         {
             realmUser = [[MXRealmUser alloc] initWithValue:@{
-                                                            @"userId": userID,
-                                                            }];
-
+                @"userId": userID,
+            }];
+            
             [realm addObject:realmUser];
         }
-
+        
         MXRealmDeviceInfo *realmDevice = [[realmUser.devices objectsWhere:@"deviceId = %@", device.deviceId] firstObject];
         if (!realmDevice)
         {
             realmDevice = [[MXRealmDeviceInfo alloc] initWithValue:@{
-                                                                    @"deviceId": device.deviceId,
-                                                                    @"deviceInfoData": [NSKeyedArchiver archivedDataWithRootObject:device]
-                                                                    }];
+                @"deviceId": device.deviceId,
+                @"deviceInfoData": [NSKeyedArchiver archivedDataWithRootObject:device]
+            }];
             realmDevice.identityKey = device.identityKey;
             [realmUser.devices addObject:realmDevice];
         }
@@ -551,22 +551,22 @@ RLM_ARRAY_TYPE(MXRealmSecret)
         {
             realmDevice.deviceInfoData = [NSKeyedArchiver archivedDataWithRootObject:device];
         }
-
+        
     }];
-
+    
     NSLog(@"[MXRealmCryptoStore] storeDeviceForUser in %.3fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 }
 
 - (MXDeviceInfo*)deviceWithDeviceId:(NSString*)deviceId forUser:(NSString*)userID
 {
     MXRealmUser *realmUser = [MXRealmUser objectsInRealm:self.realm where:@"userId = %@", userID].firstObject;
-
+    
     MXRealmDeviceInfo *realmDevice = [[realmUser.devices objectsWhere:@"deviceId = %@", deviceId] firstObject];
     if (realmDevice)
     {
         return [NSKeyedUnarchiver unarchiveObjectWithData:realmDevice.deviceInfoData];
     }
-
+    
     return nil;
 }
 
@@ -577,24 +577,24 @@ RLM_ARRAY_TYPE(MXRealmSecret)
     {
         return [NSKeyedUnarchiver unarchiveObjectWithData:realmDevice.deviceInfoData];
     }
-
+    
     return nil;
 }
 
 - (void)storeDevicesForUser:(NSString*)userID devices:(NSDictionary<NSString*, MXDeviceInfo*>*)devices
 {
     NSDate *startDate = [NSDate date];
-
+    
     RLMRealm *realm = self.realm;
-
+    
     [realm transactionWithBlock:^{
-
+        
         MXRealmUser *realmUser = [MXRealmUser objectsInRealm:realm where:@"userId = %@", userID].firstObject;
         if (!realmUser)
         {
             realmUser = [[MXRealmUser alloc] initWithValue:@{
-                                                             @"userId": userID,
-                                                             }];
+                @"userId": userID,
+            }];
             [realm addObject:realmUser];
         }
         else
@@ -602,37 +602,37 @@ RLM_ARRAY_TYPE(MXRealmSecret)
             // Reset all previously stored devices for this user
             [realm deleteObjects:realmUser.devices];
         }
-
+        
         for (NSString *deviceId in devices)
         {
             MXDeviceInfo *device = devices[deviceId];
             MXRealmDeviceInfo *realmDevice = [[MXRealmDeviceInfo alloc] initWithValue:@{
-                                                                                        @"deviceId": device.deviceId,
-                                                                                        @"deviceInfoData": [NSKeyedArchiver archivedDataWithRootObject:device]
-                                                                                        }];
+                @"deviceId": device.deviceId,
+                @"deviceInfoData": [NSKeyedArchiver archivedDataWithRootObject:device]
+            }];
             realmDevice.identityKey = device.identityKey;
             [realmUser.devices addObject:realmDevice];
         }
     }];
-
+    
     NSLog(@"[MXRealmCryptoStore] storeDevicesForUser (count: %tu) in %.3fms", devices.count, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 }
 
 - (NSDictionary<NSString*, MXDeviceInfo*>*)devicesForUser:(NSString*)userID
 {
     NSMutableDictionary *devicesForUser;
-
+    
     MXRealmUser *realmUser = [MXRealmUser objectsInRealm:self.realm where:@"userId = %@", userID].firstObject;
     if (realmUser)
     {
         devicesForUser = [NSMutableDictionary dictionary];
-
+        
         for (MXRealmDeviceInfo *realmDevice in realmUser.devices)
         {
             devicesForUser[realmDevice.deviceId] = [NSKeyedUnarchiver unarchiveObjectWithData:realmDevice.deviceInfoData];
         }
     }
-
+    
     return devicesForUser;
 }
 
@@ -646,7 +646,7 @@ RLM_ARRAY_TYPE(MXRealmSecret)
 {
     MXRealmOlmAccount *account = self.accountInCurrentThread;
     [account.realm transactionWithBlock:^{
-
+        
         account.deviceTrackingStatusData = [NSKeyedArchiver archivedDataWithRootObject:statusMap];
     }];
 }
@@ -657,22 +657,22 @@ RLM_ARRAY_TYPE(MXRealmSecret)
 - (void)storeCrossSigningKeys:(MXCrossSigningInfo*)crossSigningInfo
 {
     RLMRealm *realm = self.realm;
-
+    
     [realm transactionWithBlock:^{
-
+        
         MXRealmUser *realmUser = [MXRealmUser objectsInRealm:realm where:@"userId = %@", crossSigningInfo.userId].firstObject;
         if (!realmUser)
         {
             realmUser = [[MXRealmUser alloc] initWithValue:@{
-                                                             @"userId": crossSigningInfo.userId,
-                                                             }];
-
+                @"userId": crossSigningInfo.userId,
+            }];
+            
             [realm addObject:realmUser];
         }
-
+        
         MXRealmCrossSigningInfo *realmCrossSigningKeys = [[MXRealmCrossSigningInfo alloc] initWithValue:@{
-                                                                                                    @"data": [NSKeyedArchiver archivedDataWithRootObject:crossSigningInfo]
-                                                                                                   }];
+            @"data": [NSKeyedArchiver archivedDataWithRootObject:crossSigningInfo]
+        }];
         if (realmUser.crossSigningKeys)
         {
             // Remove orphan MXRealmCrossSigningInfo objects from the DB
@@ -686,13 +686,13 @@ RLM_ARRAY_TYPE(MXRealmSecret)
 - (MXCrossSigningInfo*)crossSigningKeysForUser:(NSString*)userId
 {
     MXCrossSigningInfo *crossSigningKeys;
-
+    
     MXRealmUser *realmUser = [MXRealmUser objectsInRealm:self.realm where:@"userId = %@", userId].firstObject;
     if (realmUser)
     {
         crossSigningKeys = [NSKeyedUnarchiver unarchiveObjectWithData:realmUser.crossSigningKeys.data];
     }
-
+    
     return crossSigningKeys;
 }
 
@@ -715,10 +715,10 @@ RLM_ARRAY_TYPE(MXRealmSecret)
 {
     __block BOOL isNew = NO;
     NSDate *startDate = [NSDate date];
-
+    
     RLMRealm *realm = self.realm;
     [realm transactionWithBlock:^{
-
+        
         MXRealmRoomAlgorithm *roomAlgorithm = [self realmRoomAlgorithmForRoom:roomId inRealm:realm];
         if (roomAlgorithm)
         {
@@ -729,13 +729,13 @@ RLM_ARRAY_TYPE(MXRealmSecret)
         {
             // Create it
             roomAlgorithm = [[MXRealmRoomAlgorithm alloc] initWithValue:@{
-                                                                          @"roomId": roomId,
-                                                                          @"algorithm": algorithm
-                                                                          }];
+                @"roomId": roomId,
+                @"algorithm": algorithm
+            }];
             [realm addObject:roomAlgorithm];
         }
     }];
-
+    
     NSLog(@"[MXRealmCryptoStore] storeAlgorithmForRoom (%@) in %.3fms", (isNew?@"NEW":@"UPDATE"), [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 }
 
@@ -748,10 +748,10 @@ RLM_ARRAY_TYPE(MXRealmSecret)
 {
     BOOL isNew = NO;
     NSDate *startDate = [NSDate date];
-
+    
     RLMRealm *realm = self.realm;
     [realm transactionWithBlock:^{
-
+        
         MXRealmRoomAlgorithm *roomAlgorithm = [self realmRoomAlgorithmForRoom:roomId inRealm:realm];
         if (roomAlgorithm)
         {
@@ -762,13 +762,13 @@ RLM_ARRAY_TYPE(MXRealmSecret)
         {
             // Create it
             roomAlgorithm = [[MXRealmRoomAlgorithm alloc] initWithValue:@{
-                                                                          @"roomId": roomId,
-                                                                          @"blacklist": @(blacklist)
-                                                                          }];
+                @"roomId": roomId,
+                @"blacklist": @(blacklist)
+            }];
             [realm addObject:roomAlgorithm];
         }
     }];
-
+    
     NSLog(@"[MXRealmCryptoStore] storeBlacklistUnverifiedDevicesInRoom (%@) in %.3fms", (isNew?@"NEW":@"UPDATE"), [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 }
 
@@ -787,10 +787,10 @@ RLM_ARRAY_TYPE(MXRealmSecret)
 {
     __block BOOL isNew = NO;
     NSDate *startDate = [NSDate date];
-
+    
     RLMRealm *realm = self.realm;
     [realm transactionWithBlock:^{
-
+        
         MXRealmOlmSession *realmOlmSession = [MXRealmOlmSession objectsInRealm:realm where:@"sessionId = %@ AND deviceKey = %@", session.session.sessionIdentifier, deviceKey].firstObject;
         if (realmOlmSession)
         {
@@ -802,33 +802,33 @@ RLM_ARRAY_TYPE(MXRealmSecret)
             // Create it
             isNew = YES;
             realmOlmSession = [[MXRealmOlmSession alloc] initWithValue:@{
-                                                                         @"sessionId": session.session.sessionIdentifier,
-                                                                         @"deviceKey": deviceKey,
-                                                                         @"olmSessionData": [NSKeyedArchiver archivedDataWithRootObject:session.session]
-                                                                         }];
+                @"sessionId": session.session.sessionIdentifier,
+                @"deviceKey": deviceKey,
+                @"olmSessionData": [NSKeyedArchiver archivedDataWithRootObject:session.session]
+            }];
             realmOlmSession.lastReceivedMessageTs = session.lastReceivedMessageTs;
-
+            
             [realm addObject:realmOlmSession];
         }
     }];
-
+    
     NSLog(@"[MXRealmCryptoStore] storeSession (%@) in %.3fms", (isNew?@"NEW":@"UPDATE"), [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 }
 
 - (MXOlmSession*)sessionWithDevice:(NSString*)deviceKey andSessionId:(NSString*)sessionId
 {
     MXRealmOlmSession *realmOlmSession = [MXRealmOlmSession objectsInRealm:self.realm
-                                                                      where:@"sessionId = %@ AND deviceKey = %@", sessionId, deviceKey].firstObject;
-
+                                                                     where:@"sessionId = %@ AND deviceKey = %@", sessionId, deviceKey].firstObject;
+    
     MXOlmSession *mxOlmSession;
     if (realmOlmSession.olmSessionData)
     {
         OLMSession *olmSession = [NSKeyedUnarchiver unarchiveObjectWithData:realmOlmSession.olmSessionData];
-
+        
         mxOlmSession = [[MXOlmSession alloc] initWithOlmSession:olmSession];
         mxOlmSession.lastReceivedMessageTs = realmOlmSession.lastReceivedMessageTs;
     }
-
+    
     return mxOlmSession;
 }
 
@@ -839,7 +839,7 @@ RLM_ARRAY_TYPE(MXRealmSecret)
     RLMRealm *realm = self.realm;
     
     [realm beginWriteTransaction];
-        
+    
     MXRealmOlmSession *realmOlmSession = [MXRealmOlmSession objectsInRealm:self.realm
                                                                      where:@"sessionId = %@ AND deviceKey = %@", sessionId, deviceKey].firstObject;
     if (realmOlmSession.olmSessionData)
@@ -867,7 +867,7 @@ RLM_ARRAY_TYPE(MXRealmSecret)
 - (NSArray<MXOlmSession*>*)sessionsWithDevice:(NSString*)deviceKey;
 {
     NSMutableArray<MXOlmSession*> *sessionsWithDevice;
-
+    
     RLMResults<MXRealmOlmSession *> *realmOlmSessions = [[MXRealmOlmSession objectsInRealm:self.realm
                                                                                      where:@"deviceKey = %@", deviceKey]
                                                          sortedResultsUsingKeyPath:@"lastReceivedMessageTs" ascending:NO];
@@ -877,18 +877,18 @@ RLM_ARRAY_TYPE(MXRealmSecret)
         {
             sessionsWithDevice = [NSMutableArray array];
         }
-
+        
         if (realmOlmSession.olmSessionData)
         {
             OLMSession *olmSession = [NSKeyedUnarchiver unarchiveObjectWithData:realmOlmSession.olmSessionData];
-
+            
             MXOlmSession *mxOlmSession = [[MXOlmSession alloc] initWithOlmSession:olmSession];
             mxOlmSession.lastReceivedMessageTs = realmOlmSession.lastReceivedMessageTs;
-
+            
             [sessionsWithDevice addObject:mxOlmSession];
         }
     }
-
+    
     return sessionsWithDevice;
 }
 
@@ -901,7 +901,7 @@ RLM_ARRAY_TYPE(MXRealmSecret)
 
     RLMRealm *realm = self.realm;
     [realm transactionWithBlock:^{
-
+        
         for (MXOlmInboundGroupSession *session in sessions)
         {
             NSString *sessionIdSenderKey = [MXRealmOlmInboundGroupSession primaryKeyWithSessionId:session.session.sessionIdentifier
@@ -919,18 +919,18 @@ RLM_ARRAY_TYPE(MXRealmSecret)
                 NSString *sessionIdSenderKey = [MXRealmOlmInboundGroupSession primaryKeyWithSessionId:session.session.sessionIdentifier
                                                                                             senderKey:session.senderKey];
                 realmSession = [[MXRealmOlmInboundGroupSession alloc] initWithValue:@{
-                                                                                      @"sessionId": session.session.sessionIdentifier,
-                                                                                      @"senderKey": session.senderKey,
-                                                                                      @"sessionIdSenderKey": sessionIdSenderKey,
-                                                                                      @"olmInboundGroupSessionData": [NSKeyedArchiver archivedDataWithRootObject:session]
-                                                                                      }];
-
+                    @"sessionId": session.session.sessionIdentifier,
+                    @"senderKey": session.senderKey,
+                    @"sessionIdSenderKey": sessionIdSenderKey,
+                    @"olmInboundGroupSessionData": [NSKeyedArchiver archivedDataWithRootObject:session]
+                }];
+                
                 [realm addObject:realmSession];
             }
         }
     }];
-
-
+    
+    
     NSLog(@"[MXRealmCryptoStore] storeInboundGroupSessions: store %@ keys (%@ new) in %.3fms", @(sessions.count), @(newCount), [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 }
 
@@ -940,19 +940,19 @@ RLM_ARRAY_TYPE(MXRealmSecret)
     NSString *sessionIdSenderKey = [MXRealmOlmInboundGroupSession primaryKeyWithSessionId:sessionId
                                                                                 senderKey:senderKey];
     MXRealmOlmInboundGroupSession *realmSession = [MXRealmOlmInboundGroupSession objectsInRealm:self.realm where:@"sessionIdSenderKey = %@", sessionIdSenderKey].firstObject;
-
+    
     NSLog(@"[MXRealmCryptoStore] inboundGroupSessionWithId: %@ -> %@", sessionId, realmSession ? @"found" : @"not found");
-
+    
     if (realmSession)
     {
         session = [NSKeyedUnarchiver unarchiveObjectWithData:realmSession.olmInboundGroupSessionData];
-
+        
         if (!session)
         {
             NSLog(@"[MXRealmCryptoStore] inboundGroupSessionWithId: ERROR: Failed to create MXOlmInboundGroupSession object");
         }
     }
-
+    
     return session;
 }
 
@@ -997,12 +997,12 @@ RLM_ARRAY_TYPE(MXRealmSecret)
 - (NSArray<MXOlmInboundGroupSession *> *)inboundGroupSessions
 {
     NSMutableArray *sessions = [NSMutableArray array];
-
+    
     for (MXRealmOlmInboundGroupSession *realmSession in [MXRealmOlmInboundGroupSession allObjectsInRealm:self.realm])
     {
         [sessions addObject:[NSKeyedUnarchiver unarchiveObjectWithData:realmSession.olmInboundGroupSessionData]];
     }
-
+    
     return sessions;
 }
 
@@ -1010,9 +1010,9 @@ RLM_ARRAY_TYPE(MXRealmSecret)
 {
     RLMRealm *realm = self.realm;
     [realm transactionWithBlock:^{
-
+        
         RLMResults<MXRealmOlmInboundGroupSession *> *realmSessions = [MXRealmOlmInboundGroupSession objectsInRealm:realm where:@"sessionId = %@ AND senderKey = %@", sessionId, senderKey];
-
+        
         [realm deleteObjects:realmSessions];
     }];
 }
@@ -1222,14 +1222,14 @@ RLM_ARRAY_TYPE(MXRealmSecret)
 {
     RLMRealm *realm = self.realm;
     [realm transactionWithBlock:^{
-
+        
         RLMResults<MXRealmOlmInboundGroupSession *> *realmSessions = [MXRealmOlmInboundGroupSession allObjectsInRealm:realm];
-
+        
         for (MXRealmOlmInboundGroupSession *realmSession in realmSessions)
         {
             realmSession.backedUp = NO;
         }
-
+        
         [realm addOrUpdateObjects:realmSessions];
     }];
 }
@@ -1238,17 +1238,17 @@ RLM_ARRAY_TYPE(MXRealmSecret)
 {
     RLMRealm *realm = self.realm;
     [realm transactionWithBlock:^{
-
+        
         for (MXOlmInboundGroupSession *session in sessions)
         {
             NSString *sessionIdSenderKey = [MXRealmOlmInboundGroupSession primaryKeyWithSessionId:session.session.sessionIdentifier
                                                                                         senderKey:session.senderKey];
             MXRealmOlmInboundGroupSession *realmSession = [MXRealmOlmInboundGroupSession objectsInRealm:realm where:@"sessionIdSenderKey = %@", sessionIdSenderKey].firstObject;
-
+            
             if (realmSession)
             {
                 realmSession.backedUp = YES;
-
+                
                 [realm addOrUpdateObject:realmSession];
             }
         }
@@ -1258,22 +1258,22 @@ RLM_ARRAY_TYPE(MXRealmSecret)
 - (NSArray<MXOlmInboundGroupSession*>*)inboundGroupSessionsToBackup:(NSUInteger)limit
 {
     NSMutableArray *sessions = [NSMutableArray new];
-
+    
     RLMRealm *realm = self.realm;
-
+    
     RLMResults<MXRealmOlmInboundGroupSession *> *realmSessions = [MXRealmOlmInboundGroupSession objectsInRealm:realm where:@"backedUp = NO"];
-
+    
     for (MXRealmOlmInboundGroupSession *realmSession in realmSessions)
     {
         MXOlmInboundGroupSession *session = [NSKeyedUnarchiver unarchiveObjectWithData:realmSession.olmInboundGroupSessionData];
         [sessions addObject:session];
-
+        
         if (sessions.count >= limit)
         {
             break;
         }
     }
-
+    
     return sessions;
 }
 
@@ -1281,7 +1281,7 @@ RLM_ARRAY_TYPE(MXRealmSecret)
 {
     RLMRealm *realm = self.realm;
     RLMResults<MXRealmOlmInboundGroupSession *> *realmSessions;
-
+    
     if (onlyBackedUp)
     {
         realmSessions = [MXRealmOlmInboundGroupSession objectsInRealm:realm where:@"backedUp = YES"];
@@ -1290,7 +1290,7 @@ RLM_ARRAY_TYPE(MXRealmSecret)
     {
         realmSessions = [MXRealmOlmInboundGroupSession allObjectsInRealm:realm];
     }
-
+    
     return realmSessions.count;
 }
 
@@ -1299,28 +1299,28 @@ RLM_ARRAY_TYPE(MXRealmSecret)
 - (MXOutgoingRoomKeyRequest*)outgoingRoomKeyRequestWithRequestBody:(NSDictionary *)requestBody
 {
     MXOutgoingRoomKeyRequest *request;
-
+    
     NSString *requestBodyHash = [MXCryptoTools canonicalJSONStringForJSON:requestBody];
-
+    
     RLMResults<MXRealmOutgoingRoomKeyRequest *> *realmOutgoingRoomKeyRequests =  [MXRealmOutgoingRoomKeyRequest objectsInRealm:self.realm where:@"requestBodyHash = %@", requestBodyHash];
     if (realmOutgoingRoomKeyRequests.count)
     {
         request = realmOutgoingRoomKeyRequests[0].outgoingRoomKeyRequest;
     }
-
+    
     return request;
 }
 
 - (MXOutgoingRoomKeyRequest*)outgoingRoomKeyRequestWithState:(MXRoomKeyRequestState)state
 {
     MXOutgoingRoomKeyRequest *request;
-
+    
     RLMResults<MXRealmOutgoingRoomKeyRequest *> *realmOutgoingRoomKeyRequests = [MXRealmOutgoingRoomKeyRequest objectsInRealm:self.realm where:@"state = %@", @(state)];
     if (realmOutgoingRoomKeyRequests.count)
     {
         request = realmOutgoingRoomKeyRequests[0].outgoingRoomKeyRequest;
     }
-
+    
     return request;
 }
 
@@ -1340,21 +1340,21 @@ RLM_ARRAY_TYPE(MXRealmSecret)
 {
     RLMRealm *realm = self.realm;
     [realm transactionWithBlock:^{
-
+        
         NSString *requestBodyString = [MXTools serialiseJSONObject:request.requestBody];
         NSString *requestBodyHash = [MXCryptoTools canonicalJSONStringForJSON:request.requestBody];
-
+        
         MXRealmOutgoingRoomKeyRequest *realmOutgoingRoomKeyRequest =
         [[MXRealmOutgoingRoomKeyRequest alloc] initWithValue:@{
-                                                               @"requestId": request.requestId,
-                                                               @"recipientsData": [NSKeyedArchiver archivedDataWithRootObject:request.recipients],
-                                                               @"requestBodyString": requestBodyString,
-                                                               @"requestBodyHash": requestBodyHash,
-                                                               @"state": @(request.state)
-                                                               }];
-
+            @"requestId": request.requestId,
+            @"recipientsData": [NSKeyedArchiver archivedDataWithRootObject:request.recipients],
+            @"requestBodyString": requestBodyString,
+            @"requestBodyHash": requestBodyHash,
+            @"state": @(request.state)
+        }];
+        
         realmOutgoingRoomKeyRequest.cancellationTxnId = request.cancellationTxnId;
-
+        
         [realm addObject:realmOutgoingRoomKeyRequest];
     }];
 }
@@ -1363,14 +1363,14 @@ RLM_ARRAY_TYPE(MXRealmSecret)
 {
     RLMRealm *realm = self.realm;
     [realm transactionWithBlock:^{
-
+        
         MXRealmOutgoingRoomKeyRequest *realmOutgoingRoomKeyRequest = [MXRealmOutgoingRoomKeyRequest objectsInRealm:realm where:@"requestId = %@", request.requestId].firstObject;
-
+        
         if (realmOutgoingRoomKeyRequest)
         {
             // Well, only the state changes
             realmOutgoingRoomKeyRequest.state = @(request.state);
-
+            
             [realm addOrUpdateObject:realmOutgoingRoomKeyRequest];
         }
     }];
@@ -1380,9 +1380,9 @@ RLM_ARRAY_TYPE(MXRealmSecret)
 {
     RLMRealm *realm = self.realm;
     [realm transactionWithBlock:^{
-
+        
         RLMResults<MXRealmOutgoingRoomKeyRequest *> *realmOutgoingRoomKeyRequests = [MXRealmOutgoingRoomKeyRequest objectsInRealm:realm where:@"requestId = %@", requestId];
-
+        
         [realm deleteObjects:realmOutgoingRoomKeyRequests];
     }];
 }
@@ -1394,14 +1394,14 @@ RLM_ARRAY_TYPE(MXRealmSecret)
 {
     RLMRealm *realm = self.realm;
     [realm transactionWithBlock:^{
-
+        
         MXRealmIncomingRoomKeyRequest *realmIncomingRoomKeyRequest =
         [[MXRealmIncomingRoomKeyRequest alloc] initWithValue:@{
-                                                               @"requestId": request.requestId,
-                                                               @"userId": request.userId,
-                                                               @"deviceId": request.deviceId,
-                                                               @"requestBodyData": [NSKeyedArchiver archivedDataWithRootObject:request.requestBody]
-                                                               }];
+            @"requestId": request.requestId,
+            @"userId": request.userId,
+            @"deviceId": request.deviceId,
+            @"requestBodyData": [NSKeyedArchiver archivedDataWithRootObject:request.requestBody]
+        }];
         [realm addObject:realmIncomingRoomKeyRequest];
     }];
 }
@@ -1410,7 +1410,7 @@ RLM_ARRAY_TYPE(MXRealmSecret)
 {
     RLMRealm *realm = self.realm;
     [realm transactionWithBlock:^{
-
+        
         RLMResults<MXRealmIncomingRoomKeyRequest *> *realmIncomingRoomKeyRequests = [MXRealmIncomingRoomKeyRequest objectsInRealm:realm where:@"requestId = %@ AND userId = %@ AND deviceId = %@", requestId, userId, deviceId];
         
         [realm deleteObjects:realmIncomingRoomKeyRequests];
@@ -1420,33 +1420,33 @@ RLM_ARRAY_TYPE(MXRealmSecret)
 - (MXIncomingRoomKeyRequest*)incomingRoomKeyRequestWithRequestId:(NSString*)requestId fromUser:(NSString*)userId andDevice:(NSString*)deviceId
 {
     RLMRealm *realm = self.realm;
-
+    
     RLMResults<MXRealmIncomingRoomKeyRequest *> *realmIncomingRoomKeyRequests = [MXRealmIncomingRoomKeyRequest objectsInRealm:realm where:@"requestId = %@ AND userId = %@ AND deviceId = %@", requestId, userId, deviceId];
-
+    
     return realmIncomingRoomKeyRequests.firstObject.incomingRoomKeyRequest;
 }
 
 - (MXUsersDevicesMap<NSArray<MXIncomingRoomKeyRequest *> *> *)incomingRoomKeyRequests
 {
     MXUsersDevicesMap<NSMutableArray<MXIncomingRoomKeyRequest *> *> *incomingRoomKeyRequests = [[MXUsersDevicesMap alloc] init];
-
+    
     RLMRealm *realm = self.realm;
-
+    
     RLMResults<MXRealmIncomingRoomKeyRequest *> *realmIncomingRoomKeyRequests = [MXRealmIncomingRoomKeyRequest allObjectsInRealm:realm];
     for (MXRealmIncomingRoomKeyRequest *realmRequest in realmIncomingRoomKeyRequests)
     {
         MXIncomingRoomKeyRequest *request = realmRequest.incomingRoomKeyRequest;
-
+        
         NSMutableArray<MXIncomingRoomKeyRequest *> *requests = [incomingRoomKeyRequests objectForDevice:request.deviceId forUser:request.userId];
         if (!requests)
         {
             requests = [[NSMutableArray alloc] init];
             [incomingRoomKeyRequests setObject:requests forUser:request.userId andDevice:request.deviceId];
         }
-
+        
         [requests addObject:request];
     }
-
+    
     return incomingRoomKeyRequests;
 }
 
@@ -1460,9 +1460,9 @@ RLM_ARRAY_TYPE(MXRealmSecret)
         
         MXRealmSecret *realmSecret =
         [[MXRealmSecret alloc] initWithValue:@{
-                                               @"secretId": secretId,
-                                               @"secret": secret,
-                                               }];
+            @"secretId": secretId,
+            @"secret": secret,
+        }];
         [realm addOrUpdateObject:realmSecret];
     }];
 }
@@ -1534,9 +1534,9 @@ RLM_ARRAY_TYPE(MXRealmSecret)
     config.objectClasses = @[
                              MXRealmDeviceInfo.class,
                              MXRealmCrossSigningInfo.class,
-                             MXRealmUser.class,
-                             MXRealmRoomAlgorithm.class,
-                             MXRealmOlmSession.class,
+        MXRealmUser.class,
+        MXRealmRoomAlgorithm.class,
+        MXRealmOlmSession.class,
                              MXRealmOlmInboundGroupSession.class,   
                              MXRealmOlmAccount.class,
                              MXRealmOutgoingRoomKeyRequest.class,
@@ -1547,284 +1547,63 @@ RLM_ARRAY_TYPE(MXRealmSecret)
                              ];
 
     config.schemaVersion = kMXRealmCryptoStoreVersion;
-
+    
     __block BOOL cleanDuplicatedDevices = NO;
-
+    
     // Set the block which will be called automatically when opening a Realm with a
     // schema version lower than the one set above
     config.migrationBlock = ^(RLMMigration *migration, uint64_t oldSchemaVersion) {
-
-        // Note: There is nothing to do most of the time
-        // Realm will automatically detect new properties and removed properties
-        // And will update the schema on disk automatically
-
-        if (oldSchemaVersion < kMXRealmCryptoStoreVersion)
-        {
-            NSLog(@"[MXRealmCryptoStore] Required migration detected. oldSchemaVersion: %llu - current: %tu", oldSchemaVersion, kMXRealmCryptoStoreVersion);
-
-            switch (oldSchemaVersion)
-            {
-                case 1:
-                {
-                    // There was a bug in schema version #1 where inbound group sessions
-                    // and olm sessions were duplicated:
-                    // https://github.com/matrix-org/matrix-ios-sdk/issues/227
-
-                    NSLog(@"[MXRealmCryptoStore] Migration from schema #1 -> #2");
-
-                    // We need to update the db because a sessionId property has been added MXRealmOlmSession
-                    // to ensure uniqueness
-                    NSLog(@"[MXRealmCryptoStore]    Add sessionId field to all MXRealmOlmSession objects");
-                    [migration enumerateObjects:MXRealmOlmSession.className block:^(RLMObject *oldObject, RLMObject *newObject) {
-
-                        OLMSession *olmSession =  [NSKeyedUnarchiver unarchiveObjectWithData:oldObject[@"olmSessionData"]];
-
-                        newObject[@"sessionId"] = olmSession.sessionIdentifier;
-                    }];
-
-                    // We need to clean the db from duplicated MXRealmOlmSessions
-                    NSLog(@"[MXRealmCryptoStore]    Make MXRealmOlmSession objects unique for the (sessionId, deviceKey) pair");
-                    __block NSUInteger deleteCount = 0;
-                    NSMutableArray<NSString*> *olmSessionUniquePairs = [NSMutableArray array];
-                    [migration enumerateObjects:MXRealmOlmSession.className block:^(RLMObject *oldObject, RLMObject *newObject) {
-
-                        NSString *olmSessionUniquePair = [NSString stringWithFormat:@"%@ - %@", newObject[@"sessionId"], newObject[@"deviceKey"]];
-
-                        if (NSNotFound == [olmSessionUniquePairs indexOfObject:olmSessionUniquePair])
-                        {
-                            [olmSessionUniquePairs addObject:olmSessionUniquePair];
-                        }
-                        else
-                        {
-                            NSLog(@"[MXRealmCryptoStore]        - delete MXRealmOlmSession: %@", olmSessionUniquePair);
-                            [migration deleteObject:newObject];
-                            deleteCount++;
-                        }
-                    }];
-
-                    NSLog(@"[MXRealmCryptoStore]    -> deleted %tu duplicated MXRealmOlmSession objects", deleteCount);
-
-                    // And from duplicated MXRealmOlmInboundGroupSessions
-                    NSLog(@"[MXRealmCryptoStore]    Make MXRealmOlmInboundGroupSession objects unique for the (sessionId, senderKey) pair");
-                    deleteCount = 0;
-                    NSMutableArray<NSString*> *olmInboundGroupSessionUniquePairs = [NSMutableArray array];
-                    [migration enumerateObjects:MXRealmOlmInboundGroupSession.className block:^(RLMObject *oldObject, RLMObject *newObject) {
-
-                        NSString *olmInboundGroupSessionUniquePair = [NSString stringWithFormat:@"%@ - %@", newObject[@"sessionId"], newObject[@"senderKey"]];
-
-                        if (NSNotFound == [olmInboundGroupSessionUniquePairs indexOfObject:olmInboundGroupSessionUniquePair])
-                        {
-                            [olmInboundGroupSessionUniquePairs addObject:olmInboundGroupSessionUniquePair];
-                        }
-                        else
-                        {
-                            NSLog(@"[MXRealmCryptoStore]        - delete MXRealmOlmInboundGroupSession: %@", olmInboundGroupSessionUniquePair);
-                            [migration deleteObject:newObject];
-                            deleteCount++;
-                        }
-                    }];
-
-                    NSLog(@"[MXRealmCryptoStore]    -> deleted %tu duplicated MXRealmOlmInboundGroupSession objects", deleteCount);
-
-                    NSLog(@"[MXRealmCryptoStore] Migration from schema #1 -> #2 completed");
-                }
-
-                case 2:
-                    NSLog(@"[MXRealmCryptoStore] Migration from schema #2 -> #3: Nothing to do (add MXRealmOlmAccount.deviceSyncToken)");
-
-                case 3:
-                    NSLog(@"[MXRealmCryptoStore] Migration from schema #3 -> #4: Nothing to do (add MXRealmOlmAccount.globalBlacklistUnverifiedDevices & MXRealmRoomAlgortithm.blacklistUnverifiedDevices)");
-
-                case 4:
-                    NSLog(@"[MXRealmCryptoStore] Migration from schema #4 -> #5: Nothing to do (add deviceTrackingStatusData)");
-
-                case 5:
-                    NSLog(@"[MXRealmCryptoStore] Migration from schema #5 -> #6: Nothing to do (remove MXRealmOlmAccount.deviceAnnounced)");
-
-                case 6:
-                {
-                    NSLog(@"[MXRealmCryptoStore] Migration from schema #6 -> #7");
-
-                    // We need to update the db because a sessionId property has been added to MXRealmOlmInboundGroupSession
-                    // to ensure uniqueness
-                    NSLog(@"[MXRealmCryptoStore]    Add sessionIdSenderKey, a combined primary key, to all MXRealmOlmInboundGroupSession objects");
-                    [migration enumerateObjects:MXRealmOlmInboundGroupSession.className block:^(RLMObject *oldObject, RLMObject *newObject) {
-
-                        newObject[@"sessionIdSenderKey"] = [MXRealmOlmInboundGroupSession primaryKeyWithSessionId:oldObject[@"sessionId"]
-                                                                                                        senderKey:oldObject[@"senderKey"]];
-                    }];
-
-                    // We need to update the db because a identityKey property has been added to MXRealmDeviceInfo
-                    NSLog(@"[MXRealmCryptoStore]    Add identityKey to all MXRealmDeviceInfo objects");
-                    [migration enumerateObjects:MXRealmDeviceInfo.className block:^(RLMObject *oldObject, RLMObject *newObject) {
-
-                        MXDeviceInfo *device = [NSKeyedUnarchiver unarchiveObjectWithData:oldObject[@"deviceInfoData"]];
-                        NSString *identityKey = device.identityKey;
-                        if (identityKey)
-                        {
-                            newObject[@"identityKey"] = identityKey;
-                        }
-                    }];
-
-                    NSLog(@"[MXRealmCryptoStore] Migration from schema #6 -> #7 completed");
-                }
-
-                case 7:
-                {
-                    NSLog(@"[MXRealmCryptoStore] Migration from schema #7 -> #8");
-
-                    // This schema update is only for cleaning duplicated devices.
-                    // With the Realm Obj-C SDK, the realm instance is not public. We cannot
-                    // make queries. So, the cleaning will be done afterwards.
-                    cleanDuplicatedDevices = YES;
-                }
-
-                case 8:
-                {
-                    // MXRealmOlmSession.lastReceivedMessageTs has been added to implement:
-                    // Use the last olm session that got a message
-                    // https://github.com/vector-im/riot-ios/issues/2128
-
-                    NSLog(@"[MXRealmCryptoStore] Migration from schema #8 -> #9");
-
-                    NSLog(@"[MXRealmCryptoStore]    Add lastReceivedMessageTs = 0 to all MXRealmOlmSession objects");
-                    [migration enumerateObjects:MXRealmOlmSession.className block:^(RLMObject *oldObject, RLMObject *newObject) {
-
-                        newObject[@"lastReceivedMessageTs"] = @(0);
-                    }];
-
-                    NSLog(@"[MXRealmCryptoStore] Migration from schema #8 -> #9 completed");
-                }
-
-                case 9:
-                {
-                    NSLog(@"[MXRealmCryptoStore] Migration from schema #9 -> #10");
-
-                    NSLog(@"[MXRealmCryptoStore]    Add requestBodyHash to all MXRealmOutgoingRoomKeyRequest objects");
-                    [migration enumerateObjects:MXRealmOutgoingRoomKeyRequest.className block:^(RLMObject *oldObject, RLMObject *newObject) {
-
-                        NSDictionary *requestBody = [MXTools deserialiseJSONString:oldObject[@"requestBodyString"]];
-                        if (requestBody)
-                        {
-                            newObject[@"requestBodyHash"] = [MXCryptoTools canonicalJSONStringForJSON:requestBody];
-                        }
-                    }];
-
-                    // This schema update needs a fix of cleanDuplicatedDevicesInRealm introduced in schema #8.
-                    cleanDuplicatedDevices = YES;
-                }
-
-                case 10:
-                    NSLog(@"[MXRealmCryptoStore] Migration from schema #10 -> #11: Nothing to do (added optional MXRealmUser.crossSigningKeys)");
-
-                case 11:
-                {
-                    NSLog(@"[MXRealmCryptoStore] Migration from schema #10 -> #11");
-
-                    // Because of https://github.com/vector-im/riot-ios/issues/2896, algorithms were not stored
-                    // Fix it by defaulting to usual values
-                    NSLog(@"[MXRealmCryptoStore]    Fix missing algorithms to all MXRealmDeviceInfo objects");
-
-                    [migration enumerateObjects:MXRealmDeviceInfo.className block:^(RLMObject *oldObject, RLMObject *newObject) {
-
-                        MXDeviceInfo *device = [NSKeyedUnarchiver unarchiveObjectWithData:oldObject[@"deviceInfoData"]];
-                        if (!device.algorithms)
-                        {
-                            device.algorithms = @[
-                                                  kMXCryptoOlmAlgorithm,
-                                                  kMXCryptoMegolmAlgorithm
-                                                  ];
-                        }
-                        newObject[@"deviceInfoData"] = [NSKeyedArchiver archivedDataWithRootObject:device];
-                    }];
-                }
-                    
-                case 12:
-                {
-                    NSLog(@"[MXRealmCryptoStore] Migration from schema #12 -> #13");
-                    
-                    // Ìntroduction of MXCryptoStore.cryptoVersion
-                    // Set the default value
-                    NSLog(@"[MXRealmCryptoStore]    Add new MXRealmOlmAccount.cryptoVersion. Set it to MXCryptoVersion1");
-                    
-                    [migration enumerateObjects:MXRealmOlmAccount.className block:^(RLMObject *oldObject, RLMObject *newObject) {
-                        newObject[@"cryptoVersion"] = @(MXCryptoVersion1);
-                    }];
-                }
-                    
-                case 13:
-                {
-                    NSLog(@"[MXRealmCryptoStore] Migration from schema #13 -> #14: Nothing to do (added MXRealmOlmOutboundGroupSession)");
-                }
-                    
-                case 14:
-                {
-                    NSLog(@"[MXRealmCryptoStore] Migration from schema #14 -> #15: Nothing to do (added MXRealmSharedOutboundSession)");
-                }
-            }
-        }
+        cleanDuplicatedDevices = [self finaliseMigrationWith:migration oldSchemaVersion:oldSchemaVersion];
     };
     
-    config.shouldCompactOnLaunch = nil;
-    if ([self shouldCompactReamDBForUserWithUserId:userId andDevice:deviceId])
+    [self setupShouldCompactOnLaunch:config userId:userId deviceId:deviceId];
+    
+    NSError *error;
+    RLMRealm *realm;
+    
+    @autoreleasepool
     {
-        config.shouldCompactOnLaunch = ^BOOL(NSUInteger totalBytes, NSUInteger bytesUsed) {
-            // totalBytes refers to the size of the file on disk in bytes (data + free space)
-            // usedBytes refers to the number of bytes used by data in the file
-            NSLog(@"[MXRealmCryptoStore] Realm DB file size (in bytes): %lu, used (in bytes): %lu", (unsigned long)totalBytes, (unsigned long)bytesUsed);
+        realm = [RLMRealm realmWithConfiguration:config error:&error];
+        if (error)
+        {
+            NSLog(@"[MXRealmCryptoStore] realmForUser gets error: %@", error);
             
-            // Compact if the file is less than 50% 'used'
-            BOOL result = (float)((float)bytesUsed / totalBytes) < 0.5;
-            if (result)
+            // Remove the db file
+            NSError *error;
+            [[NSFileManager defaultManager] removeItemAtPath:config.fileURL.path error:&error];
+            NSLog(@"[MXRealmCryptoStore] removeItemAtPath error result: %@", error);
+            
+            // And try again
+            realm = [RLMRealm realmWithConfiguration:config error:&error];
+            if (!realm)
             {
-                NSLog(@"[MXRealmCryptoStore] Will compact database: File size (in bytes): %lu, used (in bytes): %lu", (unsigned long)totalBytes, (unsigned long)bytesUsed);
+                NSLog(@"[MXRealmCryptoStore] realmForUser still gets after reset. Error: %@", error);
             }
             
-            return result;
-        };
-    }
-
-    NSError *error;
-    RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:&error];
-    if (error)
-    {
-        NSLog(@"[MXRealmCryptoStore] realmForUser gets error: %@", error);
-
-        // Remove the db file
-        NSError *error;
-        [[NSFileManager defaultManager] removeItemAtPath:config.fileURL.path error:&error];
-        NSLog(@"[MXRealmCryptoStore] removeItemAtPath error result: %@", error);
-
-        // And try again
-        realm = [RLMRealm realmWithConfiguration:config error:&error];
-        if (!realm)
-        {
-            NSLog(@"[MXRealmCryptoStore] realmForUser still gets after reset. Error: %@", error);
+            // Report this db reset to higher modules
+            // A user logout and in is anyway required to make crypto work reliably again
+            dispatch_async(dispatch_get_main_queue(),^{
+                [[NSNotificationCenter defaultCenter] postNotificationName:kMXSessionCryptoDidCorruptDataNotification
+                                                                    object:userId
+                                                                  userInfo:nil];
+            });
         }
-
-        // Report this db reset to higher modules
-        // A user logout and in is anyway required to make crypto work reliably again
-        dispatch_async(dispatch_get_main_queue(),^{
-            [[NSNotificationCenter defaultCenter] postNotificationName:kMXSessionCryptoDidCorruptDataNotification
-                                                                object:userId
-                                                              userInfo:nil];
-        });
     }
-
+    
     if (cleanDuplicatedDevices)
     {
         NSLog(@"[MXRealmCryptoStore] Do cleaning for duplicating devices");
-
+        
         NSUInteger before = [MXRealmDeviceInfo allObjectsInRealm:realm].count;
         [self cleanDuplicatedDevicesInRealm:realm];
         NSUInteger after = [MXRealmDeviceInfo allObjectsInRealm:realm].count;
-
+        
         NSLog(@"[MXRealmCryptoStore] Cleaning for duplicating devices completed. There are now %@ devices. There were %@ before. %@ devices have been removed.", @(after), @(before), @(before - after));
     }
-
+    
     // Wait for completion of other operations on this realm launched from other threads
     [realm refresh];
-
+    
     return realm;
 }
 
@@ -1838,15 +1617,7 @@ RLM_ARRAY_TYPE(MXRealmSecret)
     NSURL *defaultRealmPathURL = config.fileURL.URLByDeletingLastPathComponent;
     
     // Default db file URL: use the default directory, but replace the filename with the userId.
-    NSString *realmFile = userId;
-    
-    if (MXTools.isRunningUnitTests)
-    {
-        // Append the device id for unit tests so that we can run e2e tests
-        // with users with several devices
-        realmFile = [NSString stringWithFormat:@"%@-%@", userId, deviceId];
-    }
-    
+    NSString *realmFile = [self realmFileNameWithUserId:userId deviceId:deviceId];
     NSURL *defaultRealmFileURL = [[defaultRealmPathURL URLByAppendingPathComponent:realmFile]
                                   URLByAppendingPathExtension:@"realm"];
     
@@ -1868,6 +1639,26 @@ RLM_ARRAY_TYPE(MXRealmSecret)
     return realmFileURL;
 }
 
+/**
+ Gives the file name of the Realm file
+ 
+ @param userId ID of the current user
+ @param deviceId ID of the current device (used for unit tests)
+ 
+ @return the file name of the Realm file according to the given user and device IDs.
+ */
++ (NSString *)realmFileNameWithUserId:(NSString *)userId deviceId:deviceId
+{
+    if (MXTools.isRunningUnitTests)
+    {
+        // Append the device id for unit tests so that we can run e2e tests
+        // with users with several devices
+        return [NSString stringWithFormat:@"%@-%@", userId, deviceId];
+    }
+    
+    return userId;
+}
+
 // Make sure the full path exists before giving it to Realm
 + (void)ensurePathExistenceForFileAtFileURL:(NSURL*)fileURL
 {
@@ -1879,39 +1670,43 @@ RLM_ARRAY_TYPE(MXRealmSecret)
     }
 }
 
-/**
- Clean duplicated & orphan devices.
-
- @param realm the DB instance to clean.
- */
-+ (void)cleanDuplicatedDevicesInRealm:(RLMRealm*)realm
-{
-    [realm transactionWithBlock:^{
-
-        // Due to a bug (https://github.com/vector-im/riot-ios/issues/2132), there were
-        // duplicated devices living in the database without no more relationship with
-        // their user.
-        // Keep only devices with a relationship with a user and delete all others.
-        for (MXRealmUser *realmUser in [MXRealmUser allObjectsInRealm:realm])
-        {
-            for (MXRealmDeviceInfo *device in realmUser.devices)
-            {
-                if (!device.isInvalidated)
-                {
-                    // The related device needs to be cloned in order to add it afterwards
-                    MXRealmDeviceInfo *deviceCopy = [[MXRealmDeviceInfo alloc] initWithValue:device];
-
-                    [realm deleteObjects:[MXRealmDeviceInfo objectsInRealm:realm where:@"identityKey = %@", device.identityKey]];
-
-                    [realmUser.devices addObject:deviceCopy];
-                }
-            }
-        }
-    }];
-}
-
 
 #pragma mark - shouldCompactOnLaunch
+
+/**
+ Set the shouldCompactOnLaunch block to the given RLMRealmConfiguration instance.
+ 
+ @param config RLMRealmConfiguration instance to be set up.
+ @param userId ID of the current user.
+ @param deviceId ID of the current device.
+ */
++ (void)setupShouldCompactOnLaunch:(RLMRealmConfiguration *)config userId:(NSString *)userId deviceId:deviceId
+{
+    config.shouldCompactOnLaunch = nil;
+    if ([self shouldCompactReamDBForUserWithUserId:userId andDevice:deviceId])
+    {
+        config.shouldCompactOnLaunch = ^BOOL(NSUInteger totalBytes, NSUInteger bytesUsed) {
+            // totalBytes refers to the size of the file on disk in bytes (data + free space)
+            // usedBytes refers to the number of bytes used by data in the file
+            
+            static BOOL logDBFileSizeAtLaunch = YES;
+            if (logDBFileSizeAtLaunch)
+            {
+                NSLog(@"[MXRealmCryptoStore] Realm DB file size (in bytes): %lu, used (in bytes): %lu", (unsigned long)totalBytes, (unsigned long)bytesUsed);
+                logDBFileSizeAtLaunch = NO;
+            }
+            
+            // Compact if the file is less than 50% 'used'
+            BOOL result = (float)((float)bytesUsed / totalBytes) < 0.5;
+            if (result)
+            {
+                NSLog(@"[MXRealmCryptoStore] Will compact database: File size (in bytes): %lu, used (in bytes): %lu", (unsigned long)totalBytes, (unsigned long)bytesUsed);
+            }
+            
+            return result;
+        };
+    }
+}
 
 static BOOL shouldCompactOnLaunch = YES;
 + (BOOL)shouldCompactOnLaunch
@@ -1948,6 +1743,269 @@ static BOOL shouldCompactOnLaunch = YES;
     compactedDB[userDeviceId] = @(YES);
     
     return YES;
+}
+
+
+#pragma mark - Schema migration
+/**
+ Finalise migration performed by Realm.
+ 
+ Basically fixes migration glitches between some versions of schema.
+ 
+ @param migration   A `RLMMigration` object used to perform the migration. The
+ migration object allows you to enumerate and alter any
+ existing objects which require migration.
+ 
+ @param oldSchemaVersion    The schema version of the Realm being migrated.
+ 
+ @return YES if a clean up of duplicated devices should be performed. NO otherwise.
+ */
++ (BOOL)finaliseMigrationWith:(RLMMigration *)migration oldSchemaVersion:(uint64_t)oldSchemaVersion
+{
+    BOOL cleanDuplicatedDevices = NO;
+    
+    // Note: There is nothing to do most of the time
+        // Realm will automatically detect new properties and removed properties
+        // And will update the schema on disk automatically
+
+        if (oldSchemaVersion < kMXRealmCryptoStoreVersion)
+        {
+        NSLog(@"[MXRealmCryptoStore] Required migration detected. oldSchemaVersion: %llu - current: %tu", oldSchemaVersion, kMXRealmCryptoStoreVersion);
+        
+        switch (oldSchemaVersion)
+        {
+            case 1:
+            {
+                // There was a bug in schema version #1 where inbound group sessions
+                // and olm sessions were duplicated:
+                // https://github.com/matrix-org/matrix-ios-sdk/issues/227
+                
+                NSLog(@"[MXRealmCryptoStore] Migration from schema #1 -> #2");
+                
+                // We need to update the db because a sessionId property has been added MXRealmOlmSession
+                // to ensure uniqueness
+                NSLog(@"[MXRealmCryptoStore]    Add sessionId field to all MXRealmOlmSession objects");
+                [migration enumerateObjects:MXRealmOlmSession.className block:^(RLMObject *oldObject, RLMObject *newObject) {
+                    
+                    OLMSession *olmSession =  [NSKeyedUnarchiver unarchiveObjectWithData:oldObject[@"olmSessionData"]];
+                    
+                    newObject[@"sessionId"] = olmSession.sessionIdentifier;
+                }];
+                
+                // We need to clean the db from duplicated MXRealmOlmSessions
+                NSLog(@"[MXRealmCryptoStore]    Make MXRealmOlmSession objects unique for the (sessionId, deviceKey) pair");
+                __block NSUInteger deleteCount = 0;
+                NSMutableArray<NSString*> *olmSessionUniquePairs = [NSMutableArray array];
+                [migration enumerateObjects:MXRealmOlmSession.className block:^(RLMObject *oldObject, RLMObject *newObject) {
+                    
+                    NSString *olmSessionUniquePair = [NSString stringWithFormat:@"%@ - %@", newObject[@"sessionId"], newObject[@"deviceKey"]];
+                    
+                    if (NSNotFound == [olmSessionUniquePairs indexOfObject:olmSessionUniquePair])
+                    {
+                        [olmSessionUniquePairs addObject:olmSessionUniquePair];
+                    }
+                    else
+                    {
+                        NSLog(@"[MXRealmCryptoStore]        - delete MXRealmOlmSession: %@", olmSessionUniquePair);
+                        [migration deleteObject:newObject];
+                        deleteCount++;
+                    }
+                }];
+                
+                NSLog(@"[MXRealmCryptoStore]    -> deleted %tu duplicated MXRealmOlmSession objects", deleteCount);
+                
+                // And from duplicated MXRealmOlmInboundGroupSessions
+                NSLog(@"[MXRealmCryptoStore]    Make MXRealmOlmInboundGroupSession objects unique for the (sessionId, senderKey) pair");
+                deleteCount = 0;
+                NSMutableArray<NSString*> *olmInboundGroupSessionUniquePairs = [NSMutableArray array];
+                [migration enumerateObjects:MXRealmOlmInboundGroupSession.className block:^(RLMObject *oldObject, RLMObject *newObject) {
+                    
+                    NSString *olmInboundGroupSessionUniquePair = [NSString stringWithFormat:@"%@ - %@", newObject[@"sessionId"], newObject[@"senderKey"]];
+                    
+                    if (NSNotFound == [olmInboundGroupSessionUniquePairs indexOfObject:olmInboundGroupSessionUniquePair])
+                    {
+                        [olmInboundGroupSessionUniquePairs addObject:olmInboundGroupSessionUniquePair];
+                    }
+                    else
+                    {
+                        NSLog(@"[MXRealmCryptoStore]        - delete MXRealmOlmInboundGroupSession: %@", olmInboundGroupSessionUniquePair);
+                        [migration deleteObject:newObject];
+                        deleteCount++;
+                    }
+                }];
+                
+                NSLog(@"[MXRealmCryptoStore]    -> deleted %tu duplicated MXRealmOlmInboundGroupSession objects", deleteCount);
+                
+                NSLog(@"[MXRealmCryptoStore] Migration from schema #1 -> #2 completed");
+            }
+                
+            case 2:
+                NSLog(@"[MXRealmCryptoStore] Migration from schema #2 -> #3: Nothing to do (add MXRealmOlmAccount.deviceSyncToken)");
+                
+            case 3:
+                NSLog(@"[MXRealmCryptoStore] Migration from schema #3 -> #4: Nothing to do (add MXRealmOlmAccount.globalBlacklistUnverifiedDevices & MXRealmRoomAlgortithm.blacklistUnverifiedDevices)");
+                
+            case 4:
+                NSLog(@"[MXRealmCryptoStore] Migration from schema #4 -> #5: Nothing to do (add deviceTrackingStatusData)");
+                
+            case 5:
+                NSLog(@"[MXRealmCryptoStore] Migration from schema #5 -> #6: Nothing to do (remove MXRealmOlmAccount.deviceAnnounced)");
+                
+            case 6:
+            {
+                NSLog(@"[MXRealmCryptoStore] Migration from schema #6 -> #7");
+                
+                // We need to update the db because a sessionId property has been added to MXRealmOlmInboundGroupSession
+                // to ensure uniqueness
+                NSLog(@"[MXRealmCryptoStore]    Add sessionIdSenderKey, a combined primary key, to all MXRealmOlmInboundGroupSession objects");
+                [migration enumerateObjects:MXRealmOlmInboundGroupSession.className block:^(RLMObject *oldObject, RLMObject *newObject) {
+                    
+                    newObject[@"sessionIdSenderKey"] = [MXRealmOlmInboundGroupSession primaryKeyWithSessionId:oldObject[@"sessionId"]
+                                                                                                    senderKey:oldObject[@"senderKey"]];
+                }];
+                
+                // We need to update the db because a identityKey property has been added to MXRealmDeviceInfo
+                NSLog(@"[MXRealmCryptoStore]    Add identityKey to all MXRealmDeviceInfo objects");
+                [migration enumerateObjects:MXRealmDeviceInfo.className block:^(RLMObject *oldObject, RLMObject *newObject) {
+                    
+                    MXDeviceInfo *device = [NSKeyedUnarchiver unarchiveObjectWithData:oldObject[@"deviceInfoData"]];
+                    NSString *identityKey = device.identityKey;
+                    if (identityKey)
+                    {
+                        newObject[@"identityKey"] = identityKey;
+                    }
+                }];
+                
+                NSLog(@"[MXRealmCryptoStore] Migration from schema #6 -> #7 completed");
+            }
+                
+            case 7:
+            {
+                NSLog(@"[MXRealmCryptoStore] Migration from schema #7 -> #8");
+                
+                // This schema update is only for cleaning duplicated devices.
+                // With the Realm Obj-C SDK, the realm instance is not public. We cannot
+                // make queries. So, the cleaning will be done afterwards.
+                cleanDuplicatedDevices = YES;
+            }
+                
+            case 8:
+            {
+                // MXRealmOlmSession.lastReceivedMessageTs has been added to implement:
+                // Use the last olm session that got a message
+                // https://github.com/vector-im/riot-ios/issues/2128
+                
+                NSLog(@"[MXRealmCryptoStore] Migration from schema #8 -> #9");
+                
+                NSLog(@"[MXRealmCryptoStore]    Add lastReceivedMessageTs = 0 to all MXRealmOlmSession objects");
+                [migration enumerateObjects:MXRealmOlmSession.className block:^(RLMObject *oldObject, RLMObject *newObject) {
+                    
+                    newObject[@"lastReceivedMessageTs"] = @(0);
+                }];
+                
+                NSLog(@"[MXRealmCryptoStore] Migration from schema #8 -> #9 completed");
+            }
+                
+            case 9:
+            {
+                NSLog(@"[MXRealmCryptoStore] Migration from schema #9 -> #10");
+                
+                NSLog(@"[MXRealmCryptoStore]    Add requestBodyHash to all MXRealmOutgoingRoomKeyRequest objects");
+                [migration enumerateObjects:MXRealmOutgoingRoomKeyRequest.className block:^(RLMObject *oldObject, RLMObject *newObject) {
+                    
+                    NSDictionary *requestBody = [MXTools deserialiseJSONString:oldObject[@"requestBodyString"]];
+                    if (requestBody)
+                    {
+                        newObject[@"requestBodyHash"] = [MXCryptoTools canonicalJSONStringForJSON:requestBody];
+                    }
+                }];
+                
+                // This schema update needs a fix of cleanDuplicatedDevicesInRealm introduced in schema #8.
+                cleanDuplicatedDevices = YES;
+            }
+                
+            case 10:
+                NSLog(@"[MXRealmCryptoStore] Migration from schema #10 -> #11: Nothing to do (added optional MXRealmUser.crossSigningKeys)");
+                
+            case 11:
+            {
+                NSLog(@"[MXRealmCryptoStore] Migration from schema #10 -> #11");
+                
+                // Because of https://github.com/vector-im/riot-ios/issues/2896, algorithms were not stored
+                // Fix it by defaulting to usual values
+                NSLog(@"[MXRealmCryptoStore]    Fix missing algorithms to all MXRealmDeviceInfo objects");
+                
+                [migration enumerateObjects:MXRealmDeviceInfo.className block:^(RLMObject *oldObject, RLMObject *newObject) {
+                    
+                    MXDeviceInfo *device = [NSKeyedUnarchiver unarchiveObjectWithData:oldObject[@"deviceInfoData"]];
+                    if (!device.algorithms)
+                    {
+                        device.algorithms = @[
+                            kMXCryptoOlmAlgorithm,
+                            kMXCryptoMegolmAlgorithm
+                        ];
+                    }
+                    newObject[@"deviceInfoData"] = [NSKeyedArchiver archivedDataWithRootObject:device];
+                }];
+            }
+                
+            case 12:
+            {
+                NSLog(@"[MXRealmCryptoStore] Migration from schema #12 -> #13");
+                
+                // Ìntroduction of MXCryptoStore.cryptoVersion
+                // Set the default value
+                NSLog(@"[MXRealmCryptoStore]    Add new MXRealmOlmAccount.cryptoVersion. Set it to MXCryptoVersion1");
+                
+                [migration enumerateObjects:MXRealmOlmAccount.className block:^(RLMObject *oldObject, RLMObject *newObject) {
+                        newObject[@"cryptoVersion"] = @(MXCryptoVersion1);
+                    }];
+                }
+                    
+                case 13:
+                {
+                    NSLog(@"[MXRealmCryptoStore] Migration from schema #13 -> #14: Nothing to do (added MXRealmOlmOutboundGroupSession)");
+                }
+                    
+                case 14:
+                {
+                    NSLog(@"[MXRealmCryptoStore] Migration from schema #14 -> #15: Nothing to do (added MXRealmSharedOutboundSession)");
+                }
+            }
+    }
+    
+    return cleanDuplicatedDevices;
+}
+
+/**
+ Clean duplicated & orphan devices.
+ 
+ @param realm the DB instance to clean.
+ */
++ (void)cleanDuplicatedDevicesInRealm:(RLMRealm*)realm
+{
+    [realm transactionWithBlock:^{
+        
+        // Due to a bug (https://github.com/vector-im/riot-ios/issues/2132), there were
+        // duplicated devices living in the database without no more relationship with
+        // their user.
+        // Keep only devices with a relationship with a user and delete all others.
+        for (MXRealmUser *realmUser in [MXRealmUser allObjectsInRealm:realm])
+        {
+            for (MXRealmDeviceInfo *device in realmUser.devices)
+            {
+                if (!device.isInvalidated)
+                {
+                    // The related device needs to be cloned in order to add it afterwards
+                    MXRealmDeviceInfo *deviceCopy = [[MXRealmDeviceInfo alloc] initWithValue:device];
+                    
+                    [realm deleteObjects:[MXRealmDeviceInfo objectsInRealm:realm where:@"identityKey = %@", device.identityKey]];
+                    
+                    [realmUser.devices addObject:deviceCopy];
+                }
+            }
+        }
+    }];
 }
 
 @end

--- a/MatrixSDK/Crypto/KeyProvider/MXKeyProvider.m
+++ b/MatrixSDK/Crypto/KeyProvider/MXKeyProvider.m
@@ -72,7 +72,7 @@ static MXKeyProvider *sharedInstance = nil;
         [NSException raise:@"MandatoryKey" format:@"No key value for mandatory Key (data type : %@)", dataType];
     }
 
-    if (keyData.type != keyType)
+    if (keyData && keyData.type != keyType)
     {
         [NSException raise:@"KeyType" format:@"Wrong key type (%lu expected %lu) for data of type : %@", keyData.type, keyType, dataType];
     }

--- a/Podfile
+++ b/Podfile
@@ -5,7 +5,7 @@ abstract_target 'MatrixSDK' do
     pod 'AFNetworking', '~> 4.0.0'
     pod 'GZIP', '~> 1.3.0'
     
-    pod 'OLMKit', '~> 3.1.0', :inhibit_warnings => true
+    pod 'OLMKit', '~> 3.2.2', :inhibit_warnings => true
     #pod 'OLMKit', :path => '../olm/OLMKit.podspec'
     
     pod 'Realm', '10.1.4'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -29,11 +29,11 @@ PODS:
   - OHHTTPStubs/NSURLSession (9.0.0):
     - OHHTTPStubs/Core
   - OHHTTPStubs/OHPathHelpers (9.0.0)
-  - OLMKit (3.1.0):
-    - OLMKit/olmc (= 3.1.0)
-    - OLMKit/olmcpp (= 3.1.0)
-  - OLMKit/olmc (3.1.0)
-  - OLMKit/olmcpp (3.1.0)
+  - OLMKit (3.2.2):
+    - OLMKit/olmc (= 3.2.2)
+    - OLMKit/olmcpp (= 3.2.2)
+  - OLMKit/olmc (3.2.2)
+  - OLMKit/olmcpp (3.2.2)
   - Realm (10.1.4):
     - Realm/Headers (= 10.1.4)
   - Realm/Headers (10.1.4)
@@ -43,7 +43,7 @@ DEPENDENCIES:
   - GZIP (~> 1.3.0)
   - libbase58 (~> 0.1.4)
   - OHHTTPStubs (~> 9.0.0)
-  - OLMKit (~> 3.1.0)
+  - OLMKit (~> 3.2.2)
   - Realm (= 10.1.4)
 
 SPEC REPOS:
@@ -60,9 +60,9 @@ SPEC CHECKSUMS:
   GZIP: 416858efbe66b41b206895ac6dfd5493200d95b3
   libbase58: 7c040313537b8c44b6e2d15586af8e21f7354efd
   OHHTTPStubs: cb29d2a9d09a828ecb93349a2b0c64f99e0db89f
-  OLMKit: 4ee0159d63feeb86d836fdcfefe418e163511639
+  OLMKit: 20d1c564033a1ae7148f8f599378d4c798363905
   Realm: 80f4fb2971ccb9adc27a47d0955ae8e533a7030b
 
-PODFILE CHECKSUM: 94b04346b278bff5535960219bf37af5c5a33442
+PODFILE CHECKSUM: 5c03869e21642872cded066055388959f8b96b48
 
 COCOAPODS: 1.10.0


### PR DESCRIPTION
Fix https://github.com/vector-im/element-ios/issues/3867
Require https://gitlab.matrix.org/matrix-org/olm/-/merge_requests/17.

It embeds the realm db migration code refactoring made in https://github.com/matrix-org/matrix-ios-sdk/pull/973 even if no migration is required here.

We cannot use the built-in encryption offered by Realm because it does not support multi-process. So, let's encrypt every single thing in a clear Realm db.

- [x] Olm data (account, megolm keys, etc). Done by using v2 pickle of OLMKit which use single global pickle key the app can store in keychain
- [x] Secrets used for 4S (private keys for key backup, MSDK, USK, SSK)