### PR TITLE
MXRoomMembers: Fix wrong view of room members when paginating

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Changes to be released in next version
 
 🐛 Bugfix
  * MXSession: Fix deadlock regression in resume() (vector-im/element-ios/issues/4202).
+ * MXRoomMembers: Fix wrong view of room members when paginating (vector-im/element-ios/issues/4204).
 
 ⚠️ API Changes
  * 

--- a/MatrixSDK/Data/MXRoomMembers.h
+++ b/MatrixSDK/Data/MXRoomMembers.h
@@ -38,12 +38,6 @@
  @return The newly-initialized MXRoomMembers.
  */
 - (instancetype)initWithRoomState:(MXRoomState*)state andMatrixSession:(MXSession*)matrixSession;
-
-/**
- The room state belonging to this object.
- */
-@property (nonatomic, readonly) MXRoomState *roomState;
-
 /**
  A copy of the list of room members.
  */
@@ -114,17 +108,5 @@
  @return YES if there was a change in MXRoomMembers.
  */
 - (BOOL)handleStateEvents:(NSArray<MXEvent *> *)stateEvents;
-
-#pragma mark - NSCopying
-
-/**
- Copy the receiver and update the room state reference. This is useful when the copying happens
- as part of copying an MXRoomState object.
-
- @param zone a memory zone.
- @param state the new/copied room state.
- @return a copy of the receiver.
- */
-- (id)copyWithZone:(NSZone *)zone andState:(MXRoomState *)state;
 
 @end

--- a/MatrixSDK/Data/MXRoomState.m
+++ b/MatrixSDK/Data/MXRoomState.m
@@ -607,7 +607,7 @@
         stateCopy->stateEvents[key] = [[NSMutableArray allocWithZone:zone] initWithArray:stateEvents[key]];
     }
 
-    stateCopy->_members = [_members copyWithZone:zone andState:stateCopy];
+    stateCopy->_members = [_members copyWithZone:zone];
 
     stateCopy->_membersCount = [_membersCount copyWithZone:zone];
     

--- a/MatrixSDKTests/MXRoomStateTests.m
+++ b/MatrixSDKTests/MXRoomStateTests.m
@@ -1269,7 +1269,7 @@
         mxSession = mxSession2;
         [room state:^(MXRoomState *roomState) {
             MXRoomState *roomStateCopy = [roomState copy];
-            XCTAssertEqual(roomStateCopy.members.roomState, roomStateCopy);
+            XCTAssertEqual(roomStateCopy.members.members.count, roomState.members.members.count);
             [expectation fulfill];
         }];
     }];


### PR DESCRIPTION
Fix vector-im/element-ios/issues/4204

Fix a regression introduced by https://github.com/matrix-org/matrix-ios-sdk/pull/1040.
While paginating, the kept MXRoomState instance could be released, creating a bad view of room members. 

Remove the bad dependency to MXRoomState to avoid any retain cycle.

![image](https://user-images.githubusercontent.com/8418515/114670611-7ba7f680-9d03-11eb-948d-9052d143ce77.png)
