### PR TITLE
VoIP: Check Remote partyId for select_answer Events

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Changes to be released in next version
 
 🐛 Bugfix
  * MXRoomSummary: Fix decryption of the last message when it is edited (vector-im/element-ios/issues/4322).
+ * MXCall: Check remote partyId for select_answer events (vector-im/element-ios/issues/4337).
 
 ⚠️ API Changes
  * MXRoom: MXRoom.outgoingMessages does not decrypt messages anymore. Use MXSession.decryptEvents to get decrypted events.

--- a/MatrixSDK/VoIP/MXCall.m
+++ b/MatrixSDK/VoIP/MXCall.m
@@ -1103,7 +1103,8 @@ NSString *const kMXCallSupportsTransferringStatusDidChange = @"kMXCallSupportsTr
             }];
         };
         
-        if ([content.version isEqualToString:kMXCallVersion])
+        //  The content doesn't have to have a partyId, as `content.version` fallbacks to `kMXCallVersion` if not provided.
+        if ([content.version isEqualToString:kMXCallVersion] && content.partyId)
         {
             NSDictionary *selectAnswerContent = @{
                 @"call_id": self.callId,


### PR DESCRIPTION
Fix vector-im/element-ios#4337