### PR TITLE
MXKeyBackup: Do not reset the backup if forceRefresh() is called too early

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Changes to be released in next version
  * MXRoomSummary: Improve reset resetLastMessage to avoid pagination loop and to limit number of decryptions.
  * MXSession: Limit the number of decryptions when processing an initial sync (vector-im/element-ios/issues/4307).
  * Adapt sync response models to new sync API (vector-im/element-ios/issues/4309).
+ * MXKeyBackup: Do not reset the backup if forceRefresh() is called too early.
 
 🐛 Bugfix
  * MXRoomSummary: Fix decryption of the last message when it is edited (vector-im/element-ios/issues/4322).

--- a/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.m
+++ b/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.m
@@ -634,6 +634,21 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
 - (MXHTTPOperation*)forceRefresh:(nullable void (^)(BOOL valid))success
                          failure:(nullable void (^)(NSError *error))failure
 {
+    if (_state == MXKeyBackupStateUnknown || _state == MXKeyBackupStateCheckingBackUpOnHomeserver)
+    {
+        NSLog(@"[MXKeyBackup] forceRefresh: Invalid state (%@) to force the refresh", @(_state));
+        if (failure)
+        {
+            NSError *error = [NSError errorWithDomain:MXKeyBackupErrorDomain
+                                                 code:MXKeyBackupErrorInvalidStateCode
+                                             userInfo:@{
+                                                 NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Invalid state (%@) to force the refresh of the backup", @(_state)]
+                                             }];
+            failure(error);
+        }
+        return nil;
+    }
+    
     // Fetch the last backup version on the server, compare it to the backup version
     // currently used. If versions are not the same, the current backup is forgotten and
     // checkAndStartKeyBackup is called in order to restart on the last version on the HS.


### PR DESCRIPTION
which what element does now with recent changes on its navigation.

At
https://github.com/vector-im/element-ios/blob/v1.3.9/Riot/Modules/Common/Recents/DataSources/RecentsDataSource.m#L166, `self.mxSession.crypto` used to be nil at startup. With the new navigation, it is no more nil but the crypto and backup is not fully started. Before this commit, it reset the backup on every startup.