### PR TITLE
MXFileStore: Logs all files when a data corruption is detected

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changes to be released in next version
 
 🙌 Improvements
  * MXCallKitAdapter: Update incoming calls if answered from application UI.
+ * MXFileStore: Logs all files when a data corruption is detected (to track vector-im/element-ios/issues/4921).
 
 🐛 Bugfix
  * MXTools: Fix bad linkification of matrix alias and URL (vector-im/element-ios/issues/4258).


### PR DESCRIPTION
 to track vector-im/element-ios/issues/4921

Logs we get:
```
2021-05-03 11:06:50.882880+0200 Riot[33542:3706384] [MXFileStore] logFiles: Files in /private/var/mobile/Containers/Shared/AppGroup/1BA58BA0-0EE3-496C-A30A-3FAACE58A0C9/MXFileStore/@Manu:matrix.org:
2021-05-03 11:06:50.986452+0200 Riot[33542:3706384] [MXFileStore] logFiles:     - filters: 378 bytes
2021-05-03 11:06:50.986709+0200 Riot[33542:3706384] [MXFileStore] logFiles:     - MXFileStore: 48 KB
2021-05-03 11:06:50.986899+0200 Riot[33542:3706384] [MXFileStore] logFiles:     - groups: 64 bytes
2021-05-03 11:06:50.987056+0200 Riot[33542:3706384] [MXFileStore] logFiles:     - users: 160 bytes
2021-05-03 11:06:50.987207+0200 Riot[33542:3706384] [MXFileStore] logFiles:     - users/33: 569 bytes
2021-05-03 11:06:50.987356+0200 Riot[33542:3706384] [MXFileStore] logFiles:     - users/26: 532 bytes
2021-05-03 11:06:50.987505+0200 Riot[33542:3706384] [MXFileStore] logFiles:     - users/38: 603 bytes
2021-05-03 11:06:50.987658+0200 Riot[33542:3706384] [MXFileStore] logFiles:     - rooms: 20 KB
2021-05-03 11:06:50.987807+0200 Riot[33542:3706384] [MXFileStore] logFiles:     - rooms/!eWbgsMUbktULNQJwYt:matrix.org: 192 bytes
2021-05-03 11:06:50.987953+0200 Riot[33542:3706384] [MXFileStore] logFiles:     - rooms/!eWbgsMUbktULNQJwYt:matrix.org/messages: 3 KB
2021-05-03 11:06:50.988097+0200 Riot[33542:3706384] [MXFileStore] logFiles:     - rooms/!eWbgsMUbktULNQJwYt:matrix.org/state: 3 KB
2021-05-03 11:06:50.988249+0200 Riot[33542:3706384] [MXFileStore] logFiles:     - rooms/!eWbgsMUbktULNQJwYt:matrix.org/accountData: 385 bytes
2021-05-03 11:06:50.988401+0200 Riot[33542:3706384] [MXFileStore] logFiles:     - rooms/!eWbgsMUbktULNQJwYt:matrix.org/summary: 2 KB
2021-05-03 11:06:50.988578+0200 Riot[33542:3706384] [MXFileStore] logFiles:     - rooms/!KiklMHrTiKDIcDavmb:matrix.org: 192 bytes
...
2021-05-03 11:06:52.195616+0200 Riot[33542:3706573] [MXFileStore] logFiles:  3131 files: 15,9 MB