### PR TITLE
Remove padding from base64 encoded `iv` value

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changes to be released in next version
  * 
 
 🐛 Bugfix
- * 
+ * Remove padding from base64 encoded `iv` value (vector-im/element-ios/issues/4172).
 
 ⚠️ API Changes
  * 

--- a/MatrixSDK/Crypto/Data/MXEncryptedAttachments.m
+++ b/MatrixSDK/Crypto/Data/MXEncryptedAttachments.m
@@ -170,7 +170,7 @@ NSString *const MXEncryptedAttachmentsErrorDomain = @"MXEncryptedAttachmentsErro
         encryptedContentFile.url = url;
         encryptedContentFile.mimetype = mimeType;
         encryptedContentFile.key = encryptedContentKey;
-        encryptedContentFile.iv = [iv base64EncodedStringWithOptions:0];
+        encryptedContentFile.iv = [MXBase64Tools base64ToUnpaddedBase64:[iv base64EncodedStringWithOptions:0]];
         encryptedContentFile.hashes = @{
                                         @"sha256": [MXBase64Tools base64ToUnpaddedBase64:[computedSha256 base64EncodedStringWithOptions:0]],
                                         };


### PR DESCRIPTION
This uses the existing `MXBase64Tools` to trim the `=` padding from the base64 encoded string. The reinsertion of the padding prior to decoding was already implemented (line [224](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/MatrixSDK/Crypto/Data/MXEncryptedAttachments.m#L224) in the same file).

Closes: vector-im/element-ios#4172

Signed-off-by: Johannes Marbach <n0-0ne+github@mailbox.org>

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request updates [CHANGES.rst](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CHANGES.rst)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)
