### PR TITLE
MXCrypto: Move decryptions out of the main thread

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Changes to be released in next version
 🙌 Improvements
  * MXSession: Cache initial sync response until it is fully handled (vector-im/element-ios/issues/4317).
  * MXStore: New commit method accepting a completion block.
+ * MXSession: eventWithEventId: Decrypt the event if needed.
 
 🐛 Bugfix
  * MXRoomSummary: Fix decryption of the last message when it is edited (vector-im/element-ios/issues/4322).

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,9 @@ Changes to be released in next version
 🙌 Improvements
  * MXSession: Cache initial sync response until it is fully handled (vector-im/element-ios/issues/4317).
  * MXStore: New commit method accepting a completion block.
- * MXSession: eventWithEventId: Decrypt the event if needed.
+ * MXCrypto: Decrypt events asynchronously and no more on the main thread )(vector-im/element-ios/issues/4306).
+ * MXSession: Add the decryptEvents method to decypt a bunch of events asynchronously.
+ * MXSession: Make the eventWithEventId method decrypt the event if needed.
 
 🐛 Bugfix
  * MXRoomSummary: Fix decryption of the last message when it is edited (vector-im/element-ios/issues/4322).

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,12 +10,17 @@ Changes to be released in next version
  * MXCrypto: Decrypt events asynchronously and no more on the main thread )(vector-im/element-ios/issues/4306).
  * MXSession: Add the decryptEvents method to decypt a bunch of events asynchronously.
  * MXSession: Make the eventWithEventId method decrypt the event if needed.
+ * MXEventTimeline: Add NSCopying implementation so that another pagination can be done on the same set of data.
+ * MXCrypto: eventDeviceInfo: Do not synchronise anymore the operation with the decryption queue.
 
 🐛 Bugfix
  * MXRoomSummary: Fix decryption of the last message when it is edited (vector-im/element-ios/issues/4322).
 
 ⚠️ API Changes
- * 
+ * MXRoom: MXRoom.outgoingMessages does not decrypt messages anymore. Use MXSession.decryptEvents to get decrypted events.
+ * MXSession: [MXSession decryptEvent:inTimeline:] is deprecated, use [MXSession decryptEvents:inTimeline:onComplete:] instead.
+ * MXCrypto: [MXCrypto decryptEvent:inTimeline:] is deprecated, use [MXCrypto decryptEvents:inTimeline:onComplete:] instead.
+ * MXCrypto: [MXCrypto hasKeysToDecryptEvent:] is now asynchronous.
 
 🗣 Translations
  * 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,7 @@ Changes to be released in next version
  * MXStore: New commit method accepting a completion block.
 
 🐛 Bugfix
- * 
+ * MXRoomSummary: Fix decryption of the last message when it is edited (vector-im/element-ios/issues/4322).
 
 ⚠️ API Changes
  * 

--- a/MatrixSDK/Aggregations/MXAggregatedEditsUpdater.m
+++ b/MatrixSDK/Aggregations/MXAggregatedEditsUpdater.m
@@ -243,13 +243,6 @@
             if (editedEvent)
             {
                 [self.matrixStore replaceEvent:editedEvent inRoom:roomId];
-
-                if (editedEvent.isEncrypted && !editedEvent.clearEvent)
-                {
-                    [self.mxSession decryptEvent:editedEvent inTimeline:nil];
-                }
-
-
                 [self notifyEventEditsListenersOfRoom:roomId replaceEvent:replaceEvent];
             }
         }

--- a/MatrixSDK/Aggregations/MXAggregatedEditsUpdater.m
+++ b/MatrixSDK/Aggregations/MXAggregatedEditsUpdater.m
@@ -70,17 +70,6 @@
         failure(nil);
         return nil;
     }
-
-    // If it is not already done, decrypt the event to build the new content
-    if (event.isEncrypted && !event.clearEvent)
-    {
-        if (![self.mxSession decryptEvent:event inTimeline:nil])
-        {
-            NSLog(@"[MXAggregations] replaceTextMessageEvent: Fail to decrypt original event: %@", event.eventId);
-            failure(nil);
-            return nil;
-        }
-    }
     
     NSString *messageType = event.content[@"msgtype"];
     

--- a/MatrixSDK/Aggregations/MXAggregatedReferencesUpdater.m
+++ b/MatrixSDK/Aggregations/MXAggregatedReferencesUpdater.m
@@ -58,11 +58,6 @@
         {
             [self.matrixStore replaceEvent:newEvent inRoom:roomId];
 
-            if (newEvent.isEncrypted && !newEvent.clearEvent)
-            {
-                [self.mxSession decryptEvent:newEvent inTimeline:nil];
-            }
-
             // TODO or not?
             //[self notifyEventEditsListenersOfRoom:roomId replaceEvent:replaceEvent];
         }

--- a/MatrixSDK/Aggregations/MXAggregations.m
+++ b/MatrixSDK/Aggregations/MXAggregations.m
@@ -158,15 +158,25 @@
             }
         }
         
+        NSMutableArray *eventsToDecrypt = [NSMutableArray array];
         for (MXEvent *event in allEvents)
         {
             if (event.isEncrypted && !event.clearEvent)
             {
-                [self.mxSession decryptEvent:event inTimeline:nil];
+                [eventsToDecrypt addObject:event];
             }
         }
         
-        success(paginatedResponse);
+        if (eventsToDecrypt.count)
+        {
+            [self.mxSession decryptEvents:eventsToDecrypt inTimeline:nil onComplete:^(NSArray<MXEvent *> *failedEvents) {
+                success(paginatedResponse);
+            }];
+        }
+        else
+        {
+            success(paginatedResponse);
+        }
     };
     
     MXEvent *event = [self.mxSession.store eventWithEventId:eventId inRoom:roomId];

--- a/MatrixSDK/Crypto/Algorithms/MXDecrypting.h
+++ b/MatrixSDK/Crypto/Algorithms/MXDecrypting.h
@@ -47,17 +47,13 @@
 /**
  Decrypt a message.
 
- In case of success, the event is updated with clear data.
- In case of failure, event.decryptionError contains the error.
-
  @param event the raw event.
  @param timeline the id of the timeline where the event is decrypted. It is used
-                 to prevent replay attack.
- @param error the result error if there is a problem decrypting the event.
+                 to prevent replay attack. Can be nil.
 
- @return The decryption result. Nil if it failed.
+ @return The decryption result.
  */
-- (MXEventDecryptionResult *)decryptEvent:(MXEvent*)event inTimeline:(NSString*)timeline error:(NSError** )error;
+- (MXEventDecryptionResult *)decryptEvent:(MXEvent*)event inTimeline:(NSString*)timeline;
 
 /**
  * Handle a key event.

--- a/MatrixSDK/Crypto/Algorithms/MXEventDecryptionResult.h
+++ b/MatrixSDK/Crypto/Algorithms/MXEventDecryptionResult.h
@@ -1,5 +1,6 @@
 /*
  Copyright 2017 Vector Creations Ltd
+ Copyright 2021 The Matrix.org Foundation C.I.C
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -43,5 +44,10 @@
  claimedEd25519Key. See MXEvent.forwardingCurve25519KeyChain.
  */
 @property NSArray<NSString *> *forwardingCurve25519KeyChain;
+
+/**
+ If any, the error that occured during decryption.
+ */
+@property (nonatomic) NSError *error;
 
 @end

--- a/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmDecryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmDecryption.m
@@ -68,8 +68,8 @@
     
     NSString *senderKey, *sessionId;
     
-    MXJSONModelSetString(senderKey, event.content[@"sender_key"]);
-    MXJSONModelSetString(sessionId, event.content[@"session_id"]);
+    MXJSONModelSetString(senderKey, event.wireContent[@"sender_key"]);
+    MXJSONModelSetString(sessionId, event.wireContent[@"session_id"]);
     if (senderKey && sessionId)
     {
         hasKeys = ([crypto.store inboundGroupSessionWithId:sessionId andSenderKey:senderKey] != nil);
@@ -83,9 +83,9 @@
     MXEventDecryptionResult *result;
     NSString *senderKey, *ciphertext, *sessionId;
 
-    MXJSONModelSetString(senderKey, event.content[@"sender_key"]);
-    MXJSONModelSetString(ciphertext, event.content[@"ciphertext"]);
-    MXJSONModelSetString(sessionId, event.content[@"session_id"]);
+    MXJSONModelSetString(senderKey, event.wireContent[@"sender_key"]);
+    MXJSONModelSetString(ciphertext, event.wireContent[@"ciphertext"]);
+    MXJSONModelSetString(sessionId, event.wireContent[@"session_id"]);
 
     if (!senderKey || !sessionId || !ciphertext)
     {

--- a/MatrixSDK/Crypto/Algorithms/Olm/MXOlmDecryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Olm/MXOlmDecryption.m
@@ -65,8 +65,8 @@
     NSString *deviceKey;
     NSDictionary *ciphertext;
 
-    MXJSONModelSetString(deviceKey, event.content[@"sender_key"]);
-    MXJSONModelSetDictionary(ciphertext, event.content[@"ciphertext"]);
+    MXJSONModelSetString(deviceKey, event.wireContent[@"sender_key"]);
+    MXJSONModelSetDictionary(ciphertext, event.wireContent[@"ciphertext"]);
 
     if (!ciphertext)
     {

--- a/MatrixSDK/Crypto/Algorithms/Olm/MXOlmDecryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Olm/MXOlmDecryption.m
@@ -60,7 +60,7 @@
     return NO;
 }
 
-- (MXEventDecryptionResult *)decryptEvent:(MXEvent *)event inTimeline:(NSString *)timeline error:(NSError *__autoreleasing *)error
+- (MXEventDecryptionResult *)decryptEvent:(MXEvent *)event inTimeline:(NSString *)timeline
 {
     NSString *deviceKey;
     NSDictionary *ciphertext;
@@ -71,31 +71,27 @@
     if (!ciphertext)
     {
         NSLog(@"[MXOlmDecryption] decryptEvent: Error: Missing ciphertext");
-
-        if (error)
-        {
-            *error = [NSError errorWithDomain:MXDecryptingErrorDomain
-                                         code:MXDecryptingErrorMissingCiphertextCode
-                                     userInfo:@{
-                                                NSLocalizedDescriptionKey: MXDecryptingErrorMissingCiphertextReason
-                                                }];
-        }
-        return nil;
+        
+        MXEventDecryptionResult *result = [MXEventDecryptionResult new];
+        result.error = [NSError errorWithDomain:MXDecryptingErrorDomain
+                                           code:MXDecryptingErrorMissingCiphertextCode
+                                       userInfo:@{
+                                           NSLocalizedDescriptionKey: MXDecryptingErrorMissingCiphertextReason
+                                       }];
+        return result;
     }
 
     if (!ciphertext[olmDevice.deviceCurve25519Key])
     {
         NSLog(@"[MXOlmDecryption] decryptEvent: Error: our device %@ is not included in recipients. Event: %@", olmDevice.deviceCurve25519Key, event.JSONDictionary);
-
-        if (error)
-        {
-            *error = [NSError errorWithDomain:MXDecryptingErrorDomain
-                                         code:MXDecryptingErrorNotIncludedInRecipientsCode
-                                     userInfo:@{
-                                                NSLocalizedDescriptionKey: MXDecryptingErrorNotIncludedInRecipientsReason
-                                                }];
-        }
-        return nil;
+        
+        MXEventDecryptionResult *result = [MXEventDecryptionResult new];
+        result.error = [NSError errorWithDomain:MXDecryptingErrorDomain
+                                           code:MXDecryptingErrorNotIncludedInRecipientsCode
+                                       userInfo:@{
+                                           NSLocalizedDescriptionKey: MXDecryptingErrorNotIncludedInRecipientsReason
+                                       }];
+        return result;
     }
 
     // The message for myUser
@@ -105,16 +101,14 @@
     if (!payloadString)
     {
         NSLog(@"[MXOlmDecryption] decryptEvent: Failed to decrypt Olm event (id= %@) from %@", event.eventId, deviceKey);
-
-        if (error)
-        {
-            *error = [NSError errorWithDomain:MXDecryptingErrorDomain
-                                         code:MXDecryptingErrorBadEncryptedMessageCode
-                                     userInfo:@{
-                                                NSLocalizedDescriptionKey: MXDecryptingErrorBadEncryptedMessageReason
-                                                }];
-        }
-        return nil;
+        
+        MXEventDecryptionResult *result = [MXEventDecryptionResult new];
+        result.error = [NSError errorWithDomain:MXDecryptingErrorDomain
+                                           code:MXDecryptingErrorBadEncryptedMessageCode
+                                       userInfo:@{
+                                           NSLocalizedDescriptionKey: MXDecryptingErrorBadEncryptedMessageReason
+                                       }];
+        return result;
     }
 
     NSDictionary *payload = [NSJSONSerialization JSONObjectWithData:[payloadString dataUsingEncoding:NSUTF8StringEncoding] options:0 error:nil];
@@ -124,59 +118,51 @@
     if (!payload[@"recipient"])
     {
         NSLog(@"[MXOlmDecryption] decryptEvent: Olm event (id=%@) contains no 'recipient' property; cannot prevent unknown-key attack", event.eventId);
-
-        if (error)
-        {
-            *error = [NSError errorWithDomain:MXDecryptingErrorDomain
-                                         code:MXDecryptingErrorMissingPropertyCode
-                                     userInfo:@{
-                                                NSLocalizedDescriptionKey: [NSString stringWithFormat:MXDecryptingErrorMissingPropertyReason, @"recipient"]
-                                                }];
-        }
-        return nil;
+        
+        MXEventDecryptionResult *result = [MXEventDecryptionResult new];
+        result.error = [NSError errorWithDomain:MXDecryptingErrorDomain
+                                           code:MXDecryptingErrorMissingPropertyCode
+                                       userInfo:@{
+                                           NSLocalizedDescriptionKey: [NSString stringWithFormat:MXDecryptingErrorMissingPropertyReason, @"recipient"]
+                                       }];
+        return result;
     }
     else if (![payload[@"recipient"] isEqualToString:userId])
     {
         NSLog(@"[MXOlmDecryption] decryptEvent: Event %@: Intended recipient %@ does not match our id %@", event.eventId, payload[@"recipient"], userId);
 
-        if (error)
-        {
-            *error = [NSError errorWithDomain:MXDecryptingErrorDomain
+        MXEventDecryptionResult *result = [MXEventDecryptionResult new];
+        result.error = [NSError errorWithDomain:MXDecryptingErrorDomain
                                          code:MXDecryptingErrorBadRecipientCode
                                      userInfo:@{
                                                 NSLocalizedDescriptionKey: [NSString stringWithFormat:MXDecryptingErrorBadRecipientReason, payload[@"recipient"]]
                                                 }];
-        }
-        return nil;
+        return result;
     }
 
     if (!payload[@"recipient_keys"])
     {
         NSLog(@"[MXOlmDecryption] decryptEvent: Olm event (id=%@) contains no 'recipient_keys' property; cannot prevent unknown-key attack", event.eventId);
 
-        if (error)
-        {
-            *error =  [NSError errorWithDomain:MXDecryptingErrorDomain
+        MXEventDecryptionResult *result = [MXEventDecryptionResult new];
+        result.error = [NSError errorWithDomain:MXDecryptingErrorDomain
                                           code:MXDecryptingErrorMissingPropertyCode
                                       userInfo:@{
                                                  NSLocalizedDescriptionKey: [NSString stringWithFormat:MXDecryptingErrorMissingPropertyReason, @"recipient_keys"]
                                                  }];
-        }
-        return nil;
+        return result;
     }
     else if (![payload[@"recipient_keys"][@"ed25519"] isEqualToString:olmDevice.deviceEd25519Key])
     {
         NSLog(@"[MXOlmDecryption] decryptEvent: Event %@: Intended recipient ed25519 key %@ does not match ours", event.eventId, payload[@"recipient_keys"][@"ed25519"]);
 
-        if (error)
-        {
-            *error =  [NSError errorWithDomain:MXDecryptingErrorDomain
+        MXEventDecryptionResult *result = [MXEventDecryptionResult new];
+        result.error = [NSError errorWithDomain:MXDecryptingErrorDomain
                                           code:MXDecryptingErrorBadRecipientKeyCode
                                       userInfo:@{
                                                  NSLocalizedDescriptionKey: MXDecryptingErrorBadRecipientKeyReason
                                                  }];
-        }
-        return nil;
+        return result;
     }
 
     // Check that the original sender matches what the homeserver told us, to
@@ -187,29 +173,25 @@
     {
         NSLog(@"[MXOlmDecryption] decryptEvent: Olm event (id=%@) contains no 'sender' property; cannot prevent unknown-key attack", event.eventId);
 
-        if (error)
-        {
-            *error =  [NSError errorWithDomain:MXDecryptingErrorDomain
+        MXEventDecryptionResult *result = [MXEventDecryptionResult new];
+        result.error = [NSError errorWithDomain:MXDecryptingErrorDomain
                                           code:MXDecryptingErrorMissingPropertyCode
                                       userInfo:@{
                                                  NSLocalizedDescriptionKey: [NSString stringWithFormat:MXDecryptingErrorMissingPropertyReason, @"sender"]
                                                  }];
-        }
-        return nil;
+        return result;
     }
     else if (![payload[@"sender"] isEqualToString:event.sender])
     {
         NSLog(@"[MXOlmDecryption] decryptEvent: Event %@: original sender %@ does not match reported sender %@", event.eventId, payload[@"sender"], event.sender);
 
-        if (error)
-        {
-            *error =  [NSError errorWithDomain:MXDecryptingErrorDomain
+        MXEventDecryptionResult *result = [MXEventDecryptionResult new];
+        result.error = [NSError errorWithDomain:MXDecryptingErrorDomain
                                           code:MXDecryptingErrorForwardedMessageCode
                                       userInfo:@{
                                                  NSLocalizedDescriptionKey: [NSString stringWithFormat:MXDecryptingErrorForwardedMessageReason, payload[@"sender"]]
                                                  }];
-        }
-        return nil;
+        return result;
     }
 
     // Olm events intended for a room have a room_id.
@@ -217,15 +199,13 @@
     {
         NSLog(@"[MXOlmDecryption] decryptEvent: Event %@: original room %@ does not match reported room %@", event.eventId, payload[@"room_id"], event.roomId);
 
-        if (error)
-        {
-            *error =  [NSError errorWithDomain:MXDecryptingErrorDomain
+        MXEventDecryptionResult *result = [MXEventDecryptionResult new];
+        result.error = [NSError errorWithDomain:MXDecryptingErrorDomain
                                           code:MXDecryptingErrorBadRoomCode
                                       userInfo:@{
                                                  NSLocalizedDescriptionKey: [NSString stringWithFormat:MXDecryptingErrorBadRoomReason, payload[@"room_id"]]
                                                  }];
-        }
-        return nil;
+        return result;
     }
 
     NSDictionary *claimedKeys = payload[@"keys"];

--- a/MatrixSDK/Crypto/CrossSigning/MXCrossSigning.m
+++ b/MatrixSDK/Crypto/CrossSigning/MXCrossSigning.m
@@ -481,7 +481,7 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
     NSLog(@"[MXCrossSigning] refreshState for device %@: Current state: %@", self.crypto.store.deviceId, @(self.state));
 
     // Refresh user's keys
-    [self.crypto.deviceList downloadKeys:@[myUserId] forceDownload:YES success:^(MXUsersDevicesMap<MXDeviceInfo *> *usersDevicesInfoMap, NSDictionary<NSString *,MXCrossSigningInfo *> *crossSigningKeysMap) {
+    [self.crypto downloadKeys:@[myUserId] forceDownload:YES success:^(MXUsersDevicesMap<MXDeviceInfo *> *usersDevicesInfoMap, NSDictionary<NSString *,MXCrossSigningInfo *> *crossSigningKeysMap) {
         
         BOOL sameCrossSigningKeys = [myUserCrossSigningKeysBefore hasSameKeysAsCrossSigningInfo:crossSigningKeysMap[myUserId]];
         self.myUserCrossSigningKeys = crossSigningKeysMap[myUserId];

--- a/MatrixSDK/Crypto/MXCrypto.h
+++ b/MatrixSDK/Crypto/MXCrypto.h
@@ -173,20 +173,23 @@ extern NSString *const MXDeviceListDidUpdateUsersDevicesNotification;
  
  @param event the event to decrypt.
 
- @return YES if keys are present.
+ @param onComplete the block called when the operations completes. It returns the result
  */
-- (BOOL)hasKeysToDecryptEvent:(MXEvent*)event;
+- (void)hasKeysToDecryptEvent:(MXEvent*)event
+                   onComplete:(void (^)(BOOL))onComplete;
 
 /**
  Decrypt a received event.
 
+ @warning This method is deprecated, use -[MXCrypto decryptEvents:inTimeline:onComplete:] instead.
+ 
  @param event the raw event.
  @param timeline the id of the timeline where the event is decrypted. It is used
                  to prevent replay attack.
  
  @return The decryption result.
  */
-- (MXEventDecryptionResult *)decryptEvent:(MXEvent*)event inTimeline:(NSString*)timeline;
+- (MXEventDecryptionResult *)decryptEvent:(MXEvent*)event inTimeline:(NSString*)timeline __attribute__((deprecated("use -[MXCrypto decryptEvents:inTimeline:onComplete:] instead")));
 
 /**
  Decrypt events asynchronously.

--- a/MatrixSDK/Crypto/MXCrypto.h
+++ b/MatrixSDK/Crypto/MXCrypto.h
@@ -189,6 +189,18 @@ extern NSString *const MXDeviceListDidUpdateUsersDevicesNotification;
 - (MXEventDecryptionResult *)decryptEvent:(MXEvent*)event inTimeline:(NSString*)timeline;
 
 /**
+ Decrypt events asynchronously.
+ 
+ @param events the events to decrypt.
+ @param timeline the id of the timeline where the events are decrypted. It is used
+        to prevent replay attack.
+ @return a dictionary {EventId -> MXEventDecryptionResult} with decryption results.
+ */
+- (void)decryptEvents:(NSArray<MXEvent*> *)events
+           inTimeline:(NSString*)timeline
+           onComplete:(void (^)(NSDictionary<NSString *, MXEventDecryptionResult *>*))onComplete;
+
+/**
  Ensure that the outbound session is ready to encrypt events.
  
  Thus, the next [MXCrypto encryptEvent] should be encrypted without any HTTP requests.

--- a/MatrixSDK/Crypto/MXCrypto.h
+++ b/MatrixSDK/Crypto/MXCrypto.h
@@ -194,11 +194,11 @@ extern NSString *const MXDeviceListDidUpdateUsersDevicesNotification;
  @param events the events to decrypt.
  @param timeline the id of the timeline where the events are decrypted. It is used
         to prevent replay attack.
- @return a dictionary {EventId -> MXEventDecryptionResult} with decryption results.
+ @param onComplete the block called when the operations completes. It returns the decryption result for every event.
  */
 - (void)decryptEvents:(NSArray<MXEvent*> *)events
            inTimeline:(NSString*)timeline
-           onComplete:(void (^)(NSDictionary<NSString *, MXEventDecryptionResult *>*))onComplete;
+           onComplete:(void (^)(NSArray<MXEventDecryptionResult *>*))onComplete;
 
 /**
  Ensure that the outbound session is ready to encrypt events.

--- a/MatrixSDK/Crypto/MXCrypto.h
+++ b/MatrixSDK/Crypto/MXCrypto.h
@@ -241,6 +241,14 @@ extern NSString *const MXDeviceListDidUpdateUsersDevicesNotification;
 - (void)handleDeviceOneTimeKeysCount:(NSDictionary<NSString *, NSNumber*>*)deviceOneTimeKeysCount;
 
 /**
+ Handle a room key event.
+ 
+ @param event the room key event.
+ @param onComplete the block called when the operation completes.
+ */
+- (void)handleRoomKeyEvent:(MXEvent*)event onComplete:(void (^)(void))onComplete;
+
+/**
  Handle the completion of a /sync.
 
  This is called after the processing of each successful /sync response.

--- a/MatrixSDK/Crypto/MXCrypto.h
+++ b/MatrixSDK/Crypto/MXCrypto.h
@@ -179,19 +179,14 @@ extern NSString *const MXDeviceListDidUpdateUsersDevicesNotification;
 
 /**
  Decrypt a received event.
- 
- In case of success, the event is updated with clear data.
- In case of failure, event.decryptionError contains the error.
 
  @param event the raw event.
  @param timeline the id of the timeline where the event is decrypted. It is used
                  to prevent replay attack.
  
- @param error the result error if there is a problem decrypting the event.
-
- @return The decryption result. Nil if it failed.
+ @return The decryption result.
  */
-- (MXEventDecryptionResult *)decryptEvent:(MXEvent*)event inTimeline:(NSString*)timeline error:(NSError** )error;
+- (MXEventDecryptionResult *)decryptEvent:(MXEvent*)event inTimeline:(NSString*)timeline;
 
 /**
  Ensure that the outbound session is ready to encrypt events.

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -593,16 +593,16 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 
 - (void)decryptEvents:(NSArray<MXEvent*> *)events
            inTimeline:(NSString*)timeline
-           onComplete:(void (^)(NSDictionary<NSString *, MXEventDecryptionResult *>*))onComplete
+           onComplete:(void (^)(NSArray<MXEventDecryptionResult *>*))onComplete
 {
     dispatch_async(decryptionQueue, ^{
-        NSMutableDictionary<NSString *, MXEventDecryptionResult *> *results = [NSMutableDictionary dictionaryWithCapacity:events.count];
+        NSMutableArray<MXEventDecryptionResult *> *results = [NSMutableArray arrayWithCapacity:events.count];
         
         // TODO: Implement bulk decrypt to speed up the process.
         //
         for (MXEvent *event in events)
         {
-            results[event.eventId] = [self decryptEvent2:event inTimeline:timeline];
+            [results addObject:[self decryptEvent2:event inTimeline:timeline]];
         }
         
         dispatch_async(dispatch_get_main_queue(), ^{

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -526,7 +526,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     return hasKeys;
 }
 
-- (MXEventDecryptionResult *)decryptEvent:(MXEvent *)event inTimeline:(NSString*)timeline error:(NSError* __autoreleasing * )error
+- (MXEventDecryptionResult *)decryptEvent:(MXEvent *)event inTimeline:(NSString*)timeline
 {
 #ifdef MX_CRYPTO
 
@@ -550,25 +550,23 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
         {
             NSLog(@"[MXCrypto] decryptEvent: Unable to decrypt %@ with algorithm %@. Event: %@", event.eventId, event.content[@"algorithm"], event.JSONDictionary);
 
-            if (error)
-            {
-                *error = [NSError errorWithDomain:MXDecryptingErrorDomain
-                                             code:MXDecryptingErrorUnableToDecryptCode
-                                         userInfo:@{
-                                                    NSLocalizedDescriptionKey: MXDecryptingErrorUnableToDecrypt,
-                                                    NSLocalizedFailureReasonErrorKey: [NSString stringWithFormat:MXDecryptingErrorUnableToDecryptReason, event, event.content[@"algorithm"]]
-                                                    }];
-            }
+            result = [MXEventDecryptionResult new];
+            result.error = [NSError errorWithDomain:MXDecryptingErrorDomain
+                                               code:MXDecryptingErrorUnableToDecryptCode
+                                           userInfo:@{
+                                               NSLocalizedDescriptionKey: MXDecryptingErrorUnableToDecrypt,
+                                               NSLocalizedFailureReasonErrorKey: [NSString stringWithFormat:MXDecryptingErrorUnableToDecryptReason, event, event.content[@"algorithm"]]
+                                           }];
         }
         else
         {
-            result = [alg decryptEvent:event inTimeline:timeline error:error];
-            if (error && *error)
+            result = [alg decryptEvent:event inTimeline:timeline];
+            if (result.error)
             {
-                NSLog(@"[MXCrypto] decryptEvent: Error for %@: %@\nEvent: %@", event.eventId, *error, event.JSONDictionary);
+                NSLog(@"[MXCrypto] decryptEvent: Error for %@: %@\nEvent: %@", event.eventId, result.error, event.JSONDictionary);
                 
-                if ([(*error).domain isEqualToString:MXDecryptingErrorDomain]
-                    && (*error).code == MXDecryptingErrorBadEncryptedMessageCode)
+                if ([result.error.domain isEqualToString:MXDecryptingErrorDomain]
+                    && result.error.code == MXDecryptingErrorBadEncryptedMessageCode)
                 {
                     dispatch_async(self.cryptoQueue, ^{
                         [self markOlmSessionForUnwedgingInEvent:event];

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -598,8 +598,8 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     dispatch_async(decryptionQueue, ^{
         NSMutableArray<MXEventDecryptionResult *> *results = [NSMutableArray arrayWithCapacity:events.count];
         
-        // TODO: Implement bulk decrypt to speed up the process.
-        //
+        // TODO: Implement bulk decryption to speed up the process.
+        // We need a [MXDecrypting decryptEvents:] method to limit the number of back and forth with olm/megolm module.
         for (MXEvent *event in events)
         {
             [results addObject:[self decryptEvent2:event inTimeline:timeline]];

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -763,6 +763,18 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 #endif
 }
 
+- (void)handleRoomKeyEvent:(MXEvent*)event onComplete:(void (^)(void))onComplete
+{
+    // Use decryptionQueue as synchronisation because decryptions require room keys
+    dispatch_async(decryptionQueue, ^{
+        [self onRoomKeyEvent:event];
+        
+        dispatch_async(dispatch_get_main_queue(), ^{
+            onComplete();
+        });
+    });
+}
+
 - (void)handleDeviceOneTimeKeysCount:(NSDictionary<NSString *, NSNumber*>*)deviceOneTimeKeysCount
 {
 #ifdef MX_CRYPTO
@@ -2518,7 +2530,6 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
         MXWeakify(self);
         switch (event.eventType)
         {
-            case MXEventTypeRoomKey:
             case MXEventTypeRoomForwardedKey:
             {
                 dispatch_async(_cryptoQueue, ^{

--- a/MatrixSDK/Data/MXEventTimeline.h
+++ b/MatrixSDK/Data/MXEventTimeline.h
@@ -205,16 +205,18 @@ typedef void (^MXOnRoomEvent)(MXEvent *event, MXTimelineDirection direction, MXR
 /**
  For live timeline, update data according to the received /sync response.
 
- @param roomSync information to sync the room with the home server data
+ @param roomSync information to sync the room with the home server data.
+ @param onComplete the block called when the operation completes.
  */
-- (void)handleJoinedRoomSync:(MXRoomSync*)roomSync;
+- (void)handleJoinedRoomSync:(MXRoomSync*)roomSync onComplete:(void (^)(void))onComplete;
 
 /**
  For live timeline, update invited room state according to the received /sync response.
 
  @param invitedRoomSync information to update the room state.
+ @param onComplete the block called when the operation completes.
  */
-- (void)handleInvitedRoomSync:(MXInvitedRoomSync *)invitedRoomSync;
+- (void)handleInvitedRoomSync:(MXInvitedRoomSync *)invitedRoomSync onComplete:(void (^)(void))onComplete;
 
 /**
  For live timeline, enrich lazy loaded state events with more state events.

--- a/MatrixSDK/Data/MXEventTimeline.h
+++ b/MatrixSDK/Data/MXEventTimeline.h
@@ -55,7 +55,7 @@ typedef void (^MXOnRoomEvent)(MXEvent *event, MXTimelineDirection direction, MXR
       with events on calls of [MXEventTimeline paginate] in backwards or forwards direction.
       Events are stored in a in-memory store (MXMemoryStore) (@TODO: To be confirmed once they will be implemented). So, they are not permanent.
  */
-@interface MXEventTimeline : NSObject
+@interface MXEventTimeline : NSObject <NSCopying>
 
 /**
  The id of this timeline.
@@ -100,7 +100,7 @@ typedef void (^MXOnRoomEvent)(MXEvent *event, MXTimelineDirection direction, MXR
  @param initialEventId the initial event for the timeline. A nil value will create a live timeline.
  @return a MXEventTimeline instance.
  */
-- (id)initWithRoom:(MXRoom*)room andInitialEventId:(NSString*)initialEventId;
+- (instancetype)initWithRoom:(MXRoom*)room andInitialEventId:(NSString*)initialEventId;
 
 /**
  Create a timeline instance for a room and force it to use the given MXStore to store events.
@@ -110,7 +110,7 @@ typedef void (^MXOnRoomEvent)(MXEvent *event, MXTimelineDirection direction, MXR
  @param store the store to use to store timeline events.
  @return a MXEventTimeline instance.
  */
-- (id)initWithRoom:(MXRoom*)room initialEventId:(NSString*)initialEventId andStore:(id<MXStore>)store;
+- (instancetype)initWithRoom:(MXRoom*)room initialEventId:(NSString*)initialEventId andStore:(id<MXStore>)store;
 
 /**
  Initialise the room evenTimeline state.

--- a/MatrixSDK/Data/MXEventTimeline.m
+++ b/MatrixSDK/Data/MXEventTimeline.m
@@ -939,7 +939,7 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
         return;
     }
     
-    [room.mxSession decryptEvents:eventsToDecrypt inTimeline:_timelineId onComplete:^(NSDictionary<NSString *,NSError *> *errors) {
+    [room.mxSession decryptEvents:eventsToDecrypt inTimeline:_timelineId onComplete:^(NSArray<MXEvent *> *failedEvents) {
         onComplete();
     }];
 }

--- a/MatrixSDK/Data/MXEventTimeline.m
+++ b/MatrixSDK/Data/MXEventTimeline.m
@@ -920,26 +920,17 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
 
 - (void)decryptEvents:(NSArray<MXEvent*>*)events onComplete:(void (^)(void))onComplete
 {
-    NSMutableArray *eventsToDecrypt = [NSMutableArray array];
+    // The state event providing the encrytion algorithm can be part of the timeline.
+    // Extract if before starting decrypting.
     for (MXEvent *event in events)
     {
-        if (event.eventType == MXEventTypeRoomEncrypted)
-        {
-            [eventsToDecrypt addObject:event];
-        }
-        else if (event.eventType ==  MXEventTypeRoomEncryption)
+        if (event.eventType == MXEventTypeRoomEncryption)
         {
             [_state handleStateEvents:@[event]];
         }
     }
     
-    if (eventsToDecrypt.count == 0)
-    {
-        onComplete();
-        return;
-    }
-    
-    [room.mxSession decryptEvents:eventsToDecrypt inTimeline:_timelineId onComplete:^(NSArray<MXEvent *> *failedEvents) {
+    [room.mxSession decryptEvents:events inTimeline:_timelineId onComplete:^(NSArray<MXEvent *> *failedEvents) {
         onComplete();
     }];
 }

--- a/MatrixSDK/Data/MXRoom.h
+++ b/MatrixSDK/Data/MXRoom.h
@@ -223,16 +223,18 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidFlushDataNotification;
 /**
  Update room data according to the provided sync response.
  
- @param roomSync information to sync the room with the home server data
+ @param roomSync information to sync the room with the home server data.
+ @param onComplete the block called when the operation completes.
  */
-- (void)handleJoinedRoomSync:(MXRoomSync*)roomSync;
+- (void)handleJoinedRoomSync:(MXRoomSync*)roomSync onComplete:(void (^)(void))onComplete;
 
 /**
  Update the invited room state according to the provided data.
  
  @param invitedRoomSync information to update the room state.
+ @param onComplete the block called when the operation completes.
  */
-- (void)handleInvitedRoomSync:(MXInvitedRoomSync *)invitedRoomSync;
+- (void)handleInvitedRoomSync:(MXInvitedRoomSync *)invitedRoomSync onComplete:(void (^)(void))onComplete;
 
 
 #pragma mark - Stored messages enumerator

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -2377,19 +2377,6 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
     if ([mxSession.store respondsToSelector:@selector(outgoingMessagesInRoom:)])
     {
         NSArray<MXEvent*> *outgoingMessages = [mxSession.store outgoingMessagesInRoom:self.roomId];
-        
-        for (MXEvent *event in outgoingMessages)
-        {
-            // Decrypt event if necessary
-            if (event.eventType == MXEventTypeRoomEncrypted)
-            {
-                if (![self.mxSession decryptEvent:event inTimeline:nil])
-                {
-                    NSLog(@"[MXRoom] outgoingMessages: Warning: Unable to decrypt outgoing event: %@", event.decryptionError);
-                }
-            }
-        }
-        
         return outgoingMessages;
     }
     else

--- a/MatrixSDK/Data/MXRoomSummary.h
+++ b/MatrixSDK/Data/MXRoomSummary.h
@@ -247,6 +247,13 @@ FOUNDATION_EXPORT NSString *const kMXRoomSummaryDidChangeNotification;
 @property (nonatomic) MXEvent *lastMessageEvent;
 
 /**
+ Intenal SDK method to load and decrypt the MXEvent of the last message.
+ 
+ @param onComplete the callback called once operation is done.
+ */
+-(void)loadLastEvent:(void (^)(void))onComplete;
+
+/**
  Reset the last message.
  
  The operation is asynchronous as it may require pagination from the homeserver.

--- a/MatrixSDK/Data/MXRoomSummary.m
+++ b/MatrixSDK/Data/MXRoomSummary.m
@@ -257,25 +257,30 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
     _lastMessageAttributedString = nil;
     [_lastMessageOthers removeAllObjects];
 
-    return [self fetchLastMessage:complete failure:failure lastEventIdChecked:nil operation:nil commit:commit];
+    return [self fetchLastMessage:complete failure:failure liveTimeline:nil onlyFromStore:YES operation:nil commit:commit];
 }
 
 /**
- Find the event to be used as last message.
+ Find recursively the event to be used as last message.
 
  @param complete A block object called when the operation completes.
  @param failure A block object called when the operation fails.
- @param lastEventIdChecked the id of the last candidate event checked to be the last message.
-        Nil means we will start checking from the last event in the store.
+ @param liveTimeline the timeline to use to paginate and get more events.
+ @param onlyFromStore YES for the first call. For quickness, we want to avoid any HTTP requests at first.
  @param operation the current http operation if any.
         The method may need several requests before fetching the right last message.
         If it happens, the first one is mutated to the others with [MXHTTPOperation mutateTo:].
  @param commit tell whether the updated room summary must be committed to the store. Use NO when a more
- global [MXStore commit] will happen. This optimises IO.
+        global [MXStore commit] will happen. This optimises IO.
  @return a MXHTTPOperation
  */
-- (MXHTTPOperation *)fetchLastMessage:(void (^)(void))complete failure:(void (^)(NSError *))failure lastEventIdChecked:(NSString*)lastEventIdChecked operation:(MXHTTPOperation *)operation commit:(BOOL)commit
+- (MXHTTPOperation *)fetchLastMessage:(void (^)(void))complete
+                              failure:(void (^)(NSError *))failure
+                         liveTimeline:(MXEventTimeline *)liveTimeline
+                        onlyFromStore:(BOOL)onlyFromStore
+                            operation:(MXHTTPOperation *)operation commit:(BOOL)commit
 {
+    // Sanity checks
     MXRoom *room = self.room;
     if (!room)
     {
@@ -291,126 +296,59 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
         // Create an empty operation that will be mutated later
         operation = [[MXHTTPOperation alloc] init];
     }
-
-    MXWeakify(self);
-    [self.room state:^(MXRoomState *roomState) {
-        MXStrongifyAndReturnIfNil(self);
-
-        // Start by checking events we have in the store
-        MXRoomState *state = roomState;
-        id<MXEventsEnumerator> messagesEnumerator = room.enumeratorForStoredMessages;
-        NSUInteger messagesInStore = messagesEnumerator.remaining;
-        MXEvent *event = messagesEnumerator.nextEvent;
-        NSString *lastEventIdCheckedInBlock = lastEventIdChecked;
-
-        // 1.1 Find where we stopped at the previous call in the fetchLastMessage calls loop
-        BOOL firstIteration = YES;
-        if (lastEventIdCheckedInBlock)
-        {
-            firstIteration = NO;
-            while (event)
-            {
-                NSString *eventId = event.eventId;
-
-                event = messagesEnumerator.nextEvent;
-
-                if ([eventId isEqualToString:lastEventIdCheckedInBlock])
-                {
-                    break;
-                }
-            }
-        }
-
-        // 1.2 Check events one by one until finding the right last message for the room
-        BOOL lastMessageUpdated = NO;
-        while (event)
-        {
-            // Decrypt the event if necessary
-            if (event.eventType == MXEventTypeRoomEncrypted)
-            {
-                if (![self.mxSession decryptEvent:event inTimeline:nil])
-                {
-                    NSLog(@"[MXRoomSummary] fetchLastMessage: Warning: Unable to decrypt event: %@\nError: %@", event.content[@"body"], event.decryptionError);
-                }
-            }
-
-            if (event.isState)
-            {
-                // Need to go backward in the state to provide it as it was when the event occured
-                if (state.isLive)
-                {
-                    state = [state copy];
-                    state.isLive = NO;
-                }
-
-                [state handleStateEvents:@[event]];
-            }
-
-            lastEventIdCheckedInBlock = event.eventId;
-
-            // Propose the event as last message
-            lastMessageUpdated = [self.mxSession.roomSummaryUpdateDelegate session:self.mxSession updateRoomSummary:self withLastEvent:event eventState:state roomState:roomState];
-            if (lastMessageUpdated)
-            {
-                // The event is accepted. We have our last message
-                // The roomSummaryUpdateDelegate has stored the _lastMessageEventId
-                break;
-            }
-
-            event = messagesEnumerator.nextEvent;
-        }
-
-        // 2.1 If lastMessageEventId is still nil, fetch events from the homeserver
-        MXWeakify(self);
+    
+    // Get the room timeline
+    if (!liveTimeline)
+    {
         [room liveTimeline:^(MXEventTimeline *liveTimeline) {
-            MXStrongifyAndReturnIfNil(self);
-
-            if (!self->_lastMessageEventId && [liveTimeline canPaginate:MXTimelineDirectionBackwards])
-            {
-                NSUInteger messagesToPaginate = 30;
-
-                // Reset pagination the first time
-                if (firstIteration)
-                {
-                    [liveTimeline resetPagination];
-
-                    // Make sure we paginate more than the events we have already in the store
-                    messagesToPaginate += messagesInStore;
-                }
-
-                // Paginate events from the homeserver
-                // XXX: Pagination on the timeline may conflict with request from the app
-                __block MXHTTPOperation *newOperation;
-                newOperation = [liveTimeline paginate:messagesToPaginate direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^{
-
-                    // Received messages have been stored in the store. We can make a new loop
-                    // XXX: This is only true for a permanent storage. Only MXNoStore is not permanent.
-                    // MXNoStore is only used for tests. We can skip it here.
-                    if (self.mxSession.store.isPermanent)
-                    {
-                        [self fetchLastMessage:complete failure:failure
-                            lastEventIdChecked:lastEventIdCheckedInBlock
-                                     operation:(operation ? operation : newOperation)
-                                        commit:commit];
-                    }
-
-                } failure:failure];
-
-                // Update the current HTTP operation
-                [operation mutateTo:newOperation];
-            }
-            else
-            {
-                if (complete)
-                {
-                    complete();
-                }
-
-                [self save:commit];
-            }
+            [liveTimeline resetPagination];
+            [self fetchLastMessage:complete failure:failure liveTimeline:liveTimeline onlyFromStore:onlyFromStore operation:operation commit:commit];
         }];
+        return operation;
+    }
+    
+    // Make sure we can still paginate
+    if (![liveTimeline canPaginate:MXTimelineDirectionBackwards])
+    {
+        if (complete)
+        {
+            complete();
+        }
+        return operation;
+    }
+    
+    // Process every message received by back pagination
+    __block BOOL lastMessageUpdated = NO;
+    [liveTimeline listenToEvents:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *eventState) {
+        if (direction == MXTimelineDirectionBackwards
+            && !lastMessageUpdated)
+        {
+            lastMessageUpdated = [self.mxSession.roomSummaryUpdateDelegate session:self.mxSession updateRoomSummary:self withLastEvent:event eventState:eventState roomState:liveTimeline.state];
+        }
     }];
-
+    
+    // Back paginate. First only from the store. Then, allow pagination requests to the homeserver
+    MXHTTPOperation *newOperation = [liveTimeline paginate:30 direction:MXTimelineDirectionBackwards onlyFromStore:onlyFromStore complete:^{
+        if (lastMessageUpdated)
+        {
+            // We are done
+            [self save:commit];
+            
+            if (complete)
+            {
+                complete();
+            }
+        }
+        else
+        {
+            // Need more message
+            [self fetchLastMessage:complete failure:failure liveTimeline:liveTimeline onlyFromStore:NO operation:operation commit:commit];
+        }
+        
+    } failure:failure];
+    
+    [operation mutateTo:newOperation];
+    
     return operation;
 }
 

--- a/MatrixSDK/Data/MXRoomSummary.m
+++ b/MatrixSDK/Data/MXRoomSummary.m
@@ -104,8 +104,6 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
 
 - (void)destroy
 {
-    NSLog(@"[MXKRoomSummary] Destroy %p - room id: %@", self, _roomId);
-
     [[NSNotificationCenter defaultCenter] removeObserver:self name:kMXEventDidChangeSentStateNotification object:nil];
     [[NSNotificationCenter defaultCenter] removeObserver:self name:kMXEventDidChangeIdentifierNotification object:nil];
     [[NSNotificationCenter defaultCenter] removeObserver:self name:kMXRoomDidFlushDataNotification object:nil];

--- a/MatrixSDK/Data/MXRoomSummary.m
+++ b/MatrixSDK/Data/MXRoomSummary.m
@@ -225,10 +225,17 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
         }
     }
     
+    if (!lastMessageEvent)
+    {
+        NSLog(@"[MXRoomSummary] loadLastEvent: Cannot find event %@ in store", _lastMessageEventId);
+        onComplete();
+        return;
+    }
+    
     [_mxSession decryptEvents:@[lastMessageEvent] inTimeline:nil onComplete:^(NSArray<MXEvent *> *failedEvents) {
         if (failedEvents.count)
         {
-            NSLog(@"[MXRoomSummary] lastMessageEvent: Warning: Unable to decrypt event. Error: %@", self.lastMessageEvent.decryptionError);
+            NSLog(@"[MXRoomSummary] loadLastEvent: Warning: Unable to decrypt event. Error: %@", self.lastMessageEvent.decryptionError);
         }
         onComplete();
     }];
@@ -256,7 +263,7 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
     _lastMessageAttributedString = nil;
     [_lastMessageOthers removeAllObjects];
 
-    return [self fetchLastMessage:complete failure:failure liveTimeline:nil onlyFromStore:YES operation:nil commit:commit];
+    return [self fetchLastMessage:complete failure:failure timeline:nil onlyFromStore:YES operation:nil commit:commit];
 }
 
 /**
@@ -275,7 +282,7 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
  */
 - (MXHTTPOperation *)fetchLastMessage:(void (^)(void))complete
                               failure:(void (^)(NSError *))failure
-                         liveTimeline:(MXEventTimeline *)liveTimeline
+                             timeline:(MXEventTimeline *)timeline
                         onlyFromStore:(BOOL)onlyFromStore
                             operation:(MXHTTPOperation *)operation commit:(BOOL)commit
 {
@@ -297,17 +304,19 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
     }
     
     // Get the room timeline
-    if (!liveTimeline)
+    if (!timeline)
     {
         [room liveTimeline:^(MXEventTimeline *liveTimeline) {
-            [liveTimeline resetPagination];
-            [self fetchLastMessage:complete failure:failure liveTimeline:liveTimeline onlyFromStore:onlyFromStore operation:operation commit:commit];
+            // Use a copy of the live timeline to avoid any conflicts with listeners to the unique live timeline
+            MXEventTimeline *timeline = [liveTimeline copy];
+            [timeline resetPagination];
+            [self fetchLastMessage:complete failure:failure timeline:timeline onlyFromStore:onlyFromStore operation:operation commit:commit];
         }];
         return operation;
     }
     
     // Make sure we can still paginate
-    if (![liveTimeline canPaginate:MXTimelineDirectionBackwards])
+    if (![timeline canPaginate:MXTimelineDirectionBackwards])
     {
         if (complete)
         {
@@ -318,16 +327,16 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
     
     // Process every message received by back pagination
     __block BOOL lastMessageUpdated = NO;
-    [liveTimeline listenToEvents:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *eventState) {
+    [timeline listenToEvents:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *eventState) {
         if (direction == MXTimelineDirectionBackwards
             && !lastMessageUpdated)
         {
-            lastMessageUpdated = [self.mxSession.roomSummaryUpdateDelegate session:self.mxSession updateRoomSummary:self withLastEvent:event eventState:eventState roomState:liveTimeline.state];
+            lastMessageUpdated = [self.mxSession.roomSummaryUpdateDelegate session:self.mxSession updateRoomSummary:self withLastEvent:event eventState:eventState roomState:timeline.state];
         }
     }];
     
     // Back paginate. First only from the store. Then, allow pagination requests to the homeserver
-    MXHTTPOperation *newOperation = [liveTimeline paginate:30 direction:MXTimelineDirectionBackwards onlyFromStore:onlyFromStore complete:^{
+    MXHTTPOperation *newOperation = [timeline paginate:30 direction:MXTimelineDirectionBackwards onlyFromStore:onlyFromStore complete:^{
         if (lastMessageUpdated)
         {
             // We are done
@@ -341,7 +350,7 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
         else
         {
             // Need more message
-            [self fetchLastMessage:complete failure:failure liveTimeline:liveTimeline onlyFromStore:NO operation:operation commit:commit];
+            [self fetchLastMessage:complete failure:failure timeline:timeline onlyFromStore:NO operation:operation commit:commit];
         }
         
     } failure:failure];

--- a/MatrixSDK/JSONModels/MXEvent.m
+++ b/MatrixSDK/JSONModels/MXEvent.m
@@ -837,6 +837,13 @@ NSString *const kMXEventIdentifierKey = @"kMXEventIdentifierKey";
 - (void)setClearData:(MXEventDecryptionResult *)decryptionResult
 {
     _clearEvent = nil;
+    
+    if (decryptionResult.error)
+    {
+        _decryptionError = decryptionResult.error;
+        return;
+    }
+    
     if (decryptionResult.clearEvent)
     {
         NSDictionary *clearEventJSON, *clearEventJSONContent;

--- a/MatrixSDK/JSONModels/MXEvent.m
+++ b/MatrixSDK/JSONModels/MXEvent.m
@@ -683,6 +683,11 @@ NSString *const kMXEventIdentifierKey = @"kMXEventIdentifierKey";
 
     newEvent = [MXEvent modelFromJSON:newEventDict];
     
+    if (self.isEncrypted)
+    {
+        [newEvent setClearData:[self decryptionResult]];
+    }
+    
     return newEvent;
 }
 

--- a/MatrixSDK/MXSession.h
+++ b/MatrixSDK/MXSession.h
@@ -974,6 +974,7 @@ typedef void (^MXOnBackgroundSyncFail)(NSError *error);
 #pragma mark - Matrix Events
 /**
  Retrieve an event from its event id.
+ It will be decrypted if needed.
 
  @param eventId the id of the event to retrieve.
  @param roomId (optional) the id of the room.

--- a/MatrixSDK/MXSession.h
+++ b/MatrixSDK/MXSession.h
@@ -1451,12 +1451,14 @@ typedef void (^MXOnBackgroundSyncFail)(NSError *error);
 /**
  Decrypt an event and update its data.
 
+ @warning This method is deprecated, use -[MXSession decryptEvents:inTimeline:onComplete:] instead.
+ 
  @param event the event to decrypt.
  @param timeline the id of the timeline where the event is decrypted. It is used
         to prevent replay attack.
  @return YES if decryption is successful.
  */
-- (BOOL)decryptEvent:(MXEvent*)event inTimeline:(NSString*)timeline;
+- (BOOL)decryptEvent:(MXEvent*)event inTimeline:(NSString*)timeline  __attribute__((deprecated("use -[MXSession decryptEvents:inTimeline:onComplete:] instead")));
 
 /**
  Decrypt events asynchronously and update their data.

--- a/MatrixSDK/MXSession.h
+++ b/MatrixSDK/MXSession.h
@@ -1463,11 +1463,11 @@ typedef void (^MXOnBackgroundSyncFail)(NSError *error);
  @param events the events to decrypt.
  @param timeline the id of the timeline where the events are decrypted. It is used
         to prevent replay attack.
- @return a dictionary {EventId -> NSError} with encountered errors. 
+ @param onComplete the block called when the operations completes. It returns events that failed to decrypt.
  */
 - (void)decryptEvents:(NSArray<MXEvent*> *)events
            inTimeline:(NSString*)timeline
-           onComplete:(void (^)(NSDictionary<NSString *, NSError *>*))onComplete;
+           onComplete:(void (^)(NSArray<MXEvent*> *failedEvents))onComplete;
 
 /**
  Reset replay attack data for the given timeline.

--- a/MatrixSDK/MXSession.h
+++ b/MatrixSDK/MXSession.h
@@ -1462,7 +1462,7 @@ typedef void (^MXOnBackgroundSyncFail)(NSError *error);
  
  @param events the events to decrypt.
  @param timeline the id of the timeline where the events are decrypted. It is used
- to prevent replay attack.
+        to prevent replay attack.
  @return a dictionary {EventId -> NSError} with encountered errors. 
  */
 - (void)decryptEvents:(NSArray<MXEvent*> *)events

--- a/MatrixSDK/MXSession.h
+++ b/MatrixSDK/MXSession.h
@@ -1458,6 +1458,18 @@ typedef void (^MXOnBackgroundSyncFail)(NSError *error);
 - (BOOL)decryptEvent:(MXEvent*)event inTimeline:(NSString*)timeline;
 
 /**
+ Decrypt events asynchronously and update their data.
+ 
+ @param events the events to decrypt.
+ @param timeline the id of the timeline where the events are decrypted. It is used
+ to prevent replay attack.
+ @return a dictionary {EventId -> NSError} with encountered errors. 
+ */
+- (void)decryptEvents:(NSArray<MXEvent*> *)events
+           inTimeline:(NSString*)timeline
+           onComplete:(void (^)(NSDictionary<NSString *, NSError *>*))onComplete;
+
+/**
  Reset replay attack data for the given timeline.
 
  @param timeline the id of the timeline.

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -4020,33 +4020,26 @@ typedef void (^MXOnResumeDone)(void);
     MXEventDecryptionResult *result;
     if (event.eventType == MXEventTypeRoomEncrypted)
     {
-        NSError *error;
         if (_crypto)
         {
             // TODO: One day, this method will be async
-            result = [_crypto decryptEvent:event inTimeline:timeline error:&error];
-            if (result)
-            {
-                [event setClearData:result];
-            }
+            result = [_crypto decryptEvent:event inTimeline:timeline];
         }
         else
         {
             // Encryption not enabled
-            error = [NSError errorWithDomain:MXDecryptingErrorDomain
-                                        code:MXDecryptingErrorEncryptionNotEnabledCode
-                                    userInfo:@{
+            result = [MXEventDecryptionResult new];
+            result.error = [NSError errorWithDomain:MXDecryptingErrorDomain
+                                               code:MXDecryptingErrorEncryptionNotEnabledCode
+                                           userInfo:@{
                                                NSLocalizedDescriptionKey: MXDecryptingErrorEncryptionNotEnabledReason
-                                               }];
+                                           }];
         }
-
-        if (error)
-        {
-            event.decryptionError = error;
-        }
+        
+        [event setClearData:result];
     }
-
-    return (result != nil);
+    
+    return (result.error == nil);
 }
 
 - (void)resetReplayAttackCheckInTimeline:(NSString*)timeline

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -434,6 +434,23 @@ typedef void (^MXOnResumeDone)(void);
     }];
 }
 
+// Load the last event for all room summaries.
+-(void)loadRoomSummaryLastEvents:(void (^)(void))onComplete
+{
+    dispatch_group_t dispatchGroup = dispatch_group_create();
+    for (MXRoomSummary *roomSummary in self.roomsSummaries)
+    {
+        dispatch_group_enter(dispatchGroup);
+        [roomSummary loadLastEvent:^{
+            dispatch_group_leave(dispatchGroup);
+        }];
+    }
+    
+    dispatch_group_notify(dispatchGroup, dispatch_get_main_queue(), ^{
+        onComplete();
+    });
+}
+
 /// Handle a sync response and decide serverTimeout for the next sync request.
 /// @param syncResponse The sync response object
 /// @param completion Completion block to be called at the end of the process. Will be called on the caller thread.

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -393,16 +393,21 @@ typedef void (^MXOnResumeDone)(void);
                 }
 
                 NSLog(@"[MXSession] Built %lu MXRooms in %.0fms", (unsigned long)self->rooms.count, [[NSDate date] timeIntervalSinceDate:startDate3] * 1000);
-
-                taskProfile.units = self->rooms.count;
-                [MXSDKOptions.sharedInstance.profiler stopMeasuringTaskWithProfile:taskProfile];
                 
-                NSLog(@"[MXSession] Total time to mount SDK data from MXStore: %.0fms", taskProfile.duration * 1000);
-                
-                [self setState:MXSessionStateStoreDataReady];
-
-                // The SDK client can use this data
-                onStoreDataReady();
+                NSDate *startDate4 = [NSDate date];
+                [self loadRoomSummaryLastEvents:^{
+                    NSLog(@"[MXSession] Loaded %lu MXRoomSummaries last events in  in %.0fms", (unsigned long)self->roomsSummaries.count, [[NSDate date] timeIntervalSinceDate:startDate4] * 1000);
+                    
+                    taskProfile.units = self->rooms.count;
+                    [MXSDKOptions.sharedInstance.profiler stopMeasuringTaskWithProfile:taskProfile];
+                    
+                    NSLog(@"[MXSession] Total time to mount SDK data from MXStore: %.0fms", taskProfile.duration * 1000);
+                    
+                    [self setState:MXSessionStateStoreDataReady];
+                    
+                    // The SDK client can use this data
+                    onStoreDataReady();
+                }];
             }
             else
             {

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -438,218 +438,215 @@ typedef void (^MXOnResumeDone)(void);
            storeCompletion:(void (^)(void))storeCompletion
 {
     NSLog(@"[MXSession] handleSyncResponse: Received %tu joined rooms, %tu invited rooms, %tu left rooms, %tu toDevice events.", syncResponse.rooms.join.count, syncResponse.rooms.invite.count, syncResponse.rooms.leave.count, syncResponse.toDevice.events.count);
-
-    dispatch_group_t dispatchGroup = dispatch_group_create();
     
     // Check whether this is the initial sync
     BOOL isInitialSync = !self.isEventStreamInitialised;
 
-    // Handle the to device events before the room ones
-    // to ensure to decrypt them properly
-    for (MXEvent *toDeviceEvent in syncResponse.toDevice.events)
-    {
-        [self handleToDeviceEvent:toDeviceEvent];
-    }
-    
-    // Handle top-level account data
-    if (syncResponse.accountData)
-    {
-        [self handleAccountData:syncResponse.accountData];
-    }
-
-    // Handle first joined rooms
-    for (NSString *roomId in syncResponse.rooms.join)
-    {
-        MXRoomSync *roomSync = syncResponse.rooms.join[roomId];
-
-        @autoreleasepool {
-
-            // Retrieve existing room or create a new one
-            MXRoom *room = [self getOrCreateRoom:roomId notify:!isInitialSync];
-
-            // Sync room
-            dispatch_group_enter(dispatchGroup);
-            [room liveTimeline:^(MXEventTimeline *liveTimeline) {
-                [room handleJoinedRoomSync:roomSync onComplete:^{
-                    [room.summary handleJoinedRoomSync:roomSync];
-                    dispatch_group_leave(dispatchGroup);
-                }];
-            }];
+    // Handle to_device events before everything else to make future decryptions work
+    [self handleToDeviceEvents:syncResponse.toDevice.events onComplete:^{
+        
+        dispatch_group_t dispatchGroup = dispatch_group_create();
+        
+        // Handle top-level account data
+        if (syncResponse.accountData)
+        {
+            [self handleAccountData:syncResponse.accountData];
+        }
+        
+        // Handle first joined rooms
+        for (NSString *roomId in syncResponse.rooms.join)
+        {
+            MXRoomSync *roomSync = syncResponse.rooms.join[roomId];
             
-            for (MXEvent *event in roomSync.accountData.events)
-            {
-                if ([event.type isEqualToString:kRoomIsVirtualJSONKey])
+            @autoreleasepool {
+                
+                // Retrieve existing room or create a new one
+                MXRoom *room = [self getOrCreateRoom:roomId notify:!isInitialSync];
+                
+                // Sync room
+                dispatch_group_enter(dispatchGroup);
+                [room liveTimeline:^(MXEventTimeline *liveTimeline) {
+                    [room handleJoinedRoomSync:roomSync onComplete:^{
+                        [room.summary handleJoinedRoomSync:roomSync];
+                        dispatch_group_leave(dispatchGroup);
+                    }];
+                }];
+                
+                for (MXEvent *event in roomSync.accountData.events)
                 {
-                    MXVirtualRoomInfo *virtualRoomInfo = [MXVirtualRoomInfo modelFromJSON:event.content];
-                    if (virtualRoomInfo.isVirtual)
+                    if ([event.type isEqualToString:kRoomIsVirtualJSONKey])
                     {
-                        //  cache this info
-                        [self.roomAccountDataUpdateDelegate updateAccountDataIfRequiredForRoom:room
-                                                                              withNativeRoomId:virtualRoomInfo.nativeRoomId
-                                                                                    completion:nil];
+                        MXVirtualRoomInfo *virtualRoomInfo = [MXVirtualRoomInfo modelFromJSON:event.content];
+                        if (virtualRoomInfo.isVirtual)
+                        {
+                            //  cache this info
+                            [self.roomAccountDataUpdateDelegate updateAccountDataIfRequiredForRoom:room
+                                                                                  withNativeRoomId:virtualRoomInfo.nativeRoomId
+                                                                                        completion:nil];
+                        }
                     }
                 }
             }
         }
-    }
-
-    // Handle invited rooms
-    for (NSString *roomId in syncResponse.rooms.invite)
-    {
-        MXInvitedRoomSync *invitedRoomSync = syncResponse.rooms.invite[roomId];
-
-        @autoreleasepool {
-
-            // Retrieve existing room or create a new one
-            MXRoom *room = [self getOrCreateRoom:roomId notify:!isInitialSync];
-
-            // Prepare invited room
-            dispatch_group_enter(dispatchGroup);
-            [room liveTimeline:^(MXEventTimeline *liveTimeline) {
-                [room handleInvitedRoomSync:invitedRoomSync onComplete:^{
-                    [room.summary handleInvitedRoomSync:invitedRoomSync];
-                    dispatch_group_leave(dispatchGroup);
-                }];
-            }];
-        }
-    }
-
-    // Handle archived rooms
-    for (NSString *roomId in syncResponse.rooms.leave)
-    {
-        MXRoomSync *leftRoomSync = syncResponse.rooms.leave[roomId];
-
-        @autoreleasepool {
-
-            // Presently we remove the existing room from the rooms list.
-            // FIXME SYNCV2 Archive/Display the left rooms!
-            // For that create 'handleArchivedRoomSync' method
-
-            // Retrieve existing room
-            MXRoom *room = [self roomWithRoomId:roomId];
-            if (room)
-            {
-                // FIXME SYNCV2: While 'handleArchivedRoomSync' is not available,
-                // use 'handleJoinedRoomSync' to pass the last events to the room before leaving it.
-                // The room will then able to notify its listeners.
+        
+        // Handle invited rooms
+        for (NSString *roomId in syncResponse.rooms.invite)
+        {
+            MXInvitedRoomSync *invitedRoomSync = syncResponse.rooms.invite[roomId];
+            
+            @autoreleasepool {
+                
+                // Retrieve existing room or create a new one
+                MXRoom *room = [self getOrCreateRoom:roomId notify:!isInitialSync];
+                
+                // Prepare invited room
                 dispatch_group_enter(dispatchGroup);
                 [room liveTimeline:^(MXEventTimeline *liveTimeline) {
-                    [room handleJoinedRoomSync:leftRoomSync onComplete:^{
-                        [room.summary handleJoinedRoomSync:leftRoomSync];
-                        
-                        // Look for the last room member event
-                        MXEvent *roomMemberEvent;
-                        NSInteger index = leftRoomSync.timeline.events.count;
-                        while (index--)
-                        {
-                            MXEvent *event = leftRoomSync.timeline.events[index];
-                            
-                            if ([event.type isEqualToString:kMXEventTypeStringRoomMember])
-                            {
-                                roomMemberEvent = event;
-                                break;
-                            }
-                        }
-                        
-                        // Notify the room is going to disappear
-                        NSMutableDictionary *userInfo = [NSMutableDictionary dictionaryWithObject:room.roomId forKey:kMXSessionNotificationRoomIdKey];
-                        if (roomMemberEvent)
-                        {
-                            userInfo[kMXSessionNotificationEventKey] = roomMemberEvent;
-                        }
-                        [[NSNotificationCenter defaultCenter] postNotificationName:kMXSessionWillLeaveRoomNotification
-                                                                            object:self
-                                                                          userInfo:userInfo];
-                        // Remove the room from the rooms list
-                        [self removeRoom:room.roomId];
-                        
+                    [room handleInvitedRoomSync:invitedRoomSync onComplete:^{
+                        [room.summary handleInvitedRoomSync:invitedRoomSync];
                         dispatch_group_leave(dispatchGroup);
                     }];
                 }];
             }
         }
-    }
-
-    // Check the conditions to update summaries direct user ids for retrieved rooms (We have to do it
-    // when we receive some invites to handle correctly a new invite to a direct chat that the user has left).
-    if (isInitialSync || syncResponse.rooms.invite.count)
-    {
-        [self updateSummaryDirectUserIdForRooms:[self directRoomIds]];
-    }
-
-    // Handle invited groups
-    for (NSString *groupId in syncResponse.groups.invite)
-    {
-        // Create a new group for each invite
-        MXInvitedGroupSync *invitedGroupSync = syncResponse.groups.invite[groupId];
-        [self createGroupInviteWithId:groupId profile:invitedGroupSync.profile andInviter:invitedGroupSync.inviter notify:!isInitialSync];
-    }
-
-    // Handle joined groups
-    for (NSString *groupId in syncResponse.groups.join)
-    {
-        // Join an existing group or create a new one
-        [self didJoinGroupWithId:groupId notify:!isInitialSync];
-    }
-
-    // Handle left groups
-    for (NSString *groupId in syncResponse.groups.leave)
-    {
-        // Remove the group from the group list
-        [self removeGroup:groupId];
-    }
-
-    // Handle presence of other users
-    for (MXEvent *presenceEvent in syncResponse.presence.events)
-    {
-        [self handlePresenceEvent:presenceEvent direction:MXTimelineDirectionForwards];
-    }
-
-    // Sync point: wait that all rooms in the /sync response have been loaded
-    // and their /sync response has been processed
-    dispatch_group_notify(dispatchGroup, dispatch_get_main_queue(), ^{
-
-        if (self.crypto)
+        
+        // Handle archived rooms
+        for (NSString *roomId in syncResponse.rooms.leave)
         {
-            // Handle device list updates
-            if (syncResponse.deviceLists)
-            {
-                [self.crypto handleDeviceListsChanges:syncResponse.deviceLists];
+            MXRoomSync *leftRoomSync = syncResponse.rooms.leave[roomId];
+            
+            @autoreleasepool {
+                
+                // Presently we remove the existing room from the rooms list.
+                // FIXME SYNCV2 Archive/Display the left rooms!
+                // For that create 'handleArchivedRoomSync' method
+                
+                // Retrieve existing room
+                MXRoom *room = [self roomWithRoomId:roomId];
+                if (room)
+                {
+                    // FIXME SYNCV2: While 'handleArchivedRoomSync' is not available,
+                    // use 'handleJoinedRoomSync' to pass the last events to the room before leaving it.
+                    // The room will then able to notify its listeners.
+                    dispatch_group_enter(dispatchGroup);
+                    [room liveTimeline:^(MXEventTimeline *liveTimeline) {
+                        [room handleJoinedRoomSync:leftRoomSync onComplete:^{
+                            [room.summary handleJoinedRoomSync:leftRoomSync];
+                            
+                            // Look for the last room member event
+                            MXEvent *roomMemberEvent;
+                            NSInteger index = leftRoomSync.timeline.events.count;
+                            while (index--)
+                            {
+                                MXEvent *event = leftRoomSync.timeline.events[index];
+                                
+                                if ([event.type isEqualToString:kMXEventTypeStringRoomMember])
+                                {
+                                    roomMemberEvent = event;
+                                    break;
+                                }
+                            }
+                            
+                            // Notify the room is going to disappear
+                            NSMutableDictionary *userInfo = [NSMutableDictionary dictionaryWithObject:room.roomId forKey:kMXSessionNotificationRoomIdKey];
+                            if (roomMemberEvent)
+                            {
+                                userInfo[kMXSessionNotificationEventKey] = roomMemberEvent;
+                            }
+                            [[NSNotificationCenter defaultCenter] postNotificationName:kMXSessionWillLeaveRoomNotification
+                                                                                object:self
+                                                                              userInfo:userInfo];
+                            // Remove the room from the rooms list
+                            [self removeRoom:room.roomId];
+                            
+                            dispatch_group_leave(dispatchGroup);
+                        }];
+                    }];
+                }
             }
-
-            // Handle one_time_keys_count
-            if (syncResponse.deviceOneTimeKeysCount)
+        }
+        
+        // Check the conditions to update summaries direct user ids for retrieved rooms (We have to do it
+        // when we receive some invites to handle correctly a new invite to a direct chat that the user has left).
+        if (isInitialSync || syncResponse.rooms.invite.count)
+        {
+            [self updateSummaryDirectUserIdForRooms:[self directRoomIds]];
+        }
+        
+        // Handle invited groups
+        for (NSString *groupId in syncResponse.groups.invite)
+        {
+            // Create a new group for each invite
+            MXInvitedGroupSync *invitedGroupSync = syncResponse.groups.invite[groupId];
+            [self createGroupInviteWithId:groupId profile:invitedGroupSync.profile andInviter:invitedGroupSync.inviter notify:!isInitialSync];
+        }
+        
+        // Handle joined groups
+        for (NSString *groupId in syncResponse.groups.join)
+        {
+            // Join an existing group or create a new one
+            [self didJoinGroupWithId:groupId notify:!isInitialSync];
+        }
+        
+        // Handle left groups
+        for (NSString *groupId in syncResponse.groups.leave)
+        {
+            // Remove the group from the group list
+            [self removeGroup:groupId];
+        }
+        
+        // Handle presence of other users
+        for (MXEvent *presenceEvent in syncResponse.presence.events)
+        {
+            [self handlePresenceEvent:presenceEvent direction:MXTimelineDirectionForwards];
+        }
+        
+        // Sync point: wait that all rooms in the /sync response have been loaded
+        // and their /sync response has been processed
+        dispatch_group_notify(dispatchGroup, dispatch_get_main_queue(), ^{
+            
+            if (self.crypto)
             {
-                [self.crypto handleDeviceOneTimeKeysCount:syncResponse.deviceOneTimeKeysCount];
-            }
-
-            // Tell the crypto module to do its processing
-            [self.crypto onSyncCompleted:self.store.eventStreamToken
-                           nextSyncToken:syncResponse.nextBatch
-                              catchingUp:self.catchingUp];
+                // Handle device list updates
+                if (syncResponse.deviceLists)
+                {
+                    [self.crypto handleDeviceListsChanges:syncResponse.deviceLists];
+                }
+                
+                // Handle one_time_keys_count
+                if (syncResponse.deviceOneTimeKeysCount)
+                {
+                    [self.crypto handleDeviceOneTimeKeysCount:syncResponse.deviceOneTimeKeysCount];
+                }
+                
+                // Tell the crypto module to do its processing
+                [self.crypto onSyncCompleted:self.store.eventStreamToken
+                               nextSyncToken:syncResponse.nextBatch
+                                  catchingUp:self.catchingUp];
         }
 
         // Update live event stream token
-        NSLog(@"[MXSession] Next sync token: %@", syncResponse.nextBatch);
-        self.store.eventStreamToken = syncResponse.nextBatch;
-        
-        if (completion)
-        {
-            completion();
-        }
-        
-        // Broadcast that a server sync has been processed.
-        [[NSNotificationCenter defaultCenter] postNotificationName:kMXSessionDidSyncNotification
-                                                            object:self
-                                                          userInfo:@{
-                                                              kMXSessionNotificationSyncResponseKey: syncResponse
-                                                          }];
+            NSLog(@"[MXSession] Next sync token: %@", syncResponse.nextBatch);
+            self.store.eventStreamToken = syncResponse.nextBatch;
+            
+            if (completion)
+            {
+                completion();
+            }
+            
+            // Broadcast that a server sync has been processed.
+            [[NSNotificationCenter defaultCenter] postNotificationName:kMXSessionDidSyncNotification
+                                                                object:self
+                                                              userInfo:@{
+                                                                  kMXSessionNotificationSyncResponseKey: syncResponse
+                                                              }];
 
-        // Commit store changes
-        if ([self.store respondsToSelector:@selector(commitWithCompletion:)])
-        {
-            [self.store commitWithCompletion:storeCompletion];
-        }
+            // Commit store changes
+            if ([self.store respondsToSelector:@selector(commitWithCompletion:)])
+            {
+                [self.store commitWithCompletion:storeCompletion];
+            }
+        });
     }];
 }
 
@@ -1718,23 +1715,62 @@ typedef void (^MXOnResumeDone)(void);
     }
 }
 
-- (void)handleToDeviceEvent:(MXEvent *)event
+- (void)handleToDeviceEvents:(NSArray<MXEvent *> *)events  onComplete:(void (^)(void))onComplete
 {
-    // Decrypt event if necessary
-    if (event.eventType == MXEventTypeRoomEncrypted)
+    if (events.count == 0)
     {
-        if (![self decryptEvent:event inTimeline:nil])
-        {
-            NSLog(@"[MXSession] handleToDeviceEvent: Warning: Unable to decrypt to-device event: %@\nError: %@", event.wireContent[@"body"], event.decryptionError);
-            return;
-        }
+        onComplete();
+        return;
     }
+    
+    [self decryptEvents:events inTimeline:nil onComplete:^(NSArray<MXEvent *> *failedEvents) {
+        dispatch_group_t dispatchGroup = dispatch_group_create();
+        
+        for (MXEvent *event in events)
+        {
+            if (!event.decryptionError)
+            {
+                dispatch_group_enter(dispatchGroup);
+                [self handleToDeviceEvent:event onComplete:^{
+                    dispatch_group_leave(dispatchGroup);
+                }];
+            }
+            else
+            {
+                NSLog(@"[MXSession] handleToDeviceEvents: Warning: Unable to decrypt to-device event: %@\nError: %@", event.wireContent[@"body"], event.decryptionError);
+            }
+        }
+        
+        dispatch_group_notify(dispatchGroup, dispatch_get_main_queue(), ^{
+            onComplete();
+        });
+    }];
+}
 
-    [[NSNotificationCenter defaultCenter] postNotificationName:kMXSessionOnToDeviceEventNotification
-                                                        object:self
-                                                      userInfo:@{
-                                                                 kMXSessionNotificationEventKey: event
-                                                                 }];
+- (void)handleToDeviceEvent:(MXEvent *)event onComplete:(void (^)(void))onComplete
+{
+    void (^onHandleToDeviceEventDone)(void) = ^(void) {
+        [[NSNotificationCenter defaultCenter] postNotificationName:kMXSessionOnToDeviceEventNotification
+                                                            object:self
+                                                          userInfo:@{
+                                                              kMXSessionNotificationEventKey: event
+                                                          }];
+        
+        onComplete();
+    };
+    
+    switch (event.eventType)
+    {
+        case MXEventTypeRoomKey:
+        {
+            [_crypto handleRoomKeyEvent:event onComplete:onHandleToDeviceEventDone];
+            break;
+        }
+            
+        default:
+            onHandleToDeviceEventDone();
+            break;
+    }
 }
 
 /**
@@ -1833,12 +1869,7 @@ typedef void (^MXOnResumeDone)(void);
     NSLog(@"[MXSession] handleOutdatedSyncResponse: %tu joined rooms, %tu invited rooms, %tu left rooms, %tu toDevice events.", syncResponse.rooms.join.count, syncResponse.rooms.invite.count, syncResponse.rooms.leave.count, syncResponse.toDevice.events.count);
     
     // Handle only to_device events. They are sent only once by the homeserver
-    for (MXEvent *toDeviceEvent in syncResponse.toDevice.events)
-    {
-        [self handleToDeviceEvent:toDeviceEvent];
-    }
-    
-    completion();
+    [self handleToDeviceEvents:syncResponse.toDevice.events onComplete:completion];
 }
 
 

--- a/MatrixSDKTests/MXBackgroundSyncServiceTests.swift
+++ b/MatrixSDKTests/MXBackgroundSyncServiceTests.swift
@@ -866,7 +866,6 @@ class MXBackgroundSyncServiceTests: XCTestCase {
                 
                 // -> Bob session must have the key to decrypt the first message
                 bobSession.event(withEventId: firstEventId, inRoom: roomId) { (event) in
-                    bobSession.decryptEvent(event, inTimeline: nil)
                     XCTAssertNotNil(event?.clear)
                     
                     // -> The background service cache must be reset after session resume
@@ -938,7 +937,6 @@ class MXBackgroundSyncServiceTests: XCTestCase {
                 
                 // -> Bob session must have the key to decrypt the first message
                 bobSession.event(withEventId: firstEventId, inRoom: roomId) { (event) in
-                    bobSession.decryptEvent(event, inTimeline: nil)
                     XCTAssertNotNil(event?.clear)
                     
                     // -> The background service cache must be reset after session resume
@@ -1004,7 +1002,6 @@ class MXBackgroundSyncServiceTests: XCTestCase {
                 
                 // -> Bob session must have the key to decrypt the first message
                 bobSession.event(withEventId: firstEventId, inRoom: roomId) { (event) in
-                    bobSession.decryptEvent(event, inTimeline: nil)
                     XCTAssertNotNil(event?.clear)
                     
                     // -> The background service cache must be reset after session resume
@@ -1076,7 +1073,6 @@ class MXBackgroundSyncServiceTests: XCTestCase {
                 
                 // -> Bob session must have the key to decrypt the first message
                 bobSession.event(withEventId: firstEventId, inRoom: roomId) { (event) in
-                    bobSession.decryptEvent(event, inTimeline: nil)
                     XCTAssertNotNil(event?.clear)
                     
                     // -> The background service cache must be reset after session resume
@@ -1261,10 +1257,7 @@ class MXBackgroundSyncServiceTests: XCTestCase {
                         // -> Bob session must have the key to decrypt the first and the last message
                         bobSession.event(withEventId: firstEventId, inRoom: roomId) { (firstEvent) in
                             bobSession.event(withEventId: lastEventId, inRoom: roomId) { (lastEvent) in
-                                
-                                bobSession.decryptEvent(firstEvent, inTimeline: nil)
                                 XCTAssertNotNil(firstEvent?.clear)
-                                bobSession.decryptEvent(lastEvent, inTimeline: nil)
                                 XCTAssertNotNil(lastEvent?.clear)
                                 
                                 // -> The background service cache must be reset after session restart
@@ -1328,10 +1321,7 @@ class MXBackgroundSyncServiceTests: XCTestCase {
                         // -> Bob session must have the key to decrypt the first and the last message
                         bobSession2.event(withEventId: firstEventId, inRoom: roomId) { (firstEvent) in
                             bobSession2.event(withEventId: lastEventId, inRoom: roomId) { (lastEvent) in
-                                
-                                bobSession2.decryptEvent(firstEvent, inTimeline: nil)
                                 XCTAssertNotNil(firstEvent?.clear)
-                                bobSession2.decryptEvent(lastEvent, inTimeline: nil)
                                 XCTAssertNotNil(lastEvent?.clear)
                                 
                                 // -> The background service cache must be reset after session restart

--- a/MatrixSDKTests/MXCryptoTests.m
+++ b/MatrixSDKTests/MXCryptoTests.m
@@ -1867,11 +1867,7 @@
                 newContent[@"session_key"] = sessionInfo.session.sessionKey;
                 toDeviceEvent.clearEvent.wireContent = newContent;
 
-                [[NSNotificationCenter defaultCenter] postNotificationName:kMXSessionOnToDeviceEventNotification
-                                                                    object:bobSession
-                                                                  userInfo:@{
-                                                                             kMXSessionNotificationEventKey: toDeviceEvent
-                                                                             }];
+                [bobSession.crypto handleRoomKeyEvent:toDeviceEvent onComplete:^{}];
 
                 // We still must be able to decrypt the event
                 // ie, the implementation must have ignored the new room key with the advanced outbound group

--- a/MatrixSDKTests/MXCryptoTests.m
+++ b/MatrixSDKTests/MXCryptoTests.m
@@ -1721,17 +1721,19 @@
                 [bobSession eventWithEventId:eventId inRoom:roomId success:^(MXEvent *event) {
                     
                     // -> But he does not have keys decrypt it
-                    BOOL hasKeys = [bobSession.crypto hasKeysToDecryptEvent:event];
-                    XCTAssertFalse(hasKeys);
-                    
-                    // - Bob resumes his session
-                    [bobSession resume:^{
+                    [bobSession.crypto hasKeysToDecryptEvent:event onComplete:^(BOOL hasKeys) {
+                        XCTAssertFalse(hasKeys);
                         
-                        // -> He has keys now
-                        BOOL hasKeys = [bobSession.crypto hasKeysToDecryptEvent:event];
-                        XCTAssertTrue(hasKeys);
-                        
-                        [expectation fulfill];
+                        // - Bob resumes his session
+                        [bobSession resume:^{
+                            
+                            // -> He has keys now
+                            [bobSession.crypto hasKeysToDecryptEvent:event onComplete:^(BOOL hasKeys) {
+                                XCTAssertTrue(hasKeys);
+                                
+                                [expectation fulfill];
+                            }];
+                        }];
                     }];
 
                 } failure:^(NSError *error) {

--- a/MatrixSDKTests/MXCryptoTests.m
+++ b/MatrixSDKTests/MXCryptoTests.m
@@ -372,6 +372,40 @@
 }
 
 
+#pragma mark - MXSession
+
+// Test MXSession.event(withEventId:)
+// - Have Alice with an encrypted message
+// - Get the event content using MXSession.event(withEventId:)
+// -> The event must be decrypted
+- (void)testMXSessionEventWithEventId
+{
+    NSString *message = @"Hello myself!";
+    
+    // - Have Alice with an encrypted message
+    [matrixSDKTestsE2EData doE2ETestWithAliceInARoom:self readyToTest:^(MXSession *aliceSession, NSString *roomId, XCTestExpectation *expectation) {
+        MXRoom *roomFromAlicePOV = [aliceSession roomWithRoomId:roomId];
+        [roomFromAlicePOV sendTextMessage:message success:^(NSString *eventId) {
+
+            // - Get the event content using MXSession.event(withEventId:)
+            [aliceSession eventWithEventId:eventId inRoom:nil success:^(MXEvent *event) {
+                
+                // -> The event must be decrypted
+                XCTAssertEqual(0, [self checkEncryptedEvent:event roomId:roomId clearMessage:message senderSession:aliceSession]);
+                [expectation fulfill];
+                
+            } failure:^(NSError *error) {
+                XCTFail(@"The request should not fail - NSError: %@", error);
+                [expectation fulfill];
+            }];
+        } failure:^(NSError *error) {
+            XCTFail(@"Cannot set up intial test conditions - error: %@", error);
+            [expectation fulfill];
+        }];
+    }];
+}
+
+
 #pragma mark - MXRoom
 - (void)testRoomIsEncrypted
 {

--- a/MatrixSDKTests/MXCryptoTests.m
+++ b/MatrixSDKTests/MXCryptoTests.m
@@ -1944,11 +1944,7 @@
                 }];
 
                 // Reinject the m.room_key event. This mimics a room_key event that arrives after message events.
-                [[NSNotificationCenter defaultCenter] postNotificationName:kMXSessionOnToDeviceEventNotification
-                                                                    object:bobSession
-                                                                  userInfo:@{
-                                                                             kMXSessionNotificationEventKey: toDeviceEvent
-                                                                             }];
+                [bobSession.crypto handleRoomKeyEvent:toDeviceEvent onComplete:^{}];
             }];
         }];
 

--- a/MatrixSDKTests/MXRoomSummaryTests.m
+++ b/MatrixSDKTests/MXRoomSummaryTests.m
@@ -1038,7 +1038,7 @@ NSString *uisiString = @"The sender's device has not sent us the keys for this m
             XCTAssert(summary.isEncrypted);
 
             // Use dispatch_async for not closing the session in the middle of stg
-            dispatch_async(dispatch_get_main_queue(), ^{
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.1 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
 
                 // Close the session
                 MXRestClient *aliceRestClient = aliceSession.matrixRestClient;
@@ -1051,10 +1051,11 @@ NSString *uisiString = @"The sender's device has not sent us the keys for this m
                     // A hack to directly read the file built by MXFileStore
                     NSString *roomSummaryFile = [store performSelector:@selector(summaryFileForRoom:forBackup:) withObject:roomId withObject:NSNull.null];
                     XCTAssert(roomSummaryFile.length);
+                    XCTAssertGreaterThan(roomSummaryFile.length, 0);
                     [store close];
 
                     NSData *roomSummaryFileData = [[NSData alloc] initWithContentsOfFile:roomSummaryFile];
-                    XCTAssert(roomSummaryFileData.length);
+                    XCTAssertGreaterThan(roomSummaryFileData.length, 0);
 
                     NSData *pattern = [lastMessageEventId dataUsingEncoding:NSUTF8StringEncoding];
                     NSRange range = [roomSummaryFileData rangeOfData:pattern options:0 range:NSMakeRange(0, roomSummaryFileData.length)];
@@ -1135,7 +1136,7 @@ NSString *uisiString = @"The sender's device has not sent us the keys for this m
             XCTAssertEqualObjects(event.content[@"body"], message);
 
             // Use dispatch_async for not closing the session in the middle of stg
-            dispatch_async(dispatch_get_main_queue(), ^{
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.1 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
 
                 // Close the session
                 MXRestClient *aliceRestClient = aliceSession.matrixRestClient;
@@ -1234,6 +1235,8 @@ NSString *uisiString = @"The sender's device has not sent us the keys for this m
 
         id summaryObserver;
         summaryObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kMXRoomSummaryDidChangeNotification object:roomSummaryFromBobPOV queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *note) {
+            
+            NSLog(@"WWWWWW %@", roomSummaryFromBobPOV.lastMessageString);
 
             switch (notifCount++)
             {

--- a/MatrixSDKTests/MXRoomSummaryTests.m
+++ b/MatrixSDKTests/MXRoomSummaryTests.m
@@ -1235,9 +1235,6 @@ NSString *uisiString = @"The sender's device has not sent us the keys for this m
 
         id summaryObserver;
         summaryObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kMXRoomSummaryDidChangeNotification object:roomSummaryFromBobPOV queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *note) {
-            
-            NSLog(@"WWWWWW %@", roomSummaryFromBobPOV.lastMessageString);
-
             switch (notifCount++)
             {
                 case 0:
@@ -1247,9 +1244,13 @@ NSString *uisiString = @"The sender's device has not sent us the keys for this m
 
                     MXEvent *event = roomSummaryFromBobPOV.lastMessageEvent;
                     XCTAssertNil(event.clearEvent);
+                    
+                    // Attempt a new decryption
+                    [bobSession decryptEvents:@[event] inTimeline:nil onComplete:^(NSArray<MXEvent *> *failedEvents) {
+                        // Reinject the m.room_key event. This mimics a room_key event that arrives after message events.
+                        [bobSession.crypto handleRoomKeyEvent:toDeviceEvent onComplete:^{}];
+                    }];
 
-                    // Reinject the m.room_key event. This mimics a room_key event that arrives after message events.
-                    [bobSession.crypto handleRoomKeyEvent:toDeviceEvent onComplete:^{}];
                     break;
                 }
 

--- a/MatrixSDKTests/MXRoomSummaryTests.m
+++ b/MatrixSDKTests/MXRoomSummaryTests.m
@@ -1221,9 +1221,9 @@ NSString *uisiString = @"The sender's device has not sent us the keys for this m
 
                 // So that we cannot decrypt it anymore right now
                 [event setClearData:nil];
-                BOOL b = [bobSession decryptEvent:event inTimeline:nil];
-
-                XCTAssertFalse(b, @"Failed to set up test condition");
+                [bobSession decryptEvents:@[event] inTimeline:nil onComplete:^(NSArray<MXEvent *> *failedEvents) {
+                    XCTAssertEqual(failedEvents.count, 1, @"Failed to set up test condition");
+                }];
             }];
         }];
 

--- a/MatrixSDKTests/MXRoomSummaryTests.m
+++ b/MatrixSDKTests/MXRoomSummaryTests.m
@@ -1211,19 +1211,19 @@ NSString *uisiString = @"The sender's device has not sent us the keys for this m
             
             [liveTimeline listenToEventsOfTypes:@[kMXEventTypeStringRoomMessage] onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
 
-                // Make crypto forget the inbound group session now
-                // MXRoomSummary will not be able to decrypt it
-                XCTAssert(toDeviceEvent);
-                NSString *sessionId = toDeviceEvent.content[@"session_id"];
-
-                id<MXCryptoStore> bobCryptoStore = (id<MXCryptoStore>)[bobSession.crypto.olmDevice valueForKey:@"store"];
-                [bobCryptoStore removeInboundGroupSessionWithId:sessionId andSenderKey:toDeviceEvent.senderKey];
-
-                // So that we cannot decrypt it anymore right now
-                [event setClearData:nil];
-                [bobSession decryptEvents:@[event] inTimeline:nil onComplete:^(NSArray<MXEvent *> *failedEvents) {
-                    XCTAssertEqual(failedEvents.count, 1, @"Failed to set up test condition");
-                }];
+                if (direction == MXTimelineDirectionForwards)
+                {
+                    // Make crypto forget the inbound group session now
+                    // MXRoomSummary will not be able to decrypt it
+                    XCTAssert(toDeviceEvent);
+                    NSString *sessionId = toDeviceEvent.content[@"session_id"];
+                    
+                    id<MXCryptoStore> bobCryptoStore = (id<MXCryptoStore>)[bobSession.crypto.olmDevice valueForKey:@"store"];
+                    [bobCryptoStore removeInboundGroupSessionWithId:sessionId andSenderKey:toDeviceEvent.senderKey];
+                    
+                    // So that we cannot decrypt it anymore right now
+                    [event setClearData:nil];
+                }
             }];
         }];
 

--- a/MatrixSDKTests/MXRoomSummaryTests.m
+++ b/MatrixSDKTests/MXRoomSummaryTests.m
@@ -1246,11 +1246,7 @@ NSString *uisiString = @"The sender's device has not sent us the keys for this m
                     XCTAssertNil(event.clearEvent);
 
                     // Reinject the m.room_key event. This mimics a room_key event that arrives after message events.
-                    [[NSNotificationCenter defaultCenter] postNotificationName:kMXSessionOnToDeviceEventNotification
-                                                                        object:bobSession
-                                                                      userInfo:@{
-                                                                                 kMXSessionNotificationEventKey: toDeviceEvent
-                                                                                 }];
+                    [bobSession.crypto handleRoomKeyEvent:toDeviceEvent onComplete:^{}];
                     break;
                 }
 


### PR DESCRIPTION
Fix https://github.com/vector-im/element-ios/issues/4306.
Fix vector-im/element-ios/issues/4322 in https://github.com/matrix-org/matrix-ios-sdk/pull/1091/commits/6bfeee516849eeba1e60a01f1ae455f095cb3c3c

Events are now asynchronously decrypted upstream, where upstream can be:
 - during the sync response parsing
 - during pagination
 - during SDK data loading for MXRoomSummary.lastMessageEvent

This means we can remove latter calls of [MXSession decryptEvent:] that is synchronous and called mostly on the main thread.

On my account, an initial sync took 12.4 seconds on the main thread in the call of [MXSession decryptEvent:]. Now decryption takes 11s but on the decryption thread.

This change is more noticeable on incremental syncs, specially on the app restart, where decryption does not steal anymore time from the main thread (5 to 10 ms per decryption).

Note there is still a call of `[MXCrypto decryptEvent:]` for `MXRoom.outgoingMessages`. It will be removed in a next PR.
Commits can be reviewed one by one.