### PR TITLE
fix: update media/v1 to media/r0

### DIFF
--- a/MatrixSDK/MXEnumConstants.m
+++ b/MatrixSDK/MXEnumConstants.m
@@ -22,7 +22,7 @@
  Matrix content respository path
  */
 NSString *const kMXContentUriScheme  = @"mxc://";
-NSString *const kMXContentPrefixPath = @"_matrix/media/v1";
+NSString *const kMXContentPrefixPath = @"_matrix/media/r0";
 
 /**
  Prefix used in path of antivirus server API requests.


### PR DESCRIPTION
For some reason Element ios still uses /_matrix/media/v1 endpoints. These are outdated and not in the spec anymore. They have been replace by /_matrix/media/r0 ( https://matrix.org/docs/spec/client_server/r0.6.1#id67 ).

I grepped this repository and found this one occurrence and replaced it. There was one other instance "_matrix/media/v1/identicon/%40mxbob" in MatrixSDKTests/MXMyUserTests.m, but I left it at v1 because indenticon is not in the spec. Tell me if I should update this too.

I don't have an iOS device and could not even build the repository to test it, so please review carefully :).

* [x] Pull request is based on the develop branch
* [ ] Pull request updates [CHANGES.rst](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CHANGES.rst)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)

Signed-off-by: Timo Kösters <timo@koesters.xyz>