### PR TITLE
MXTools: Fix bad linkification of matrix alias and URL for real

### DIFF
--- a/MatrixSDK/Utils/MXTools.m
+++ b/MatrixSDK/Utils/MXTools.m
@@ -31,7 +31,7 @@
 NSString *const kMXToolsRegexStringForEmailAddress              = @"[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,}";
 
 // The HS domain part in Matrix identifiers
-#define MATRIX_HOMESERVER_DOMAIN_REGEX                        @"[A-Z0-9.-]+(?:\\.+\\w+)+(:[0-9]{2,5})?"
+#define MATRIX_HOMESERVER_DOMAIN_REGEX                            @"[A-Z0-9]+((\\.|\\-)[A-Z0-9]+){0,}(:[0-9]{2,5})?"
 
 NSString *const kMXToolsRegexStringForMatrixUserIdentifier      = @"@[\\x21-\\x39\\x3B-\\x7F]+:" MATRIX_HOMESERVER_DOMAIN_REGEX;
 NSString *const kMXToolsRegexStringForMatrixRoomAlias           = @"#[A-Z0-9._%#@=+-]+:" MATRIX_HOMESERVER_DOMAIN_REGEX;

--- a/MatrixSDKTests/MXToolsTests.m
+++ b/MatrixSDKTests/MXToolsTests.m
@@ -46,15 +46,21 @@
     // Tests on homeserver domain (https://matrix.org/docs/spec/legacy/#users)
     XCTAssertTrue([MXTools isMatrixUserIdentifier:@"@bob:matrix.org"]);
     XCTAssertTrue([MXTools isMatrixUserIdentifier:@"@bob:chat1234.matrix.org"]);
+    XCTAssertTrue([MXTools isMatrixUserIdentifier:@"@bob:chat-1234.matrix.org"]);
+    XCTAssertTrue([MXTools isMatrixUserIdentifier:@"@bob:chat-1234.aa.bbbb.matrix.org"]);
     XCTAssertTrue([MXTools isMatrixUserIdentifier:@"@bob:matrix.org:8480"]);
-// XXX: Those tests do not pass anymore but there are edge cases and less critical that other cases
-//    XCTAssertTrue([MXTools isMatrixUserIdentifier:@"@bob:localhost"]);
-//    XCTAssertTrue([MXTools isMatrixUserIdentifier:@"@bob:localhost:8480"]);
+    XCTAssertTrue([MXTools isMatrixUserIdentifier:@"@bob:localhost"]);
+    XCTAssertTrue([MXTools isMatrixUserIdentifier:@"@bob:localhost:8480"]);
     XCTAssertTrue([MXTools isMatrixUserIdentifier:@"@bob:127.0.0.1"]);
     XCTAssertTrue([MXTools isMatrixUserIdentifier:@"@bob:127.0.0.1:8480"]);
+    
     XCTAssertFalse([MXTools isMatrixUserIdentifier:@"@bob:matrix+25.org"]);
     XCTAssertFalse([MXTools isMatrixUserIdentifier:@"@bob:matrix[].org"]);
-
+    XCTAssertFalse([MXTools isMatrixUserIdentifier:@"@bob:matrix.org."]);
+    XCTAssertFalse([MXTools isMatrixUserIdentifier:@"@bob:matrix.org-"]);
+    XCTAssertFalse([MXTools isMatrixUserIdentifier:@"@bob:matrix-.org"]);
+    XCTAssertFalse([MXTools isMatrixUserIdentifier:@"@bob:matrix.&aaz.org"]);
+    
     XCTAssertTrue([MXTools isMatrixUserIdentifier:@"@Bob:matrix.org"]);
     XCTAssertTrue([MXTools isMatrixUserIdentifier:@"@bob1234:matrix.org"]);
     XCTAssertTrue([MXTools isMatrixUserIdentifier:@"@+33012:matrix.org"]);


### PR DESCRIPTION
Fix https://github.com/vector-im/element-ios/issues/4258

This time there is no compromise. Disabled tests pass now. There are more tests, include one for the original GH issue where `@bob:matrix.org.` must not be considered as a valid matrix id.

Visualisation of the new `MATRIX_HOMESERVER_DOMAIN_REGEX `: https://regexper.com/#%5BA-Z0-9%5D%2B%28%28%5C.%7C%5C-%29%5BA-Z0-9%5D%2B%29%7B0%2C%7D%28%3A%5B0-9%5D%7B2%2C5%7D%29%3F
