### PR TITLE
MXRoomState/MXRoomMembers: Fix memory leak and copying

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changes to be released in next version
  * 
 
 🐛 Bugfix
- * 
+ * MXRoomState/MXRoomMembers: Fix memory leak and copying.
 
 ⚠️ API Changes
  * 

--- a/MatrixSDK/Data/MXRoomMembers.h
+++ b/MatrixSDK/Data/MXRoomMembers.h
@@ -32,12 +32,17 @@
 /**
  Create a `MXRoomMembers` instance.
 
- @paran state the room state it depends on.
+ @param state the room state it depends on. The object will not be retained.
  @param matrixSession the session to the home server.
 
  @return The newly-initialized MXRoomMembers.
  */
 - (instancetype)initWithRoomState:(MXRoomState*)state andMatrixSession:(MXSession*)matrixSession;
+
+/**
+ The room state belonging to this object.
+ */
+@property (nonatomic, readonly) MXRoomState *roomState;
 
 /**
  A copy of the list of room members.
@@ -109,5 +114,17 @@
  @return YES if there was a change in MXRoomMembers.
  */
 - (BOOL)handleStateEvents:(NSArray<MXEvent *> *)stateEvents;
+
+#pragma mark - NSCopying
+
+/**
+ Copy the receiver and update the room state reference. This is useful when the copying happens
+ as part of copying an MXRoomState object.
+
+ @param zone a memory zone.
+ @param state the new/copied room state.
+ @return a copy of the receiver.
+ */
+- (id)copyWithZone:(NSZone *)zone andState:(MXRoomState *)state;
 
 @end

--- a/MatrixSDK/Data/MXRoomMembers.m
+++ b/MatrixSDK/Data/MXRoomMembers.m
@@ -23,7 +23,7 @@
 @interface MXRoomMembers ()
 {
     MXSession *mxSession;
-    MXRoomState *state;
+    __weak MXRoomState *state;
 
     /**
      Members ordered by userId.
@@ -53,6 +53,11 @@
         membersNamesInUse = [NSMutableDictionary dictionary];
     }
     return self;
+}
+
+- (MXRoomState *)roomState
+{
+    return state;
 }
 
 - (NSArray<MXRoomMember *> *)members
@@ -308,6 +313,13 @@
 }
 
 #pragma mark - NSCopying
+
+- (id)copyWithZone:(NSZone *)zone andState:(MXRoomState *)state {
+    MXRoomMembers *copy = [self copyWithZone:zone];
+    copy->state = state;
+    return copy;
+}
+
 - (id)copyWithZone:(NSZone *)zone
 {
     MXRoomMembers *membersCopy = [[MXRoomMembers allocWithZone:zone] init];

--- a/MatrixSDK/Data/MXRoomState.m
+++ b/MatrixSDK/Data/MXRoomState.m
@@ -607,7 +607,7 @@
         stateCopy->stateEvents[key] = [[NSMutableArray allocWithZone:zone] initWithArray:stateEvents[key]];
     }
 
-    stateCopy->_members = [_members copyWithZone:zone];
+    stateCopy->_members = [_members copyWithZone:zone andState:stateCopy];
 
     stateCopy->_membersCount = [_membersCount copyWithZone:zone];
     

--- a/MatrixSDKTests/MXRoomStateTests.m
+++ b/MatrixSDKTests/MXRoomStateTests.m
@@ -1248,6 +1248,33 @@
     }];
 }
 
+- (void)testDeallocation
+{
+    __weak __block MXRoomState *weakState;
+    [matrixSDKTestsData doMXSessionTestWithBobAndThePublicRoom:self readyToTest:^(MXSession *mxSession2, MXRoom *room, XCTestExpectation *expectation) {
+        mxSession = mxSession2;
+        [room state:^(MXRoomState *roomState) {
+            weakState = roomState;
+            XCTAssertNotNil(weakState);
+            [expectation fulfill];
+        }];
+        [mxSession2 close]; // Force room deallocation
+    }];
+    XCTAssertNil(weakState);
+}
+
+- (void)testCopying
+{
+    [matrixSDKTestsData doMXSessionTestWithBobAndThePublicRoom:self readyToTest:^(MXSession *mxSession2, MXRoom *room, XCTestExpectation *expectation) {
+        mxSession = mxSession2;
+        [room state:^(MXRoomState *roomState) {
+            MXRoomState *roomStateCopy = [roomState copy];
+            XCTAssertEqual(roomStateCopy.members.roomState, roomStateCopy);
+            [expectation fulfill];
+        }];
+    }];
+}
+
 #pragma clang diagnostic pop
 
 @end


### PR DESCRIPTION
`MXRoomState` and `MXRoomMembers` currently hold mutual strong references to each other via the `members` property and the `state` ivar, respectively. This leads to a memory leak preventing both objects from being deallocated. The leak is easy to reproduce in the Element iOS app. Just launch the app, use a few rooms and start the memory graph debugger. At this point you'll find orphaned objects retaining each other such as:

![Screenshot 2021-03-06 at 20 21 28](https://user-images.githubusercontent.com/1137962/110253135-05d4a080-7f89-11eb-9b80-b8e8149abece.png)

Additionally, the leak is masqueraded by a bug in `MXRoomState`'s `copyWithZone:` method. The latter copies the `MXRoomMembers` object but doesn't update its `state` ivar to point to the `MXRoomState` copy. As a result, copying an `MXRoomState` object does *not* introduce another leak. I've noticed this when writing a unit test for the leak. Instead of the retain cycle, there now is a chain where `MXRoomMembers` is owned by one room state but points "back" to another.

![Screenshot 2021-03-07 at 19 51 58](https://user-images.githubusercontent.com/1137962/110253188-31f02180-7f89-11eb-8fcf-16f35eba55e3.png)

The present pull request addresses both issues. First, the `state` ivar on `MXRoomMembers` is made weak. This seems safe because `MXRoomState` retains its `members` property and `MXRoomMembers` should not exist on its own without a room state owning it.

Secondly, a new method `copyWithZone:andState:` is introduced on `MXRoomMembers`. The latter copies the receiver and updates the `state` ivar to the specified `MXRoomState`.

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request updates [CHANGES.rst](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CHANGES.rst)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)
