### PR TITLE
MXBackgroundService: Keep all cached sync responses until there are processed by MXSession

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changes to be released in next version
 
 🙌 Improvements
  * Create secret storage with a given private key (vector-im/element-ios/issues/4189).
+ * MXAsyncTaskQueue: New tool to run asynchronous tasks one at a time.
 
 🐛 Bugfix
  * Notifications: Fix background sync out of memory (vector-im/element-ios#3957).

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Changes to be released in next version
 
 🐛 Bugfix
  * Notifications: Fix background sync out of memory (vector-im/element-ios#3957).
+ * Notifications: MXBackgroundService: Keep all cached sync responses until there are processed by MXSession (vector-im/element-ios#4074).
  * Remove padding from base64 encoded `iv` value (vector-im/element-ios/issues/4172).
  * Check for null before changing a user's displayname or avatar URL based on an m.room.member event.
 

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -459,6 +459,10 @@
 		32AF929824115D8B0008A0FD /* MXPendingSecretShareRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 32AF929524115D8B0008A0FD /* MXPendingSecretShareRequest.h */; };
 		32AF929924115D8B0008A0FD /* MXPendingSecretShareRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 32AF929624115D8B0008A0FD /* MXPendingSecretShareRequest.m */; };
 		32AF929A24115D8B0008A0FD /* MXPendingSecretShareRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 32AF929624115D8B0008A0FD /* MXPendingSecretShareRequest.m */; };
+		32B090E2261F709B002924AA /* MXAsyncTaskQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32B090E1261F709B002924AA /* MXAsyncTaskQueue.swift */; };
+		32B090E3261F709B002924AA /* MXAsyncTaskQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32B090E1261F709B002924AA /* MXAsyncTaskQueue.swift */; };
+		32B090FD26201C8D002924AA /* MXAsyncTaskQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32B090FC26201C8D002924AA /* MXAsyncTaskQueueTests.swift */; };
+		32B090FE26201C8D002924AA /* MXAsyncTaskQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32B090FC26201C8D002924AA /* MXAsyncTaskQueueTests.swift */; };
 		32B0E33923A2989A0054FF1A /* MXEventReferenceChunk.h in Headers */ = {isa = PBXBuildFile; fileRef = 32B0E33723A2989A0054FF1A /* MXEventReferenceChunk.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		32B0E33A23A2989A0054FF1A /* MXEventReferenceChunk.h in Headers */ = {isa = PBXBuildFile; fileRef = 32B0E33723A2989A0054FF1A /* MXEventReferenceChunk.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		32B0E33B23A2989A0054FF1A /* MXEventReferenceChunk.m in Sources */ = {isa = PBXBuildFile; fileRef = 32B0E33823A2989A0054FF1A /* MXEventReferenceChunk.m */; };
@@ -1776,6 +1780,8 @@
 		32AF9291241112850008A0FD /* MXCryptoSecretShareTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXCryptoSecretShareTests.m; sourceTree = "<group>"; };
 		32AF929524115D8B0008A0FD /* MXPendingSecretShareRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXPendingSecretShareRequest.h; sourceTree = "<group>"; };
 		32AF929624115D8B0008A0FD /* MXPendingSecretShareRequest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXPendingSecretShareRequest.m; sourceTree = "<group>"; };
+		32B090E1261F709B002924AA /* MXAsyncTaskQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXAsyncTaskQueue.swift; sourceTree = "<group>"; };
+		32B090FC26201C8D002924AA /* MXAsyncTaskQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXAsyncTaskQueueTests.swift; sourceTree = "<group>"; };
 		32B0E33723A2989A0054FF1A /* MXEventReferenceChunk.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXEventReferenceChunk.h; sourceTree = "<group>"; };
 		32B0E33823A2989A0054FF1A /* MXEventReferenceChunk.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXEventReferenceChunk.m; sourceTree = "<group>"; };
 		32B0E33D23A378310054FF1A /* MXEventReference.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXEventReference.h; sourceTree = "<group>"; };
@@ -2311,6 +2317,7 @@
 				F08B8D591E014711006171A8 /* Categories */,
 				F03EF4F91DF014D9009DF592 /* Media */,
 				B146D46E21A5939000D8C2C6 /* Realm */,
+				32B090E1261F709B002924AA /* MXAsyncTaskQueue.swift */,
 				F03EF5021DF01596009DF592 /* MXLRUCache.h */,
 				F03EF5031DF01596009DF592 /* MXLRUCache.m */,
 				320DFDD719DD99B60068622A /* MXHTTPClient.h */,
@@ -3129,6 +3136,7 @@
 		32C6F93919DD814400EA4E9C /* MatrixSDKTests */ = {
 			isa = PBXGroup;
 			children = (
+				32B090FC26201C8D002924AA /* MXAsyncTaskQueueTests.swift */,
 				32EEA8492603FDD60041425B /* MXResponseTest.swift */,
 				32EEA83E2603CA140041425B /* MXRestClientExtensionsTests.m */,
 				32C78BA6256D227D008130B1 /* MXCryptoMigrationTests.m */,
@@ -4867,6 +4875,7 @@
 				32720D9D222EAA6F0086FFF5 /* MXDiscoveredClientConfig.m in Sources */,
 				B146D4F321A5AF7F00D8C2C6 /* MXRealmEventScan.m in Sources */,
 				B14EECD92577DE7A00448735 /* MXLoginSSOIdentityProvider.m in Sources */,
+				32B090E2261F709B002924AA /* MXAsyncTaskQueue.swift in Sources */,
 				322691371E5EFF8700966A6E /* MXDeviceListOperationsPool.m in Sources */,
 				C6F935801E5B3ACA00FC34BF /* MXResponse.swift in Sources */,
 				32EEA8632604014A0041425B /* MXSummable.swift in Sources */,
@@ -4925,6 +4934,7 @@
 				32DC15D71A8DFF0D006F9AD3 /* MXNotificationCenterTests.m in Sources */,
 				329571991B024D2B00ABB3BA /* MXMockCallStack.m in Sources */,
 				3281E8A819E41A2000976E1A /* MatrixSDKTestsData.m in Sources */,
+				32B090FD26201C8D002924AA /* MXAsyncTaskQueueTests.swift in Sources */,
 				322A51D81D9E846800C8536D /* MXCryptoTests.m in Sources */,
 				B146D4FF21A5C0BD00D8C2C6 /* MXMediaScanStoreTests.m in Sources */,
 				32BD34BE1E84134A006EDC0D /* MatrixSDKTestsE2EData.m in Sources */,
@@ -5212,6 +5222,7 @@
 				B14EF25C2397E90400758AF0 /* MXRoomTombStoneContent.m in Sources */,
 				B14EF25D2397E90400758AF0 /* MXImage.swift in Sources */,
 				B14EF25E2397E90400758AF0 /* (null) in Sources */,
+				32B090E3261F709B002924AA /* MXAsyncTaskQueue.swift in Sources */,
 				B14EF25F2397E90400758AF0 /* MXServerNoticeContent.m in Sources */,
 				B14EF2602397E90400758AF0 /* MXContentScanResult.m in Sources */,
 				B14EF2612397E90400758AF0 /* MXRealmAggregationsStore.m in Sources */,
@@ -5312,6 +5323,7 @@
 				B1E09A392397FD7D0057C069 /* MXMyUserTests.m in Sources */,
 				B1E09A202397FCE90057C069 /* MXCryptoBackupTests.m in Sources */,
 				B1E09A3B2397FD820057C069 /* MXStoreNoStoreTests.m in Sources */,
+				32B090FE26201C8D002924AA /* MXAsyncTaskQueueTests.swift in Sources */,
 				B1E09A242397FCE90057C069 /* MXPeekingRoomTests.m in Sources */,
 				B1E09A452397FD990057C069 /* MXLazyLoadingTests.m in Sources */,
 				B1E09A1C2397FCE90057C069 /* MXEventAnnotationTests.swift in Sources */,

--- a/MatrixSDK/Background/Store/MXSyncResponseStore.swift
+++ b/MatrixSDK/Background/Store/MXSyncResponseStore.swift
@@ -32,14 +32,25 @@ public enum MXSyncResponseStoreError: Error {
     func updateSyncResponse(withId id: String, syncResponse: MXCachedSyncResponse)
     func deleteSyncResponse(withId id: String)
     
-    // All ids of stored sync responses.
-    // Sync responses are stored in chunks to save RAM when processing it
-    // The array order is chronological
+    /// All ids of valid stored sync responses.
+    /// Sync responses are stored in chunks to save RAM when processing it
+    /// The array order is chronological
     var syncResponseIds: [String] { get }
+    
+    /// Mark as outdated some stored sync responses
+    func markOutdated(syncResponseIds: [String])
+    /// All outdated sync responses
+    var outdatedSyncResponseIds: [String] { get }
     
     /// User account data
     var accountData: [String : Any]? { get set }
     
     /// Delete all data in the store
     func deleteData()
+}
+
+extension MXSyncResponseStore {
+    var allSyncResponseIds : [String] {
+        outdatedSyncResponseIds + syncResponseIds
+    }
 }

--- a/MatrixSDK/Background/Store/MXSyncResponseStoreManager.swift
+++ b/MatrixSDK/Background/Store/MXSyncResponseStoreManager.swift
@@ -66,13 +66,14 @@ public class MXSyncResponseStoreManager: NSObject {
         return syncResponse
     }
     
-    public func resetData() {
-        NSLog("[MXSyncResponseStoreManager] resetData. The sync token was \(String(describing: syncToken))")
+    public func markDataOutdated() {
+        let syncResponseIds = syncResponseStore.syncResponseIds
+        if syncResponseIds.count == 0 {
+            return
+        }
         
-        // Delete all the store
-        // TODO: Don't do that. We loose ephemeral data we will never received again in /sync requests like e2ee keys.
-        // It will be fixed in https://github.com/vector-im/element-ios/issues/4074
-        syncResponseStore.deleteData()
+        NSLog("[MXSyncResponseStoreManager] markDataOutdated \(syncResponseIds.count) cached sync responses. The sync token was \(String(describing: syncToken()))")
+        syncResponseStore.markOutdated(syncResponseIds: syncResponseIds)
     }
     
 

--- a/MatrixSDK/Background/Store/Model/MXSyncResponseStoreMetaDataModel.swift
+++ b/MatrixSDK/Background/Store/Model/MXSyncResponseStoreMetaDataModel.swift
@@ -28,8 +28,11 @@ struct MXSyncResponseStoreMetaDataModel {
     /// User account data
     var accountData: [String : Any]?
     
-    /// All cached sync responses, chronologically ordered
+    /// All valid cached sync responses, chronologically ordered
     var syncResponseIds: [String] = []
+    
+    /// All obsolote cached sync responses, chronologically ordered
+    var outdatedSyncResponseIds: [String] = []
 }
 
 
@@ -38,6 +41,7 @@ extension MXSyncResponseStoreMetaDataModel: Codable {
         case version
         case accountData
         case syncResponseIds
+        case outdatedSyncResponseIds
     }
     
     init(from decoder: Decoder) throws {
@@ -48,6 +52,7 @@ extension MXSyncResponseStoreMetaDataModel: Codable {
             accountData =  try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
         }
         syncResponseIds = try values.decode([String].self, forKey: .syncResponseIds)
+        outdatedSyncResponseIds = try values.decode([String].self, forKey: .outdatedSyncResponseIds)
     }
     
     func encode(to encoder: Encoder) throws {
@@ -59,5 +64,6 @@ extension MXSyncResponseStoreMetaDataModel: Codable {
             try container.encodeIfPresent(data, forKey: .accountData)
         }
         try container.encode(syncResponseIds, forKey: .syncResponseIds)
+        try container.encode(outdatedSyncResponseIds, forKey: .outdatedSyncResponseIds)
     }
 }

--- a/MatrixSDK/Background/Store/SyncResponseFileStore/MXSyncResponseFileStore.swift
+++ b/MatrixSDK/Background/Store/SyncResponseFileStore/MXSyncResponseFileStore.swift
@@ -173,21 +173,14 @@ public class MXSyncResponseFileStore: NSObject {
     
     private func addSyncResponseId(id: String) {
         var metadata = readMetaData()
-        
-        var syncResponseIds = metadata.syncResponseIds
-        syncResponseIds.append(id)
-        
-        metadata.syncResponseIds = syncResponseIds
+        metadata.syncResponseIds.append(id)
         saveMetaData(metadata)
     }
     
     private func deleteSyncResponseId(id: String) {
         var metadata = readMetaData()
-        
-        var syncResponseIds = metadata.syncResponseIds
-        syncResponseIds.removeAll(where: { $0 == id })
-        
-        metadata.syncResponseIds = syncResponseIds
+        metadata.syncResponseIds.removeAll(where: { $0 == id })
+        metadata.outdatedSyncResponseIds.removeAll(where: { $0 == id })
         saveMetaData(metadata)
     }
 }
@@ -231,6 +224,21 @@ extension MXSyncResponseFileStore: MXSyncResponseStore {
         readMetaData().syncResponseIds
     }
     
+    public var outdatedSyncResponseIds: [String] {
+        readMetaData().outdatedSyncResponseIds
+    }
+    
+    public func markOutdated(syncResponseIds: [String]) {
+        var metadata = readMetaData()
+        syncResponseIds.forEach { syncResponseId in
+            if let index = metadata.syncResponseIds.firstIndex(of: syncResponseId) {
+                metadata.syncResponseIds.remove(at: index)
+                metadata.outdatedSyncResponseIds.append(syncResponseId)
+            }
+        }
+        saveMetaData(metadata)
+    }
+    
     
     public var accountData: [String : Any]? {
         get {
@@ -245,7 +253,7 @@ extension MXSyncResponseFileStore: MXSyncResponseStore {
     
     
     public func deleteData() {
-        let syncResponseIds = self.syncResponseIds
+        let syncResponseIds = self.allSyncResponseIds
         syncResponseIds.forEach { id in
             deleteSyncResponse(withId: id)
         }

--- a/MatrixSDK/Crypto/MXCrypto.h
+++ b/MatrixSDK/Crypto/MXCrypto.h
@@ -212,6 +212,14 @@ extern NSString *const MXDeviceListDidUpdateUsersDevicesNotification;
                                    failure:(void (^)(NSError *error))failure;
 
 /**
+ Discard the current outbound group session for a specific room.
+ 
+ @param roomId Identifer of the room.
+ @param onComplete the callback called once operation is done.
+ */
+- (void)discardOutboundGroupSessionForRoomWithRoomId:(NSString*)roomId onComplete:(void (^)(void))onComplete;
+
+/**
  Handle list of changed users provided in the /sync response.
 
  @param deviceLists the list of users who have a change in their devices.

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -684,6 +684,24 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     return operation;
 }
 
+- (void)discardOutboundGroupSessionForRoomWithRoomId:(NSString*)roomId onComplete:(void (^)(void))onComplete
+{
+#ifdef MX_CRYPTO
+    MXWeakify(self);
+    dispatch_async(self.cryptoQueue, ^{
+        MXStrongifyAndReturnIfNil(self);
+        
+        [self.olmDevice discardOutboundGroupSessionForRoomWithRoomId:roomId];
+        
+        dispatch_async(dispatch_get_main_queue(), ^{
+            onComplete();
+        });
+    });
+#else
+    onComplete();
+#endif
+}
+
 - (void)handleDeviceListsChanges:(MXDeviceListResponse*)deviceLists
 {
 #ifdef MX_CRYPTO

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -176,6 +176,11 @@ typedef void (^MXOnResumeDone)(void);
      Each key is a native room id. Each value is the virtual room id.
      */
     NSMutableDictionary<NSString*, NSString*> *nativeToVirtualRoomIds;
+    
+    /**
+     Async queue to run a single task at a time.
+     */
+    MXAsyncTaskQueue *asyncTaskQueue;
 }
 
 /**
@@ -216,6 +221,7 @@ typedef void (^MXOnResumeDone)(void);
         directRoomsOperationsQueue = [NSMutableArray array];
         publicisedGroupsByUserId = [[NSMutableDictionary alloc] init];
         nativeToVirtualRoomIds = [NSMutableDictionary dictionary];
+        asyncTaskQueue = [[MXAsyncTaskQueue alloc] initWithDispatchQueue:dispatch_get_main_queue() label:@"MXAsyncTaskQueue-MXSession"];
 
         [self setIdentityServer:mxRestClient.identityServer andAccessToken:mxRestClient.credentials.identityServerAccessToken];
         
@@ -1711,8 +1717,6 @@ typedef void (^MXOnResumeDone)(void);
         }
         return;
     }
-    
-    MXAsyncTaskQueue *asyncTaskQueue = [[MXAsyncTaskQueue alloc] initWithDispatchQueue:dispatch_get_main_queue() label:@"MXAsyncTaskQueue-MXSession"];
     
     for (NSString *syncResponseId in outdatedSyncResponseIds)
     {

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -1684,68 +1684,92 @@ typedef void (^MXOnResumeDone)(void);
 
 - (void)handleBackgroundSyncCacheIfRequiredWithCompletion:(void (^)(void))completion
 {
-    NSLog(@"[MXSession] handleBackgroundSyncCacheIfRequired: state %tu", _state);
-    
     MXSyncResponseFileStore *syncResponseStore = [[MXSyncResponseFileStore alloc] initWithCredentials:self.credentials];
     MXSyncResponseStoreManager *syncResponseStoreManager = [[MXSyncResponseStoreManager alloc] initWithSyncResponseStore:syncResponseStore];
     
     NSString *syncResponseStoreSyncToken = syncResponseStoreManager.syncToken;
-    if (syncResponseStoreSyncToken)
+    NSString *eventStreamToken = _store.eventStreamToken;
+
+    NSMutableArray<NSString *> *outdatedSyncResponseIds = [syncResponseStore.outdatedSyncResponseIds mutableCopy];
+    NSArray<NSString *> *syncResponseIds = syncResponseStore.syncResponseIds;
+
+    NSLog(@"[MXSession] handleBackgroundSyncCacheIfRequired: state %tu. outdatedSyncResponseIds: %@. syncResponseIds: %@. syncResponseStoreSyncToken: %@",
+          _state, @(outdatedSyncResponseIds.count), @(syncResponseIds.count) , syncResponseStoreSyncToken);
+    
+    if (![syncResponseStoreSyncToken isEqualToString:eventStreamToken])
     {
-        NSString *eventStreamToken = _store.eventStreamToken;
-        if ([syncResponseStoreSyncToken isEqualToString:eventStreamToken])
-        {
-            //  sync response really continues from where the session left
-            NSArray<NSString *> *syncResponseIds = syncResponseStore.syncResponseIds;
-            NSLog(@"[MXSession] handleBackgroundSyncCacheIfRequired: Handle %@ cached sync responses from stream token %@", @(syncResponseIds.count), eventStreamToken);
-            
-            dispatch_group_t dispatchGroup = dispatch_group_create();
-            
-            for (NSString *syncResponseId in syncResponseIds)
-            {
-                @autoreleasepool {
-                    MXCachedSyncResponse *cachedSyncResponse = [syncResponseStore syncResponseWithId:syncResponseId error:nil];
-                    if (cachedSyncResponse)
-                    {
-                        dispatch_group_enter(dispatchGroup);
-                        [self handleSyncResponse:cachedSyncResponse.syncResponse
-                                      completion:^{
-                            dispatch_group_leave(dispatchGroup);
-                        }];
-                    }
-                }
-            }
-            
-            dispatch_group_notify(dispatchGroup, dispatch_get_main_queue(), ^{
-                [syncResponseStore deleteData];
-                
-                if (completion)
-                {
-                    completion();
-                }
-            });
-        }
-        else
-        {
-            NSLog(@"[MXSession] handleBackgroundSyncCacheIfRequired: Ignore cache: MXSession stream token: %@. MXBackgroundSyncService cache stream token: %@", eventStreamToken, syncResponseStoreSyncToken);
-            
-            //  this sync response will break the continuity in session, ignore & remove it
-            [syncResponseStore deleteData];
-            
-            if (completion)
-            {
-                completion();
-            }
-        }
+        NSLog(@"[MXSession] handleBackgroundSyncCacheIfRequired: ");
+        [outdatedSyncResponseIds addObjectsFromArray:syncResponseIds];
+        syncResponseIds = @[];
     }
-    else
+    
+    if (outdatedSyncResponseIds.count == 0 && syncResponseIds.count == 0)
     {
         if (completion)
         {
             completion();
         }
+        return;
     }
+    
+    MXAsyncTaskQueue *asyncTaskQueue = [[MXAsyncTaskQueue alloc] initWithDispatchQueue:dispatch_get_main_queue() label:@"MXAsyncTaskQueue-MXSession"];
+    
+    for (NSString *syncResponseId in outdatedSyncResponseIds)
+    {
+        @autoreleasepool {
+            MXCachedSyncResponse *cachedSyncResponse = [syncResponseStore syncResponseWithId:syncResponseId error:nil];
+            if (cachedSyncResponse)
+            {
+                [asyncTaskQueue asyncWithExecute:^(void (^ taskCompleted)(void)) {
+                    [self handleOutdatedSyncResponse:cachedSyncResponse.syncResponse
+                                  completion:^{
+                        taskCompleted();
+                    }];
+                }];
+            }
+        }
+    }
+    
+    for (NSString *syncResponseId in syncResponseIds)
+    {
+        @autoreleasepool {
+            MXCachedSyncResponse *cachedSyncResponse = [syncResponseStore syncResponseWithId:syncResponseId error:nil];
+            if (cachedSyncResponse)
+            {
+                [asyncTaskQueue asyncWithExecute:^(void (^ taskCompleted)(void)) {
+                    [self handleSyncResponse:cachedSyncResponse.syncResponse
+                                  completion:^{
+                        taskCompleted();
+                    }];
+                }];
+            }
+        }
+    }
+    
+    [asyncTaskQueue asyncWithExecute:^(void (^ taskCompleted)(void)) {
+        [syncResponseStore deleteData];
+        
+        if (completion)
+        {
+            completion();
+        }
+    }];
 }
+
+- (void)handleOutdatedSyncResponse:(MXSyncResponse *)syncResponse
+                        completion:(void (^)(void))completion
+{
+    NSLog(@"[MXSession] handleOutdatedSyncResponse: %tu joined rooms, %tu invited rooms, %tu left rooms, %tu toDevice events.", syncResponse.rooms.join.count, syncResponse.rooms.invite.count, syncResponse.rooms.leave.count, syncResponse.toDevice.events.count);
+    
+    // Handle only to_device events. They are sent only once by the homeserver
+    for (MXEvent *toDeviceEvent in syncResponse.toDevice.events)
+    {
+        [self handleToDeviceEvent:toDeviceEvent];
+    }
+    
+    completion();
+}
+
 
 #pragma mark - Options
 - (void)enableVoIPWithCallStack:(id<MXCallStack>)callStack

--- a/MatrixSDK/Utils/MXAsyncTaskQueue.swift
+++ b/MatrixSDK/Utils/MXAsyncTaskQueue.swift
@@ -16,12 +16,12 @@
 
 import Foundation
 
-/// Scheduler to run run one asynchronous or synchronous task at a time.
+/// Scheduler to run one asynchronous or synchronous task at a time.
 @objcMembers public class MXAsyncTaskQueue: NSObject {
     
     /// Serial queue where tasks are stacked
     private let dispatchGroupQueue: DispatchQueue
-    ///Mechanism to run one task at a time
+    /// Mechanism to run one task at a time
     private let dispatchGroup: DispatchGroup
 
     /// Queue from where tasks are executed
@@ -36,6 +36,7 @@ import Foundation
     /// Schedule a new task.
     ///
     /// Call the passed `taskCompleted` block when the task is done.
+    /// 
     /// - Parameter block: the task to execute
     public func async(execute block: @escaping (_ completion: @escaping() -> Void) -> Void) {
         dispatchGroupQueue.async {

--- a/MatrixSDK/Utils/MXAsyncTaskQueue.swift
+++ b/MatrixSDK/Utils/MXAsyncTaskQueue.swift
@@ -1,0 +1,54 @@
+// 
+// Copyright 2021 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+/// Scheduler to run run one asynchronous or synchronous task at a time.
+@objcMembers public class MXAsyncTaskQueue: NSObject {
+    
+    /// Serial queue where tasks are stacked
+    private let dispatchGroupQueue: DispatchQueue
+    ///Mechanism to run one task at a time
+    private let dispatchGroup: DispatchGroup
+
+    /// Queue from where tasks are executed
+    private let dispatchQueue: DispatchQueue
+    
+    public init(dispatchQueue: DispatchQueue = DispatchQueue.main, label: String = "MXAsyncTaskQueue-" + MXTools.generateSecret()) {
+        dispatchGroup = DispatchGroup()
+        dispatchGroupQueue = DispatchQueue(label: label)
+        self.dispatchQueue = dispatchQueue
+    }
+    
+    /// Schedule a new task.
+    ///
+    /// Call the passed `taskCompleted` block when the task is done.
+    /// - Parameter block: the task to execute
+    public func async(execute block: @escaping (_ completion: @escaping() -> Void) -> Void) {
+        dispatchGroupQueue.async {
+            // If any, wait for the completion of the previous task
+            self.dispatchGroup.wait()
+            self.dispatchGroup.enter()
+            
+            self.dispatchQueue.async {
+                block {
+                    // Task completed. Next one can start
+                    self.dispatchGroup.leave()
+                }
+            }
+        }
+    }
+}

--- a/MatrixSDKTests/MXAsyncTaskQueueTests.swift
+++ b/MatrixSDKTests/MXAsyncTaskQueueTests.swift
@@ -1,0 +1,61 @@
+// 
+// Copyright 2021 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import XCTest
+
+class MXAsyncTaskQueueTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    /// Check that tasks and async tasks are run
+    func test() throws {
+        let expectation = self.expectation(description: "test")
+        var result = ""
+        
+        let asyncTaskQueue = MXAsyncTaskQueue(dispatchQueue: DispatchQueue(label: "MXAsyncTaskQueueTests"))
+                
+        asyncTaskQueue.async { taskCompleted in
+            Thread.sleep(forTimeInterval: 0.5)
+            result = result + "1"
+            taskCompleted()
+        }
+        asyncTaskQueue.async { taskCompleted in
+            // Pure async call
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                result = result + "2"
+                taskCompleted()
+            }
+        }
+        asyncTaskQueue.async { taskCompleted in
+            Thread.sleep(forTimeInterval: 0.01)
+            result = result + "3"
+            taskCompleted()
+        }
+        
+        asyncTaskQueue.async { _ in
+            XCTAssertEqual(result, "123")
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 1)
+    }
+}

--- a/MatrixSDKTests/MXAsyncTaskQueueTests.swift
+++ b/MatrixSDKTests/MXAsyncTaskQueueTests.swift
@@ -39,7 +39,7 @@ class MXAsyncTaskQueueTests: XCTestCase {
             taskCompleted()
         }
         asyncTaskQueue.async { taskCompleted in
-            // Pure async call
+            // True async task
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                 result = result + "2"
                 taskCompleted()


### PR DESCRIPTION
Fix vector-im/element-ios#4074

So that we will not lose e2ee keys received by the push extension.