### PR TITLE
End of the removal of decryption on the main thread

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Changes to be released in next version
  * MXSession: Add the decryptEvents method to decypt a bunch of events asynchronously.
  * MXSession: Make the eventWithEventId method decrypt the event if needed.
  * MXEventTimeline: Add NSCopying implementation so that another pagination can be done on the same set of data.
+ * MXCrypto: eventDeviceInfo: Do not synchronise anymore the operation with the decryption queue.
 
 🐛 Bugfix
  * MXRoomSummary: Fix decryption of the last message when it is edited (vector-im/element-ios/issues/4322).

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@ Changes to be released in next version
  * MXRoom: MXRoom.outgoingMessages does not decrypt messages anymore. Use MXSession.decryptEvents to get decrypted events.
  * MXSession: [MXSession decryptEvent:inTimeline:] is deprecated, use [MXSession decryptEvents:inTimeline:onComplete:] instead.
  * MXCrypto: [MXCrypto decryptEvent:inTimeline:] is deprecated, use [MXCrypto decryptEvents:inTimeline:onComplete:] instead.
+ * MXCrypto: [MXCrypto hasKeysToDecryptEvent:] is now asynchronous.
 
 🗣 Translations
  * 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Changes to be released in next version
  * MXCrypto: Decrypt events asynchronously and no more on the main thread )(vector-im/element-ios/issues/4306).
  * MXSession: Add the decryptEvents method to decypt a bunch of events asynchronously.
  * MXSession: Make the eventWithEventId method decrypt the event if needed.
+ * MXEventTimeline: Add NSCopying implementation so that another pagination can be done on the same set of data.
 
 🐛 Bugfix
  * MXRoomSummary: Fix decryption of the last message when it is edited (vector-im/element-ios/issues/4322).

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@ Changes to be released in next version
 
 ⚠️ API Changes
  * MXRoom: MXRoom.outgoingMessages does not decrypt messages anymore. Use MXSession.decryptEvents to get decrypted events.
+ * MXSession: [MXSession decryptEvent:inTimeline:] is deprecated, use [MXSession decryptEvents:inTimeline:onComplete:] instead.
+ * MXCrypto: [MXCrypto decryptEvent:inTimeline:] is deprecated, use [MXCrypto decryptEvents:inTimeline:onComplete:] instead.
 
 🗣 Translations
  * 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,7 @@ Changes to be released in next version
  * MXRoomSummary: Fix decryption of the last message when it is edited (vector-im/element-ios/issues/4322).
 
 ⚠️ API Changes
- * 
+ * MXRoom: MXRoom.outgoingMessages does not decrypt messages anymore. Use MXSession.decryptEvents to get decrypted events.
 
 🗣 Translations
  * 

--- a/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmDecryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmDecryption.m
@@ -68,8 +68,8 @@
     
     NSString *senderKey, *sessionId;
     
-    MXJSONModelSetString(senderKey, event.content[@"sender_key"]);
-    MXJSONModelSetString(sessionId, event.content[@"session_id"]);
+    MXJSONModelSetString(senderKey, event.wireContent[@"sender_key"]);
+    MXJSONModelSetString(sessionId, event.wireContent[@"session_id"]);
     if (senderKey && sessionId)
     {
         hasKeys = ([crypto.store inboundGroupSessionWithId:sessionId andSenderKey:senderKey] != nil);
@@ -83,9 +83,9 @@
     MXEventDecryptionResult *result;
     NSString *senderKey, *ciphertext, *sessionId;
 
-    MXJSONModelSetString(senderKey, event.content[@"sender_key"]);
-    MXJSONModelSetString(ciphertext, event.content[@"ciphertext"]);
-    MXJSONModelSetString(sessionId, event.content[@"session_id"]);
+    MXJSONModelSetString(senderKey, event.wireContent[@"sender_key"]);
+    MXJSONModelSetString(ciphertext, event.wireContent[@"ciphertext"]);
+    MXJSONModelSetString(sessionId, event.wireContent[@"session_id"]);
 
     if (!senderKey || !sessionId || !ciphertext)
     {

--- a/MatrixSDK/Crypto/Algorithms/Olm/MXOlmDecryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Olm/MXOlmDecryption.m
@@ -65,8 +65,8 @@
     NSString *deviceKey;
     NSDictionary *ciphertext;
 
-    MXJSONModelSetString(deviceKey, event.content[@"sender_key"]);
-    MXJSONModelSetDictionary(ciphertext, event.content[@"ciphertext"]);
+    MXJSONModelSetString(deviceKey, event.wireContent[@"sender_key"]);
+    MXJSONModelSetDictionary(ciphertext, event.wireContent[@"ciphertext"]);
 
     if (!ciphertext)
     {

--- a/MatrixSDK/Crypto/CrossSigning/MXCrossSigning.m
+++ b/MatrixSDK/Crypto/CrossSigning/MXCrossSigning.m
@@ -481,7 +481,7 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
     NSLog(@"[MXCrossSigning] refreshState for device %@: Current state: %@", self.crypto.store.deviceId, @(self.state));
 
     // Refresh user's keys
-    [self.crypto.deviceList downloadKeys:@[myUserId] forceDownload:YES success:^(MXUsersDevicesMap<MXDeviceInfo *> *usersDevicesInfoMap, NSDictionary<NSString *,MXCrossSigningInfo *> *crossSigningKeysMap) {
+    [self.crypto downloadKeys:@[myUserId] forceDownload:YES success:^(MXUsersDevicesMap<MXDeviceInfo *> *usersDevicesInfoMap, NSDictionary<NSString *,MXCrossSigningInfo *> *crossSigningKeysMap) {
         
         BOOL sameCrossSigningKeys = [myUserCrossSigningKeysBefore hasSameKeysAsCrossSigningInfo:crossSigningKeysMap[myUserId]];
         self.myUserCrossSigningKeys = crossSigningKeysMap[myUserId];

--- a/MatrixSDK/Crypto/MXCrypto.h
+++ b/MatrixSDK/Crypto/MXCrypto.h
@@ -173,9 +173,10 @@ extern NSString *const MXDeviceListDidUpdateUsersDevicesNotification;
  
  @param event the event to decrypt.
 
- @return YES if keys are present.
+ @param onComplete the block called when the operations completes. It returns the result
  */
-- (BOOL)hasKeysToDecryptEvent:(MXEvent*)event;
+- (void)hasKeysToDecryptEvent:(MXEvent*)event
+                   onComplete:(void (^)(BOOL))onComplete;
 
 /**
  Decrypt a received event.

--- a/MatrixSDK/Crypto/MXCrypto.h
+++ b/MatrixSDK/Crypto/MXCrypto.h
@@ -180,13 +180,15 @@ extern NSString *const MXDeviceListDidUpdateUsersDevicesNotification;
 /**
  Decrypt a received event.
 
+ @warning This method is deprecated, use -[MXCrypto decryptEvents:inTimeline:onComplete:] instead.
+ 
  @param event the raw event.
  @param timeline the id of the timeline where the event is decrypted. It is used
                  to prevent replay attack.
  
  @return The decryption result.
  */
-- (MXEventDecryptionResult *)decryptEvent:(MXEvent*)event inTimeline:(NSString*)timeline;
+- (MXEventDecryptionResult *)decryptEvent:(MXEvent*)event inTimeline:(NSString*)timeline __attribute__((deprecated("use -[MXCrypto decryptEvents:inTimeline:onComplete:] instead")));
 
 /**
  Decrypt events asynchronously.

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -516,7 +516,8 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     // We need to go to decryptionQueue only to use getRoomDecryptor
     // Other subsequent calls are thread safe because of the implementation of MXCryptoStore
     dispatch_sync(decryptionQueue, ^{
-        id<MXDecrypting> alg = [self getRoomDecryptor:event.roomId algorithm:event.content[@"algorithm"]];
+        NSString *algorithm = event.wireContent[@"algorithm"];
+        id<MXDecrypting> alg = [self getRoomDecryptor:event.roomId algorithm:algorithm];
         
         hasKeys = [alg hasKeysToDecryptEvent:event];
     });
@@ -558,17 +559,18 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
         return result;
     }
     
-    id<MXDecrypting> alg = [self getRoomDecryptor:event.roomId algorithm:event.content[@"algorithm"]];
+    NSString *algorithm = event.wireContent[@"algorithm"];
+    id<MXDecrypting> alg = [self getRoomDecryptor:event.roomId algorithm:algorithm];
     if (!alg)
     {
-        NSLog(@"[MXCrypto] decryptEvent: Unable to decrypt %@ with algorithm %@. Event: %@", event.eventId, event.content[@"algorithm"], event.JSONDictionary);
+        NSLog(@"[MXCrypto] decryptEvent: Unable to decrypt %@ with algorithm %@. Event: %@", event.eventId, algorithm, event.JSONDictionary);
         
         result = [MXEventDecryptionResult new];
         result.error = [NSError errorWithDomain:MXDecryptingErrorDomain
                                            code:MXDecryptingErrorUnableToDecryptCode
                                        userInfo:@{
                                            NSLocalizedDescriptionKey: MXDecryptingErrorUnableToDecrypt,
-                                           NSLocalizedFailureReasonErrorKey: [NSString stringWithFormat:MXDecryptingErrorUnableToDecryptReason, event, event.content[@"algorithm"]]
+                                           NSLocalizedFailureReasonErrorKey: [NSString stringWithFormat:MXDecryptingErrorUnableToDecryptReason, event, algorithm]
                                        }];
     }
     else

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -875,17 +875,10 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 
     if (event.isEncrypted)
     {
-        // Use decryptionQueue because this is a simple read in the db
-        // AND we do it synchronously
-        // @TODO: dispatch_async
-        MXWeakify(self);
-        dispatch_sync(decryptionQueue, ^{
-            MXStrongifyAndReturnIfNil(self);
-
-            NSString *algorithm = event.wireContent[@"algorithm"];
-            device = [self.deviceList deviceWithIdentityKey:event.senderKey andAlgorithm:algorithm];
-
-        });
+        // This is a simple read in the db which is thread safe.
+        // Return synchronously
+        NSString *algorithm = event.wireContent[@"algorithm"];
+        device = [self.deviceList deviceWithIdentityKey:event.senderKey andAlgorithm:algorithm];
     }
 
 #endif

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -507,24 +507,21 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 #endif
 }
 
-- (BOOL)hasKeysToDecryptEvent:(MXEvent *)event
+- (void)hasKeysToDecryptEvent:(MXEvent *)event onComplete:(void (^)(BOOL))onComplete
 {
-    __block BOOL hasKeys = NO;
-    
 #ifdef MX_CRYPTO
     
     // We need to go to decryptionQueue only to use getRoomDecryptor
     // Other subsequent calls are thread safe because of the implementation of MXCryptoStore
-    dispatch_sync(decryptionQueue, ^{
+    dispatch_async(decryptionQueue, ^{
         NSString *algorithm = event.wireContent[@"algorithm"];
         id<MXDecrypting> alg = [self getRoomDecryptor:event.roomId algorithm:algorithm];
         
-        hasKeys = [alg hasKeysToDecryptEvent:event];
+        BOOL hasKeys = [alg hasKeysToDecryptEvent:event];
+        onComplete(hasKeys);
     });
     
 #endif
-    
-    return hasKeys;
 }
 
 - (MXEventDecryptionResult *)decryptEvent:(MXEvent *)event inTimeline:(NSString*)timeline

--- a/MatrixSDK/Data/MXEventTimeline.h
+++ b/MatrixSDK/Data/MXEventTimeline.h
@@ -55,7 +55,7 @@ typedef void (^MXOnRoomEvent)(MXEvent *event, MXTimelineDirection direction, MXR
       with events on calls of [MXEventTimeline paginate] in backwards or forwards direction.
       Events are stored in a in-memory store (MXMemoryStore) (@TODO: To be confirmed once they will be implemented). So, they are not permanent.
  */
-@interface MXEventTimeline : NSObject
+@interface MXEventTimeline : NSObject <NSCopying>
 
 /**
  The id of this timeline.

--- a/MatrixSDK/Data/MXEventTimeline.h
+++ b/MatrixSDK/Data/MXEventTimeline.h
@@ -100,7 +100,7 @@ typedef void (^MXOnRoomEvent)(MXEvent *event, MXTimelineDirection direction, MXR
  @param initialEventId the initial event for the timeline. A nil value will create a live timeline.
  @return a MXEventTimeline instance.
  */
-- (id)initWithRoom:(MXRoom*)room andInitialEventId:(NSString*)initialEventId;
+- (instancetype)initWithRoom:(MXRoom*)room andInitialEventId:(NSString*)initialEventId;
 
 /**
  Create a timeline instance for a room and force it to use the given MXStore to store events.
@@ -110,7 +110,7 @@ typedef void (^MXOnRoomEvent)(MXEvent *event, MXTimelineDirection direction, MXR
  @param store the store to use to store timeline events.
  @return a MXEventTimeline instance.
  */
-- (id)initWithRoom:(MXRoom*)room initialEventId:(NSString*)initialEventId andStore:(id<MXStore>)store;
+- (instancetype)initWithRoom:(MXRoom*)room initialEventId:(NSString*)initialEventId andStore:(id<MXStore>)store;
 
 /**
  Initialise the room evenTimeline state.

--- a/MatrixSDK/Data/MXEventTimeline.m
+++ b/MatrixSDK/Data/MXEventTimeline.m
@@ -299,18 +299,22 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
                 
             if (onlyFromStore && eventsFromStoreCount)
             {
-                complete();
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    NSLog(@"[MXEventTimeline] paginate : is done from the store");
+                    complete();
+                });
 
-                NSLog(@"[MXEventTimeline] paginate : is done from the store");
                 return;
             }
 
             if (0 == remainingNumItems || YES == [self->store hasReachedHomeServerPaginationEndForRoom:self.state.roomId])
             {
-                // Nothing more to do
-                complete();
-
-                NSLog(@"[MXEventTimeline] paginate: is done");
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    // Nothing more to do
+                    NSLog(@"[MXEventTimeline] paginate: is done");
+                    complete();
+                });
+                
                 return;
             }
         }
@@ -318,10 +322,12 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
         // Do not try to paginate forward if end has been reached
         if (direction == MXTimelineDirectionForwards && YES == self->hasReachedHomeServerForwardsPaginationEnd)
         {
-            // Nothing more to do
-            complete();
+            dispatch_async(dispatch_get_main_queue(), ^{
+                // Nothing more to do
+                NSLog(@"[MXEventTimeline] paginate: is done");
+                complete();
+            });
 
-            NSLog(@"[MXEventTimeline] paginate: is done");
             return;
         }
 
@@ -355,18 +361,17 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
                 || [self->room.mxSession isPeekingInRoomWithRoomId:self->room.roomId])
             {
                 [self handlePaginationResponse:paginatedResponse direction:direction onComplete:^{
+                    NSLog(@"[MXEventTimeline] paginate: is done");
+                    
                     // Inform the method caller
                     complete();
-
-                    NSLog(@"[MXEventTimeline] paginate: is done");
                 }];
             }
             else
             {
+                NSLog(@"[MXEventTimeline] paginate: is done");
                 // Inform the method caller
                 complete();
-
-                NSLog(@"[MXEventTimeline] paginate: is done");
             }
 
         } failure:^(NSError *error) {

--- a/MatrixSDK/Data/MXEventTimeline.m
+++ b/MatrixSDK/Data/MXEventTimeline.m
@@ -81,7 +81,7 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
     return self;
 }
 
-- (id)initWithRoom:(MXRoom*)theRoom andInitialEventId:(NSString*)initialEventId
+- (instancetype)initWithRoom:(MXRoom*)theRoom andInitialEventId:(NSString*)initialEventId
 {
     // Is it a past or live timeline?
     if (initialEventId)
@@ -100,7 +100,7 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
     return self;
 }
 
-- (id)initWithRoom:(MXRoom*)theRoom initialEventId:(NSString*)initialEventId andStore:(id<MXStore>)theStore
+- (instancetype)initWithRoom:(MXRoom*)theRoom initialEventId:(NSString*)initialEventId andStore:(id<MXStore>)theStore
 {
     self = [self init];
     if (self)

--- a/MatrixSDK/Data/MXEventTimeline.m
+++ b/MatrixSDK/Data/MXEventTimeline.m
@@ -69,6 +69,18 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
 @implementation MXEventTimeline
 
 #pragma mark - Initialisation
+
+- (id)init
+{
+    self = [super init];
+    if (self)
+    {
+        _timelineId = [[NSUUID UUID] UUIDString];
+        eventListeners = [NSMutableArray array];
+    }
+    return self;
+}
+
 - (id)initWithRoom:(MXRoom*)theRoom andInitialEventId:(NSString*)initialEventId
 {
     // Is it a past or live timeline?
@@ -90,14 +102,12 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
 
 - (id)initWithRoom:(MXRoom*)theRoom initialEventId:(NSString*)initialEventId andStore:(id<MXStore>)theStore
 {
-    self = [super init];
+    self = [self init];
     if (self)
     {
-        _timelineId = [[NSUUID UUID] UUIDString];
         _initialEventId = initialEventId;
         room = theRoom;
         store = theStore;
-        eventListeners = [NSMutableArray array];
 
         if (!initialEventId)
         {
@@ -933,6 +943,24 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
     [room.mxSession decryptEvents:events inTimeline:_timelineId onComplete:^(NSArray<MXEvent *> *failedEvents) {
         onComplete();
     }];
+}
+
+
+#pragma mark - NSCopying
+
+- (nonnull id)copyWithZone:(nullable NSZone *)zone
+{
+    MXEventTimeline *timeline = [[MXEventTimeline allocWithZone:zone] init];
+    timeline->_initialEventId = _initialEventId;
+    timeline->_roomEventFilter = _roomEventFilter;
+    timeline->_state = [_state copyWithZone:zone];
+    timeline->room = room;
+    timeline->store = store;
+    
+    // There can be only a single live timeline
+    timeline->_isLiveTimeline = NO;
+    
+    return timeline;
 }
 
 @end

--- a/MatrixSDK/Data/MXEventTimeline.m
+++ b/MatrixSDK/Data/MXEventTimeline.m
@@ -955,7 +955,7 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
 
 - (nonnull id)copyWithZone:(nullable NSZone *)zone
 {
-    MXEventTimeline *timeline = [[MXEventTimeline allocWithZone:zone] init];
+    MXEventTimeline *timeline = [[self class] allocWithZone:zone];
     timeline->_initialEventId = _initialEventId;
     timeline->_roomEventFilter = _roomEventFilter;
     timeline->_state = [_state copyWithZone:zone];

--- a/MatrixSDK/Data/MXEventTimeline.m
+++ b/MatrixSDK/Data/MXEventTimeline.m
@@ -70,7 +70,7 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
 
 #pragma mark - Initialisation
 
-- (id)init
+- (instancetype)init
 {
     self = [super init];
     if (self)

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -2377,19 +2377,6 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
     if ([mxSession.store respondsToSelector:@selector(outgoingMessagesInRoom:)])
     {
         NSArray<MXEvent*> *outgoingMessages = [mxSession.store outgoingMessagesInRoom:self.roomId];
-        
-        for (MXEvent *event in outgoingMessages)
-        {
-            // Decrypt event if necessary
-            if (event.eventType == MXEventTypeRoomEncrypted)
-            {
-                if (![self.mxSession decryptEvent:event inTimeline:nil])
-                {
-                    NSLog(@"[MXRoom] outgoingMessages: Warning: Unable to decrypt outgoing event: %@", event.decryptionError);
-                }
-            }
-        }
-        
         return outgoingMessages;
     }
     else

--- a/MatrixSDK/Data/MXRoomSummary.m
+++ b/MatrixSDK/Data/MXRoomSummary.m
@@ -225,10 +225,17 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
         }
     }
     
+    if (!lastMessageEvent)
+    {
+        NSLog(@"[MXRoomSummary] loadLastEvent: Cannot find event %@ in store", _lastMessageEventId);
+        onComplete();
+        return;
+    }
+    
     [_mxSession decryptEvents:@[lastMessageEvent] inTimeline:nil onComplete:^(NSArray<MXEvent *> *failedEvents) {
         if (failedEvents.count)
         {
-            NSLog(@"[MXRoomSummary] lastMessageEvent: Warning: Unable to decrypt event. Error: %@", self.lastMessageEvent.decryptionError);
+            NSLog(@"[MXRoomSummary] loadLastEvent: Warning: Unable to decrypt event. Error: %@", self.lastMessageEvent.decryptionError);
         }
         onComplete();
     }];

--- a/MatrixSDK/MXSession.h
+++ b/MatrixSDK/MXSession.h
@@ -1451,12 +1451,14 @@ typedef void (^MXOnBackgroundSyncFail)(NSError *error);
 /**
  Decrypt an event and update its data.
 
+ @warning This method is deprecated, use -[MXSession decryptEvents:inTimeline:onComplete:] instead.
+ 
  @param event the event to decrypt.
  @param timeline the id of the timeline where the event is decrypted. It is used
         to prevent replay attack.
  @return YES if decryption is successful.
  */
-- (BOOL)decryptEvent:(MXEvent*)event inTimeline:(NSString*)timeline;
+- (BOOL)decryptEvent:(MXEvent*)event inTimeline:(NSString*)timeline  __attribute__((deprecated("use -[MXSession decryptEvents:inTimeline:onComplete:] instead")));
 
 /**
  Decrypt events asynchronously and update their data.

--- a/MatrixSDKTests/MXCryptoTests.m
+++ b/MatrixSDKTests/MXCryptoTests.m
@@ -1721,17 +1721,19 @@
                 [bobSession eventWithEventId:eventId inRoom:roomId success:^(MXEvent *event) {
                     
                     // -> But he does not have keys decrypt it
-                    BOOL hasKeys = [bobSession.crypto hasKeysToDecryptEvent:event];
-                    XCTAssertFalse(hasKeys);
-                    
-                    // - Bob resumes his session
-                    [bobSession resume:^{
+                    [bobSession.crypto hasKeysToDecryptEvent:event onComplete:^(BOOL hasKeys) {
+                        XCTAssertFalse(hasKeys);
                         
-                        // -> He has keys now
-                        BOOL hasKeys = [bobSession.crypto hasKeysToDecryptEvent:event];
-                        XCTAssertTrue(hasKeys);
-                        
-                        [expectation fulfill];
+                        // - Bob resumes his session
+                        [bobSession resume:^{
+                            
+                            // -> He has keys now
+                            [bobSession.crypto hasKeysToDecryptEvent:event onComplete:^(BOOL hasKeys) {
+                                XCTAssertTrue(hasKeys);
+                                
+                                [expectation fulfill];
+                            }];
+                        }];
                     }];
 
                 } failure:^(NSError *error) {


### PR DESCRIPTION
Finish the work started in #1091.

Decryptions do not happen anymore on the main thread.
Synchronous decryption methods are marked as deprecated. 

This makes the app much more reactive.