### PR TITLE
MXCrypto: Disable optimisation on room members list to make sure we share keys to all

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changes to be released in next version
  * MXHTTPOperation: Expose the HTTP response (vector-im/element-ios/issues/4206).
 
 🐛 Bugfix
- * 
+ * MXCrypto: Disable optimisation on room members list to make sure we share keys to all (vector-im/element-ios/issues/3807).
 
 ⚠️ API Changes
  * 

--- a/MatrixSDK/Data/MXEventTimeline.m
+++ b/MatrixSDK/Data/MXEventTimeline.m
@@ -801,7 +801,12 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
         {
             // If there is no lazy loading of room members, consider we have fetched
             // all of them
-            [store storeHasLoadedAllRoomMembersForRoom:room.roomId andValue:YES];
+            NSLog(@"[MXEventTimeline] handleStateEvents: syncWithLazyLoadOfRoomMembers disabled. Mark all room members loaded for room %@",  room.roomId);
+            
+            // XXX: Optimisation removed because of https://github.com/vector-im/element-ios/issues/3807
+            // There can be a race on mxSession.syncWithLazyLoadOfRoomMembers. Its value may be not set yet.
+            // LL should be always enabled now. So, we should never come here.
+            //[store storeHasLoadedAllRoomMembersForRoom:room.roomId andValue:YES];
         }
     }
 }

--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
@@ -26,7 +26,7 @@
 #import "MXSDKOptions.h"
 #import "MXTools.h"
 
-static NSUInteger const kMXFileVersion = 69;
+static NSUInteger const kMXFileVersion = 70;
 
 static NSString *const kMXFileStoreFolder = @"MXFileStore";
 static NSString *const kMXFileStoreMedaDataFile = @"MXFileStore";
@@ -401,6 +401,9 @@ static NSUInteger preloadOptions;
 
 - (void)storeHasLoadedAllRoomMembersForRoom:(NSString *)roomId andValue:(BOOL)value
 {
+    // XXX: To remove once https://github.com/vector-im/element-ios/issues/3807 is fixed
+    NSLog(@"[MXFileStore] storeHasLoadedAllRoomMembersForRoom: %@ value: %@", roomId, @(value));
+          
     [super storeHasLoadedAllRoomMembersForRoom:roomId andValue:value];
 
     if (NSNotFound == [roomsToCommitForMessages indexOfObject:roomId])

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -748,6 +748,7 @@ typedef void (^MXOnResumeDone)(void);
 
             if (filter.room.state.lazyLoadMembers)
             {
+                NSLog(@"[MXSession] Set syncWithLazyLoadOfRoomMembers to YES");
                 self->_syncWithLazyLoadOfRoomMembers = YES;
             }
         } failure:nil];


### PR DESCRIPTION
Fix vector-im/element-ios/issues/3807

We know the problem is around a bad value of `hasLoadedAllRoomMembersForRoom`. The SDK can believe that it had all room members before encrypting a message and sharing the key. This is wrong in some cases.

I failed to reproduce the issue but `hasLoadedAllRoomMembersForRoom` is set to YES only in 2 places. In this PR, I removed the one made for optimisation when lazy loading of room members is not used. It is safe to remove this optimisation as we should run mostly with LL on.

The root issue is race condition on `MXSession.syncWithLazyLoadOfRoomMembers`, which value may be not the expected one. It will be managed separately in https://github.com/vector-im/element-ios/issues/4254.

A clear cache is mandatory to clean all stored `hasLoadedAllRoomMembersForRoom` values

This PR fixes more issues than crypto. Read receipts should be better displayed for example because all members will be loaded.