### PR TITLE
Support adding DISABLE_CALLKIT preprocessor macro to disable compilation of CallKit

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,7 @@ Changes to be released in next version
 🧱 Build
  * build.sh: Add xcframework argument to build a universal MatrixSDK.xcframework
  * MatrixSDKTests-macOS: Remove tests from macOS profile and archive builds to match iOS.
+ * Support adding DISABLE_CALLKIT preprocessor macro to disable compilation of CallKit.
 
 Others
  * 

--- a/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.h
+++ b/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.h
@@ -14,6 +14,7 @@
  limitations under the License.
  */
 
+#ifndef DISABLE_CALLKIT
 #if TARGET_OS_IPHONE
 
 @import Foundation;
@@ -63,4 +64,5 @@ API_AVAILABLE(ios(10.0))
 
 NS_ASSUME_NONNULL_END
 
+#endif
 #endif

--- a/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.m
+++ b/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.m
@@ -14,6 +14,7 @@
  limitations under the License.
  */
 
+#ifndef DISABLE_CALLKIT
 #if TARGET_OS_IPHONE
 
 #import "MXCallKitAdapter.h"
@@ -369,4 +370,5 @@ NSString * const kMXCallKitAdapterAudioSessionDidActive = @"kMXCallKitAdapterAud
 
 @end
 
+#endif
 #endif

--- a/MatrixSDK/VoIP/CallKit/MXCallKitConfiguration.h
+++ b/MatrixSDK/VoIP/CallKit/MXCallKitConfiguration.h
@@ -14,6 +14,8 @@
  limitations under the License.
  */
 
+#ifndef DISABLE_CALLKIT
+
 @import Foundation;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -60,3 +62,5 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+
+#endif

--- a/MatrixSDK/VoIP/CallKit/MXCallKitConfiguration.m
+++ b/MatrixSDK/VoIP/CallKit/MXCallKitConfiguration.m
@@ -14,6 +14,8 @@
  limitations under the License.
  */
 
+#ifndef DISABLE_CALLKIT
+
 #import "MXCallKitConfiguration.h"
 
 @implementation MXCallKitConfiguration
@@ -44,3 +46,5 @@
 }
 
 @end
+
+#endif

--- a/MatrixSDK/VoIP/MXCallManager.h
+++ b/MatrixSDK/VoIP/MXCallManager.h
@@ -20,7 +20,10 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class MXCall;
+#ifndef DISABLE_CALLKIT
 @class MXCallKitAdapter;
+#endif
+
 @class MXRoom, MXRoomState;
 @class MXRoomMember;
 @class MXSession;
@@ -137,8 +140,10 @@ extern NSString *const kMXCallManagerPSTNSupportUpdated;
  The CallKit adapter.
  Provide it if you want to add CallKit support.
  */
+#ifndef DISABLE_CALLKIT
 #if TARGET_OS_IPHONE
 @property (nonatomic, nullable) MXCallKitAdapter *callKitAdapter;
+#endif
 #endif
 
 /**

--- a/MatrixSDK/VoIP/MXCallManager.m
+++ b/MatrixSDK/VoIP/MXCallManager.m
@@ -564,6 +564,7 @@ NSTimeInterval const kMXCallDirectRoomJoinTimeout = 30;
 
 - (void)handleCallStateDidChangeNotification:(NSNotification *)notification
 {
+#ifndef DISABLE_CALLKIT
 #if TARGET_OS_IPHONE
     MXCall *call = notification.object;
     
@@ -590,14 +591,17 @@ NSTimeInterval const kMXCallDirectRoomJoinTimeout = 30;
             break;
     }
 #endif
+#endif
 }
 
 - (void)handleCallSupportHoldingStatusDidChange:(NSNotification *)notification
 {
+#ifndef DISABLE_CALLKIT
 #if TARGET_OS_IPHONE
     MXCall *call = notification.object;
     
     [self.callKitAdapter updateSupportsHoldingForCall:call];
+#endif
 #endif
 }
 


### PR DESCRIPTION
Due to the policy, CallKit needs to be disabled.

> Chinese Ministry of Industry and Information Technology (MIIT) requested that CallKit functionality be deactivated in all apps available on the China App Store. 