### PR TITLE
MXDeviceListOperation: Fix memory leak

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changes to be released in next version
  * 
 
 🐛 Bugfix
- * 
+ * MXDeviceListOperation: Fix memory leak.
 
 ⚠️ API Changes
  * 

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -604,6 +604,8 @@
 		9274AFE81EE580240009BEB6 /* MXCallKitAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = 9274AFE61EE580240009BEB6 /* MXCallKitAdapter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9274AFE91EE580240009BEB6 /* MXCallKitAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9274AFE71EE580240009BEB6 /* MXCallKitAdapter.m */; };
 		9CC8EFC1457B94FB58DFF1F7 /* libPods-MatrixSDK-MatrixSDK-macOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FA84A2BE7767F3645CAEC2AF /* libPods-MatrixSDK-MatrixSDK-macOS.a */; };
+		A816247C25F60C7700A46F05 /* MXDeviceListOperationsPoolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A816247B25F60C7700A46F05 /* MXDeviceListOperationsPoolTests.swift */; };
+		A816248525F60D0300A46F05 /* MXDeviceListOperationsPoolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A816247B25F60C7700A46F05 /* MXDeviceListOperationsPoolTests.swift */; };
 		B10AFB4322A970060092E6AF /* MXEventReplace.h in Headers */ = {isa = PBXBuildFile; fileRef = B10AFB4122A970060092E6AF /* MXEventReplace.h */; };
 		B10AFB4422A970060092E6AF /* MXEventReplace.m in Sources */ = {isa = PBXBuildFile; fileRef = B10AFB4222A970060092E6AF /* MXEventReplace.m */; };
 		B10AFB4722AA8A8E0092E6AF /* MXEventEditsListener.h in Headers */ = {isa = PBXBuildFile; fileRef = B10AFB4522AA8A8D0092E6AF /* MXEventEditsListener.h */; };
@@ -1871,6 +1873,7 @@
 		92634B811EF2E3C400DB9F60 /* MXCallKitConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXCallKitConfiguration.m; sourceTree = "<group>"; };
 		9274AFE61EE580240009BEB6 /* MXCallKitAdapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXCallKitAdapter.h; sourceTree = "<group>"; };
 		9274AFE71EE580240009BEB6 /* MXCallKitAdapter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXCallKitAdapter.m; sourceTree = "<group>"; };
+		A816247B25F60C7700A46F05 /* MXDeviceListOperationsPoolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXDeviceListOperationsPoolTests.swift; sourceTree = "<group>"; };
 		B10AFB4122A970060092E6AF /* MXEventReplace.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXEventReplace.h; sourceTree = "<group>"; };
 		B10AFB4222A970060092E6AF /* MXEventReplace.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXEventReplace.m; sourceTree = "<group>"; };
 		B10AFB4522AA8A8D0092E6AF /* MXEventEditsListener.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXEventEditsListener.h; sourceTree = "<group>"; };
@@ -3120,6 +3123,7 @@
 				3AE97790256FC190003883EF /* MXAesTests.m */,
 				3A108E6625826F52005EEBE9 /* MXKeyProviderTests.m */,
 				B14EECED2578FE3F00448735 /* MXAuthenticationSessionTests.swift */,
+				A816247B25F60C7700A46F05 /* MXDeviceListOperationsPoolTests.swift */,
 				EC383BC12542F251002FBBE6 /* MatrixSDKTests-Bridging-Header.h */,
 			);
 			path = MatrixSDKTests;
@@ -4838,6 +4842,7 @@
 				32832B5D1BCC048300241108 /* MXStoreMemoryStoreTests.m in Sources */,
 				32114A7F1A24E15500FF2EC4 /* MXMyUserTests.m in Sources */,
 				32832B5E1BCC048300241108 /* MXStoreNoStoreTests.m in Sources */,
+				A816247C25F60C7700A46F05 /* MXDeviceListOperationsPoolTests.swift in Sources */,
 				32C9B71823E81A1C00C6F30A /* MXCrossSigningVerificationTests.m in Sources */,
 				323C5A081A70E53500FB0549 /* MXToolsTests.m in Sources */,
 				3281E89E19E299C000976E1A /* MXErrorTests.m in Sources */,
@@ -5245,6 +5250,7 @@
 				B1E09A2D2397FD750057C069 /* MXRestClientNoAuthAPITests.m in Sources */,
 				B1E09A332397FD750057C069 /* MXRoomStateTests.m in Sources */,
 				B1E09A352397FD7D0057C069 /* MXEventTests.m in Sources */,
+				A816248525F60D0300A46F05 /* MXDeviceListOperationsPoolTests.swift in Sources */,
 				B1E09A312397FD750057C069 /* MXSessionTests.m in Sources */,
 				B1E09A322397FD750057C069 /* MXRoomTests.m in Sources */,
 				32C78BA8256D227D008130B1 /* MXCryptoMigrationTests.m in Sources */,

--- a/MatrixSDK/Crypto/Data/MXDeviceListOperation.m
+++ b/MatrixSDK/Crypto/Data/MXDeviceListOperation.m
@@ -22,7 +22,7 @@
 
 @interface MXDeviceListOperation ()
 {
-    MXDeviceListOperationsPool *pool;
+    __weak MXDeviceListOperationsPool *pool;
 }
 
 @end

--- a/MatrixSDKTests/MXDeviceListOperationsPoolTests.swift
+++ b/MatrixSDKTests/MXDeviceListOperationsPoolTests.swift
@@ -1,5 +1,5 @@
-// 
-// Copyright 2020 The Matrix.org Foundation C.I.C
+//
+// Copyright 2021 The Matrix.org Foundation C.I.C
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,11 +14,18 @@
 // limitations under the License.
 //
 
-#ifndef MatrixSDKTests_Bridging_Header_h
-#define MatrixSDKTests_Bridging_Header_h
+import XCTest
 
-#import "MatrixSDKTestsData.h"
-#import "MatrixSDKTestsE2EData.h"
-#import "MXDeviceListOperationsPool.h"
+import MatrixSDK
 
-#endif /* MatrixSDKTests_Bridging_Header_h */
+class MXDeviceListOperationsPoolTests: XCTestCase {
+
+    func testDeallocate() {
+        var pool: MXDeviceListOperationsPool? = MXDeviceListOperationsPool(crypto: nil)
+        weak var weakPool = pool
+        MXDeviceListOperation(userIds: ["foo"], success: nil, failure: nil).add(to: pool)
+        pool = nil
+        XCTAssertNil(weakPool)
+    }
+
+}


### PR DESCRIPTION
This breaks a strong reference cycle between `MXDeviceListOperation` and `MXDeviceListOperationsPool`. When an operation is added to a pool, both objects hold mutual strong references to each other by means of the `pool` and `_operations` ivars. This prevents them from being deallocated when the operation has finished.

The leak can easily be reproduced in the Element iOS app:

1. Start the app
2. Open settings
3. Open security settings (loads a list of sessions / devices)
4. Start memory graph debugger in Xcode

At this point you'll notice orphaned `MXDeviceListOperation` and `MXDeviceListOperationsPool` objects that retain each other (red box). Note that there is another memory leak visible in the screenshot below where `MXDeviceListOperation` retains itself. This is addressed in #1042.

![Screenshot 2021-03-08 at 08 54 03 copy](https://user-images.githubusercontent.com/1137962/110292921-37cc1e00-7fee-11eb-8661-8e540695e26f.png)

This pull request breaks the cycle by weakifying the `pool` ivar in `MXDeviceListOperation`. This is safe because the operation should always be managed by an operation pool and the latter is retained in `MXDeviceList`.

After applying the fix, only the self retain cycle in `MXDeviceListOperation` remains. As mentioned above, this is fixed in #1042.

![Screenshot 2021-03-08 at 08 55 21](https://user-images.githubusercontent.com/1137962/110293329-b923b080-7fee-11eb-8574-0081733c674f.png)

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request updates [CHANGES.rst](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CHANGES.rst)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)
