### PR TITLE
GitHub Actions: Run pod lib lint

### DIFF
--- a/.github/workflows/cocoapods.yml
+++ b/.github/workflows/cocoapods.yml
@@ -1,0 +1,24 @@
+name: Cocoapods
+
+on:
+  # Triggers the workflow on any pull request and push to develop
+  push:
+    branches: [ develop ]
+  pull_request:
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  lint:
+    name: pod lib lint
+    runs-on: macos-latest
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      
+      - name: Setup
+        run: bundle install
+
+      - name: Lint MatrixSDK.podspec
+        run: bundle exec fastlane lint_pods

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,7 +24,7 @@ Changes to be released in next version
  * build.sh: When building an xcframework, zip the binary ready for distribution.
 
 Others
- * 
+ * GitHub Actions: Run pod lib lint
 
 Changes in 0.18.5 (2021-03-11)
 =================================================

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
 gem "fastlane"
-gem "cocoapods", '~>1.10.0'
+gem "cocoapods", '~>1.10.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (3.0.2)
-    activesupport (5.2.4.4)
+    activesupport (5.2.4.5)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -31,10 +31,10 @@ GEM
       aws-eventstream (~> 1, >= 1.0.2)
     babosa (1.0.4)
     claide (1.0.3)
-    cocoapods (1.10.0)
+    cocoapods (1.10.1)
       addressable (~> 2.6)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.10.0)
+      cocoapods-core (= 1.10.1)
       cocoapods-deintegrate (>= 1.0.3, < 2.0)
       cocoapods-downloader (>= 1.4.0, < 2.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
@@ -49,7 +49,7 @@ GEM
       nap (~> 1.0)
       ruby-macho (~> 1.4)
       xcodeproj (>= 1.19.0, < 2.0)
-    cocoapods-core (1.10.0)
+    cocoapods-core (1.10.1)
       activesupport (> 5.0, < 6)
       addressable (~> 2.6)
       algoliasearch (~> 1.0)
@@ -72,7 +72,7 @@ GEM
     colored2 (3.1.2)
     commander-fastlane (4.4.6)
       highline (~> 1.7.2)
-    concurrent-ruby (1.1.7)
+    concurrent-ruby (1.1.8)
     declarative (0.0.20)
     declarative-option (0.1.0)
     digest-crc (0.6.1)
@@ -166,7 +166,7 @@ GEM
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     httpclient (2.8.3)
-    i18n (1.8.5)
+    i18n (1.8.9)
       concurrent-ruby (~> 1.0)
     jmespath (1.4.0)
     json (2.3.1)
@@ -174,7 +174,7 @@ GEM
     memoist (0.16.2)
     mini_magick (4.11.0)
     mini_mime (1.0.2)
-    minitest (5.14.2)
+    minitest (5.14.4)
     molinillo (0.6.6)
     multi_json (1.15.0)
     multipart-post (2.0.0)
@@ -215,7 +215,7 @@ GEM
       tty-cursor (~> 0.7)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
-    tzinfo (1.2.8)
+    tzinfo (1.2.9)
       thread_safe (~> 0.1)
     uber (0.1.0)
     unf (0.1.4)
@@ -238,8 +238,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  cocoapods (~> 1.10.0)
+  cocoapods (~> 1.10.1)
   fastlane
 
 BUNDLED WITH
-   2.1.4
+   2.2.14

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -23,8 +23,8 @@ platform :ios do
 
   desc "Lint MatrixSDK podspec"
   lane :lint_pod_MatrixSDK do
-    # Use Release config to divide build time by 2
-    custom_pod_lib_lint(podspec: "../MatrixSDK.podspec", parameters: ["--allow-warnings", "--fail-fast", "--configuration=Release"])
+    # Use Debug config to divide build time by 3
+    custom_pod_lib_lint(podspec: "../MatrixSDK.podspec", parameters: ["--allow-warnings", "--fail-fast", "--configuration=Debug"])
   end
 
   desc "Push all pods"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -24,7 +24,8 @@ platform :ios do
 
   desc "Lint MatrixSDK podspec"
   lane :lint_pod_MatrixSDK do
-    custom_pod_lib_lint(podspec: "../MatrixSDK.podspec", parameters: ["--allow-warnings", "--verbose"])
+    # Use Release config to divide build time by 2
+    custom_pod_lib_lint(podspec: "../MatrixSDK.podspec", parameters: ["--allow-warnings", "--fail-fast", "--configuration=Release"])
   end
 
   desc "Lint SwiftMatrixSDK podspec"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -19,7 +19,6 @@ platform :ios do
   desc "Lint all podspecs"
   lane :lint_pods do
     lint_pod_MatrixSDK
-    lint_pod_SwiftMatrixSDK
   end
 
   desc "Lint MatrixSDK podspec"
@@ -28,25 +27,14 @@ platform :ios do
     custom_pod_lib_lint(podspec: "../MatrixSDK.podspec", parameters: ["--allow-warnings", "--fail-fast", "--configuration=Release"])
   end
 
-  desc "Lint SwiftMatrixSDK podspec"
-  lane :lint_pod_SwiftMatrixSDK do
-    custom_pod_lib_lint(podspec: "../SwiftMatrixSDK.podspec", parameters: ["--allow-warnings", "--verbose"])
-  end
-
   desc "Push all pods"
   lane :push_pods do
     push_pod_MatrixSDK
-    push_pod_SwiftMatrixSDK
   end
 
   desc "Push MatrixSDK pod"
   lane :push_pod_MatrixSDK do
     pod_push(path: "MatrixSDK.podspec", allow_warnings: true)
-  end
-
-  desc "Push SwiftMatrixSDK pod"
-  lane :push_pod_SwiftMatrixSDK do
-    pod_push(path: "SwiftMatrixSDK.podspec", allow_warnings: true)
   end
 
   #### Build ####


### PR DESCRIPTION
Let's try GH actions for long operation like `pod lib lin``
It is done only for Release to save half the time.

This is a test. We will probably do more later.