### PR TITLE
SDK: Expose the HTTP response in MXHTTPOperation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changes to be released in next version
  * 
 
 🙌 Improvements
- * SDK: Expose the HTTP response in MXHTTPOperation (vector-im/element-ios/issues/4206).
+ * MXHTTPOperation: Expose the HTTP response (vector-im/element-ios/issues/4206).
 
 🐛 Bugfix
  * 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changes to be released in next version
  * 
 
 🙌 Improvements
- * 
+ * SDK: Expose the HTTP response in MXHTTPOperation (vector-im/element-ios/issues/4206).
 
 🐛 Bugfix
  * 

--- a/MatrixSDK/Utils/MXHTTPClient.m
+++ b/MatrixSDK/Utils/MXHTTPClient.m
@@ -374,6 +374,7 @@ static NSUInteger requestCount = 0;
         
     } downloadProgress:nil completionHandler:^(NSURLResponse * _Nonnull theResponse, NSDictionary *JSONResponse, NSError * _Nullable error) {
         NSHTTPURLResponse *response = (NSHTTPURLResponse*)theResponse;
+        mxHTTPOperation.httpResponse = response;
 
         NSLog(@"[MXHTTPClient] #%@ - %@ %@ completed in %.0fms" ,@(requestNumber), httpMethod, path, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 

--- a/MatrixSDK/Utils/MXHTTPOperation.h
+++ b/MatrixSDK/Utils/MXHTTPOperation.h
@@ -31,7 +31,7 @@
  The underlying HTTP request.
  The reference changes in case of retries.
  */
-@property (nonatomic) NSURLSessionDataTask *operation;
+@property (nonatomic, nullable) NSURLSessionDataTask *operation;
 
 /**
  The age in milliseconds of the instance.
@@ -79,7 +79,7 @@
  
  @param operation the other operation to copy data from. If the other operation is nil do nothing.
  */
-- (void)mutateTo:(MXHTTPOperation*)operation;
+- (void)mutateTo:(MXHTTPOperation* _Nullable)operation;
 
 /**
  Extract the NSHTTPURLResponse from an error.
@@ -87,6 +87,6 @@
  @param error the request error.
  @return the HTTP response.
  */
-+ (NSHTTPURLResponse *)urlResponseFromError:(NSError*)error;
++ (NSHTTPURLResponse * _Nullable)urlResponseFromError:(NSError* _Nullable)error;
 
 @end

--- a/MatrixSDK/Utils/MXHTTPOperation.h
+++ b/MatrixSDK/Utils/MXHTTPOperation.h
@@ -61,6 +61,11 @@
 @property (nonatomic, readonly, getter=isCancelled) BOOL canceled;
 
 /**
+ The HTTP response.
+ */
+@property (nonatomic, nullable) NSHTTPURLResponse *httpResponse;
+
+/**
  Cancel the HTTP request.
  */
 - (void)cancel;

--- a/MatrixSDK/Utils/MXHTTPOperation.m
+++ b/MatrixSDK/Utils/MXHTTPOperation.m
@@ -62,6 +62,7 @@
     _maxNumberOfTries = 0;
     _maxRetriesTime = 0;
     _canceled = YES;
+    _httpResponse = nil;
     [_operation cancel];
 }
 
@@ -83,6 +84,7 @@
     _numberOfTries = operation.numberOfTries;
     _maxNumberOfTries = operation.maxRetriesTime;
     _maxRetriesTime = operation.maxRetriesTime;
+    _httpResponse = operation.httpResponse;
 
     // If the current operation was canceled, cancel the new one to avoid
     // that the chained operations ends up with a successful operation


### PR DESCRIPTION
fix https://github.com/vector-im/element-ios/issues/4206