### PR TITLE
MXSession: Fix deadlock regression in `resume()`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changes to be released in next version
  * 
 
 🐛 Bugfix
- * 
+ * MXSession: Fix deadlock regression in resume() (vector-im/element-ios/issues/4202).
 
 ⚠️ API Changes
  * 

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -1757,6 +1757,8 @@ typedef void (^MXOnResumeDone)(void);
         {
             completion();
         }
+        
+        taskCompleted();
     }];
 }
 


### PR DESCRIPTION
Fix vector-im/element-ios/issues/4202.

The `start()` method locked the `asyncTaskQueue` forever preventing next call of `resume()` from resuming the sync stream.
