### PR TITLE
MXDeviceList: Fix memory leak

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changes to be released in next version
  * 
 
 🐛 Bugfix
- * 
+ * MXDeviceList: Fix memory leak.
 
 ⚠️ API Changes
  * 

--- a/MatrixSDK/Crypto/Data/MXDeviceList.m
+++ b/MatrixSDK/Crypto/Data/MXDeviceList.m
@@ -126,7 +126,7 @@
         }
     }
 
-    __block MXDeviceListOperation *operation;
+    MXDeviceListOperation *operation;
 
     if (usersToDownload.count)
     {
@@ -141,8 +141,10 @@
         [self persistDeviceTrackingStatus];
 
         MXWeakify(self);
-        operation = [[MXDeviceListOperation alloc] initWithUserIds:usersToDownload success:^(NSArray<NSString *> *succeededUserIds, NSArray<NSString *> *failedUserIds) {
+        __block MXWeakify(operation);
+        weakoperation = operation = [[MXDeviceListOperation alloc] initWithUserIds:usersToDownload success:^(NSArray<NSString *> *succeededUserIds, NSArray<NSString *> *failedUserIds) {
             MXStrongifyAndReturnIfNil(self);
+            MXStrongifyAndReturnIfNil(operation);
 
             NSLog(@"[MXDeviceList] downloadKeys (operation: %p) -> DONE", operation);
 


### PR DESCRIPTION
When creating an `MXDeviceListOperation` in `MXDeviceList`, the block passed into the `success` parameter captures a strong reference to the operation. Since the `success` block is stored with a strong reference in `MXDeviceListOperation`, this creates a strong reference cycle that prevents the operation from being deallocated.

The leak is easily reproduced in the Element iOS app:

1. Start the app
2. Open settings
3. Open security settings (loads a list of sessions / devices)
4. Start memory graph debugger in Xcode

At this point you'll notice leaked `MXDeviceListOperation` objects that retain themselves (red box). Note that there is another memory leak visible in the screenshot below where `MXDeviceListOperation` and `MXDeviceListOperationsPool` retain each other. This leak is addressed in  #1041.

![Screenshot 2021-03-08 at 08 54 03](https://user-images.githubusercontent.com/1137962/110297234-8cbe6300-7ff3-11eb-8e58-4f56c59c398a.png)

This pull request breaks the cycle by passing a weak reference to the operation into the `success` block. Using a weak reference is safe because, as mentioned above, the block is held as a strong reference by the operation itself.

After applying the fix, only the retain cycle between `MXDeviceListOperation` and `MXDeviceListOperationsPool` remains. As mentioned above, this is fixed in  #1041.

![Screenshot 2021-03-08 at 09 33 49](https://user-images.githubusercontent.com/1137962/110297463-cc854a80-7ff3-11eb-94b0-ba995224a679.png)

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request updates [CHANGES.rst](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CHANGES.rst)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)
