### PR TITLE
MXCrossSigning: Fix setupWithPassword method crash when a grace period is enabled

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changes to be released in next version
  * 
 
 🐛 Bugfix
- * MXCrossSigning: Fix setupWithPassword method crash when a grace period is enabled.
+ * MXCrossSigning: Fix setupWithPassword method crash when a grace period is enabled (Fix vector-im/element-ios#4099).
 
 ⚠️ API Changes
  * 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-Changes to be released in next version
+Changes in 0.18.4 (2021-03-03)
 =================================================
 
 ✨ Features
@@ -8,7 +8,7 @@ Changes to be released in next version
  * 
 
 🐛 Bugfix
- * 
+ * MXCrossSigning: Fix setupWithPassword method crash when a grace period is enabled.
 
 ⚠️ API Changes
  * 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-Changes in 0.18.4 (2021-03-03)
+Changes to be released in next version
 =================================================
 
 ✨ Features

--- a/MatrixSDK/Crypto/CrossSigning/MXCrossSigning.m
+++ b/MatrixSDK/Crypto/CrossSigning/MXCrossSigning.m
@@ -67,12 +67,22 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
     // Do the auth dance to upload them to the HS
     [self.crypto.matrixRestClient authSessionToUploadDeviceSigningKeys:^(MXAuthenticationSession *authSession) {
         
-        NSDictionary *authParams = @{
-                                     @"session": authSession.session,
-                                     @"user": myCreds.userId,
-                                     @"password": password,
-                                     @"type": kMXLoginFlowTypePassword
-                                     };
+        NSDictionary *authParams;
+        
+        if (authSession)
+        {
+            authParams= @{
+                @"session": authSession.session,
+                @"user": myCreds.userId,
+                @"password": password,
+                @"type": kMXLoginFlowTypePassword
+            };
+        }
+        else
+        {
+            // Try to setup cross-signing without authentication parameters in case if a grace period is enabled
+            authParams = @{};
+        }
         
         [self setupWithAuthParams:authParams success:success failure:failure];
         


### PR DESCRIPTION
Fix vector-im/element-ios#4099