### PR TITLE
Remove useless decryptions on /sync

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Changes to be released in next version
  * MXEventTimeline: Add NSCopying implementation so that another pagination can be done on the same set of data.
  * MXCrypto: eventDeviceInfo: Do not synchronise anymore the operation with the decryption queue.
  * MXRoomSummary: Improve reset resetLastMessage to avoid pagination loop and to limit number of decryptions.
+ * MXSession: Limit the number of decryptions when processing an initial sync (vector-im/element-ios/issues/4307).
 
 🐛 Bugfix
  * MXRoomSummary: Fix decryption of the last message when it is edited (vector-im/element-ios/issues/4322).

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ Changes to be released in next version
  * MXSession: Make the eventWithEventId method decrypt the event if needed.
  * MXEventTimeline: Add NSCopying implementation so that another pagination can be done on the same set of data.
  * MXCrypto: eventDeviceInfo: Do not synchronise anymore the operation with the decryption queue.
+ * MXRoomSummary: Improve reset resetLastMessage to avoid pagination loop and to limit number of decryptions.
 
 🐛 Bugfix
  * MXRoomSummary: Fix decryption of the last message when it is edited (vector-im/element-ios/issues/4322).

--- a/MatrixSDK/Data/MXEventTimeline.m
+++ b/MatrixSDK/Data/MXEventTimeline.m
@@ -955,7 +955,7 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
 
 - (nonnull id)copyWithZone:(nullable NSZone *)zone
 {
-    MXEventTimeline *timeline = [[self class] allocWithZone:zone];
+    MXEventTimeline *timeline = [[[self class] allocWithZone:zone] init];
     timeline->_initialEventId = _initialEventId;
     timeline->_roomEventFilter = _roomEventFilter;
     timeline->_state = [_state copyWithZone:zone];

--- a/MatrixSDK/Data/MXRoom.h
+++ b/MatrixSDK/Data/MXRoom.h
@@ -1049,15 +1049,7 @@ Remove a tag applied on an event of the room
                    success:(void (^)(MXCall *call))success
                    failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
-#pragma mark - Read receipts management
-
-/**
- Handle a receipt event.
- 
- @param event the event to handle.
- @param direction the timeline direction.
- */
-- (BOOL)handleReceiptEvent:(MXEvent *)event direction:(MXTimelineDirection)direction;
+#pragma mark - Read receipts
 
 /**
  If the event was not acknowledged yet, this method acknowlegdes it by sending a receipt event.

--- a/MatrixSDK/Data/MXRoomSummary.h
+++ b/MatrixSDK/Data/MXRoomSummary.h
@@ -43,6 +43,8 @@
  */
 FOUNDATION_EXPORT NSString *const kMXRoomSummaryDidChangeNotification;
 
+/// Number of events retrieved when doing pagination from the homeserver.
+FOUNDATION_EXPORT NSUInteger const MXRoomSummaryPaginationChunkSize;
 
 /**
  `MXRoomSummary` exposes and caches data for a room.
@@ -254,18 +256,32 @@ FOUNDATION_EXPORT NSString *const kMXRoomSummaryDidChangeNotification;
 -(void)loadLastEvent:(void (^)(void))onComplete;
 
 /**
- Reset the last message.
+ Reset the last message from data in the store.
  
- The operation is asynchronous as it may require pagination from the homeserver.
- 
- @param complete A block object called when the operation completes.
+ @param onComplete A block object called when the operation completes.
  @param failure A block object called when the operation fails.
  @param commit  Tell whether the updated room summary must be committed to the store. Use NO when a more
  global [MXStore commit] will happen. This optimises IO.
 
  @return a MXHTTPOperation instance.
  */
-- (MXHTTPOperation*)resetLastMessage:(void (^)(void))complete failure:(void (^)(NSError *))failure commit:(BOOL)commit;
+- (MXHTTPOperation*)resetLastMessage:(void (^)(void))onComplete failure:(void (^)(NSError *))failure commit:(BOOL)commit;
+
+/**
+ Reset the last message by paginating messages from the homeserver if needed.
+ 
+ @param maxServerPaginationCount The max number of messages to retrieve from the server.
+ @param onComplete A block object called when the operation completes.
+ @param failure A block object called when the operation fails.
+ @param commit  Tell whether the updated room summary must be committed to the store. Use NO when a more
+ global [MXStore commit] will happen. This optimises IO.
+ 
+ @return a MXHTTPOperation instance.
+ */
+- (MXHTTPOperation *)resetLastMessageWithMaxServerPaginationCount:(NSUInteger)maxServerPaginationCount
+                                                       onComplete:(void (^)(void))onComplete
+                                                          failure:(void (^)(NSError *))failure
+                                                           commit:(BOOL)commit;
 
 
 #pragma mark - Data related to business logic

--- a/MatrixSDK/Data/MXRoomSummary.h
+++ b/MatrixSDK/Data/MXRoomSummary.h
@@ -357,8 +357,9 @@ FOUNDATION_EXPORT NSString *const kMXRoomSummaryDidChangeNotification;
  Note: state events have been previously sent to `handleStateEvents`.
 
  @param roomSync information to sync the room with the home server data.
+ @param onComplete the block called when the operation completes.
  */
-- (void)handleJoinedRoomSync:(MXRoomSync*)roomSync;
+- (void)handleJoinedRoomSync:(MXRoomSync*)roomSync onComplete:(void (^)(void))onComplete;
 
 /**
  Update the invited room state according to the provided data.

--- a/MatrixSDK/Data/MXRoomSummary.m
+++ b/MatrixSDK/Data/MXRoomSummary.m
@@ -661,7 +661,7 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
     }
 }
 
-- (void)handleJoinedRoomSync:(MXRoomSync*)roomSync
+- (void)handleJoinedRoomSync:(MXRoomSync*)roomSync onComplete:(void (^)(void))onComplete
 {
     MXWeakify(self);
     [self.room state:^(MXRoomState *roomState) {
@@ -732,7 +732,8 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
         {
             [self save:NO];
         }
-
+        
+        onComplete();
     }];
 }
 

--- a/MatrixSDK/Data/MXRoomSummary.m
+++ b/MatrixSDK/Data/MXRoomSummary.m
@@ -41,6 +41,7 @@ typedef NS_ENUM(NSUInteger, MXRoomSummaryNextTrustComputation) {
 
 
 NSString *const kMXRoomSummaryDidChangeNotification = @"kMXRoomSummaryDidChangeNotification";
+NSUInteger const MXRoomSummaryPaginationChunkSize = 50;
 
 /**
  Time to wait before refreshing trust when a change has been detected.
@@ -254,7 +255,12 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
     _isLastMessageEncrypted = event.isEncrypted;
 }
 
-- (MXHTTPOperation *)resetLastMessage:(void (^)(void))complete failure:(void (^)(NSError *))failure commit:(BOOL)commit
+- (MXHTTPOperation *)resetLastMessage:(void (^)(void))onComplete failure:(void (^)(NSError *))failure commit:(BOOL)commit
+{
+    return [self resetLastMessageWithMaxServerPaginationCount:0 onComplete:onComplete failure:failure commit:commit];
+}
+
+- (MXHTTPOperation *)resetLastMessageWithMaxServerPaginationCount:(NSUInteger)maxServerPaginationCount onComplete:(void (^)(void))onComplete failure:(void (^)(NSError *))failure commit:(BOOL)commit
 {
     lastMessageEvent = nil;
     _lastMessageEventId = nil;
@@ -263,16 +269,21 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
     _lastMessageAttributedString = nil;
     [_lastMessageOthers removeAllObjects];
 
-    return [self fetchLastMessage:complete failure:failure timeline:nil onlyFromStore:YES operation:nil commit:commit];
+    return [self fetchLastMessageWithMaxServerPaginationCount:maxServerPaginationCount onComplete:^{
+        if (onComplete)
+        {
+            onComplete();
+        }
+    } failure:failure timeline:nil operation:nil commit:commit];
 }
 
 /**
  Find recursively the event to be used as last message.
 
- @param complete A block object called when the operation completes.
+ @param maxServerPaginationCount The max number of messages to retrieve from the server.
+ @param onComplete A block object called when the operation completes.
  @param failure A block object called when the operation fails.
- @param liveTimeline the timeline to use to paginate and get more events.
- @param onlyFromStore YES for the first call. For quickness, we want to avoid any HTTP requests at first.
+ @param timeline the timeline to use to paginate and get more events.
  @param operation the current http operation if any.
         The method may need several requests before fetching the right last message.
         If it happens, the first one is mutated to the others with [MXHTTPOperation mutateTo:].
@@ -280,11 +291,11 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
         global [MXStore commit] will happen. This optimises IO.
  @return a MXHTTPOperation
  */
-- (MXHTTPOperation *)fetchLastMessage:(void (^)(void))complete
-                              failure:(void (^)(NSError *))failure
-                             timeline:(MXEventTimeline *)timeline
-                        onlyFromStore:(BOOL)onlyFromStore
-                            operation:(MXHTTPOperation *)operation commit:(BOOL)commit
+- (MXHTTPOperation *)fetchLastMessageWithMaxServerPaginationCount:(NSUInteger)maxServerPaginationCount
+                                                       onComplete:(void (^)(void))onComplete
+                                                          failure:(void (^)(NSError *))failure
+                                                         timeline:(MXEventTimeline *)timeline
+                                                        operation:(MXHTTPOperation *)operation commit:(BOOL)commit
 {
     // Sanity checks
     MXRoom *room = self.room;
@@ -310,7 +321,7 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
             // Use a copy of the live timeline to avoid any conflicts with listeners to the unique live timeline
             MXEventTimeline *timeline = [liveTimeline copy];
             [timeline resetPagination];
-            [self fetchLastMessage:complete failure:failure timeline:timeline onlyFromStore:onlyFromStore operation:operation commit:commit];
+            [self fetchLastMessageWithMaxServerPaginationCount:maxServerPaginationCount onComplete:onComplete failure:failure timeline:timeline operation:operation commit:commit];
         }];
         return operation;
     }
@@ -318,10 +329,7 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
     // Make sure we can still paginate
     if (![timeline canPaginate:MXTimelineDirectionBackwards])
     {
-        if (complete)
-        {
-            complete();
-        }
+        onComplete();
         return operation;
     }
     
@@ -335,27 +343,63 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
         }
     }];
     
-    // Back paginate. First only from the store. Then, allow pagination requests to the homeserver
-    MXHTTPOperation *newOperation = [timeline paginate:30 direction:MXTimelineDirectionBackwards onlyFromStore:onlyFromStore complete:^{
-        if (lastMessageUpdated)
-        {
-            // We are done
-            [self save:commit];
-            
-            if (complete)
+   
+    if (timeline.remainingMessagesForBackPaginationInStore)
+    {
+        // First, for performance reason, read messages only from the store
+        // Do it one by one to decrypt the minimal number of events.
+        MXHTTPOperation *newOperation = [timeline paginate:1 direction:MXTimelineDirectionBackwards onlyFromStore:YES complete:^{
+            if (lastMessageUpdated)
             {
-                complete();
+                // We are done
+                [self save:commit];
+                onComplete();
             }
-        }
-        else
-        {
-            // Need more message
-            [self fetchLastMessage:complete failure:failure timeline:timeline onlyFromStore:NO operation:operation commit:commit];
-        }
+            else
+            {
+                // Need more messages
+                [self fetchLastMessageWithMaxServerPaginationCount:maxServerPaginationCount onComplete:onComplete failure:failure timeline:timeline operation:operation commit:commit];
+            }
+            
+        } failure:failure];
         
-    } failure:failure];
-    
-    [operation mutateTo:newOperation];
+        [operation mutateTo:newOperation];
+    }
+    else if (maxServerPaginationCount)
+    {
+        // If requested, get messages from the homeserver
+        // Fetch them by batch of 50 messages
+        NSUInteger paginationCount = MIN(maxServerPaginationCount, MXRoomSummaryPaginationChunkSize);
+        NSLog(@"[MXRoomSummary] fetchLastMessage: paginate %@ (%@) messages from the server in %@", @(paginationCount), @(maxServerPaginationCount), _roomId);
+        
+        MXHTTPOperation *newOperation = [timeline paginate:paginationCount direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^{
+            if (lastMessageUpdated)
+            {
+                // We are done
+                [self save:commit];
+                onComplete();
+            }
+            else if (maxServerPaginationCount > MXRoomSummaryPaginationChunkSize)
+            {
+                NSLog(@"[MXRoomSummary] fetchLastMessage: Failed to find last message in %@. Paginate more...", self.roomId);
+                NSUInteger newMaxServerPaginationCount = maxServerPaginationCount - MXRoomSummaryPaginationChunkSize;
+                [self fetchLastMessageWithMaxServerPaginationCount:newMaxServerPaginationCount onComplete:onComplete failure:failure timeline:timeline operation:operation commit:commit];
+            }
+            else
+            {
+                NSLog(@"[MXRoomSummary] fetchLastMessage: Failed to find last message in %@. Stop paginating.", self.roomId);
+                onComplete();
+            }
+            
+        } failure:failure];
+        
+        [operation mutateTo:newOperation];
+    }
+    else
+    {
+        NSLog(@"[MXRoomSummary] fetchLastMessage: Failed to find last message in %@.", self.roomId);
+        onComplete();
+    }
     
     return operation;
 }

--- a/MatrixSDK/MXSession.h
+++ b/MatrixSDK/MXSession.h
@@ -1458,7 +1458,7 @@ typedef void (^MXOnBackgroundSyncFail)(NSError *error);
         to prevent replay attack.
  @return YES if decryption is successful.
  */
-- (BOOL)decryptEvent:(MXEvent*)event inTimeline:(NSString*)timeline  __attribute__((deprecated("use -[MXSession decryptEvents:inTimeline:onComplete:] instead")));
+- (BOOL)decryptEvent:(MXEvent*)event inTimeline:(NSString*)timeline __attribute__((deprecated("use -[MXSession decryptEvents:inTimeline:onComplete:] instead")));
 
 /**
  Decrypt events asynchronously and update their data.

--- a/MatrixSDK/MXSession.h
+++ b/MatrixSDK/MXSession.h
@@ -1020,8 +1020,11 @@ typedef void (^MXOnBackgroundSyncFail)(NSError *error);
  
  This may lead to pagination requests to the homeserver. Updated room summaries will be 
  notified by `kMXRoomSummaryDidChangeNotification`.
+ 
+ @param maxServerPaginationCount the maximal number of messages to paginate from the homeserver. Default is 50.
  */
 - (void)fixRoomsSummariesLastMessage;
+- (void)fixRoomsSummariesLastMessageWithMaxServerPaginationCount:(NSUInteger)maxServerPaginationCount;
 
 /**
  Delegate for updating room summaries.

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -2816,18 +2816,23 @@ typedef void (^MXOnResumeDone)(void);
 
 - (void)fixRoomsSummariesLastMessage
 {
+    [self fixRoomsSummariesLastMessageWithMaxServerPaginationCount:MXRoomSummaryPaginationChunkSize];
+}
+
+- (void)fixRoomsSummariesLastMessageWithMaxServerPaginationCount:(NSUInteger)maxServerPaginationCount
+{
     for (MXRoomSummary *summary in self.roomsSummaries)
     {
         if (!summary.lastMessageEventId)
         {
-            NSLog(@"[MXSession] Fixing last message for room %@", summary.roomId);
+            NSLog(@"[MXSession] fixRoomsSummariesLastMessage: Fixing last message for room %@", summary.roomId);
             
-            [summary resetLastMessage:^{
-                NSLog(@"[MXSession] Fixing last message operation for room %@ has complete. lastMessageEventId: %@", summary.roomId, summary.lastMessageEventId);
+            [summary resetLastMessageWithMaxServerPaginationCount:maxServerPaginationCount onComplete:^{
+                NSLog(@"[MXSession] fixRoomsSummariesLastMessage:Fixing last message operation for room %@ has complete. lastMessageEventId: %@", summary.roomId, summary.lastMessageEventId);
             } failure:^(NSError *error) {
-                NSLog(@"[MXSession] Cannot fix last message for room %@", summary.roomId);
+                NSLog(@"[MXSession] fixRoomsSummariesLastMessage: Cannot fix last message for room %@ with maxServerPaginationCount: %@", summary.roomId, @(maxServerPaginationCount));
             }
-                               commit:NO];
+                                                           commit:NO];
         }
     }
     

--- a/MatrixSDKTests/MXRoomSummaryTests.m
+++ b/MatrixSDKTests/MXRoomSummaryTests.m
@@ -283,7 +283,7 @@ NSString *uisiString = @"The sender's device has not sent us the keys for this m
                 }];
 
                 // Force the summary to fetch events from the homeserver to get the last one
-                MXHTTPOperation *operation = [summary2 resetLastMessage:nil failure:^(NSError *error) {
+                MXHTTPOperation *operation = [summary2 resetLastMessageWithMaxServerPaginationCount:100 onComplete:nil failure:^(NSError *error) {
 
                     XCTFail(@"The operation should not fail - NSError: %@", error);
                     [expectation fulfill];
@@ -337,7 +337,7 @@ NSString *uisiString = @"The sender's device has not sent us the keys for this m
 
 
                     // Force the summary to fetch events from the homeserver to get the last one
-                    MXHTTPOperation *operation = [summary2 resetLastMessage:nil failure:^(NSError *error) {
+                    MXHTTPOperation *operation = [summary2 resetLastMessageWithMaxServerPaginationCount:1000 onComplete:nil failure:^(NSError *error) {
 
                         XCTFail(@"The operation should not fail - NSError: %@", error);
                         [expectation fulfill];


### PR DESCRIPTION
Fix vector-im/element-ios/issues/4307.

On my account, time spent to decrypt events from an initial sync is 2.8 seconds with this PR instead of 10.7s (it was 12.4s in 1.3.9). It decrypts 467 events instead of 2083 before.

This PR also removes useless paginations made to fix last room message.