### PR TITLE
XCFramework tweaks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,8 +17,8 @@ Changes to be released in next version
  * 
     
 🧱 Build
- * Support passing CFBundleShortVersionString and CFBundleVersion as arguments to ./build xcframework.
- * When running ./build xcframework, zip the binary ready for distribution.
+ * build.sh: Support passing CFBundleShortVersionString and CFBundleVersion when building an xcframework.
+ * build.sh: When building an xcframework, zip the binary ready for distribution.
 
 Others
  * Ignore event editors other than the original sender.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,7 +17,8 @@ Changes to be released in next version
  * 
     
 🧱 Build
- * 
+ * Support passing CFBundleShortVersionString and CFBundleVersion as arguments to ./build xcframework.
+ * When running ./build xcframework, zip the binary ready for distribution.
 
 Others
  * Ignore event editors other than the original sender.

--- a/MatrixSDK/Info.plist
+++ b/MatrixSDK/Info.plist
@@ -14,6 +14,8 @@
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/build.sh
+++ b/build.sh
@@ -17,9 +17,11 @@ then
 
 	# clean xcframework artifacts
 	if [ -d 'MatrixSDK.xcframework' ]; then rm -rf MatrixSDK.xcframework; fi
+	if [ -f 'MatrixSDK.xcframework.zip' ]; then rm -rf MatrixSDK.xcframework.zip; fi
 
-	# build the xcframework
+	# build and zip the xcframework
 	xcodebuild -create-xcframework -framework MatrixSDK-iOS.xcarchive/Products/Library/Frameworks/MatrixSDK.framework -framework MatrixSDK-iOSSimulator.xcarchive/Products/Library/Frameworks/MatrixSDK.framework -framework MatrixSDK-macOS.xcarchive/Products/Library/Frameworks/MatrixSDK.framework -framework MatrixSDK-MacCatalyst.xcarchive/Products/Library/Frameworks/MatrixSDK.framework -output MatrixSDK.xcframework
+	zip -ry MatrixSDK.xcframework.zip MatrixSDK.xcframework
 else
 	xcodebuild -workspace MatrixSDK.xcworkspace/ -scheme MatrixSDK -sdk iphonesimulator  -destination 'name=iPhone 5s'
 fi

--- a/build.sh
+++ b/build.sh
@@ -5,13 +5,13 @@ set -x
 
 pod install
 
-if [ $1 == 'xcframework' ]
+if [ $1 == 'xcframework' ]	# optionally supports additional arguments for CFBundleShortVersionString and CFBundleVersion
 then
 	# archive the framework for iOS, macOS, Catalyst and the Simulator
-	xcodebuild archive -workspace MatrixSDK.xcworkspace -scheme MatrixSDK-iOS -destination "generic/platform=iOS" -archivePath build/MatrixSDK-iOS SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES IPHONEOS_DEPLOYMENT_TARGET=11.0 GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS=NO
-	xcodebuild archive -workspace MatrixSDK.xcworkspace -scheme MatrixSDK-iOS -destination "generic/platform=iOS Simulator" -archivePath build/MatrixSDK-iOSSimulator SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES IPHONEOS_DEPLOYMENT_TARGET=11.0 GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS=NO
-	xcodebuild archive -workspace MatrixSDK.xcworkspace -scheme MatrixSDK-macOS -destination "generic/platform=macOS" -archivePath build/MatrixSDK-macOS SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES MACOSX_DEPLOYMENT_TARGET=10.10 GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS=NO
-	xcodebuild archive -workspace MatrixSDK.xcworkspace -scheme MatrixSDK-iOS -destination "generic/platform=macOS,variant=Mac Catalyst" -archivePath ./build/MatrixSDK-MacCatalyst SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES IPHONEOS_DEPLOYMENT_TARGET=13.0 GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS=NO
+	xcodebuild archive -workspace MatrixSDK.xcworkspace -scheme MatrixSDK-iOS -destination "generic/platform=iOS" -archivePath build/MatrixSDK-iOS SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES IPHONEOS_DEPLOYMENT_TARGET=11.0 GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS=NO MARKETING_VERSION=$2 CURRENT_PROJECT_VERSION=$3
+	xcodebuild archive -workspace MatrixSDK.xcworkspace -scheme MatrixSDK-iOS -destination "generic/platform=iOS Simulator" -archivePath build/MatrixSDK-iOSSimulator SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES IPHONEOS_DEPLOYMENT_TARGET=11.0 GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS=NO MARKETING_VERSION=$2 CURRENT_PROJECT_VERSION=$3
+	xcodebuild archive -workspace MatrixSDK.xcworkspace -scheme MatrixSDK-macOS -destination "generic/platform=macOS" -archivePath build/MatrixSDK-macOS SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES MACOSX_DEPLOYMENT_TARGET=10.10 GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS=NO MARKETING_VERSION=$2 CURRENT_PROJECT_VERSION=$3
+	xcodebuild archive -workspace MatrixSDK.xcworkspace -scheme MatrixSDK-iOS -destination "generic/platform=macOS,variant=Mac Catalyst" -archivePath ./build/MatrixSDK-MacCatalyst SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES IPHONEOS_DEPLOYMENT_TARGET=13.0 GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS=NO MARKETING_VERSION=$2 CURRENT_PROJECT_VERSION=$3
 
 	cd build
 


### PR DESCRIPTION
This makes two tweaks to building MatrixSDK.xcframework:

- Allow the command to be formed as `./build.sh xcframework 0.18.4 99` to include bundle versions in the archived frameworks. This fixes a rejection from App Store Connect as these values are currently missing.
- Additionally create MatrixSDK.xcframework.zip to use as binary package if required.

Passing the versions as arguments to the build command seemed the easiest change so you don't need to update a version inside of the Xcode project as part of your release process, but if you think that makes more sense I'm happy to update 🙂

Signed-off-by: Doug Earnshaw pixlwave@users.noreply.github.com

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request updates [CHANGES.rst](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CHANGES.rst)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)
