### PR TITLE
MXTools: Avoid releasing null pointer to fix crash on M1 simulator

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Changes to be released in next version
  * MXDeviceListOperation: Fix memory leak.
  * MXRoomState/MXRoomMembers: Fix memory leak and copying.
  * MXKeyBackup: Add sanity checks to avoid crashes (vector-im/element-ios/issues/4113).
+ * MXTools: Avoid releasing null pointer to fix crash on M1 simulator (vector-im/element-ios/issues/4140)
 
 ⚠️ API Changes
  * 

--- a/MatrixSDK/Utils/MXTools.m
+++ b/MatrixSDK/Utils/MXTools.m
@@ -785,13 +785,15 @@ static NSMutableDictionary *fileExtensionByContentType = nil;
             CFStringRef mimeType = (__bridge CFStringRef)contentType;
             CFStringRef uti = UTTypeCreatePreferredIdentifierForTag(kUTTagClassMIMEType, mimeType, NULL);
             
-            NSString* extension = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass(uti, kUTTagClassFilenameExtension);
+            if (uti) {
+                NSString* extension = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass(uti, kUTTagClassFilenameExtension);
             
-            CFRelease(uti);
+                CFRelease(uti);
             
-            if (extension)
-            {
-                fileExt = [NSString stringWithFormat:@".%@", extension];
+                if (extension)
+                {
+                    fileExt = [NSString stringWithFormat:@".%@", extension];
+                }
             }
         }
         

--- a/MatrixSDKTests/MXToolsTests.m
+++ b/MatrixSDKTests/MXToolsTests.m
@@ -102,4 +102,12 @@
     XCTAssertEqualObjects([MXTools encodeURIComponent:string], @"%2Bmatrix%3Amatrix.org");
 }
 
+
+#pragma mark - File extensions
+
+- (void)testFileExtensionFromImageJPEGContentType
+{
+    XCTAssertEqualObjects([MXTools fileExtensionFromContentType:@"image/jpeg"], @".jpeg");
+}
+
 @end


### PR DESCRIPTION
Due to a Simulator bug on the Apple M1, `UTTypeCreatePreferredIdentifierForTag` can unexpectedly return `NULL`. This causes a crash because the return value is later passed into `CFRelease` which explicitly disallows `NULL` arguments.

This commit fixes the issue by ensuring the return value is not `NULL` before proceeding.

Fixes: vector-im/element-ios#4140

Signed-off-by: Johannes Marbach <n0-0ne+github@mailbox.org>

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request updates [CHANGES.rst](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CHANGES.rst)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)
