### PR TITLE
E2E improvements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Changes to be released in next version
 🙌 Improvements
  * Support room type as described in MSC1840 (vector-im/element-ios/issues/4050).
  * Pods: Update JitsiMeetSDK, OHHTTPStubs, Realm (vector-im/element-ios/issues/4120).
+ * MXCrypto: Do not load room members in e2e rooms after an initial sync.
 
 🐛 Bugfix
  * 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Changes to be released in next version
  * Support room type as described in MSC1840 (vector-im/element-ios/issues/4050).
  * Pods: Update JitsiMeetSDK, OHHTTPStubs, Realm (vector-im/element-ios/issues/4120).
  * MXCrypto: Do not load room members in e2e rooms after an initial sync.
+ * MXRoomSummary: Add enableTrustTracking() to compute and maintain trust value for the given room (vector-im/element-ios/issues/4115).
 
 🐛 Bugfix
  * 

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -2533,33 +2533,27 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 {
     MXRoom *room = [_mxSession roomWithRoomId:event.roomId];
 
-    MXWeakify(self);
-    void (^success)(MXRoomMembers *roomMembers, MXRoomState *roomState) = ^void(MXRoomMembers *roomMembers, MXRoomState *roomState)
-    {
+    MXWeakify(self);    
+    [room state:^(MXRoomState *roomState) {
         MXStrongifyAndReturnIfNil(self);
-
+        
+        // We can start tracking only lazy loaded room members
+        // All room members will be loaded when necessary, ie when encrypting in the room
+        MXRoomMembers *roomMembers = roomState.members;
+        
         NSMutableArray *members = [NSMutableArray array];
         NSArray<MXRoomMember *> *encryptionTargetMembers = [roomMembers encryptionTargetMembers:roomState.historyVisibility];
         for (MXRoomMember *roomMember in encryptionTargetMembers)
         {
             [members addObject:roomMember.userId];
         }
-
+        
         if (self.cryptoQueue)
         {
             dispatch_async(self.cryptoQueue, ^{
                 [self setEncryptionInRoom:event.roomId withMembers:members algorithm:event.content[@"algorithm"] inhibitDeviceQuery:YES];
             });
         }
-    };
-    
-    [room state:^(MXRoomState *roomState) {
-        [room members:^(MXRoomMembers *roomMembers) {
-            success(roomMembers, roomState);
-        } failure:^(NSError *error) {
-            NSLog(@"[MXCrypto] onCryptoEvent: Warning: Unable to get all members from the HS. Fallback by using lazy-loaded members");
-            success(roomState.members, roomState);
-        }];
     }];
 }
 

--- a/MatrixSDK/Data/MXRoomSummary.h
+++ b/MatrixSDK/Data/MXRoomSummary.h
@@ -323,6 +323,18 @@ FOUNDATION_EXPORT NSString *const kMXRoomSummaryDidChangeNotification;
 /// @param membershipTransitionState The new membership transition state value
 - (void)updateMembershipTransitionState:(MXMembershipTransitionState)membershipTransitionState;
 
+
+/**
+ Start computing and maintaining the trust value of this room.
+ 
+ `MXSDKOptions.computeE2ERoomSummaryTrust` allows to compute trusts for all rooms automatically but it comsumes
+ resources.
+ 
+ @param enable YES to enable trust computation.
+ */
+- (void)enableTrustTracking:(BOOL)enable;
+
+
 #pragma mark - Server sync
 
 /**

--- a/MatrixSDK/Data/MXRoomSummary.m
+++ b/MatrixSDK/Data/MXRoomSummary.m
@@ -493,7 +493,9 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
 - (void)setMembersCount:(MXRoomMembersCount *)membersCount
 {
     _membersCount = membersCount;
-    if (_isEncrypted && [MXSDKOptions sharedInstance].computeE2ERoomSummaryTrust)
+    
+    // Update trust if we computed it
+    if (_trust)
     {
         [self triggerComputeTrust:YES];
     }
@@ -501,15 +503,12 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
 
 - (void)bootstrapTrustLevelComputation
 {
-    if (_isEncrypted && [MXSDKOptions sharedInstance].computeE2ERoomSummaryTrust)
+    // Bootstrap trust computation
+    [self registerTrustLevelDidChangeNotifications];
+    
+    if (!self.trust)
     {
-        // Bootstrap trust computation
-        [self registerTrustLevelDidChangeNotifications];
-        
-        if (!self.trust)
-        {
-            [self triggerComputeTrust:YES];
-        }
+        [self triggerComputeTrust:YES];
     }
 }
 
@@ -559,11 +558,6 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
 
 - (void)triggerComputeTrust:(BOOL)forceDownload
 {
-    if (!_isEncrypted || ![MXSDKOptions sharedInstance].computeE2ERoomSummaryTrust)
-    {
-        return;
-    }
-    
     // Decide what to do
     if (nextTrustComputation == MXRoomSummaryNextTrustComputationNone)
     {

--- a/MatrixSDKTests/MXRoomSummaryTrustTests.m
+++ b/MatrixSDKTests/MXRoomSummaryTrustTests.m
@@ -324,6 +324,47 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
     }];
 }
 
+/**
+ Test MXRoomSummary.enableTrustTracking(enable:)
+ 
+ - Disable computeE2ERoomSummaryTrust
+ - Have Alice with 2 devices (Alice1 and Alice2) and Bob. All trusted via cross-signing
+ -> Trust must not be automatically computed
+ - Enable trust computation
+ -> Trust be available and everything should be green
+ */
+- (void)testEnableTrustTracking
+{
+    // - Disable computeE2ERoomSummaryTrust
+    [MXSDKOptions sharedInstance].computeE2ERoomSummaryTrust = NO;
+    
+    // - Have Alice with 2 devices (Alice1 and Alice2) and Bob. All trusted via cross-signing
+    [matrixSDKTestsE2EData doTestWithBobAndAliceWithTwoDevicesAllTrusted:self readyToTest:^(MXSession *aliceSession1, MXSession *aliceSession2, MXSession *bobSession, NSString *roomId, XCTestExpectation *expectation) {
+        
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, kMXRoomSummaryTrustComputationDelayMs * NSEC_PER_MSEC), dispatch_get_main_queue(), ^{
+            
+            // -> Trust must not be automatically computed
+            MXRoomSummary *roomSummaryFromAlicePOV = [aliceSession1 roomWithRoomId:roomId].summary;
+            MXUsersTrustLevelSummary *trust = roomSummaryFromAlicePOV.trust;
+            XCTAssertNil(trust);
+
+            // - Enable trust computation
+            [roomSummaryFromAlicePOV enableTrustTracking:YES];
+            
+            id observer = [[NSNotificationCenter defaultCenter] addObserverForName:kMXRoomSummaryDidChangeNotification object:roomSummaryFromAlicePOV queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
+                
+                // -> Trust be available and everything should be green
+                MXUsersTrustLevelSummary *trust = roomSummaryFromAlicePOV.trust;
+                XCTAssertEqual(trust.trustedUsersProgress.fractionCompleted, 1);
+                XCTAssertEqual(trust.trustedDevicesProgress.fractionCompleted, 1);
+                
+                [expectation fulfill];
+            }];
+            
+            [observers addObject:observer];
+        });
+    }];
+}
 
 @end
 


### PR DESCRIPTION
There are 2 separates improvements:
- Do not load room members in e2e rooms after an initial sync (1st commit)
- Add MXRoomSummary:.enableTrustTracking() to compute and maintain trust value for the given room (vector-im/element-ios/issues/4115).