### PR TITLE
MXKeyBackup: Add sanity checks to avoid crashes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Changes to be released in next version
  * MXDeviceList: Fix memory leak.
  * MXDeviceListOperation: Fix memory leak.
  * MXRoomState/MXRoomMembers: Fix memory leak and copying.
+ * MXKeyBackup: Add sanity checks to avoid crashes (vector-im/element-ios/issues/4113).
 
 ⚠️ API Changes
  * 


### PR DESCRIPTION
Fix vector-im/element-ios/issues/4113

Avoid crashes and log what is wrong.