### PR TITLE
Check for nil in MXRoom.updateWithRoomMember

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changes to be released in next version
  * 
 
 🐛 Bugfix
- * 
+ * Check for null before changing a user's displayname or avatar URL based on an m.room.member event.
 
 ⚠️ API Changes
  * 

--- a/MatrixSDK/Data/MXUser.m
+++ b/MatrixSDK/Data/MXUser.m
@@ -66,8 +66,14 @@
     if ((NO == [_displayname isEqualToString:roomMember.displayname]
             || NO == [_avatarUrl isEqualToString:roomMember.avatarUrl]))
     {
-        self.displayname = [roomMember.displayname copy];
-        self.avatarUrl = [roomMember.avatarUrl copy];
+        if (roomMember.displayname)
+        {
+            self.displayname = [roomMember.displayname copy];
+        }
+        if (roomMember.avatarUrl)
+        {
+            self.avatarUrl = [roomMember.avatarUrl copy];
+        }
         
         // Handle here the case where the user has no defined avatar.
         if (nil == self.avatarUrl && ![MXSDKOptions sharedInstance].disableIdenticonUseForUserAvatar)

--- a/changelog.d/1060.bugfix
+++ b/changelog.d/1060.bugfix
@@ -1,0 +1,1 @@
+Check for null before updating a user's displayname or avatar URL based on an m.room.member event.  Contributed by Charles Wright.


### PR DESCRIPTION
This PR addresses issue #1045 where users' displaynames and avatar URLs can be nulled out on receipt of an old m.room.member event.
