### PR TITLE
Consolidate logging mechanism

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@ Changes to be released in next version
  * Pod: Update Realm to 10.7.6.
  * Pod: Update Jitsi to 3.5.0.
  * MXRealmCryptoStore: Use Realm instances as read-only in background store (vector-im/element-ios/issues/4352).
+ * MXLog: centralised logging facility, use everywhere instead of NSLog (vector-im/element-ios/issues/4351).
 
 🐛 Bugfix
  * MXRoomSummary: Fix decryption of the last message when it is edited (vector-im/element-ios/issues/4322).

--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -36,6 +36,8 @@ Pod::Spec.new do |s|
       ss.dependency 'AFNetworking', '~> 4.0.0'
       ss.dependency 'GZIP', '~> 1.3.0'
 
+      ss.dependency 'SwiftyBeaver', '1.9.5'
+
       # Requirements for e2e encryption
       ss.dependency 'OLMKit', '~> 3.2.2'
       ss.dependency 'Realm', '10.7.6'

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -17,6 +17,10 @@
 		02CAD43B217DD12F0074700B /* MXContentScanEncryptedBody.h in Headers */ = {isa = PBXBuildFile; fileRef = 02CAD437217DD12F0074700B /* MXContentScanEncryptedBody.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0696FFB36962606A28BEC38E /* libPods-MatrixSDK-MatrixSDK-iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B57EF0A39A7649D55CA1208A /* libPods-MatrixSDK-MatrixSDK-iOS.a */; };
 		15C934E526232442DE7A79DE /* libPods-MatrixSDKTests-iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7290AD6ED063E2E323E9485C /* libPods-MatrixSDKTests-iOS.a */; };
+		189CC081265E361C00BE1FD8 /* MXLog.h in Headers */ = {isa = PBXBuildFile; fileRef = 189CC07F265E361500BE1FD8 /* MXLog.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		189CC082265E361D00BE1FD8 /* MXLog.h in Headers */ = {isa = PBXBuildFile; fileRef = 189CC07F265E361500BE1FD8 /* MXLog.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		189CC083265E362600BE1FD8 /* MXLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 189CC080265E361500BE1FD8 /* MXLog.swift */; };
+		189CC084265E362700BE1FD8 /* MXLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 189CC080265E361500BE1FD8 /* MXLog.swift */; };
 		3209683126396385005D64ED /* AllTestsWithSanitizers.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = 3209682F26396385005D64ED /* AllTestsWithSanitizers.xctestplan */; };
 		3209683226396385005D64ED /* AllTestsWithSanitizers.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = 3209682F26396385005D64ED /* AllTestsWithSanitizers.xctestplan */; };
 		3209683326396385005D64ED /* UnitTestsWithSanitizers.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = 3209683026396385005D64ED /* UnitTestsWithSanitizers.xctestplan */; };
@@ -1540,6 +1544,8 @@
 		02CAD436217DD12F0074700B /* MXContentScanEncryptedBody.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXContentScanEncryptedBody.m; sourceTree = "<group>"; };
 		02CAD437217DD12F0074700B /* MXContentScanEncryptedBody.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXContentScanEncryptedBody.h; sourceTree = "<group>"; };
 		15D7F292D95EB58AEE801C4E /* libPods-MatrixSDKTests-macOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-MatrixSDKTests-macOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		189CC07F265E361500BE1FD8 /* MXLog.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXLog.h; sourceTree = "<group>"; };
+		189CC080265E361500BE1FD8 /* MXLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXLog.swift; sourceTree = "<group>"; };
 		19B6947FC794531CEEDCFA7F /* Pods-MatrixSDKTests-macOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MatrixSDKTests-macOS.release.xcconfig"; path = "Target Support Files/Pods-MatrixSDKTests-macOS/Pods-MatrixSDKTests-macOS.release.xcconfig"; sourceTree = "<group>"; };
 		3209682F26396385005D64ED /* AllTestsWithSanitizers.xctestplan */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = AllTestsWithSanitizers.xctestplan; sourceTree = "<group>"; };
 		3209683026396385005D64ED /* UnitTestsWithSanitizers.xctestplan */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = UnitTestsWithSanitizers.xctestplan; sourceTree = "<group>"; };
@@ -2497,42 +2503,44 @@
 		320DFDD619DD99B60068622A /* Utils */ = {
 			isa = PBXGroup;
 			children = (
-				3259D00E2603722A00C365DB /* Protocols */,
-				323F87712554607A009E9E67 /* Profiling */,
 				F08B8D591E014711006171A8 /* Categories */,
 				F03EF4F91DF014D9009DF592 /* Media */,
+				323F87712554607A009E9E67 /* Profiling */,
+				3259D00E2603722A00C365DB /* Protocols */,
 				B146D46E21A5939000D8C2C6 /* Realm */,
-				32B090E1261F709B002924AA /* MXAsyncTaskQueue.swift */,
-				F03EF5021DF01596009DF592 /* MXLRUCache.h */,
-				F03EF5031DF01596009DF592 /* MXLRUCache.m */,
-				320DFDD719DD99B60068622A /* MXHTTPClient.h */,
-				322DB456212EB8E600F4EFE9 /* MXHTTPClient_Private.h */,
-				320DFDD819DD99B60068622A /* MXHTTPClient.m */,
-				32CAB1091A925B41008C5BB9 /* MXHTTPOperation.h */,
-				32CAB10A1A925B41008C5BB9 /* MXHTTPOperation.m */,
-				329FB1771A0A74B100A5E88E /* MXTools.h */,
-				329FB1781A0A74B100A5E88E /* MXTools.m */,
-				327E37B41A974F75007F026F /* MXLogger.h */,
-				327E37B51A974F75007F026F /* MXLogger.m */,
-				324676EB25C15F4600EA855B /* MXMemory.swift */,
 				32322A491E575F65005DD155 /* MXAllowedCertificates.h */,
 				32322A4A1E575F65005DD155 /* MXAllowedCertificates.m */,
 				C6FE1EEF1E65C4F7008587E4 /* MXAnalyticsDelegate.h */,
-				3283F7761EAF30F700C1688C /* MXBugReportRestClient.h */,
-				3283F7771EAF30F700C1688C /* MXBugReportRestClient.m */,
+				32B090E1261F709B002924AA /* MXAsyncTaskQueue.swift */,
 				32A9E8211EF4026E0081358A /* MXBackgroundModeHandler.h */,
-				32A9E8221EF4026E0081358A /* MXUIKitBackgroundModeHandler.h */,
-				32A9E8231EF4026E0081358A /* MXUIKitBackgroundModeHandler.m */,
-				3251D41E25AF01D7001E6E77 /* MXUIKitApplicationStateService.swift */,
-				32A9770221626E5C00919CC0 /* MXServerNotices.h */,
-				32A9770321626E5C00919CC0 /* MXServerNotices.m */,
 				B11976FD236B27220001EC86 /* MXBackgroundTask.h */,
-				B17B2BDA2369FC81009D6650 /* MXUIKitBackgroundTask.h */,
-				B17B2BDB2369FC81009D6650 /* MXUIKitBackgroundTask.m */,
 				B1798D0424091A0100308A8F /* MXBase64Tools.h */,
 				B1798D0524091A0100308A8F /* MXBase64Tools.m */,
+				3283F7761EAF30F700C1688C /* MXBugReportRestClient.h */,
+				3283F7771EAF30F700C1688C /* MXBugReportRestClient.m */,
+				322DB456212EB8E600F4EFE9 /* MXHTTPClient_Private.h */,
+				320DFDD719DD99B60068622A /* MXHTTPClient.h */,
+				320DFDD819DD99B60068622A /* MXHTTPClient.m */,
+				32CAB1091A925B41008C5BB9 /* MXHTTPOperation.h */,
+				32CAB10A1A925B41008C5BB9 /* MXHTTPOperation.m */,
+				327E37B41A974F75007F026F /* MXLogger.h */,
+				327E37B51A974F75007F026F /* MXLogger.m */,
+				189CC07F265E361500BE1FD8 /* MXLog.h */,
+				189CC080265E361500BE1FD8 /* MXLog.swift */,
+				F03EF5021DF01596009DF592 /* MXLRUCache.h */,
+				F03EF5031DF01596009DF592 /* MXLRUCache.m */,
+				324676EB25C15F4600EA855B /* MXMemory.swift */,
+				32A9770221626E5C00919CC0 /* MXServerNotices.h */,
+				32A9770321626E5C00919CC0 /* MXServerNotices.m */,
 				32A9F8DC244720B10069C65B /* MXThrottler.h */,
 				32A9F8DD244720B10069C65B /* MXThrottler.m */,
+				329FB1771A0A74B100A5E88E /* MXTools.h */,
+				329FB1781A0A74B100A5E88E /* MXTools.m */,
+				3251D41E25AF01D7001E6E77 /* MXUIKitApplicationStateService.swift */,
+				32A9E8221EF4026E0081358A /* MXUIKitBackgroundModeHandler.h */,
+				32A9E8231EF4026E0081358A /* MXUIKitBackgroundModeHandler.m */,
+				B17B2BDA2369FC81009D6650 /* MXUIKitBackgroundTask.h */,
+				B17B2BDB2369FC81009D6650 /* MXUIKitBackgroundTask.m */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -4059,6 +4067,7 @@
 				B146D4E621A5AEF200D8C2C6 /* MXRealmMediaScan.h in Headers */,
 				32581DE823C8C0C900832EAA /* MXUserTrustLevel.h in Headers */,
 				B146D4EF21A5AF7F00D8C2C6 /* MXRealmEventScan.h in Headers */,
+				189CC081265E361C00BE1FD8 /* MXLog.h in Headers */,
 				B146D49C21A5A04300D8C2C6 /* MXMediaScanStoreDelegate.h in Headers */,
 				32322A4B1E575F65005DD155 /* MXAllowedCertificates.h in Headers */,
 				B14EECD72577DE7A00448735 /* MXLoginSSOIdentityProvider.h in Headers */,
@@ -4637,6 +4646,7 @@
 				B14EF33A2397E90400758AF0 /* MXLoginPolicyData.h in Headers */,
 				B14EF33B2397E90400758AF0 /* MXInvite3PID.h in Headers */,
 				B14EF33C2397E90400758AF0 /* MXFileStore.h in Headers */,
+				189CC082265E361D00BE1FD8 /* MXLog.h in Headers */,
 				B14EF33D2397E90400758AF0 /* MXRealmMediaScanStore.h in Headers */,
 				B14EF3402397E90400758AF0 /* MXKeyBackupVersionTrust.h in Headers */,
 				320B3935239FA56900BE2C06 /* MXKeyVerificationByDMRequest.h in Headers */,
@@ -5212,6 +5222,7 @@
 				C602B58E1F22A8D700B67D87 /* MXImage.swift in Sources */,
 				B105CD9D261E0B70006EB204 /* MXSpaceChildrenSummary.swift in Sources */,
 				32A9F8E0244720B10069C65B /* MXThrottler.m in Sources */,
+				189CC083265E362600BE1FD8 /* MXLog.swift in Sources */,
 				EC8A53E425B1BCC6004E0802 /* MXThirdPartyUsersResponse.m in Sources */,
 				3295401A216385F100E300FC /* MXServerNoticeContent.m in Sources */,
 				B19A30A82404257700FB6F35 /* MXSASKeyVerificationStart.m in Sources */,
@@ -5699,6 +5710,7 @@
 				B14EF2872397E90400758AF0 /* MXPusherData.m in Sources */,
 				324DD2A3246AE1EF00377005 /* MXEncryptedSecretContent.m in Sources */,
 				EC8A53B625B1BC77004E0802 /* MXCallHangupEventContent.m in Sources */,
+				189CC084265E362700BE1FD8 /* MXLog.swift in Sources */,
 				B14EF2882397E90400758AF0 /* MXOlmDevice.m in Sources */,
 				B14766BA23D9D9420091F721 /* MXUsersTrustLevelSummary.m in Sources */,
 				B14EF2892397E90400758AF0 /* MXKeyBackupPassword.m in Sources */,
@@ -5868,7 +5880,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -5923,7 +5935,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = "";
@@ -5948,11 +5960,9 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
-				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = MatrixSDK/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
@@ -5976,11 +5986,9 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
-				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = MatrixSDK/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
@@ -6055,14 +6063,11 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
-				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "$(SRCROOT)/MatrixSDK/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = org.matrix.MatrixSDK;
 				PRODUCT_NAME = MatrixSDK;
@@ -6085,14 +6090,11 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
-				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "$(SRCROOT)/MatrixSDK/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = org.matrix.MatrixSDK;
 				PRODUCT_NAME = MatrixSDK;
@@ -6123,7 +6125,6 @@
 				INFOPLIST_FILE = MatrixSDKTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "matrix.org.MatrixSDKTests-macOS";
@@ -6154,7 +6155,6 @@
 				INFOPLIST_FILE = MatrixSDKTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "matrix.org.MatrixSDKTests-macOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -17,6 +17,10 @@
 		02CAD43B217DD12F0074700B /* MXContentScanEncryptedBody.h in Headers */ = {isa = PBXBuildFile; fileRef = 02CAD437217DD12F0074700B /* MXContentScanEncryptedBody.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0696FFB36962606A28BEC38E /* libPods-MatrixSDK-MatrixSDK-iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B57EF0A39A7649D55CA1208A /* libPods-MatrixSDK-MatrixSDK-iOS.a */; };
 		15C934E526232442DE7A79DE /* libPods-MatrixSDKTests-iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7290AD6ED063E2E323E9485C /* libPods-MatrixSDKTests-iOS.a */; };
+		181FD5D42660C791008EC084 /* MXLogObjcWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 181FD5D22660C791008EC084 /* MXLogObjcWrapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		181FD5D52660C791008EC084 /* MXLogObjcWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 181FD5D22660C791008EC084 /* MXLogObjcWrapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		181FD5D62660C791008EC084 /* MXLogObjcWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 181FD5D32660C791008EC084 /* MXLogObjcWrapper.m */; };
+		181FD5D72660C791008EC084 /* MXLogObjcWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 181FD5D32660C791008EC084 /* MXLogObjcWrapper.m */; };
 		189CC081265E361C00BE1FD8 /* MXLog.h in Headers */ = {isa = PBXBuildFile; fileRef = 189CC07F265E361500BE1FD8 /* MXLog.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		189CC082265E361D00BE1FD8 /* MXLog.h in Headers */ = {isa = PBXBuildFile; fileRef = 189CC07F265E361500BE1FD8 /* MXLog.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		189CC083265E362600BE1FD8 /* MXLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 189CC080265E361500BE1FD8 /* MXLog.swift */; };
@@ -758,7 +762,7 @@
 		B14EF1E32397E90400758AF0 /* MXCall.m in Sources */ = {isa = PBXBuildFile; fileRef = 3245A74D1AF7B2930001D8A7 /* MXCall.m */; };
 		B14EF1E42397E90400758AF0 /* MXWellknownIntegrations.m in Sources */ = {isa = PBXBuildFile; fileRef = 32CF439C2371AF9500907C56 /* MXWellknownIntegrations.m */; };
 		B14EF1E52397E90400758AF0 /* MXLoginPolicy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3275FD9B21A6B60B00B9C13D /* MXLoginPolicy.m */; };
-		B14EF1E62397E90400758AF0 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		B14EF1E62397E90400758AF0 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
 		B14EF1E72397E90400758AF0 /* MXRoomThirdPartyInvite.m in Sources */ = {isa = PBXBuildFile; fileRef = 327F8DB11C6112BA00581CA3 /* MXRoomThirdPartyInvite.m */; };
 		B14EF1E82397E90400758AF0 /* MXRoomPowerLevels.m in Sources */ = {isa = PBXBuildFile; fileRef = B17982F42119E4A2001FD722 /* MXRoomPowerLevels.m */; };
 		B14EF1E92397E90400758AF0 /* MXRealmMediaScanMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = B146D4DE21A5AEF100D8C2C6 /* MXRealmMediaScanMapper.m */; };
@@ -816,7 +820,7 @@
 		B14EF21D2397E90400758AF0 /* MXEncryptedContentKey.m in Sources */ = {isa = PBXBuildFile; fileRef = 021AFBA12179E91800742B2C /* MXEncryptedContentKey.m */; };
 		B14EF21E2397E90400758AF0 /* MXEventDecryptionResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 32F634AA1FC5E3470054EF49 /* MXEventDecryptionResult.m */; };
 		B14EF21F2397E90400758AF0 /* MXMyUser.m in Sources */ = {isa = PBXBuildFile; fileRef = 327137261A24D50A00DB6757 /* MXMyUser.m */; };
-		B14EF2202397E90400758AF0 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		B14EF2202397E90400758AF0 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
 		B14EF2212397E90400758AF0 /* MX3PID.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6F935831E5B3BE600FC34BF /* MX3PID.swift */; };
 		B14EF2222397E90400758AF0 /* MXMediaScan.m in Sources */ = {isa = PBXBuildFile; fileRef = B146D47621A5950800D8C2C6 /* MXMediaScan.m */; };
 		B14EF2232397E90400758AF0 /* MXEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6F935861E5B3BE600FC34BF /* MXEvent.swift */; };
@@ -831,7 +835,7 @@
 		B14EF22C2397E90400758AF0 /* MXAccountData.m in Sources */ = {isa = PBXBuildFile; fileRef = 3264DB901CEC528D00B99881 /* MXAccountData.m */; };
 		B14EF22D2397E90400758AF0 /* MXRealmReactionCount.m in Sources */ = {isa = PBXBuildFile; fileRef = 32133018228B010C0070BA9B /* MXRealmReactionCount.m */; };
 		B14EF22E2397E90400758AF0 /* MXCryptoTools.m in Sources */ = {isa = PBXBuildFile; fileRef = 3250E7C9220C913900736CB5 /* MXCryptoTools.m */; };
-		B14EF22F2397E90400758AF0 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		B14EF22F2397E90400758AF0 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
 		B14EF2302397E90400758AF0 /* MXDeviceListOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 322691311E5EF77D00966A6E /* MXDeviceListOperation.m */; };
 		B14EF2312397E90400758AF0 /* MX3PidAddSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D2CBFF23422462002BD8CA /* MX3PidAddSession.m */; };
 		B14EF2322397E90400758AF0 /* MXBugReportRestClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 3283F7771EAF30F700C1688C /* MXBugReportRestClient.m */; };
@@ -878,7 +882,7 @@
 		B14EF25B2397E90400758AF0 /* MXSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 320DFDD119DD99B60068622A /* MXSession.m */; };
 		B14EF25C2397E90400758AF0 /* MXRoomTombStoneContent.m in Sources */ = {isa = PBXBuildFile; fileRef = B17982EE2119E49F001FD722 /* MXRoomTombStoneContent.m */; };
 		B14EF25D2397E90400758AF0 /* MXImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C602B58D1F22A8D700B67D87 /* MXImage.swift */; };
-		B14EF25E2397E90400758AF0 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		B14EF25E2397E90400758AF0 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
 		B14EF25F2397E90400758AF0 /* MXServerNoticeContent.m in Sources */ = {isa = PBXBuildFile; fileRef = 32954018216385F100E300FC /* MXServerNoticeContent.m */; };
 		B14EF2602397E90400758AF0 /* MXContentScanResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 02CAD434217DD12F0074700B /* MXContentScanResult.m */; };
 		B14EF2612397E90400758AF0 /* MXRealmAggregationsStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 32133014228AF4EF0070BA9B /* MXRealmAggregationsStore.m */; };
@@ -917,7 +921,7 @@
 		B14EF2822397E90400758AF0 /* MXDeviceList.m in Sources */ = {isa = PBXBuildFile; fileRef = 32637ED31E5B00400011E20D /* MXDeviceList.m */; };
 		B14EF2832397E90400758AF0 /* MXRoomCreateContent.m in Sources */ = {isa = PBXBuildFile; fileRef = B17982F22119E4A1001FD722 /* MXRoomCreateContent.m */; };
 		B14EF2842397E90400758AF0 /* MXUIKitBackgroundModeHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 32A9E8231EF4026E0081358A /* MXUIKitBackgroundModeHandler.m */; };
-		B14EF2852397E90400758AF0 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		B14EF2852397E90400758AF0 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
 		B14EF2862397E90400758AF0 /* MXRealmMediaScanStore.m in Sources */ = {isa = PBXBuildFile; fileRef = B146D4F521A5BB9F00D8C2C6 /* MXRealmMediaScanStore.m */; };
 		B14EF2872397E90400758AF0 /* MXPusherData.m in Sources */ = {isa = PBXBuildFile; fileRef = 32999DE222DCD1AD004FF987 /* MXPusherData.m */; };
 		B14EF2882397E90400758AF0 /* MXOlmDevice.m in Sources */ = {isa = PBXBuildFile; fileRef = 322A51C61D9BBD3C00C8536D /* MXOlmDevice.m */; };
@@ -1544,6 +1548,8 @@
 		02CAD436217DD12F0074700B /* MXContentScanEncryptedBody.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXContentScanEncryptedBody.m; sourceTree = "<group>"; };
 		02CAD437217DD12F0074700B /* MXContentScanEncryptedBody.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXContentScanEncryptedBody.h; sourceTree = "<group>"; };
 		15D7F292D95EB58AEE801C4E /* libPods-MatrixSDKTests-macOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-MatrixSDKTests-macOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		181FD5D22660C791008EC084 /* MXLogObjcWrapper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXLogObjcWrapper.h; sourceTree = "<group>"; };
+		181FD5D32660C791008EC084 /* MXLogObjcWrapper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXLogObjcWrapper.m; sourceTree = "<group>"; };
 		189CC07F265E361500BE1FD8 /* MXLog.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXLog.h; sourceTree = "<group>"; };
 		189CC080265E361500BE1FD8 /* MXLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXLog.swift; sourceTree = "<group>"; };
 		19B6947FC794531CEEDCFA7F /* Pods-MatrixSDKTests-macOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MatrixSDKTests-macOS.release.xcconfig"; path = "Target Support Files/Pods-MatrixSDKTests-macOS/Pods-MatrixSDKTests-macOS.release.xcconfig"; sourceTree = "<group>"; };
@@ -2527,6 +2533,8 @@
 				327E37B51A974F75007F026F /* MXLogger.m */,
 				189CC07F265E361500BE1FD8 /* MXLog.h */,
 				189CC080265E361500BE1FD8 /* MXLog.swift */,
+				181FD5D22660C791008EC084 /* MXLogObjcWrapper.h */,
+				181FD5D32660C791008EC084 /* MXLogObjcWrapper.m */,
 				F03EF5021DF01596009DF592 /* MXLRUCache.h */,
 				F03EF5031DF01596009DF592 /* MXLRUCache.m */,
 				324676EB25C15F4600EA855B /* MXMemory.swift */,
@@ -4121,6 +4129,7 @@
 				32BA86AC21529E29008F277E /* MXRoomNameStringsLocalizable.h in Headers */,
 				B19A309E240424BD00FB6F35 /* MXQRCodeTransaction_Private.h in Headers */,
 				32BBAE742179CF4000D85F46 /* MXKeyBackup.h in Headers */,
+				181FD5D42660C791008EC084 /* MXLogObjcWrapper.h in Headers */,
 				92634B821EF2E3C400DB9F60 /* MXCallKitConfiguration.h in Headers */,
 				32618E7120ED2DF500E1D2EA /* MXFilterJSONModel.h in Headers */,
 				B146D47221A5939100D8C2C6 /* MXRealmHelper.h in Headers */,
@@ -4479,6 +4488,7 @@
 				B14EF2CB2397E90400758AF0 /* MXCallAudioSessionConfigurator.h in Headers */,
 				B14EF2CC2397E90400758AF0 /* MXMatrixVersions.h in Headers */,
 				324DD2A1246AE1EF00377005 /* MXEncryptedSecretContent.h in Headers */,
+				181FD5D52660C791008EC084 /* MXLogObjcWrapper.h in Headers */,
 				B14EF2CD2397E90400758AF0 /* MXRealmEventScanStore.h in Headers */,
 				B14EF2CE2397E90400758AF0 /* MXFileRoomStore.h in Headers */,
 				B14EF2D02397E90400758AF0 /* MXWellknownIntegrations.h in Headers */,
@@ -5011,6 +5021,7 @@
 				32DC15D51A8CF874006F9AD3 /* MXPushRuleEventMatchConditionChecker.m in Sources */,
 				32B94E06228EE90300716A26 /* MXRealmReactionRelation.m in Sources */,
 				320BBF411D6C81550079890E /* MXEventsByTypesEnumeratorOnArray.m in Sources */,
+				181FD5D62660C791008EC084 /* MXLogObjcWrapper.m in Sources */,
 				EC60ED87265CFD0700B39A4E /* MXRoomsSyncResponse.m in Sources */,
 				3213301E228B190F0070BA9B /* MXRealmAggregationsMapper.m in Sources */,
 				8EC511062568216B00EC4E5B /* MXTaggedEventInfo.m in Sources */,
@@ -5400,6 +5411,7 @@
 				B14EF1CB2397E90400758AF0 /* MXRoomAccountData.m in Sources */,
 				B14EF1CC2397E90400758AF0 /* MXEventAnnotationChunk.m in Sources */,
 				B14EF1CD2397E90400758AF0 /* MXRealmEventScanStore.m in Sources */,
+				181FD5D72660C791008EC084 /* MXLogObjcWrapper.m in Sources */,
 				324DD2C2246D658500377005 /* MXHkdfSha256.m in Sources */,
 				B14EF1CE2397E90400758AF0 /* MXScanRealmFileProvider.m in Sources */,
 				B14EF1CF2397E90400758AF0 /* MXScanManager.m in Sources */,
@@ -5431,7 +5443,7 @@
 				B14EF1E42397E90400758AF0 /* MXWellknownIntegrations.m in Sources */,
 				EC60EDF5265CFFAC00B39A4E /* MXGroupsSyncResponse.m in Sources */,
 				B14EF1E52397E90400758AF0 /* MXLoginPolicy.m in Sources */,
-				B14EF1E62397E90400758AF0 /* (null) in Sources */,
+				B14EF1E62397E90400758AF0 /* BuildFile in Sources */,
 				EC60EDB5265CFE6200B39A4E /* MXRoomSyncEphemeral.m in Sources */,
 				B14EF1E72397E90400758AF0 /* MXRoomThirdPartyInvite.m in Sources */,
 				B14EF1E82397E90400758AF0 /* MXRoomPowerLevels.m in Sources */,
@@ -5530,7 +5542,7 @@
 				3290293524CB10D000DA7BB6 /* MatrixSDKVersion.m in Sources */,
 				B14EF21F2397E90400758AF0 /* MXMyUser.m in Sources */,
 				EC60EDAB265CFE3B00B39A4E /* MXRoomSyncTimeline.m in Sources */,
-				B14EF2202397E90400758AF0 /* (null) in Sources */,
+				B14EF2202397E90400758AF0 /* BuildFile in Sources */,
 				B14EF2212397E90400758AF0 /* MX3PID.swift in Sources */,
 				EC383BB325406892002FBBE6 /* MXSyncResponseStore.swift in Sources */,
 				B14EF2222397E90400758AF0 /* MXMediaScan.m in Sources */,
@@ -5554,7 +5566,7 @@
 				B18B0E6825FBDC3000E32151 /* MXSpace.swift in Sources */,
 				B14EF22D2397E90400758AF0 /* MXRealmReactionCount.m in Sources */,
 				B14EF22E2397E90400758AF0 /* MXCryptoTools.m in Sources */,
-				B14EF22F2397E90400758AF0 /* (null) in Sources */,
+				B14EF22F2397E90400758AF0 /* BuildFile in Sources */,
 				B14EF2302397E90400758AF0 /* MXDeviceListOperation.m in Sources */,
 				32C78B6B256CFC4D008130B1 /* MXCryptoMigration.m in Sources */,
 				B14EF2312397E90400758AF0 /* MX3PidAddSession.m in Sources */,
@@ -5628,7 +5640,7 @@
 				B14EF25B2397E90400758AF0 /* MXSession.m in Sources */,
 				B14EF25C2397E90400758AF0 /* MXRoomTombStoneContent.m in Sources */,
 				B14EF25D2397E90400758AF0 /* MXImage.swift in Sources */,
-				B14EF25E2397E90400758AF0 /* (null) in Sources */,
+				B14EF25E2397E90400758AF0 /* BuildFile in Sources */,
 				32B090E3261F709B002924AA /* MXAsyncTaskQueue.swift in Sources */,
 				B14EF25F2397E90400758AF0 /* MXServerNoticeContent.m in Sources */,
 				B14EF2602397E90400758AF0 /* MXContentScanResult.m in Sources */,
@@ -5700,7 +5712,7 @@
 				EC60ED7E265CFCD100B39A4E /* MXDeviceListResponse.m in Sources */,
 				323F879025553D84009E9E67 /* MXTaskProfile.m in Sources */,
 				B14EF2842397E90400758AF0 /* MXUIKitBackgroundModeHandler.m in Sources */,
-				B14EF2852397E90400758AF0 /* (null) in Sources */,
+				B14EF2852397E90400758AF0 /* BuildFile in Sources */,
 				32A9F8E1244720B10069C65B /* MXThrottler.m in Sources */,
 				3274538D23FD918800438328 /* MXKeyVerificationByToDeviceRequest.m in Sources */,
 				32CEEF5223B0AB030039BA98 /* MXCrossSigning.m in Sources */,

--- a/MatrixSDK/Aggregations/Data/Store/Realm/MXRealmAggregationsStore.m
+++ b/MatrixSDK/Aggregations/Data/Store/Realm/MXRealmAggregationsStore.m
@@ -21,6 +21,8 @@
 
 #import "MXRealmAggregationsMapper.h"
 
+#import "MXLog.h"
+
 
 @interface MXRealmAggregationsStore ()
 
@@ -241,7 +243,7 @@
 
     if (error)
     {
-        NSLog(@"[MXRealmFileProvider] realmForUser gets error: %@", error);
+        MXLogDebug(@"[MXRealmFileProvider] realmForUser gets error: %@", error);
     }
 
     return realm;
@@ -264,7 +266,7 @@
 
     if (folderCreationError)
     {
-        NSLog(@"[MXScanRealmFileProvider] Fail to create Realm folder %@ with error: %@", realmFileFolderURL, folderCreationError);
+        MXLogDebug(@"[MXScanRealmFileProvider] Fail to create Realm folder %@ with error: %@", realmFileFolderURL, folderCreationError);
     }
 
     realmConfiguration.fileURL = realmFileURL;

--- a/MatrixSDK/Aggregations/MXAggregatedEditsUpdater.m
+++ b/MatrixSDK/Aggregations/MXAggregatedEditsUpdater.m
@@ -66,7 +66,7 @@
     MXRoom *room = [self.mxSession roomWithRoomId:roomId];
     if (!room)
     {
-        NSLog(@"[MXAggregations] replaceTextMessageEvent: Error: Unknown room: %@", roomId);
+        MXLogDebug(@"[MXAggregations] replaceTextMessageEvent: Error: Unknown room: %@", roomId);
         failure(nil);
         return nil;
     }
@@ -75,7 +75,7 @@
     
     if (![self.editSupportedMessageTypes containsObject:messageType])
     {
-        NSLog(@"[MXAggregations] replaceTextMessageEvent: Error: Only message types %@ are supported", self.editSupportedMessageTypes);
+        MXLogDebug(@"[MXAggregations] replaceTextMessageEvent: Error: Only message types %@ are supported", self.editSupportedMessageTypes);
         failure(nil);
         return nil;
     }
@@ -96,7 +96,7 @@
         }
         else
         {
-            NSLog(@"[MXAggregations] replaceTextMessageEvent: Fail to parse reply event: %@", event.eventId);
+            MXLogDebug(@"[MXAggregations] replaceTextMessageEvent: Fail to parse reply event: %@", event.eventId);
             failure(nil);
             return nil;
         }
@@ -150,7 +150,7 @@
     if (event.isLocalEvent)
     {
         // Need to wait to get the final event id of the message being sent
-        NSLog(@"[MXAggregations] replaceTextMessageEvent: Event to edit is a local echo. Wait for the end of the sending");
+        MXLogDebug(@"[MXAggregations] replaceTextMessageEvent: Event to edit is a local echo. Wait for the end of the sending");
         operation = [MXHTTPOperation new];
 
         MXWeakify(self);
@@ -160,7 +160,7 @@
 
             if (event.sentState == MXEventSentStateSent)
             {
-                NSLog(@"[MXAggregations] replaceTextMessageEvent: Edit request can be done now");
+                MXLogDebug(@"[MXAggregations] replaceTextMessageEvent: Edit request can be done now");
 
                 [[NSNotificationCenter defaultCenter] removeObserver:observer];
                 observer = nil;
@@ -222,7 +222,7 @@
         if (![event.sender isEqualToString:replaceEvent.sender])
         {
             //  not coming from the original sender, ignore
-            NSLog(@"[MXAggregations] handleReplace: Edit event not coming from the original sender, ignoring.");
+            MXLogDebug(@"[MXAggregations] handleReplace: Edit event not coming from the original sender, ignoring.");
             return;
         }
         if (![event.unsignedData.relations.replace.eventId isEqualToString:replaceEvent.eventId])
@@ -238,7 +238,7 @@
     }
     else
     {
-        NSLog(@"[MXAggregations] handleReplace: Unknown event id: %@", replaceEvent.relatesTo.eventId);
+        MXLogDebug(@"[MXAggregations] handleReplace: Unknown event id: %@", replaceEvent.relatesTo.eventId);
     }
 }
 

--- a/MatrixSDK/Aggregations/MXAggregatedReactionsUpdater.m
+++ b/MatrixSDK/Aggregations/MXAggregatedReactionsUpdater.m
@@ -136,14 +136,14 @@
             }
             else
             {
-                NSLog(@"[MXAggregations] removeReaction: ERROR: Unknown room %@", roomId);
+                MXLogDebug(@"[MXAggregations] removeReaction: ERROR: Unknown room %@", roomId);
                 [self didOperationCompleteForReaction:reaction forEvent:eventId isAdd:NO];
                 success();
             }
         }
         else
         {
-            NSLog(@"[MXAggregations] removeReaction: ERROR: Do not know reaction(%@) event on event %@", reaction, eventId);
+            MXLogDebug(@"[MXAggregations] removeReaction: ERROR: Do not know reaction(%@) event on event %@", reaction, eventId);
             [self didOperationCompleteForReaction:reaction forEvent:eventId isAdd:NO];
             success();
         }
@@ -261,7 +261,7 @@
     }
     else
     {
-        NSLog(@"[MXAggregations] handleReaction: ERROR: invalid reaction event: %@", event.JSONDictionary);
+        MXLogDebug(@"[MXAggregations] handleReaction: ERROR: invalid reaction event: %@", event.JSONDictionary);
     }
 }
 
@@ -483,8 +483,8 @@
         if (self.reactionOperations[eventId][reaction].lastObject.isAddOperation == isAdd)
         {
             // The same operation is already pending
-            NSLog(@"[MXAggregations] addOperationForReaction: Debounce same reaction operation: %@",
-                  isAdd ? @"ADD" : @"REMOVE");
+            MXLogDebug(@"[MXAggregations] addOperationForReaction: Debounce same reaction operation: %@",
+                       isAdd ? @"ADD" : @"REMOVE");
             [self notifyReactionCountChangeListenersOfRoom:roomId forLocalEchoForOperation:reactionOperation];
             block(YES);
             return;
@@ -492,8 +492,8 @@
         else if (self.reactionOperations[eventId][reaction].count > 1)
         {
             // The app requires 3 binary switch operations, keep only the pending first one
-            NSLog(@"[MXAggregations] addOperationForReaction: Debounce: do only the reaction operation: %@",
-                  isAdd ? @"ADD" : @"REMOVE");
+            MXLogDebug(@"[MXAggregations] addOperationForReaction: Debounce: do only the reaction operation: %@",
+                       isAdd ? @"ADD" : @"REMOVE");
             [self.reactionOperations[eventId][reaction] removeObjectAtIndex:1];
             [self notifyReactionCountChangeListenersOfRoom:roomId forLocalEchoForOperation:reactionOperation];
             block(YES);
@@ -641,12 +641,12 @@
                                   success:(void (^)(void))success
                                   failure:(void (^)(NSError *error))failure
 {
-    NSLog(@"[MXAggregations] sendReactionUsingHack");
+    MXLogDebug(@"[MXAggregations] sendReactionUsingHack");
 
     MXRoom *room = [self.mxSession roomWithRoomId:roomId];
     if (!room)
     {
-        NSLog(@"[MXAggregations] sendReactionUsingHack Error: Unknown room: %@", roomId);
+        MXLogDebug(@"[MXAggregations] sendReactionUsingHack Error: Unknown room: %@", roomId);
         return nil;
     }
 

--- a/MatrixSDK/Aggregations/MXAggregatedReferencesUpdater.m
+++ b/MatrixSDK/Aggregations/MXAggregatedReferencesUpdater.m
@@ -64,7 +64,7 @@
     }
     else
     {
-        NSLog(@"[MXAggregations] handleReference: Unknown event id: %@", relation.eventId);
+        MXLogDebug(@"[MXAggregations] handleReference: Unknown event id: %@", relation.eventId);
     }
 }
 

--- a/MatrixSDK/Background/MXBackgroundCryptoStore.m
+++ b/MatrixSDK/Background/MXBackgroundCryptoStore.m
@@ -59,7 +59,7 @@ NSString *const MXBackgroundCryptoStoreUserIdSuffix = @":bgCryptoStore";
         else
         {
             // Should never happen
-            NSLog(@"[MXBackgroundCryptoStore] initWithCredentials: Warning: createStoreWithCredentials: %@:%@", credentials.userId, credentials.deviceId);
+            MXLogDebug(@"[MXBackgroundCryptoStore] initWithCredentials: Warning: createStoreWithCredentials: %@:%@", credentials.userId, credentials.deviceId);
             cryptoStore = [MXRealmCryptoStore createStoreWithCredentials:credentials];
             cryptoStore.readOnly = YES;
         }
@@ -68,18 +68,18 @@ NSString *const MXBackgroundCryptoStoreUserIdSuffix = @":bgCryptoStore";
         
         if (resetBackgroundCryptoStore)
         {
-            NSLog(@"[MXBackgroundCryptoStore] initWithCredentials: Delete existing bgCryptoStore if any");
+            MXLogDebug(@"[MXBackgroundCryptoStore] initWithCredentials: Delete existing bgCryptoStore if any");
             [MXRealmCryptoStore deleteStoreWithCredentials:bgCredentials];
         }
         
         if ([MXRealmCryptoStore hasDataForCredentials:bgCredentials])
         {
-            NSLog(@"[MXBackgroundCryptoStore] initWithCredentials: Reuse existing bgCryptoStore");
+            MXLogDebug(@"[MXBackgroundCryptoStore] initWithCredentials: Reuse existing bgCryptoStore");
             bgCryptoStore = [[MXRealmCryptoStore alloc] initWithCredentials:bgCredentials];
         }
         else
         {
-            NSLog(@"[MXBackgroundCryptoStore] initWithCredentials: Create bgCryptoStore");
+            MXLogDebug(@"[MXBackgroundCryptoStore] initWithCredentials: Create bgCryptoStore");
             bgCryptoStore = [MXRealmCryptoStore createStoreWithCredentials:bgCredentials];
         }
     }
@@ -136,7 +136,7 @@ NSString *const MXBackgroundCryptoStoreUserIdSuffix = @":bgCryptoStore";
 - (void)setAccount:(OLMAccount*)account
 {
     // Should never happen
-    NSLog(@"[MXBackgroundCryptoStore] setAccount: identityKeys: %@", account.identityKeys);
+    MXLogDebug(@"[MXBackgroundCryptoStore] setAccount: identityKeys: %@", account.identityKeys);
     
     [cryptoStore setAccount:account];
     [bgCryptoStore setAccount:account];
@@ -148,7 +148,7 @@ NSString *const MXBackgroundCryptoStoreUserIdSuffix = @":bgCryptoStore";
     // If needed, transfer data from cryptoStore to bgCryptoStore first
     if (!bgCryptoStore.account)
     {
-        NSLog(@"[MXBackgroundCryptoStore] performAccountOperationWithBlock: Transfer data from cryptoStore to bgCryptoStore");
+        MXLogDebug(@"[MXBackgroundCryptoStore] performAccountOperationWithBlock: Transfer data from cryptoStore to bgCryptoStore");
         [bgCryptoStore setAccount:cryptoStore.account];
     }
     
@@ -167,7 +167,7 @@ NSString *const MXBackgroundCryptoStoreUserIdSuffix = @":bgCryptoStore";
         olmSession = [cryptoStore sessionWithDevice:deviceKey andSessionId:sessionId];
         if (olmSession)
         {
-            NSLog(@"[MXBackgroundCryptoStore] performSessionOperationWithDevice: Transfer data for %@ from cryptoStore to bgCryptoStore", sessionId);
+            MXLogDebug(@"[MXBackgroundCryptoStore] performSessionOperationWithDevice: Transfer data for %@ from cryptoStore to bgCryptoStore", sessionId);
             [bgCryptoStore storeSession:olmSession forDevice:deviceKey];
         }
     }
@@ -229,7 +229,7 @@ NSString *const MXBackgroundCryptoStoreUserIdSuffix = @":bgCryptoStore";
         inboundGroupSession = [cryptoStore inboundGroupSessionWithId:sessionId andSenderKey:senderKey];
         if (inboundGroupSession)
         {
-            NSLog(@"[MXBackgroundCryptoStore] performSessionOperationWithGroupSessionWithId: Transfer data for %@ from cryptoStore to bgCryptoStore", sessionId);
+            MXLogDebug(@"[MXBackgroundCryptoStore] performSessionOperationWithGroupSessionWithId: Transfer data for %@ from cryptoStore to bgCryptoStore", sessionId);
             [bgCryptoStore storeInboundGroupSessions:@[inboundGroupSession]];
         }
     }

--- a/MatrixSDK/Background/MXBackgroundStore.swift
+++ b/MatrixSDK/Background/MXBackgroundStore.swift
@@ -96,7 +96,7 @@ class MXBackgroundStore: NSObject, MXStore {
         
         let event = roomStore.event(withEventId: eventId)
         
-        NSLog("[MXBackgroundStore] eventWithEventId: \(eventId) \(event == nil ? "not " : "" )found")
+        MXLog.debug("[MXBackgroundStore] eventWithEventId: \(eventId) \(event == nil ? "not " : "" )found")
         return event
     }
     
@@ -109,7 +109,7 @@ class MXBackgroundStore: NSObject, MXStore {
         }
         
         guard let roomStore = fileStore.roomStore(forRoom: roomId) else {
-            NSLog("[MXBackgroundStore] roomStore: Unknown room id: \(roomId)")
+            MXLog.debug("[MXBackgroundStore] roomStore: Unknown room id: \(roomId)")
             return nil
         }
         

--- a/MatrixSDK/Background/Store/MXSyncResponseStoreManager.swift
+++ b/MatrixSDK/Background/Store/MXSyncResponseStoreManager.swift
@@ -49,7 +49,7 @@ public class MXSyncResponseStoreManager: NSObject {
             return nil
         }
         guard let syncResponse = try? syncResponseStore.syncResponse(withId: id) else {
-            NSLog("[MXSyncResponseStoreManager] firstSyncResponse: invalid id")
+            MXLog.debug("[MXSyncResponseStoreManager] firstSyncResponse: invalid id")
             return nil
         }
         return syncResponse
@@ -60,7 +60,7 @@ public class MXSyncResponseStoreManager: NSObject {
             return nil
         }
         guard let syncResponse = try? syncResponseStore.syncResponse(withId: id) else {
-            NSLog("[MXSyncResponseStoreManager] lastSyncResponse: invalid id")
+            MXLog.debug("[MXSyncResponseStoreManager] lastSyncResponse: invalid id")
             return nil
         }
         return syncResponse
@@ -72,7 +72,7 @@ public class MXSyncResponseStoreManager: NSObject {
             return
         }
         
-        NSLog("[MXSyncResponseStoreManager] markDataOutdated \(syncResponseIds.count) cached sync responses. The sync token was \(String(describing: syncToken()))")
+        MXLog.debug("[MXSyncResponseStoreManager] markDataOutdated \(syncResponseIds.count) cached sync responses. The sync token was \(String(describing: syncToken()))")
         syncResponseStore.markOutdated(syncResponseIds: syncResponseIds)
     }
     
@@ -90,7 +90,7 @@ public class MXSyncResponseStoreManager: NSObject {
             if  cachedSyncResponseSize < syncResponseCacheSizeLimit,
                 let cachedSyncResponse = try? syncResponseStore.syncResponse(withId: id) {
                 
-                NSLog("[MXSyncResponseStoreManager] updateStore: Merge new sync response to the previous one")
+                MXLog.debug("[MXSyncResponseStoreManager] updateStore: Merge new sync response to the previous one")
                 
                 //  handle new limited timelines
                 newSyncResponse.rooms?.join?.filter({ $1.timeline.limited == true }).forEach { (roomId, _) in
@@ -137,14 +137,14 @@ public class MXSyncResponseStoreManager: NSObject {
                 
             } else {
                 // Use a new chunk
-                NSLog("[MXSyncResponseStoreManager] updateStore: Create a new chunk to store the new sync response. Previous chunk size: \(cachedSyncResponseSize)")
+                MXLog.debug("[MXSyncResponseStoreManager] updateStore: Create a new chunk to store the new sync response. Previous chunk size: \(cachedSyncResponseSize)")
                 let cachedSyncResponse = MXCachedSyncResponse(syncToken: syncToken,
                                                               syncResponse: newSyncResponse)
                 _ = syncResponseStore.addSyncResponse(syncResponse: cachedSyncResponse)
             }
         } else {
             //  no current sync response, directly save the new one
-            NSLog("[MXSyncResponseStoreManager] updateStore: Start storing sync response")
+            MXLog.debug("[MXSyncResponseStoreManager] updateStore: Start storing sync response")
             let cachedSyncResponse = MXCachedSyncResponse(syncToken: syncToken,
                                                          syncResponse: newSyncResponse)
             _ = syncResponseStore.addSyncResponse(syncResponse: cachedSyncResponse)
@@ -185,7 +185,7 @@ public class MXSyncResponseStoreManager: NSObject {
             }
         }
         
-        NSLog("[MXSyncResponseStoreManager] event: Not found event \(eventId) in room \(roomId)")
+        MXLog.debug("[MXSyncResponseStoreManager] event: Not found event \(eventId) in room \(roomId)")
         return nil
     }
     
@@ -208,7 +208,7 @@ public class MXSyncResponseStoreManager: NSObject {
         let result = allEvents.first(where: { eventId == $0.eventId })
         result?.roomId = roomId
         
-        NSLog("[MXSyncResponseStoreManager] eventWithEventId: \(eventId) \(result == nil ? "not " : "" )found")
+        MXLog.debug("[MXSyncResponseStoreManager] eventWithEventId: \(eventId) \(result == nil ? "not " : "" )found")
         
         return result
     }
@@ -235,7 +235,7 @@ public class MXSyncResponseStoreManager: NSObject {
             }
         }
         
-        NSLog("[MXSyncResponseStoreManager] roomSummary: Not found for room \(roomId)")
+        MXLog.debug("[MXSyncResponseStoreManager] roomSummary: Not found for room \(roomId)")
         
         return nil
     }

--- a/MatrixSDK/Background/Store/SyncResponseFileStore/MXSyncResponseFileStore.swift
+++ b/MatrixSDK/Background/Store/SyncResponseFileStore/MXSyncResponseFileStore.swift
@@ -98,7 +98,7 @@ public class MXSyncResponseFileStore: NSObject {
             fileOperationQueue.sync {
                 fileContents = try? String(contentsOf: path,
                                            encoding: Constants.fileEncoding)
-                NSLog("[MXSyncResponseFileStore] readData: File read of \(fileContents?.count ?? 0) bytes lasted \(stopwatch.readable()). Free memory: \(MXMemory.formattedMemoryAvailable())")
+                MXLog.debug("[MXSyncResponseFileStore] readData: File read of \(fileContents?.count ?? 0) bytes lasted \(stopwatch.readable()). Free memory: \(MXMemory.formattedMemoryAvailable())")
                 
             }
             
@@ -112,7 +112,7 @@ public class MXSyncResponseFileStore: NSObject {
             
             let syncResponse = MXCachedSyncResponse(fromJSON: json)
             
-            NSLog("[MXSyncResponseFileStore] readData: Consersion to model lasted \(stopwatch.readable()). Free memory: \(MXMemory.formattedMemoryAvailable())")
+            MXLog.debug("[MXSyncResponseFileStore] readData: Consersion to model lasted \(stopwatch.readable()). Free memory: \(MXMemory.formattedMemoryAvailable())")
             return syncResponse
         }
     }
@@ -123,14 +123,14 @@ public class MXSyncResponseFileStore: NSObject {
         fileOperationQueue.async {
             guard let syncResponse = syncResponse else {
                 try? FileManager.default.removeItem(at: path)
-                NSLog("[MXSyncResponseFileStore] saveData: File remove lasted \(stopwatch.readable())")
+                MXLog.debug("[MXSyncResponseFileStore] saveData: File remove lasted \(stopwatch.readable())")
                 return
             }
             
             try? syncResponse.jsonString()?.write(to: path,
                                                   atomically: true,
                                                   encoding: Constants.fileEncoding)
-            NSLog("[MXSyncResponseFileStore] saveData: File write lasted \(stopwatch.readable()). Free memory: \(MXMemory.formattedMemoryAvailable())")
+            MXLog.debug("[MXSyncResponseFileStore] saveData: File write lasted \(stopwatch.readable()). Free memory: \(MXMemory.formattedMemoryAvailable())")
         }
     }
     
@@ -141,7 +141,7 @@ public class MXSyncResponseFileStore: NSObject {
         }
         
         guard let data = fileData else {
-            NSLog("[MXSyncResponseFileStore] readMetaData: File does not exist")
+            MXLog.debug("[MXSyncResponseFileStore] readMetaData: File does not exist")
             return MXSyncResponseStoreMetaDataModel()
         }
         
@@ -149,7 +149,7 @@ public class MXSyncResponseFileStore: NSObject {
             let metadata = try PropertyListDecoder().decode(MXSyncResponseStoreMetaDataModel.self, from: data)
             return metadata
         } catch let error {
-            NSLog("[MXSyncResponseFileStore] readMetaData: Failed to decode. Error: \(error)")
+            MXLog.debug("[MXSyncResponseFileStore] readMetaData: Failed to decode. Error: \(error)")
             return MXSyncResponseStoreMetaDataModel()
         }
     }
@@ -158,7 +158,7 @@ public class MXSyncResponseFileStore: NSObject {
         fileOperationQueue.async {
             guard let metadata = metadata else {
                 try? FileManager.default.removeItem(at: self.metadataFilePath)
-                NSLog("[MXSyncResponseFileStore] saveMetaData: Remove file")
+                MXLog.debug("[MXSyncResponseFileStore] saveMetaData: Remove file")
                 return
             }
             
@@ -166,7 +166,7 @@ public class MXSyncResponseFileStore: NSObject {
                 let data = try PropertyListEncoder().encode(metadata)
                 try data.write(to: self.metadataFilePath)
             } catch let error {
-                NSLog("[MXSyncResponseFileStore] saveMetaData: Failed to store. Error: \(error)")
+                MXLog.debug("[MXSyncResponseFileStore] saveMetaData: Failed to store. Error: \(error)")
             }
         }
     }

--- a/MatrixSDK/Categories/MXRestClient+Extensions.swift
+++ b/MatrixSDK/Categories/MXRestClient+Extensions.swift
@@ -46,7 +46,7 @@ public extension MXRestClient {
             }
         }
         
-        NSLog("[MXRestClient+Extensions] downloadKeysByChunk: \(users.count) users with chunkSize:\(chunkSize)")
+        MXLog.debug("[MXRestClient+Extensions] downloadKeysByChunk: \(users.count) users with chunkSize:\(chunkSize)")
         
         // An arbitrary MXHTTPOperation. It will not cancel requests
         // but it will avoid to call callbacks in case of a cancellation is requested
@@ -59,11 +59,9 @@ public extension MXRestClient {
             self.downloadKeys(forUsers: chunkedUsers, token: token) { response in
                 switch response {
                     case .success(let keysQueryResponse):
-                        NSLog("[MXRestClient+Extensions] downloadKeysByChunk: Got intermediate response. Got device keys for %@ users. Got cross-signing keys for %@ users",
-                              String(describing: keysQueryResponse.deviceKeys.userIds()?.count),
-                              String(describing: keysQueryResponse.crossSigningKeys.count))
+                        MXLog.debug("[MXRestClient+Extensions] downloadKeysByChunk: Got intermediate response. Got device keys for %@ users. Got cross-signing keys for %@ users \(String(describing: keysQueryResponse.deviceKeys.userIds()?.count)) \(String(describing: keysQueryResponse.crossSigningKeys.count))")
                     case .failure(let error):
-                        NSLog("[MXRestClient+Extensions] downloadKeysByChunk: Got intermediate error. Error: \(error)")
+                        MXLog.debug("[MXRestClient+Extensions] downloadKeysByChunk: Got intermediate error. Error: \(error)")
                 }
 
                 responses.append(response)
@@ -72,10 +70,10 @@ public extension MXRestClient {
         }
         
         group.notify(queue: self.completionQueue) {
-            NSLog("[MXRestClient+Extensions] downloadKeysByChunk: Got all responses")
+            MXLog.debug("[MXRestClient+Extensions] downloadKeysByChunk: Got all responses")
                 
             guard operation.isCancelled == false else {
-                NSLog("[MXRestClient+Extensions] downloadKeysByChunk: Request was cancelled")
+                MXLog.debug("[MXRestClient+Extensions] downloadKeysByChunk: Request was cancelled")
                 return
             }
             

--- a/MatrixSDK/ContentScan/Data/Store/Realm/Event/MXRealmEventScanStore.m
+++ b/MatrixSDK/ContentScan/Data/Store/Realm/Event/MXRealmEventScanStore.m
@@ -264,7 +264,7 @@
         
         if (error)
         {
-            NSLog(@"[MXRealmEventScanStore] Failed to open Realm on background worker: %@", error);
+            MXLogDebug(@"[MXRealmEventScanStore] Failed to open Realm on background worker: %@", error);
         }
         else if (change)
         {

--- a/MatrixSDK/ContentScan/Data/Store/Realm/Media/MXRealmMediaScanStore.m
+++ b/MatrixSDK/ContentScan/Data/Store/Realm/Media/MXRealmMediaScanStore.m
@@ -252,7 +252,7 @@
 
         if (error)
         {
-            NSLog(@"[MXRealmMediaScanStore] Failed to open Realm on background worker: %@", error);
+            MXLogDebug(@"[MXRealmMediaScanStore] Failed to open Realm on background worker: %@", error);
         }
         else if (change)
         {            

--- a/MatrixSDK/ContentScan/Data/Store/Realm/RealmProvider/MXScanRealmFileProvider.m
+++ b/MatrixSDK/ContentScan/Data/Store/Realm/RealmProvider/MXScanRealmFileProvider.m
@@ -21,6 +21,8 @@
 #import "MXRealmEventScan.h"
 #import "MXRealmMediaScan.h"
 
+#import "MXLog.h"
+
 @interface MXScanRealmFileProvider()
 
 @property (nonatomic, strong) RLMRealmConfiguration *realmConfiguration;
@@ -52,7 +54,7 @@
     
     if (error)
     {
-        NSLog(@"[MXRealmFileProvider] realmForUser gets error: %@", error);
+        MXLogDebug(@"[MXRealmFileProvider] realmForUser gets error: %@", error);
     }
     
     return realm;
@@ -86,7 +88,7 @@
     
     if (folderCreationError)
     {
-        NSLog(@"[MXScanRealmFileProvider] Fail to create Realm folder %@ with error: %@", realmFileFolderURL, folderCreationError);
+        MXLogDebug(@"[MXScanRealmFileProvider] Fail to create Realm folder %@ with error: %@", realmFileFolderURL, folderCreationError);
     }
     
     realmConfiguration.fileURL = realmFileURL;

--- a/MatrixSDK/ContentScan/Data/Store/Realm/RealmProvider/MXScanRealmInMemoryProvider.m
+++ b/MatrixSDK/ContentScan/Data/Store/Realm/RealmProvider/MXScanRealmInMemoryProvider.m
@@ -19,6 +19,8 @@
 #import "MXRealmEventScan.h"
 #import "MXRealmMediaScan.h"
 
+#import "MXLog.h"
+
 @interface MXScanRealmInMemoryProvider()
 
 @property (nonatomic, strong) RLMRealmConfiguration *realmConfiguration;
@@ -50,7 +52,7 @@
     
     if (error)
     {
-        NSLog(@"[MXScanRealmInMemoryProvider] realmForUser gets error: %@", error);
+        MXLogDebug(@"[MXScanRealmInMemoryProvider] realmForUser gets error: %@", error);
     }
     
     return realm;

--- a/MatrixSDK/ContentScan/MXScanManager.m
+++ b/MatrixSDK/ContentScan/MXScanManager.m
@@ -339,7 +339,7 @@ static const char * const kProcessingQueueName = "org.MatrixSDK.MXScanManager";
         }
         else
         {
-            NSLog(@"[MXScanManager] encrypt body failed, a server public key is required");
+            MXLogDebug(@"[MXScanManager] encrypt body failed, a server public key is required");
             completion(nil);
         }
     }];
@@ -365,7 +365,7 @@ static const char * const kProcessingQueueName = "org.MatrixSDK.MXScanManager";
             
         } failure:^(NSError *error) {
             
-            NSLog(@"[MXScanManager] get server key failed");
+            MXLogDebug(@"[MXScanManager] get server key failed");
             completion(nil);
             
         }];
@@ -386,7 +386,7 @@ static const char * const kProcessingQueueName = "org.MatrixSDK.MXScanManager";
 
 - (void)resetAntivirusServerPublicKey
 {
-    NSLog(@"[MXScanManager] reset server public key");
+    MXLogDebug(@"[MXScanManager] reset server public key");
     _serverPublicKey = nil;
 }
 
@@ -528,7 +528,7 @@ static const char * const kProcessingQueueName = "org.MatrixSDK.MXScanManager";
                         }
                         else
                         {
-                            NSLog(@"[MXScanManager] scan encrypted content failed, body encryption failed");
+                            MXLogDebug(@"[MXScanManager] scan encrypted content failed, body encryption failed");
                             mediaScanFailure(nil);
                         }
                     }];

--- a/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmDecryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmDecryption.m
@@ -172,7 +172,7 @@
     
     if (!pendingEvents[k][timelineId][event.eventId])
     {
-        NSLog(@"[MXMegolmDecryption] addEventToPendingList: %@ in %@ for %@", event.eventId, event.roomId, k);
+        MXLogDebug(@"[MXMegolmDecryption] addEventToPendingList: %@ in %@ for %@", event.eventId, event.roomId, k);
         pendingEvents[k][timelineId][event.eventId] = event;
         
         [self requestKeysForEvent:event];
@@ -190,14 +190,14 @@
 
     if (!roomId || !sessionId || !sessionKey)
     {
-        NSLog(@"[MXMegolmDecryption] onRoomKeyEvent: ERROR: Key event is missing fields");
+        MXLogDebug(@"[MXMegolmDecryption] onRoomKeyEvent: ERROR: Key event is missing fields");
         return;
     }
 
     NSString *senderKey = event.senderKey;
     if (!senderKey)
     {
-        NSLog(@"[MXMegolmDecryption] onRoomKeyEvent: ERROR: Key event has no sender key (not encrypted?)");
+        MXLogDebug(@"[MXMegolmDecryption] onRoomKeyEvent: ERROR: Key event has no sender key (not encrypted?)");
         return;
     }
 
@@ -223,7 +223,7 @@
         MXJSONModelSetString(senderKey, content[@"sender_key"]);
         if (!senderKey)
         {
-            NSLog(@"[MXMegolmDecryption] onRoomKeyEvent: ERROR: forwarded_room_key event is missing sender_key field");
+            MXLogDebug(@"[MXMegolmDecryption] onRoomKeyEvent: ERROR: forwarded_room_key event is missing sender_key field");
             return;
         }
 
@@ -231,7 +231,7 @@
         MXJSONModelSetString(ed25519Key, content[@"sender_claimed_ed25519_key"]);
         if (!ed25519Key)
         {
-            NSLog(@"[MXMegolmDecryption] onRoomKeyEvent: ERROR: forwarded_room_key_event is missing sender_claimed_ed25519_key field");
+            MXLogDebug(@"[MXMegolmDecryption] onRoomKeyEvent: ERROR: forwarded_room_key_event is missing sender_claimed_ed25519_key field");
             return;
         }
 
@@ -244,7 +244,7 @@
         keysClaimed = event.keysClaimed;
     }
 
-    NSLog(@"[MXMegolmDecryption] onRoomKeyEvent: Adding key for megolm session %@|%@ from %@ event", senderKey, sessionId, event.type);
+    MXLogDebug(@"[MXMegolmDecryption] onRoomKeyEvent: Adding key for megolm session %@|%@ from %@ event", senderKey, sessionId, event.type);
 
     [olmDevice addInboundGroupSession:sessionId sessionKey:sessionKey roomId:roomId senderKey:senderKey forwardingCurve25519KeyChain:forwardingKeyChain keysClaimed:keysClaimed exportFormat:exportFormat];
 
@@ -343,7 +343,7 @@
          MXJSONModelSetString(senderKey, body[@"sender_key"]);
          MXJSONModelSetString(sessionId, body[@"session_id"]);
 
-         NSLog(@"[MXMegolmDecryption] shareKeysWithDevice: sharing keys for session %@|%@ with device %@:%@", senderKey, sessionId, userId, deviceId);
+        MXLogDebug(@"[MXMegolmDecryption] shareKeysWithDevice: sharing keys for session %@|%@ with device %@:%@", senderKey, sessionId, userId, deviceId);
 
          NSDictionary *payload = [self->crypto buildMegolmKeyForwardingMessage:roomId senderKey:senderKey sessionId:sessionId chainIndex:nil];
 
@@ -389,7 +389,7 @@
                 if (event.clearEvent)
                 {
                     // This can happen when the event is in several timelines
-                    NSLog(@"[MXMegolmDecryption] retryDecryption: %@ already decrypted", event.eventId);
+                    MXLogDebug(@"[MXMegolmDecryption] retryDecryption: %@ already decrypted", event.eventId);
                 }
                 else
                 {
@@ -401,14 +401,14 @@
                     dispatch_async(dispatch_get_main_queue(), ^{
                         if (result.error)
                         {
-                            NSLog(@"[MXMegolmDecryption] retryDecryption: Still can't decrypt %@. Error: %@", event.eventId, result.error);
+                            MXLogDebug(@"[MXMegolmDecryption] retryDecryption: Still can't decrypt %@. Error: %@", event.eventId, result.error);
                             allDecrypted = NO;
                         }
 
                         if (event.clearEvent)
                         {
                             // This can happen when the event is in several timelines
-                            NSLog(@"[MXMegolmDecryption] retryDecryption: %@ already decrypted on main thread", event.eventId);
+                            MXLogDebug(@"[MXMegolmDecryption] retryDecryption: %@ already decrypted on main thread", event.eventId);
                         }
                         else
                         {
@@ -457,7 +457,7 @@
         }
         else
         {
-            NSLog(@"[MXMegolmDecryption] requestKeysForEvent: ERROR: missing fields for recipients in event %@", event);
+            MXLogDebug(@"[MXMegolmDecryption] requestKeysForEvent: ERROR: missing fields for recipients in event %@", event);
         }
     }
 
@@ -478,7 +478,7 @@
     }
     else
     {
-        NSLog(@"[MXMegolmDecryption] requestKeysForEvent: ERROR: missing fields in event %@", event);
+        MXLogDebug(@"[MXMegolmDecryption] requestKeysForEvent: ERROR: missing fields in event %@", event);
     }
 }
 

--- a/MatrixSDK/Crypto/Algorithms/Olm/MXOlmDecryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Olm/MXOlmDecryption.m
@@ -56,7 +56,7 @@
 
 - (BOOL)hasKeysToDecryptEvent:(MXEvent *)event
 {
-    NSLog(@"[MXOlmDecryption] hasKeysToDecryptEvent: ERROR: Not implemented yet");
+    MXLogDebug(@"[MXOlmDecryption] hasKeysToDecryptEvent: ERROR: Not implemented yet");
     return NO;
 }
 
@@ -70,7 +70,7 @@
 
     if (!ciphertext)
     {
-        NSLog(@"[MXOlmDecryption] decryptEvent: Error: Missing ciphertext");
+        MXLogDebug(@"[MXOlmDecryption] decryptEvent: Error: Missing ciphertext");
         
         MXEventDecryptionResult *result = [MXEventDecryptionResult new];
         result.error = [NSError errorWithDomain:MXDecryptingErrorDomain
@@ -83,7 +83,7 @@
 
     if (!ciphertext[olmDevice.deviceCurve25519Key])
     {
-        NSLog(@"[MXOlmDecryption] decryptEvent: Error: our device %@ is not included in recipients. Event: %@", olmDevice.deviceCurve25519Key, event.JSONDictionary);
+        MXLogDebug(@"[MXOlmDecryption] decryptEvent: Error: our device %@ is not included in recipients. Event: %@", olmDevice.deviceCurve25519Key, event.JSONDictionary);
         
         MXEventDecryptionResult *result = [MXEventDecryptionResult new];
         result.error = [NSError errorWithDomain:MXDecryptingErrorDomain
@@ -100,7 +100,7 @@
     NSString *payloadString = [self decryptMessage:message andTheirDeviceIdentityKey:deviceKey];
     if (!payloadString)
     {
-        NSLog(@"[MXOlmDecryption] decryptEvent: Failed to decrypt Olm event (id= %@) from %@", event.eventId, deviceKey);
+        MXLogDebug(@"[MXOlmDecryption] decryptEvent: Failed to decrypt Olm event (id= %@) from %@", event.eventId, deviceKey);
         
         MXEventDecryptionResult *result = [MXEventDecryptionResult new];
         result.error = [NSError errorWithDomain:MXDecryptingErrorDomain
@@ -117,7 +117,7 @@
     // https://github.com/vector-im/vector-web/issues/2483
     if (!payload[@"recipient"])
     {
-        NSLog(@"[MXOlmDecryption] decryptEvent: Olm event (id=%@) contains no 'recipient' property; cannot prevent unknown-key attack", event.eventId);
+        MXLogDebug(@"[MXOlmDecryption] decryptEvent: Olm event (id=%@) contains no 'recipient' property; cannot prevent unknown-key attack", event.eventId);
         
         MXEventDecryptionResult *result = [MXEventDecryptionResult new];
         result.error = [NSError errorWithDomain:MXDecryptingErrorDomain
@@ -129,7 +129,7 @@
     }
     else if (![payload[@"recipient"] isEqualToString:userId])
     {
-        NSLog(@"[MXOlmDecryption] decryptEvent: Event %@: Intended recipient %@ does not match our id %@", event.eventId, payload[@"recipient"], userId);
+        MXLogDebug(@"[MXOlmDecryption] decryptEvent: Event %@: Intended recipient %@ does not match our id %@", event.eventId, payload[@"recipient"], userId);
 
         MXEventDecryptionResult *result = [MXEventDecryptionResult new];
         result.error = [NSError errorWithDomain:MXDecryptingErrorDomain
@@ -142,7 +142,7 @@
 
     if (!payload[@"recipient_keys"])
     {
-        NSLog(@"[MXOlmDecryption] decryptEvent: Olm event (id=%@) contains no 'recipient_keys' property; cannot prevent unknown-key attack", event.eventId);
+        MXLogDebug(@"[MXOlmDecryption] decryptEvent: Olm event (id=%@) contains no 'recipient_keys' property; cannot prevent unknown-key attack", event.eventId);
 
         MXEventDecryptionResult *result = [MXEventDecryptionResult new];
         result.error = [NSError errorWithDomain:MXDecryptingErrorDomain
@@ -154,7 +154,7 @@
     }
     else if (![payload[@"recipient_keys"][@"ed25519"] isEqualToString:olmDevice.deviceEd25519Key])
     {
-        NSLog(@"[MXOlmDecryption] decryptEvent: Event %@: Intended recipient ed25519 key %@ does not match ours", event.eventId, payload[@"recipient_keys"][@"ed25519"]);
+        MXLogDebug(@"[MXOlmDecryption] decryptEvent: Event %@: Intended recipient ed25519 key %@ does not match ours", event.eventId, payload[@"recipient_keys"][@"ed25519"]);
 
         MXEventDecryptionResult *result = [MXEventDecryptionResult new];
         result.error = [NSError errorWithDomain:MXDecryptingErrorDomain
@@ -171,7 +171,7 @@
     // which is checked elsewhere).
     if (!payload[@"sender"])
     {
-        NSLog(@"[MXOlmDecryption] decryptEvent: Olm event (id=%@) contains no 'sender' property; cannot prevent unknown-key attack", event.eventId);
+        MXLogDebug(@"[MXOlmDecryption] decryptEvent: Olm event (id=%@) contains no 'sender' property; cannot prevent unknown-key attack", event.eventId);
 
         MXEventDecryptionResult *result = [MXEventDecryptionResult new];
         result.error = [NSError errorWithDomain:MXDecryptingErrorDomain
@@ -183,7 +183,7 @@
     }
     else if (![payload[@"sender"] isEqualToString:event.sender])
     {
-        NSLog(@"[MXOlmDecryption] decryptEvent: Event %@: original sender %@ does not match reported sender %@", event.eventId, payload[@"sender"], event.sender);
+        MXLogDebug(@"[MXOlmDecryption] decryptEvent: Event %@: original sender %@ does not match reported sender %@", event.eventId, payload[@"sender"], event.sender);
 
         MXEventDecryptionResult *result = [MXEventDecryptionResult new];
         result.error = [NSError errorWithDomain:MXDecryptingErrorDomain
@@ -197,7 +197,7 @@
     // Olm events intended for a room have a room_id.
     if (event.roomId && ![payload[@"room_id"] isEqualToString:event.roomId])
     {
-        NSLog(@"[MXOlmDecryption] decryptEvent: Event %@: original room %@ does not match reported room %@", event.eventId, payload[@"room_id"], event.roomId);
+        MXLogDebug(@"[MXOlmDecryption] decryptEvent: Event %@: original room %@ does not match reported room %@", event.eventId, payload[@"room_id"], event.roomId);
 
         MXEventDecryptionResult *result = [MXEventDecryptionResult new];
         result.error = [NSError errorWithDomain:MXDecryptingErrorDomain
@@ -268,7 +268,7 @@
 
         if (payload)
         {
-            NSLog(@"[MXOlmDecryption] decryptMessage: Decrypted Olm message from sender key %@ with session %@", theirDeviceIdentityKey, sessionId);
+            MXLogDebug(@"[MXOlmDecryption] decryptMessage: Decrypted Olm message from sender key %@ with session %@", theirDeviceIdentityKey, sessionId);
             return payload;
         }
         else
@@ -279,7 +279,7 @@
             {
                 // Decryption failed, but it was a prekey message matching this
                 // session, so it should have worked.
-                NSLog(@"[MXOlmDecryption] Error decrypting prekey message with existing session id %@", sessionId);
+                MXLogDebug(@"[MXOlmDecryption] Error decrypting prekey message with existing session id %@", sessionId);
                 return nil;
             }
         }
@@ -291,11 +291,11 @@
         // didn't work.
         if (sessionIds.count == 0)
         {
-            NSLog(@"[MXOlmDecryption] decryptMessage: No existing sessions");
+            MXLogDebug(@"[MXOlmDecryption] decryptMessage: No existing sessions");
         }
         else
         {
-            NSLog(@"[MXOlmDecryption] decryptMessage: Error decrypting non-prekey message with existing sessions");
+            MXLogDebug(@"[MXOlmDecryption] decryptMessage: Error decrypting non-prekey message with existing sessions");
         }
 
         return nil;
@@ -307,11 +307,11 @@
     NSString *sessionId = [olmDevice createInboundSession:theirDeviceIdentityKey messageType:messageType cipherText:messageBody payload:&payload];
     if (!sessionId)
     {
-        NSLog(@"[MXOlmDecryption] decryptMessage: Cannot create new inbound Olm session. Error decrypting non-prekey message with existing sessions");
+        MXLogDebug(@"[MXOlmDecryption] decryptMessage: Cannot create new inbound Olm session. Error decrypting non-prekey message with existing sessions");
         return nil;
     }
 
-    NSLog(@"[MXOlmDecryption] Created new inbound Olm session id %@ with %@", sessionId, theirDeviceIdentityKey);
+    MXLogDebug(@"[MXOlmDecryption] Created new inbound Olm session id %@ with %@", sessionId, theirDeviceIdentityKey);
 
     return payload;
 };

--- a/MatrixSDK/Crypto/CrossSigning/MXCrossSigning.m
+++ b/MatrixSDK/Crypto/CrossSigning/MXCrossSigning.m
@@ -99,7 +99,7 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
     NSDictionary<NSString*, NSData*> *privateKeys;
     MXCrossSigningInfo *keys = [self createKeys:&privateKeys];
     
-    NSLog(@"[MXCrossSigning] setup on device %@. MSK: %@", myCreds.deviceId, keys.masterKeys.keys);
+    MXLogDebug(@"[MXCrossSigning] setup on device %@. MSK: %@", myCreds.deviceId, keys.masterKeys.keys);
     
     void (^failureBlock)(NSError *error) = ^void(NSError *error) {
         
@@ -212,7 +212,7 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
                             success:(void (^)(void))success
                             failure:(void (^)(NSError *error))failure
 {
-    NSLog(@"[MXCrossSigning] crossSignDeviceWithDeviceId: %@", deviceId);
+    MXLogDebug(@"[MXCrossSigning] crossSignDeviceWithDeviceId: %@", deviceId);
           
     NSString *myUserId = self.crypto.mxSession.myUserId;
     
@@ -226,7 +226,7 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
             // Sanity check
             if (!device)
             {
-                NSLog(@"[MXCrossSigning] crossSignDeviceWithDeviceId: Unknown device %@", deviceId);
+                MXLogDebug(@"[MXCrossSigning] crossSignDeviceWithDeviceId: Unknown device %@", deviceId);
                 dispatch_async(dispatch_get_main_queue(), ^{
                     NSError *error = [NSError errorWithDomain:MXCrossSigningErrorDomain
                                                          code:MXCrossSigningUnknownDeviceIdErrorCode
@@ -259,7 +259,7 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
                    success:(void (^)(void))success
                    failure:(void (^)(NSError *error))failure
 {
-    NSLog(@"[MXCrossSigning] signUserWithUserId: %@", userId);
+    MXLogDebug(@"[MXCrossSigning] signUserWithUserId: %@", userId);
     
     dispatch_async(self.crypto.cryptoQueue, ^{
         // Make sure we have latest data from the user
@@ -271,7 +271,7 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
             // Sanity check
             if (!otherUserMasterKeys)
             {
-                NSLog(@"[MXCrossSigning] signUserWithUserId: User %@ unknown locally", userId);
+                MXLogDebug(@"[MXCrossSigning] signUserWithUserId: User %@ unknown locally", userId);
                 dispatch_async(dispatch_get_main_queue(), ^{
                     NSError *error = [NSError errorWithDomain:MXCrossSigningErrorDomain
                                                          code:MXCrossSigningUnknownUserIdErrorCode
@@ -310,7 +310,7 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
                 onPrivateKeysReceived:(void (^)(void))onPrivateKeysReceived
                               failure:(void (^)(NSError *error))failure
 {
-    NSLog(@"[MXCrossSigning] requestPrivateKeysToDeviceIds: %@", deviceIds);
+    MXLogDebug(@"[MXCrossSigning] requestPrivateKeysToDeviceIds: %@", deviceIds);
     
     // Make a secret share request for MSK, USK and SSK
     dispatch_group_t successGroup = dispatch_group_create();
@@ -341,7 +341,7 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
             isSecretValid = YES;
         }
         
-        NSLog(@"[MXCrossSigning] requestPrivateKeysToDeviceIds: Got MSK. isSecretValid: %@", @(isSecretValid));
+        MXLogDebug(@"[MXCrossSigning] requestPrivateKeysToDeviceIds: Got MSK. isSecretValid: %@", @(isSecretValid));
         if (isSecretValid)
         {
             [self.crypto.store storeSecret:secret withSecretId:MXSecretId.crossSigningMaster];
@@ -378,7 +378,7 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
             isSecretValid = YES;
         }
         
-        NSLog(@"[MXCrossSigning] requestPrivateKeysToDeviceIds: Got USK. isSecretValid: %@", @(isSecretValid));
+        MXLogDebug(@"[MXCrossSigning] requestPrivateKeysToDeviceIds: Got USK. isSecretValid: %@", @(isSecretValid));
         if (isSecretValid)
         {
             [self.crypto.store storeSecret:secret withSecretId:MXSecretId.crossSigningUserSigning];
@@ -415,7 +415,7 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
             isSecretValid = YES;
         }
         
-        NSLog(@"[MXCrossSigning] requestPrivateKeysToDeviceIds: Got SSK. isSecretValid: %@", @(isSecretValid));
+        MXLogDebug(@"[MXCrossSigning] requestPrivateKeysToDeviceIds: Got SSK. isSecretValid: %@", @(isSecretValid));
         if (isSecretValid)
         {
             [self.crypto.store storeSecret:secret withSecretId:MXSecretId.crossSigningSelfSigning];
@@ -433,12 +433,12 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
     }];
     
     dispatch_group_notify(successGroup, dispatch_get_main_queue(), ^{
-        NSLog(@"[MXCrossSigning] requestPrivateKeysToDeviceIds: request succeeded");
+        MXLogDebug(@"[MXCrossSigning] requestPrivateKeysToDeviceIds: request succeeded");
         success();
     });
     
     dispatch_group_notify(onPrivateKeysReceivedGroup, dispatch_get_main_queue(), ^{
-        NSLog(@"[MXCrossSigning] requestPrivateKeysToDeviceIds: Got keys");
+        MXLogDebug(@"[MXCrossSigning] requestPrivateKeysToDeviceIds: Got keys");
         [self refreshStateWithSuccess:^(BOOL stateUpdated) {
             onPrivateKeysReceived();
         } failure:^(NSError * _Nonnull error) {
@@ -478,7 +478,7 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
     NSString *myUserId = _crypto.mxSession.myUserId;
     _myUserCrossSigningKeys = [_crypto.store crossSigningKeysForUser:myUserId];
     
-    NSLog(@"[MXCrossSigning] refreshState for device %@: Current state: %@", self.crypto.store.deviceId, @(self.state));
+    MXLogDebug(@"[MXCrossSigning] refreshState for device %@: Current state: %@", self.crypto.store.deviceId, @(self.state));
 
     // Refresh user's keys
     [self.crypto downloadKeys:@[myUserId] forceDownload:YES success:^(MXUsersDevicesMap<MXDeviceInfo *> *usersDevicesInfoMap, NSDictionary<NSString *,MXCrossSigningInfo *> *crossSigningKeysMap) {
@@ -501,7 +501,7 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
             [self resetTrust];
         }
         
-        NSLog(@"[MXCrossSigning] refreshState for device %@: Updated state: %@", self.crypto.store.deviceId, @(self.state));
+        MXLogDebug(@"[MXCrossSigning] refreshState for device %@: Updated state: %@", self.crypto.store.deviceId, @(self.state));
         
         if (success)
         {
@@ -511,7 +511,7 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
             });
         }
     } failure:^(NSError *error) {
-        NSLog(@"[MXCrossSigning] refreshStateWithSuccess: Failed to load my user's keys");
+        MXLogDebug(@"[MXCrossSigning] refreshStateWithSuccess: Failed to load my user's keys");
         if (failure)
         {
             dispatch_async(dispatch_get_main_queue(), ^{
@@ -545,7 +545,7 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
                                                                       error:&error];
     if (error)
     {
-        NSLog(@"[MXCrossSigning] computeUserTrustLevelForCrossSigningKeys failed. Error: %@", error);
+        MXLogDebug(@"[MXCrossSigning] computeUserTrustLevelForCrossSigningKeys failed. Error: %@", error);
     }
 
     return isUserVerified;
@@ -641,14 +641,14 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
         }
     }
     
-    NSLog(@"[MXCrossSigning] computeState: myUserCrossSigningKeys: %@", _myUserCrossSigningKeys);
-    NSLog(@"[MXCrossSigning] computeState: state: %@ (was %@)", @(state), @(_state));
+    MXLogDebug(@"[MXCrossSigning] computeState: myUserCrossSigningKeys: %@", _myUserCrossSigningKeys);
+    MXLogDebug(@"[MXCrossSigning] computeState: state: %@ (was %@)", @(state), @(_state));
     
     _state = state;
     
     if (didTrustCrossSigning && !self.canTrustCrossSigning)
     {
-        NSLog(@"[MXCrossSigning] computeState: Detected new cross-signing keys");
+        MXLogDebug(@"[MXCrossSigning] computeState: Detected new cross-signing keys");
         dispatch_async(dispatch_get_main_queue(), ^{
             [[NSNotificationCenter defaultCenter] postNotificationName:MXCrossSigningDidChangeCrossSigningKeysNotification object:self userInfo:nil];
         });
@@ -658,14 +658,14 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
 // Recompute cross-signing trust on all users we know
 - (void)resetTrust
 {
-    NSLog(@"[MXCrossSigning] resetTrust for device %@", self.crypto.mxSession.matrixRestClient.credentials.deviceId);
+    MXLogDebug(@"[MXCrossSigning] resetTrust for device %@", self.crypto.mxSession.matrixRestClient.credentials.deviceId);
     
     for (MXCrossSigningInfo *crossSigningInfo in self.crypto.store.crossSigningKeys)
     {
         BOOL isCrossSigningVerified = [self isUserWithCrossSigningKeysVerified:crossSigningInfo];
         if (crossSigningInfo.trustLevel.isCrossSigningVerified != isCrossSigningVerified)
         {
-            NSLog(@"[MXCrossSigning] resetTrust: Change trust for %@: %@ -> %@", crossSigningInfo.userId,
+            MXLogDebug(@"[MXCrossSigning] resetTrust: Change trust for %@: %@ -> %@", crossSigningInfo.userId,
                   @(crossSigningInfo.trustLevel.isCrossSigningVerified),
                   @(isCrossSigningVerified));
             
@@ -690,7 +690,7 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
     NSString *pubKey = [pkSigning doInitWithSeed:privKey error:&error];
     if (error)
     {
-        NSLog(@"[MXCrossSigning] makeSigningKey failed. Error: %@", error);
+        MXLogDebug(@"[MXCrossSigning] makeSigningKey failed. Error: %@", error);
         return nil;
     }
 
@@ -717,7 +717,7 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
     if (!myMasterKey)
     {
         // Cross-signing is not set up
-        NSLog(@"[MXCrossSigning] isSelfTrusted: NO (No MSK)");
+        MXLogDebug(@"[MXCrossSigning] isSelfTrusted: NO (No MSK)");
         return NO;
     }
     
@@ -757,9 +757,9 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
     
     if (!isMasterKeyTrusted)
     {
-        NSLog(@"[MXCrossSigning] isSelfTrusted: NO (MSK not trusted). MSK: %@", myMasterKey);
-        NSLog(@"[MXCrossSigning] isSelfTrusted: My cross-signing info: %@", myCrossSigningInfo);
-        NSLog(@"[MXCrossSigning] isSelfTrusted: My user devices: %@", [self.crypto.store devicesForUser:myUserId]);
+        MXLogDebug(@"[MXCrossSigning] isSelfTrusted: NO (MSK not trusted). MSK: %@", myMasterKey);
+        MXLogDebug(@"[MXCrossSigning] isSelfTrusted: My cross-signing info: %@", myCrossSigningInfo);
+        MXLogDebug(@"[MXCrossSigning] isSelfTrusted: My user devices: %@", [self.crypto.store devicesForUser:myUserId]);
 
         return NO;
     }
@@ -769,8 +769,8 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
     BOOL isUSKSignatureValid = [self checkSignatureOnKey:myUserKey byKey:myMasterKey userId:myUserId];
     if (!isUSKSignatureValid)
     {
-        NSLog(@"[MXCrossSigning] isSelfTrusted: NO (Invalid MSK signature for USK). USK: %@", myUserKey);
-        NSLog(@"[MXCrossSigning] isSelfTrusted: MSK: %@", myMasterKey);
+        MXLogDebug(@"[MXCrossSigning] isSelfTrusted: NO (Invalid MSK signature for USK). USK: %@", myUserKey);
+        MXLogDebug(@"[MXCrossSigning] isSelfTrusted: MSK: %@", myMasterKey);
         return NO;
     }
     
@@ -779,8 +779,8 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
     BOOL isSSKSignatureValid = [self checkSignatureOnKey:mySelfKey byKey:myMasterKey userId:myUserId];
     if (!isSSKSignatureValid)
     {
-        NSLog(@"[MXCrossSigning] isSelfTrusted: NO (Invalid MSK signature for SSK). SSK: %@", mySelfKey);
-        NSLog(@"[MXCrossSigning] isSelfTrusted: MSK: %@", myMasterKey);
+        MXLogDebug(@"[MXCrossSigning] isSelfTrusted: NO (Invalid MSK signature for SSK). SSK: %@", mySelfKey);
+        MXLogDebug(@"[MXCrossSigning] isSelfTrusted: MSK: %@", myMasterKey);
         return NO;
     }
     
@@ -791,7 +791,7 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
 {
     if (!key)
     {
-        NSLog(@"[MXCrossSigning] checkSignatureOnKey: NO (No key)");
+        MXLogDebug(@"[MXCrossSigning] checkSignatureOnKey: NO (No key)");
         return NO;
     }
     
@@ -799,7 +799,7 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
     NSString *signatureMadeBySigningKey = [key.signatures objectForDevice:signingPublicKeyId forUser:userId];
     if (!signatureMadeBySigningKey)
     {
-        NSLog(@"[MXCrossSigning] checkSignatureOnKey: NO (Key not signed)");
+        MXLogDebug(@"[MXCrossSigning] checkSignatureOnKey: NO (Key not signed)");
         return NO;
     }
     
@@ -807,7 +807,7 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
     BOOL isSignatureValid = [_crypto.olmDevice verifySignature:signingKey.keys JSON:key.signalableJSONDictionary signature:signatureMadeBySigningKey error:&error];
     if (!isSignatureValid)
     {
-        NSLog(@"[MXCrossSigning] checkSignatureOnKey: NO (Invalid signature)");
+        MXLogDebug(@"[MXCrossSigning] checkSignatureOnKey: NO (Invalid signature)");
         return NO;
     }
     
@@ -969,7 +969,7 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
         }
         
         // Else, delete them
-        NSLog(@"[MXCrossSigning] haveCrossSigningPrivateKeysInCryptoStore: Delete local keys. They are obsolete");
+        MXLogDebug(@"[MXCrossSigning] haveCrossSigningPrivateKeysInCryptoStore: Delete local keys. They are obsolete");
         [self.crypto.store deleteSecretWithSecretId:MXSecretId.crossSigningUserSigning];
         [self.crypto.store deleteSecretWithSecretId:MXSecretId.crossSigningSelfSigning];
     }
@@ -984,7 +984,7 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
     NSString *expectedPublicKey = _myUserCrossSigningKeys.keys[keyType].keys;
     if (!expectedPublicKey)
     {
-        NSLog(@"[MXCrossSigning] getCrossSigningKeyWithKeyType: %@ failed. No such key present", keyType);
+        MXLogDebug(@"[MXCrossSigning] getCrossSigningKeyWithKeyType: %@ failed. No such key present", keyType);
         failure(nil);
         return;
     }
@@ -999,7 +999,7 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
             OLMPkSigning *pkSigning = [self pkSigningFromBase64PrivateKey:privateKeyBase64 withExpectedPublicKey:expectedPublicKey];
             if (!pkSigning)
             {
-                NSLog(@"[MXCrossSigning] getCrossSigningKeyWithKeyType failed to get PK signing");
+                MXLogDebug(@"[MXCrossSigning] getCrossSigningKeyWithKeyType failed to get PK signing");
                 failure(nil);
                 return;
             }
@@ -1009,7 +1009,7 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
         }
     }
     
-    NSLog(@"[MXCrossSigning] getCrossSigningKeyWithKeyType: %@ failed. No such key present", keyType);
+    MXLogDebug(@"[MXCrossSigning] getCrossSigningKeyWithKeyType: %@ failed. No such key present", keyType);
     failure(nil);
 }
 
@@ -1071,13 +1071,13 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
     NSString *gotPublicKey = [pkSigning doInitWithSeed:privateKey error:&error];
     if (error)
     {
-        NSLog(@"[MXCrossSigning] pkSigningFromPrivateKey failed to build PK signing. Error: %@", error);
+        MXLogDebug(@"[MXCrossSigning] pkSigningFromPrivateKey failed to build PK signing. Error: %@", error);
         return nil;
     }
     
     if (![gotPublicKey isEqualToString:expectedPublicKey])
     {
-        NSLog(@"[MXCrossSigning] pkSigningFromPrivateKey failed. Keys do not match: %@ vs %@", gotPublicKey, expectedPublicKey);
+        MXLogDebug(@"[MXCrossSigning] pkSigningFromPrivateKey failed. Keys do not match: %@ vs %@", gotPublicKey, expectedPublicKey);
         return nil;
     }
     

--- a/MatrixSDK/Crypto/CrossSigning/MXCrossSigningTools.m
+++ b/MatrixSDK/Crypto/CrossSigning/MXCrossSigningTools.m
@@ -81,7 +81,7 @@ NSString *const MXCrossSigningToolsErrorDomain = @"org.matrix.sdk.crosssigning.t
 
     if (!signature)
     {
-        NSLog(@"[MXCrossSigningTools] pkVerifyObject. Error: Missing signature for %@:%@ in %@", userId, keyId, object[@"signatures"]);
+        MXLogDebug(@"[MXCrossSigningTools] pkVerifyObject. Error: Missing signature for %@:%@ in %@", userId, keyId, object[@"signatures"]);
         if (error)
         {
             *error = [NSError errorWithDomain:MXCrossSigningToolsErrorDomain

--- a/MatrixSDK/Crypto/Data/MXDeviceList.m
+++ b/MatrixSDK/Crypto/Data/MXDeviceList.m
@@ -93,7 +93,7 @@
                                            NSDictionary<NSString* /* userId*/, MXCrossSigningInfo*> *crossSigningKeysMap))success
                          failure:(void (^)(NSError *error))failure
 {
-    NSLog(@"[MXDeviceList] downloadKeys(forceDownload: %d) for %tu users", forceDownload, userIds.count);
+    MXLogDebug(@"[MXDeviceList] downloadKeys(forceDownload: %d) for %tu users", forceDownload, userIds.count);
 
     NSMutableArray *usersToDownload = [NSMutableArray array];
     BOOL doANewQuery = NO;
@@ -102,7 +102,7 @@
     {
         if (![MXTools isMatrixUserIdentifier:userId])
         {
-            NSLog(@"[MXDeviceList] downloadKeys: ERROR: Ignore malformed user id: %@", userId);
+            MXLogDebug(@"[MXDeviceList] downloadKeys: ERROR: Ignore malformed user id: %@", userId);
             continue;
         }
 
@@ -122,7 +122,7 @@
         }
         else
         {
-            NSLog(@"[MXDeviceList] downloadKeys: Skip user %@. trackingStatus: %@", userId, @(trackingStatus));
+            MXLogDebug(@"[MXDeviceList] downloadKeys: Skip user %@. trackingStatus: %@", userId, @(trackingStatus));
         }
     }
 
@@ -130,7 +130,7 @@
 
     if (usersToDownload.count)
     {
-        NSLog(@"[MXDeviceList] downloadKeys for actually %tu users: %@", usersToDownload.count, usersToDownload);
+        MXLogDebug(@"[MXDeviceList] downloadKeys for actually %tu users: %@", usersToDownload.count, usersToDownload);
 
         for (NSString *userId in usersToDownload)
         {
@@ -146,7 +146,7 @@
             MXStrongifyAndReturnIfNil(self);
             MXStrongifyAndReturnIfNil(operation);
 
-            NSLog(@"[MXDeviceList] downloadKeys (operation: %p) -> DONE", operation);
+            MXLogDebug(@"[MXDeviceList] downloadKeys (operation: %p) -> DONE", operation);
 
             for (NSString *userId in succeededUserIds)
             {
@@ -155,7 +155,7 @@
                 // ignore the completion of the first one.
                 if (self->keyDownloadsInProgressByUser[userId] != operation)
                 {
-                    NSLog(@"[MXDeviceList] downloadKeys: Another update (operation: %p) in the queue for %@ - not marking up-to-date", self->keyDownloadsInProgressByUser[userId], userId);
+                    MXLogDebug(@"[MXDeviceList] downloadKeys: Another update (operation: %p) in the queue for %@ - not marking up-to-date", self->keyDownloadsInProgressByUser[userId], userId);
                     continue;
                 }
                 [self->keyDownloadsInProgressByUser removeObjectForKey:userId];
@@ -171,7 +171,7 @@
 
             if (failedUserIds.count)
             {
-                NSLog(@"[MXDeviceList] downloadKeys. Error updating device keys for users %@", failedUserIds);
+                MXLogDebug(@"[MXDeviceList] downloadKeys. Error updating device keys for users %@", failedUserIds);
 
                 for (NSString *userId in failedUserIds)
                 {
@@ -213,19 +213,19 @@
 
         if (doANewQuery || !currentQueryPool)
         {
-            NSLog(@"[MXDeviceList] downloadKeys: waiting for next key query. Operation: %p", operation);
+            MXLogDebug(@"[MXDeviceList] downloadKeys: waiting for next key query. Operation: %p", operation);
 
             [self startOrQueueDeviceQuery:operation];
         }
         else
         {
-            NSLog(@"[MXDeviceList] downloadKeys: waiting for in-flight query to complete. Operation: %p", operation);
+            MXLogDebug(@"[MXDeviceList] downloadKeys: waiting for in-flight query to complete. Operation: %p", operation);
             [operation addToPool:currentQueryPool];
         }
     }
     else
     {
-        NSLog(@"[MXDeviceList] downloadKeys: already have all necessary keys");
+        MXLogDebug(@"[MXDeviceList] downloadKeys: already have all necessary keys");
         if (success)
         {
             success([self devicesForUsers:userIds],
@@ -262,7 +262,7 @@
 {
     if (![MXTools isMatrixUserIdentifier:userId])
     {
-        NSLog(@"[MXDeviceList] startTrackingDeviceList: ERROR: Ignore malformed user id: %@", userId);
+        MXLogDebug(@"[MXDeviceList] startTrackingDeviceList: ERROR: Ignore malformed user id: %@", userId);
         return;
     }
 
@@ -270,7 +270,7 @@
 
     if (!trackingStatus)
     {
-        NSLog(@"[MXDeviceList] Now tracking device list for %@", userId);
+        MXLogDebug(@"[MXDeviceList] Now tracking device list for %@", userId);
         deviceTrackingStatus[userId] = @(MXDeviceTrackingStatusPendingDownload);
     }
     // we don't yet persist the tracking status, since there may be a lot
@@ -284,7 +284,7 @@
 
     if (trackingStatus)
     {
-        NSLog(@"[MXDeviceList] No longer tracking device list for %@", userId);
+        MXLogDebug(@"[MXDeviceList] No longer tracking device list for %@", userId);
         deviceTrackingStatus[userId] = @(MXDeviceTrackingStatusNotTracked);
     }
     // we don't yet persist the tracking status, since there may be a lot
@@ -298,7 +298,7 @@
 
     if (trackingStatus)
     {
-        NSLog(@"[MXDeviceList] Marking device list outdated for %@", userId);
+        MXLogDebug(@"[MXDeviceList] Marking device list outdated for %@", userId);
         deviceTrackingStatus[userId] = @(MXDeviceTrackingStatusPendingDownload);
     }
     // we don't yet persist the tracking status, since there may be a lot
@@ -334,9 +334,9 @@
     if (users.count)
     {
         [self downloadKeys:users forceDownload:NO success:^(MXUsersDevicesMap<MXDeviceInfo *> *usersDevicesInfoMap, NSDictionary<NSString *,MXCrossSigningInfo *> *crossSigningKeysMap) {
-            NSLog(@"[MXDeviceList] refreshOutdatedDeviceLists (users: %tu): %@", usersDevicesInfoMap.userIds.count, usersDevicesInfoMap.userIds);
+            MXLogDebug(@"[MXDeviceList] refreshOutdatedDeviceLists (users: %tu): %@", usersDevicesInfoMap.userIds.count, usersDevicesInfoMap.userIds);
         } failure:^(NSError *error) {
-            NSLog(@"[MXDeviceList] refreshOutdatedDeviceLists: ERROR updating device keys for users %@", users);
+            MXLogDebug(@"[MXDeviceList] refreshOutdatedDeviceLists: ERROR updating device keys for users %@", users);
         }];
     }
 }
@@ -366,7 +366,7 @@
         }
     }
 
-    NSLog(@"[MXDeviceList] devicesForUsers: %@", usersDevicesInfoMap);
+    MXLogDebug(@"[MXDeviceList] devicesForUsers: %@", usersDevicesInfoMap);
 
     return usersDevicesInfoMap;
 }
@@ -428,7 +428,7 @@
 
 - (void)startCurrentPoolQuery
 {
-    NSLog(@"[MXDeviceList] startCurrentPoolQuery(pool: %p) (users: %tu): %@", currentQueryPool, currentQueryPool.userIds.count, currentQueryPool.userIds);
+    MXLogDebug(@"[MXDeviceList] startCurrentPoolQuery(pool: %p) (users: %tu): %@", currentQueryPool, currentQueryPool.userIds.count, currentQueryPool.userIds);
 
     if (currentQueryPool.userIds)
     {
@@ -439,7 +439,7 @@
         [currentQueryPool downloadKeys:token complete:^(NSDictionary<NSString *,NSDictionary *> *failedUserIds) {
             MXStrongifyAndReturnIfNil(self);
 
-            NSLog(@"[MXDeviceList] startCurrentPoolQuery(pool: %p) -> DONE. failedUserIds (users: %tu): %@", self->currentQueryPool, failedUserIds.count, failedUserIds);
+            MXLogDebug(@"[MXDeviceList] startCurrentPoolQuery(pool: %p) -> DONE. failedUserIds (users: %tu): %@", self->currentQueryPool, failedUserIds.count, failedUserIds);
 
             if (token)
             {

--- a/MatrixSDK/Crypto/Data/MXDeviceListOperation.m
+++ b/MatrixSDK/Crypto/Data/MXDeviceListOperation.m
@@ -47,7 +47,7 @@
 {
     NSParameterAssert(!pool);
 
-    NSLog(@"[MXDeviceListOperation] addToPool: add operation: %p to pool %p", self, thePool);
+    MXLogDebug(@"[MXDeviceListOperation] addToPool: add operation: %p to pool %p", self, thePool);
 
     pool = thePool;
     [pool addOperation:self];

--- a/MatrixSDK/Crypto/Data/MXEncryptedAttachments.m
+++ b/MatrixSDK/Crypto/Data/MXEncryptedAttachments.m
@@ -278,7 +278,7 @@ NSString *const MXEncryptedAttachmentsErrorDomain = @"MXEncryptedAttachmentsErro
     
     if (![computedSha256 isEqualToData:expectedSha256])
     {
-        NSLog(@"[MXEncryptedAttachments] decryptAttachment: Hash mismatch when decrypting attachment! Expected: %@, got %@", fileInfo.hashes[@"sha256"], [computedSha256 base64EncodedStringWithOptions:0]);
+        MXLogDebug(@"[MXEncryptedAttachments] decryptAttachment: Hash mismatch when decrypting attachment! Expected: %@, got %@", fileInfo.hashes[@"sha256"], [computedSha256 base64EncodedStringWithOptions:0]);
         return [NSError errorWithDomain:MXEncryptedAttachmentsErrorDomain code:0 userInfo:@{@"err": @"hash_mismatch"}];
     }
     return nil;

--- a/MatrixSDK/Crypto/Data/MXKey.m
+++ b/MatrixSDK/Crypto/Data/MXKey.m
@@ -63,7 +63,7 @@ NSString *const kMXKeyEd25519Type = @"ed25519";
     }
     else
     {
-        NSLog(@"[MXKey] setKeyFullId: ERROR: cannot process keyFullId: %@", keyFullId);
+        MXLogDebug(@"[MXKey] setKeyFullId: ERROR: cannot process keyFullId: %@", keyFullId);
     }
 }
 

--- a/MatrixSDK/Crypto/Data/MXOlmInboundGroupSession.m
+++ b/MatrixSDK/Crypto/Data/MXOlmInboundGroupSession.m
@@ -60,7 +60,7 @@
     }
     else
     {
-        NSLog(@"[MXOlmInboundGroupSession] exportSessionData: Cannot export session with id %@-%@. Error: %@", _session.sessionIdentifier, _senderKey, error);
+        MXLogDebug(@"[MXOlmInboundGroupSession] exportSessionData: Cannot export session with id %@-%@. Error: %@", _session.sessionIdentifier, _senderKey, error);
     }
 
     return sessionData;
@@ -80,7 +80,7 @@
         _session  = [[OLMInboundGroupSession alloc] initInboundGroupSessionWithImportedSession:sessionKey error:&error];
         if (!_session)
         {
-            NSLog(@"[MXOlmInboundGroupSession] initWithImportedSessionKey failed. Error: %@", error);
+            MXLogDebug(@"[MXOlmInboundGroupSession] initWithImportedSessionKey failed. Error: %@", error);
             return nil;
         }
     }

--- a/MatrixSDK/Crypto/Data/MXOutboundSessionInfo.m
+++ b/MatrixSDK/Crypto/Data/MXOutboundSessionInfo.m
@@ -39,7 +39,7 @@
 
     if (_useCount >= rotationPeriodMsgs || sessionLifetime >= rotationPeriodMs)
     {
-        NSLog(@"[MXOutboundSessionInfo] Rotating megolm session after %tu messages, %tu ms", _useCount, sessionLifetime);
+        MXLogDebug(@"[MXOutboundSessionInfo] Rotating megolm session after %tu messages, %tu ms", _useCount, sessionLifetime);
         needsRotation = YES;
     }
 
@@ -52,7 +52,7 @@
     {
         if (![devicesInRoom deviceIdsForUser:userId])
         {
-            NSLog(@"[MXOutboundSessionInfo] Starting new session because we shared with %@",  userId);
+            MXLogDebug(@"[MXOutboundSessionInfo] Starting new session because we shared with %@",  userId);
             return YES;
         }
 
@@ -60,7 +60,7 @@
         {
             if (! [devicesInRoom objectForDevice:deviceId forUser:userId])
             {
-                NSLog(@"[MXOutboundSessionInfo] Starting new session because we shared with %@:%@", userId, deviceId);
+                MXLogDebug(@"[MXOutboundSessionInfo] Starting new session because we shared with %@:%@", userId, deviceId);
                 return YES;
             }
         }

--- a/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
+++ b/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
@@ -346,7 +346,7 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
 
 + (instancetype)createStoreWithCredentials:(MXCredentials*)credentials
 {
-    NSLog(@"[MXRealmCryptoStore] createStore for %@:%@", credentials.userId, credentials.deviceId);
+    MXLogDebug(@"[MXRealmCryptoStore] createStore for %@:%@", credentials.userId, credentials.deviceId);
     
     RLMRealm *realm = [MXRealmCryptoStore realmForUser:credentials.userId andDevice:credentials.deviceId readOnly:NO];
     
@@ -376,7 +376,7 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
 
 + (void)_deleteStoreWithCredentials:(MXCredentials*)credentials readOnly:(BOOL)readOnly
 {
-    NSLog(@"[MXRealmCryptoStore] deleteStore for %@:%@, readOnly: %@", credentials.userId, credentials.deviceId, readOnly ? @"YES" : @"NO");
+    MXLogDebug(@"[MXRealmCryptoStore] deleteStore for %@:%@, readOnly: %@", credentials.userId, credentials.deviceId, readOnly ? @"YES" : @"NO");
     
     // Delete db file directly
     // So that we can even delete corrupted realm db
@@ -393,7 +393,7 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
     
     if (![RLMRealm fileExistsForConfiguration:config])
     {
-        NSLog(@"[MXRealmCryptoStore] deleteStore: Realm db does not exist");
+        MXLogDebug(@"[MXRealmCryptoStore] deleteStore: Realm db does not exist");
         return;
     }
     
@@ -401,7 +401,7 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
     [RLMRealm deleteFilesForConfiguration:config error:&error];
     if (error)
     {
-        NSLog(@"[MXRealmCryptoStore] deleteStore: Error: %@", error);
+        MXLogDebug(@"[MXRealmCryptoStore] deleteStore: Error: %@", error);
         
         if (!readOnly)
         {
@@ -411,14 +411,14 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
             RLMRealm *realm = [MXRealmCryptoStore realmForUser:credentials.userId andDevice:credentials.deviceId readOnly:readOnly];
             if (!error)
             {
-                NSLog(@"[MXRealmCryptoStore] deleteStore: Delete at least its content");
+                MXLogDebug(@"[MXRealmCryptoStore] deleteStore: Delete at least its content");
                 [realm transactionWithBlock:^{
                     [realm deleteAllObjects];
                 }];
             }
             else
             {
-                NSLog(@"[MXRealmCryptoStore] deleteStore: Cannot open realm. Error: %@", error);
+                MXLogDebug(@"[MXRealmCryptoStore] deleteStore: Cannot open realm. Error: %@", error);
             }
         }
     }
@@ -426,7 +426,7 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
 
 - (instancetype)initWithCredentials:(MXCredentials *)credentials
 {
-    NSLog(@"[MXRealmCryptoStore] initWithCredentials for %@:%@", credentials.userId, credentials.deviceId);
+    MXLogDebug(@"[MXRealmCryptoStore] initWithCredentials for %@:%@", credentials.userId, credentials.deviceId);
     
     self = [super init];
     if (self)
@@ -444,13 +444,13 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
             // Make sure the device id corresponds
             if (account.deviceId && ![account.deviceId isEqualToString:credentials.deviceId])
             {
-                NSLog(@"[MXRealmCryptoStore] Credentials do not match");
+                MXLogDebug(@"[MXRealmCryptoStore] Credentials do not match");
                 [MXRealmCryptoStore deleteStoreWithCredentials:credentials];
                 return [MXRealmCryptoStore createStoreWithCredentials:credentials];
             }
         }
         
-        NSLog(@"[MXRealmCryptoStore] Schema version: %llu", account.realm.configuration.schemaVersion);
+        MXLogDebug(@"[MXRealmCryptoStore] Schema version: %llu", account.realm.configuration.schemaVersion);
     }
     return self;
 }
@@ -496,7 +496,7 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
         account.olmAccountData = [NSKeyedArchiver archivedDataWithRootObject:olmAccount];
     }];
     
-    NSLog(@"[MXRealmCryptoStore] storeAccount in %.3fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+    MXLogDebug(@"[MXRealmCryptoStore] storeAccount in %.3fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 }
 
 - (OLMAccount*)account
@@ -530,17 +530,17 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
         }
         else
         {
-            NSLog(@"[MXRealmCryptoStore] performAccountOperationWithBlock. Error: Cannot build OLMAccount");
+            MXLogDebug(@"[MXRealmCryptoStore] performAccountOperationWithBlock. Error: Cannot build OLMAccount");
             block(nil);
         }
     }
     else
     {
-        NSLog(@"[MXRealmCryptoStore] performAccountOperationWithBlock. Error: No OLMAccount yet");
+        MXLogDebug(@"[MXRealmCryptoStore] performAccountOperationWithBlock. Error: No OLMAccount yet");
         block(nil);
     }
     
-    NSLog(@"[MXRealmCryptoStore] performAccountOperationWithBlock done in %.3fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+    MXLogDebug(@"[MXRealmCryptoStore] performAccountOperationWithBlock done in %.3fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 }
 
 - (void)storeDeviceSyncToken:(NSString*)deviceSyncToken
@@ -592,7 +592,7 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
         
     }];
     
-    NSLog(@"[MXRealmCryptoStore] storeDeviceForUser in %.3fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+    MXLogDebug(@"[MXRealmCryptoStore] storeDeviceForUser in %.3fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 }
 
 - (MXDeviceInfo*)deviceWithDeviceId:(NSString*)deviceId forUser:(NSString*)userID
@@ -653,7 +653,7 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
         }
     }];
     
-    NSLog(@"[MXRealmCryptoStore] storeDevicesForUser (count: %tu) in %.3fms", devices.count, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+    MXLogDebug(@"[MXRealmCryptoStore] storeDevicesForUser (count: %tu) in %.3fms", devices.count, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 }
 
 - (NSDictionary<NSString*, MXDeviceInfo*>*)devicesForUser:(NSString*)userID
@@ -774,7 +774,7 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
         }
     }];
     
-    NSLog(@"[MXRealmCryptoStore] storeAlgorithmForRoom (%@) in %.3fms", (isNew?@"NEW":@"UPDATE"), [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+    MXLogDebug(@"[MXRealmCryptoStore] storeAlgorithmForRoom (%@) in %.3fms", (isNew?@"NEW":@"UPDATE"), [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 }
 
 - (NSString*)algorithmForRoom:(NSString*)roomId
@@ -807,7 +807,7 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
         }
     }];
     
-    NSLog(@"[MXRealmCryptoStore] storeBlacklistUnverifiedDevicesInRoom (%@) in %.3fms", (isNew?@"NEW":@"UPDATE"), [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+    MXLogDebug(@"[MXRealmCryptoStore] storeBlacklistUnverifiedDevicesInRoom (%@) in %.3fms", (isNew?@"NEW":@"UPDATE"), [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 }
 
 - (BOOL)blacklistUnverifiedDevicesInRoom:(NSString *)roomId
@@ -850,7 +850,7 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
         }
     }];
     
-    NSLog(@"[MXRealmCryptoStore] storeSession (%@) in %.3fms", (isNew?@"NEW":@"UPDATE"), [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+    MXLogDebug(@"[MXRealmCryptoStore] storeSession (%@) in %.3fms", (isNew?@"NEW":@"UPDATE"), [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 }
 
 - (MXOlmSession*)sessionWithDevice:(NSString*)deviceKey andSessionId:(NSString*)sessionId
@@ -893,13 +893,13 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
     }
     else
     {
-        NSLog(@"[MXRealmCryptoStore] performSessionOperationWithDevice. Error: olm session %@ not found", sessionId);
+        MXLogDebug(@"[MXRealmCryptoStore] performSessionOperationWithDevice. Error: olm session %@ not found", sessionId);
         block(nil);
     }
     
     [realm commitWriteTransaction];
     
-    NSLog(@"[MXRealmCryptoStore] performSessionOperationWithDevice done in %.3fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+    MXLogDebug(@"[MXRealmCryptoStore] performSessionOperationWithDevice done in %.3fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 }
 
 - (NSArray<MXOlmSession*>*)sessionsWithDevice:(NSString*)deviceKey;
@@ -969,7 +969,7 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
     }];
     
     
-    NSLog(@"[MXRealmCryptoStore] storeInboundGroupSessions: store %@ keys (%@ new) in %.3fms", @(sessions.count), @(newCount), [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+    MXLogDebug(@"[MXRealmCryptoStore] storeInboundGroupSessions: store %@ keys (%@ new) in %.3fms", @(sessions.count), @(newCount), [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 }
 
 - (MXOlmInboundGroupSession*)inboundGroupSessionWithId:(NSString*)sessionId andSenderKey:(NSString*)senderKey
@@ -979,7 +979,7 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
                                                                                 senderKey:senderKey];
     MXRealmOlmInboundGroupSession *realmSession = [MXRealmOlmInboundGroupSession objectsInRealm:self.realm where:@"sessionIdSenderKey = %@", sessionIdSenderKey].firstObject;
     
-    NSLog(@"[MXRealmCryptoStore] inboundGroupSessionWithId: %@ -> %@", sessionId, realmSession ? @"found" : @"not found");
+    MXLogDebug(@"[MXRealmCryptoStore] inboundGroupSessionWithId: %@ -> %@", sessionId, realmSession ? @"found" : @"not found");
     
     if (realmSession)
     {
@@ -987,7 +987,7 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
         
         if (!session)
         {
-            NSLog(@"[MXRealmCryptoStore] inboundGroupSessionWithId: ERROR: Failed to create MXOlmInboundGroupSession object");
+            MXLogDebug(@"[MXRealmCryptoStore] inboundGroupSessionWithId: ERROR: Failed to create MXOlmInboundGroupSession object");
         }
     }
     
@@ -1018,18 +1018,18 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
         }
         else
         {
-            NSLog(@"[MXRealmCryptoStore] performSessionOperationWithGroupSessionWithId. Error: Cannot build MXOlmInboundGroupSession for megolm session %@", sessionId);
+            MXLogDebug(@"[MXRealmCryptoStore] performSessionOperationWithGroupSessionWithId. Error: Cannot build MXOlmInboundGroupSession for megolm session %@", sessionId);
             block(nil);
         }    }
     else
     {
-        NSLog(@"[MXRealmCryptoStore] performSessionOperationWithGroupSessionWithId. Error: megolm session %@ not found", sessionId);
+        MXLogDebug(@"[MXRealmCryptoStore] performSessionOperationWithGroupSessionWithId. Error: megolm session %@ not found", sessionId);
         block(nil);
     }
     
     [realm commitWriteTransaction];
     
-    NSLog(@"[MXRealmCryptoStore] performSessionOperationWithGroupSessionWithId done in %.3fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+    MXLogDebug(@"[MXRealmCryptoStore] performSessionOperationWithGroupSessionWithId done in %.3fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 }
 
 - (NSArray<MXOlmInboundGroupSession *> *)inboundGroupSessions
@@ -1097,7 +1097,7 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
         storedSession = [[MXOlmOutboundGroupSession alloc] initWithSession:session roomId:roomId creationTime:realmSession.creationTime];
     }];
     
-    NSLog(@"[MXRealmCryptoStore] storeOutboundGroupSession: store 1 key (%lu new) in %.3fms", newCount, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+    MXLogDebug(@"[MXRealmCryptoStore] storeOutboundGroupSession: store 1 key (%lu new) in %.3fms", newCount, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
     
     return storedSession;
 }
@@ -1107,7 +1107,7 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
     OLMOutboundGroupSession *session;
     MXRealmOlmOutboundGroupSession *realmSession = [MXRealmOlmOutboundGroupSession objectsInRealm:self.realm where:@"roomId = %@", roomId].firstObject;
     
-    NSLog(@"[MXRealmCryptoStore] outboundGroupSessionWithRoomId: %@ -> %@", roomId, realmSession ? @"found" : @"not found");
+    MXLogDebug(@"[MXRealmCryptoStore] outboundGroupSessionWithRoomId: %@ -> %@", roomId, realmSession ? @"found" : @"not found");
     
     if (realmSession)
     {
@@ -1115,7 +1115,7 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
         
         if (!session)
         {
-            NSLog(@"[MXRealmCryptoStore] outboundGroupSessionWithRoomId: ERROR: Failed to create OLMOutboundGroupSession object");
+            MXLogDebug(@"[MXRealmCryptoStore] outboundGroupSessionWithRoomId: ERROR: Failed to create OLMOutboundGroupSession object");
         }
     }
     
@@ -1140,7 +1140,7 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
         [sessions addObject:session];
     }
     
-    NSLog(@"[MXRealmCryptoStore] outboundGroupSessions: found %lu entries", sessions.count);
+    MXLogDebug(@"[MXRealmCryptoStore] outboundGroupSessions: found %lu entries", sessions.count);
     return sessions;
 }
 
@@ -1151,7 +1151,7 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
         RLMResults<MXRealmOlmOutboundGroupSession *> *realmSessions = [MXRealmOlmOutboundGroupSession objectsInRealm:realm where:@"roomId = %@", roomId];
         
         [realm deleteObjects:realmSessions];
-        NSLog(@"[MXRealmCryptoStore] removeOutboundGroupSessionWithRoomId%@: removed %lu entries", roomId, realmSessions.count);
+        MXLogDebug(@"[MXRealmCryptoStore] removeOutboundGroupSessionWithRoomId%@: removed %lu entries", roomId, realmSessions.count);
     }];
 }
 
@@ -1170,14 +1170,14 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
                 MXRealmUser *realmUser = [MXRealmUser objectsInRealm:realm where:@"userId = %@", userId].firstObject;
                 if (!realmUser)
                 {
-                    NSLog(@"[MXRealmCryptoStore] storeSharedDevices cannot find user with the ID %@", userId);
+                    MXLogDebug(@"[MXRealmCryptoStore] storeSharedDevices cannot find user with the ID %@", userId);
                     continue;
                 }
                 
                 MXRealmDeviceInfo *realmDevice = [[realmUser.devices objectsWhere:@"deviceId = %@", deviceId] firstObject];
                 if (!realmDevice)
                 {
-                    NSLog(@"[MXRealmCryptoStore] storeSharedDevices cannot find device with the ID %@", deviceId);
+                    MXLogDebug(@"[MXRealmCryptoStore] storeSharedDevices cannot find device with the ID %@", deviceId);
                     continue;
                 }
                 
@@ -1192,7 +1192,7 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
         }
     }];
     
-    NSLog(@"[MXRealmCryptoStore] storeSharedDevices (count: %tu) in %.3fms", devices.count, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+    MXLogDebug(@"[MXRealmCryptoStore] storeSharedDevices (count: %tu) in %.3fms", devices.count, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 }
 
 - (MXUsersDevicesMap<NSNumber *> *)sharedDevicesForOutboundGroupSessionInRoomWithId:(NSString *)roomId sessionId:(NSString *)sessionId
@@ -1210,13 +1210,13 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
         MXDeviceInfo *deviceInfo = [NSKeyedUnarchiver unarchiveObjectWithData:sharedInfo.device.deviceInfoData];
         if (!deviceInfo)
         {
-            NSLog(@"[MXRealmCryptoStore] sharedDevicesForOutboundGroupSessionInRoomWithId cannot unarchive deviceInfo");
+            MXLogDebug(@"[MXRealmCryptoStore] sharedDevicesForOutboundGroupSessionInRoomWithId cannot unarchive deviceInfo");
             continue;
         }
         [devices setObject:sharedInfo.messageIndex forUser:deviceInfo.userId andDevice:deviceInfo.deviceId];
     }
     
-    NSLog(@"[MXRealmCryptoStore] sharedDevicesForOutboundGroupSessionInRoomWithId (count: %tu) in %.3fms", results.count, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+    MXLogDebug(@"[MXRealmCryptoStore] sharedDevicesForOutboundGroupSessionInRoomWithId (count: %tu) in %.3fms", results.count, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
     
     return devices;
 }
@@ -1509,7 +1509,7 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
             NSData *encryptedSecret = [MXAes encrypt:secretData aesKey:key iv:iv error:&error];
             if (error)
             {
-                NSLog(@"[MXRealmCryptoStore] storeSecret: Encryption failed for secret %@. Error: %@", secretId, error);
+                MXLogDebug(@"[MXRealmCryptoStore] storeSecret: Encryption failed for secret %@. Error: %@", secretId, error);
                 return;
             }
             
@@ -1541,14 +1541,14 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
         NSData *key = self.encryptionKey;
         if (!key)
         {
-            NSLog(@"[MXRealmCryptoStore] secretWithSecretId: ERROR: Key to decrypt secret %@ is unavailable", secretId);
+            MXLogDebug(@"[MXRealmCryptoStore] secretWithSecretId: ERROR: Key to decrypt secret %@ is unavailable", secretId);
             return nil;
         }
         
         NSData *iv = realmSecret.iv;
         if (!iv)
         {
-            NSLog(@"[MXRealmCryptoStore] secretWithSecretId: ERROR: IV for %@ is unavailable", secretId);
+            MXLogDebug(@"[MXRealmCryptoStore] secretWithSecretId: ERROR: IV for %@ is unavailable", secretId);
             return nil;
         }
         
@@ -1556,7 +1556,7 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
         NSData *secretData = [MXAes decrypt:realmSecret.encryptedSecret aesKey:key iv:iv error:&error];
         if (error || !secretData)
         {
-            NSLog(@"[MXRealmCryptoStore] secretWithSecretId: Decryption failed for secret %@. Error: %@", secretId, error);
+            MXLogDebug(@"[MXRealmCryptoStore] secretWithSecretId: Decryption failed for secret %@. Error: %@", secretId, error);
             return nil;
         }
         
@@ -1675,17 +1675,17 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
             [[NSFileManager defaultManager] copyItemAtURL:config.fileURL toURL:readOnlyURL error:&error];
             if (error)
             {
-                NSLog(@"[MXRealmCryptoStore] realmForUser: readonly copy file error: %@", error);
+                MXLogDebug(@"[MXRealmCryptoStore] realmForUser: readonly copy file error: %@", error);
             }
             else
             {
-                NSLog(@"[MXRealmCryptoStore] realmForUser: readonly copy file lasted %@, fileSize: %@", [stopwatch readableIn:MXStopwatchMeasurementUnitMilliseconds], [MXTools fileSizeToString:fileSize round:NO]);
+                MXLogDebug(@"[MXRealmCryptoStore] realmForUser: readonly copy file lasted %@, fileSize: %@", [stopwatch readableIn:MXStopwatchMeasurementUnitMilliseconds], [MXTools fileSizeToString:fileSize round:NO]);
             }
         }
         
         if (![[NSFileManager defaultManager] fileExistsAtPath:readOnlyURL.path])
         {
-            NSLog(@"[MXRealmCryptoStore] realmForUser: cannot create a read-only Realm for non-existent file.");
+            MXLogDebug(@"[MXRealmCryptoStore] realmForUser: cannot create a read-only Realm for non-existent file.");
             return nil;
         }
         config.fileURL = readOnlyURL;
@@ -1704,16 +1704,16 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
         realm = [RLMRealm realmWithConfiguration:config error:&error];
         if (error)
         {
-            NSLog(@"[MXRealmCryptoStore] realmForUser gets error: %@", error);
+            MXLogDebug(@"[MXRealmCryptoStore] realmForUser gets error: %@", error);
             
             // Remove the db file
             NSError *error;
             [[NSFileManager defaultManager] removeItemAtPath:config.fileURL.path error:&error];
-            NSLog(@"[MXRealmCryptoStore] removeItemAtPath error result: %@", error);
+            MXLogDebug(@"[MXRealmCryptoStore] removeItemAtPath error result: %@", error);
             
             if (config.readOnly)
             {
-                NSLog(@"[MXRealmCryptoStore] realmForUser: returning nil for read-only Realm");
+                MXLogDebug(@"[MXRealmCryptoStore] realmForUser: returning nil for read-only Realm");
                 return nil;
             }
             
@@ -1721,7 +1721,7 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
             realm = [RLMRealm realmWithConfiguration:config error:&error];
             if (!realm)
             {
-                NSLog(@"[MXRealmCryptoStore] realmForUser still gets after reset. Error: %@", error);
+                MXLogDebug(@"[MXRealmCryptoStore] realmForUser still gets after reset. Error: %@", error);
             }
             
             // Report this db reset to higher modules
@@ -1738,13 +1738,13 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
     {
         if (cleanDuplicatedDevices)
         {
-            NSLog(@"[MXRealmCryptoStore] Do cleaning for duplicating devices");
+            MXLogDebug(@"[MXRealmCryptoStore] Do cleaning for duplicating devices");
             
             NSUInteger before = [MXRealmDeviceInfo allObjectsInRealm:realm].count;
             [self cleanDuplicatedDevicesInRealm:realm];
             NSUInteger after = [MXRealmDeviceInfo allObjectsInRealm:realm].count;
             
-            NSLog(@"[MXRealmCryptoStore] Cleaning for duplicating devices completed. There are now %@ devices. There were %@ before. %@ devices have been removed.", @(after), @(before), @(before - after));
+            MXLogDebug(@"[MXRealmCryptoStore] Cleaning for duplicating devices completed. There are now %@ devices. There were %@ before. %@ devices have been removed.", @(after), @(before), @(before - after));
         }
         
         // Wait for completion of other operations on this realm launched from other threads
@@ -1812,7 +1812,7 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
     NSURL *fileFolderURL = fileURL.URLByDeletingLastPathComponent;
     if (![NSFileManager.defaultManager fileExistsAtPath:fileFolderURL.path])
     {
-        NSLog(@"[MXRealmCryptoStore] ensurePathExistenceForFileAtFileURL: Create full path hierarchy for %@", fileURL);
+        MXLogDebug(@"[MXRealmCryptoStore] ensurePathExistenceForFileAtFileURL: Create full path hierarchy for %@", fileURL);
         [[NSFileManager defaultManager] createDirectoryAtPath:fileFolderURL.path withIntermediateDirectories:YES attributes:nil error:nil];
     }
 }
@@ -1856,7 +1856,7 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
             static BOOL logDBFileSizeAtLaunch = YES;
             if (logDBFileSizeAtLaunch)
             {
-                NSLog(@"[MXRealmCryptoStore] Realm DB file size (in bytes): %lu, used (in bytes): %lu", (unsigned long)totalBytes, (unsigned long)bytesUsed);
+                MXLogDebug(@"[MXRealmCryptoStore] Realm DB file size (in bytes): %lu, used (in bytes): %lu", (unsigned long)totalBytes, (unsigned long)bytesUsed);
                 logDBFileSizeAtLaunch = NO;
             }
             
@@ -1864,7 +1864,7 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
             BOOL result = (float)((float)bytesUsed / totalBytes) < 0.5;
             if (result)
             {
-                NSLog(@"[MXRealmCryptoStore] Will compact database: File size (in bytes): %lu, used (in bytes): %lu", (unsigned long)totalBytes, (unsigned long)bytesUsed);
+                MXLogDebug(@"[MXRealmCryptoStore] Will compact database: File size (in bytes): %lu, used (in bytes): %lu", (unsigned long)totalBytes, (unsigned long)bytesUsed);
             }
             
             return result;
@@ -1880,7 +1880,7 @@ static BOOL shouldCompactOnLaunch = YES;
 
 + (void)setShouldCompactOnLaunch:(BOOL)theShouldCompactOnLaunch
 {
-    NSLog(@"[MXRealmCryptoStore] setShouldCompactOnLaunch: %@", theShouldCompactOnLaunch ? @"YES" : @"NO");
+    MXLogDebug(@"[MXRealmCryptoStore] setShouldCompactOnLaunch: %@", theShouldCompactOnLaunch ? @"YES" : @"NO");
     shouldCompactOnLaunch = theShouldCompactOnLaunch;
 }
 
@@ -1913,7 +1913,7 @@ static BOOL shouldCompactOnLaunch = YES;
 
 - (void)setReadOnly:(BOOL)readOnly
 {
-    NSLog(@"[MXRealmCryptoStore] setReadOnly: %@", readOnly ? @"YES" : @"NO");
+    MXLogDebug(@"[MXRealmCryptoStore] setReadOnly: %@", readOnly ? @"YES" : @"NO");
     _readOnly = readOnly;
 }
 
@@ -1946,7 +1946,7 @@ static BOOL shouldCompactOnLaunch = YES;
     
     if (oldSchemaVersion < kMXRealmCryptoStoreVersion)
     {
-        NSLog(@"[MXRealmCryptoStore] Required migration detected. oldSchemaVersion: %llu - current: %tu", oldSchemaVersion, kMXRealmCryptoStoreVersion);
+        MXLogDebug(@"[MXRealmCryptoStore] Required migration detected. oldSchemaVersion: %llu - current: %tu", oldSchemaVersion, kMXRealmCryptoStoreVersion);
         
         switch (oldSchemaVersion)
         {
@@ -1956,11 +1956,11 @@ static BOOL shouldCompactOnLaunch = YES;
                 // and olm sessions were duplicated:
                 // https://github.com/matrix-org/matrix-ios-sdk/issues/227
                 
-                NSLog(@"[MXRealmCryptoStore] Migration from schema #1 -> #2");
+                MXLogDebug(@"[MXRealmCryptoStore] Migration from schema #1 -> #2");
                 
                 // We need to update the db because a sessionId property has been added MXRealmOlmSession
                 // to ensure uniqueness
-                NSLog(@"[MXRealmCryptoStore]    Add sessionId field to all MXRealmOlmSession objects");
+                MXLogDebug(@"[MXRealmCryptoStore]    Add sessionId field to all MXRealmOlmSession objects");
                 [migration enumerateObjects:MXRealmOlmSession.className block:^(RLMObject *oldObject, RLMObject *newObject) {
                     
                     OLMSession *olmSession =  [NSKeyedUnarchiver unarchiveObjectWithData:oldObject[@"olmSessionData"]];
@@ -1969,7 +1969,7 @@ static BOOL shouldCompactOnLaunch = YES;
                 }];
                 
                 // We need to clean the db from duplicated MXRealmOlmSessions
-                NSLog(@"[MXRealmCryptoStore]    Make MXRealmOlmSession objects unique for the (sessionId, deviceKey) pair");
+                MXLogDebug(@"[MXRealmCryptoStore]    Make MXRealmOlmSession objects unique for the (sessionId, deviceKey) pair");
                 __block NSUInteger deleteCount = 0;
                 NSMutableArray<NSString*> *olmSessionUniquePairs = [NSMutableArray array];
                 [migration enumerateObjects:MXRealmOlmSession.className block:^(RLMObject *oldObject, RLMObject *newObject) {
@@ -1982,16 +1982,16 @@ static BOOL shouldCompactOnLaunch = YES;
                     }
                     else
                     {
-                        NSLog(@"[MXRealmCryptoStore]        - delete MXRealmOlmSession: %@", olmSessionUniquePair);
+                        MXLogDebug(@"[MXRealmCryptoStore]        - delete MXRealmOlmSession: %@", olmSessionUniquePair);
                         [migration deleteObject:newObject];
                         deleteCount++;
                     }
                 }];
                 
-                NSLog(@"[MXRealmCryptoStore]    -> deleted %tu duplicated MXRealmOlmSession objects", deleteCount);
+                MXLogDebug(@"[MXRealmCryptoStore]    -> deleted %tu duplicated MXRealmOlmSession objects", deleteCount);
                 
                 // And from duplicated MXRealmOlmInboundGroupSessions
-                NSLog(@"[MXRealmCryptoStore]    Make MXRealmOlmInboundGroupSession objects unique for the (sessionId, senderKey) pair");
+                MXLogDebug(@"[MXRealmCryptoStore]    Make MXRealmOlmInboundGroupSession objects unique for the (sessionId, senderKey) pair");
                 deleteCount = 0;
                 NSMutableArray<NSString*> *olmInboundGroupSessionUniquePairs = [NSMutableArray array];
                 [migration enumerateObjects:MXRealmOlmInboundGroupSession.className block:^(RLMObject *oldObject, RLMObject *newObject) {
@@ -2004,36 +2004,36 @@ static BOOL shouldCompactOnLaunch = YES;
                     }
                     else
                     {
-                        NSLog(@"[MXRealmCryptoStore]        - delete MXRealmOlmInboundGroupSession: %@", olmInboundGroupSessionUniquePair);
+                        MXLogDebug(@"[MXRealmCryptoStore]        - delete MXRealmOlmInboundGroupSession: %@", olmInboundGroupSessionUniquePair);
                         [migration deleteObject:newObject];
                         deleteCount++;
                     }
                 }];
                 
-                NSLog(@"[MXRealmCryptoStore]    -> deleted %tu duplicated MXRealmOlmInboundGroupSession objects", deleteCount);
+                MXLogDebug(@"[MXRealmCryptoStore]    -> deleted %tu duplicated MXRealmOlmInboundGroupSession objects", deleteCount);
                 
-                NSLog(@"[MXRealmCryptoStore] Migration from schema #1 -> #2 completed");
+                MXLogDebug(@"[MXRealmCryptoStore] Migration from schema #1 -> #2 completed");
             }
                 
             case 2:
-                NSLog(@"[MXRealmCryptoStore] Migration from schema #2 -> #3: Nothing to do (add MXRealmOlmAccount.deviceSyncToken)");
+                MXLogDebug(@"[MXRealmCryptoStore] Migration from schema #2 -> #3: Nothing to do (add MXRealmOlmAccount.deviceSyncToken)");
                 
             case 3:
-                NSLog(@"[MXRealmCryptoStore] Migration from schema #3 -> #4: Nothing to do (add MXRealmOlmAccount.globalBlacklistUnverifiedDevices & MXRealmRoomAlgortithm.blacklistUnverifiedDevices)");
+                MXLogDebug(@"[MXRealmCryptoStore] Migration from schema #3 -> #4: Nothing to do (add MXRealmOlmAccount.globalBlacklistUnverifiedDevices & MXRealmRoomAlgortithm.blacklistUnverifiedDevices)");
                 
             case 4:
-                NSLog(@"[MXRealmCryptoStore] Migration from schema #4 -> #5: Nothing to do (add deviceTrackingStatusData)");
+                MXLogDebug(@"[MXRealmCryptoStore] Migration from schema #4 -> #5: Nothing to do (add deviceTrackingStatusData)");
                 
             case 5:
-                NSLog(@"[MXRealmCryptoStore] Migration from schema #5 -> #6: Nothing to do (remove MXRealmOlmAccount.deviceAnnounced)");
+                MXLogDebug(@"[MXRealmCryptoStore] Migration from schema #5 -> #6: Nothing to do (remove MXRealmOlmAccount.deviceAnnounced)");
                 
             case 6:
             {
-                NSLog(@"[MXRealmCryptoStore] Migration from schema #6 -> #7");
+                MXLogDebug(@"[MXRealmCryptoStore] Migration from schema #6 -> #7");
                 
                 // We need to update the db because a sessionId property has been added to MXRealmOlmInboundGroupSession
                 // to ensure uniqueness
-                NSLog(@"[MXRealmCryptoStore]    Add sessionIdSenderKey, a combined primary key, to all MXRealmOlmInboundGroupSession objects");
+                MXLogDebug(@"[MXRealmCryptoStore]    Add sessionIdSenderKey, a combined primary key, to all MXRealmOlmInboundGroupSession objects");
                 [migration enumerateObjects:MXRealmOlmInboundGroupSession.className block:^(RLMObject *oldObject, RLMObject *newObject) {
                     
                     newObject[@"sessionIdSenderKey"] = [MXRealmOlmInboundGroupSession primaryKeyWithSessionId:oldObject[@"sessionId"]
@@ -2041,7 +2041,7 @@ static BOOL shouldCompactOnLaunch = YES;
                 }];
                 
                 // We need to update the db because a identityKey property has been added to MXRealmDeviceInfo
-                NSLog(@"[MXRealmCryptoStore]    Add identityKey to all MXRealmDeviceInfo objects");
+                MXLogDebug(@"[MXRealmCryptoStore]    Add identityKey to all MXRealmDeviceInfo objects");
                 [migration enumerateObjects:MXRealmDeviceInfo.className block:^(RLMObject *oldObject, RLMObject *newObject) {
                     
                     MXDeviceInfo *device = [NSKeyedUnarchiver unarchiveObjectWithData:oldObject[@"deviceInfoData"]];
@@ -2052,12 +2052,12 @@ static BOOL shouldCompactOnLaunch = YES;
                     }
                 }];
                 
-                NSLog(@"[MXRealmCryptoStore] Migration from schema #6 -> #7 completed");
+                MXLogDebug(@"[MXRealmCryptoStore] Migration from schema #6 -> #7 completed");
             }
                 
             case 7:
             {
-                NSLog(@"[MXRealmCryptoStore] Migration from schema #7 -> #8");
+                MXLogDebug(@"[MXRealmCryptoStore] Migration from schema #7 -> #8");
                 
                 // This schema update is only for cleaning duplicated devices.
                 // With the Realm Obj-C SDK, the realm instance is not public. We cannot
@@ -2071,22 +2071,22 @@ static BOOL shouldCompactOnLaunch = YES;
                 // Use the last olm session that got a message
                 // https://github.com/vector-im/riot-ios/issues/2128
                 
-                NSLog(@"[MXRealmCryptoStore] Migration from schema #8 -> #9");
+                MXLogDebug(@"[MXRealmCryptoStore] Migration from schema #8 -> #9");
                 
-                NSLog(@"[MXRealmCryptoStore]    Add lastReceivedMessageTs = 0 to all MXRealmOlmSession objects");
+                MXLogDebug(@"[MXRealmCryptoStore]    Add lastReceivedMessageTs = 0 to all MXRealmOlmSession objects");
                 [migration enumerateObjects:MXRealmOlmSession.className block:^(RLMObject *oldObject, RLMObject *newObject) {
                     
                     newObject[@"lastReceivedMessageTs"] = @(0);
                 }];
                 
-                NSLog(@"[MXRealmCryptoStore] Migration from schema #8 -> #9 completed");
+                MXLogDebug(@"[MXRealmCryptoStore] Migration from schema #8 -> #9 completed");
             }
                 
             case 9:
             {
-                NSLog(@"[MXRealmCryptoStore] Migration from schema #9 -> #10");
+                MXLogDebug(@"[MXRealmCryptoStore] Migration from schema #9 -> #10");
                 
-                NSLog(@"[MXRealmCryptoStore]    Add requestBodyHash to all MXRealmOutgoingRoomKeyRequest objects");
+                MXLogDebug(@"[MXRealmCryptoStore]    Add requestBodyHash to all MXRealmOutgoingRoomKeyRequest objects");
                 [migration enumerateObjects:MXRealmOutgoingRoomKeyRequest.className block:^(RLMObject *oldObject, RLMObject *newObject) {
                     
                     NSDictionary *requestBody = [MXTools deserialiseJSONString:oldObject[@"requestBodyString"]];
@@ -2101,15 +2101,15 @@ static BOOL shouldCompactOnLaunch = YES;
             }
                 
             case 10:
-                NSLog(@"[MXRealmCryptoStore] Migration from schema #10 -> #11: Nothing to do (added optional MXRealmUser.crossSigningKeys)");
+                MXLogDebug(@"[MXRealmCryptoStore] Migration from schema #10 -> #11: Nothing to do (added optional MXRealmUser.crossSigningKeys)");
                 
             case 11:
             {
-                NSLog(@"[MXRealmCryptoStore] Migration from schema #10 -> #11");
+                MXLogDebug(@"[MXRealmCryptoStore] Migration from schema #10 -> #11");
                 
                 // Because of https://github.com/vector-im/riot-ios/issues/2896, algorithms were not stored
                 // Fix it by defaulting to usual values
-                NSLog(@"[MXRealmCryptoStore]    Fix missing algorithms to all MXRealmDeviceInfo objects");
+                MXLogDebug(@"[MXRealmCryptoStore]    Fix missing algorithms to all MXRealmDeviceInfo objects");
                 
                 [migration enumerateObjects:MXRealmDeviceInfo.className block:^(RLMObject *oldObject, RLMObject *newObject) {
                     
@@ -2127,11 +2127,11 @@ static BOOL shouldCompactOnLaunch = YES;
                 
             case 12:
             {
-                NSLog(@"[MXRealmCryptoStore] Migration from schema #12 -> #13");
+                MXLogDebug(@"[MXRealmCryptoStore] Migration from schema #12 -> #13");
                 
                 // Ìntroduction of MXCryptoStore.cryptoVersion
                 // Set the default value
-                NSLog(@"[MXRealmCryptoStore]    Add new MXRealmOlmAccount.cryptoVersion. Set it to MXCryptoVersion1");
+                MXLogDebug(@"[MXRealmCryptoStore]    Add new MXRealmOlmAccount.cryptoVersion. Set it to MXCryptoVersion1");
                 
                 [migration enumerateObjects:MXRealmOlmAccount.className block:^(RLMObject *oldObject, RLMObject *newObject) {
                     newObject[@"cryptoVersion"] = @(MXCryptoVersion1);
@@ -2139,13 +2139,13 @@ static BOOL shouldCompactOnLaunch = YES;
             }
                 
             case 13:
-                NSLog(@"[MXRealmCryptoStore] Migration from schema #13 -> #14: Nothing to do (added MXRealmOlmOutboundGroupSession)");
+                MXLogDebug(@"[MXRealmCryptoStore] Migration from schema #13 -> #14: Nothing to do (added MXRealmOlmOutboundGroupSession)");
                 
             case 14:
-                NSLog(@"[MXRealmCryptoStore] Migration from schema #14 -> #15: Nothing to do (added MXRealmSharedOutboundSession)");
+                MXLogDebug(@"[MXRealmCryptoStore] Migration from schema #14 -> #15: Nothing to do (added MXRealmSharedOutboundSession)");
                 
             case 15:
-                NSLog(@"[MXRealmCryptoStore] Migration from schema #15 -> #16: Nothing to do (added optional MXRealmSecret.encryptedSecret)");
+                MXLogDebug(@"[MXRealmCryptoStore] Migration from schema #15 -> #16: Nothing to do (added optional MXRealmSecret.encryptedSecret)");
         }
     }
     

--- a/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.m
+++ b/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.m
@@ -97,14 +97,14 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
     } failure:^(NSError * _Nonnull error) {
         MXStrongifyAndReturnIfNil(self);
 
-        NSLog(@"[MXKeyBackup] checkAndStartKeyBackup: Failed to get current version: %@", error);
+        MXLogDebug(@"[MXKeyBackup] checkAndStartKeyBackup: Failed to get current version: %@", error);
         self.state = MXKeyBackupStateUnknown;
     }];
 }
 
 - (void)checkAndStartWithKeyBackupVersion:(nullable MXKeyBackupVersion*)keyBackupVersion
 {
-    NSLog(@"[MXKeyBackup] checkAndStartWithKeyBackupVersion: %@", keyBackupVersion.version);
+    MXLogDebug(@"[MXKeyBackup] checkAndStartWithKeyBackupVersion: %@", keyBackupVersion.version);
  
     self->_keyBackupVersion = keyBackupVersion;
     if (!self.keyBackupVersion)
@@ -118,13 +118,13 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
 
     if (trustInfo.usable)
     {
-        NSLog(@"[MXKeyBackup] checkAndStartWithKeyBackupVersion: Found usable key backup. version: %@", keyBackupVersion.version);
+        MXLogDebug(@"[MXKeyBackup] checkAndStartWithKeyBackupVersion: Found usable key backup. version: %@", keyBackupVersion.version);
 
         // Check the version we used at the previous app run
         NSString *versionInStore = crypto.store.backupVersion;
         if (versionInStore && ![versionInStore isEqualToString:keyBackupVersion.version])
         {
-            NSLog(@"[MXKeyBackup] -> clean the previously used version(%@)", versionInStore);
+            MXLogDebug(@"[MXKeyBackup] -> clean the previously used version(%@)", versionInStore);
             [self resetKeyBackupData];
         }
         
@@ -135,21 +135,21 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
             
             if (![self checkPkDecryptionPublicKey:pKDecryptionPublicKey forKeyBackupVersion:keyBackupVersion])
             {
-                NSLog(@"[MXKeyBackup] -> clean local private key (%@)", pKDecryptionPublicKey);
+                MXLogDebug(@"[MXKeyBackup] -> clean local private key (%@)", pKDecryptionPublicKey);
                 [crypto.store deleteSecretWithSecretId:MXSecretId.keyBackup];
             }
         }
         
-        NSLog(@"[MXKeyBackup]    -> enabling key backups");
+        MXLogDebug(@"[MXKeyBackup]    -> enabling key backups");
         [self enableKeyBackup:keyBackupVersion];
     }
     else
     {
-        NSLog(@"[MXKeyBackup] checkAndStartWithKeyBackupVersion: No usable key backup. version: %@", keyBackupVersion.version);
+        MXLogDebug(@"[MXKeyBackup] checkAndStartWithKeyBackupVersion: No usable key backup. version: %@", keyBackupVersion.version);
 
         if (crypto.store.backupVersion)
         {
-            NSLog(@"[MXKeyBackup]    -> disable the current version");
+            MXLogDebug(@"[MXKeyBackup]    -> disable the current version");
             [self resetKeyBackupData];
         }
 
@@ -184,7 +184,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
 
 - (void)resetKeyBackupData
 {
-    NSLog(@"[MXKeyBackup] resetKeyBackupData");
+    MXLogDebug(@"[MXKeyBackup] resetKeyBackupData");
     
     [self resetBackupAllGroupSessionsObjects];
     
@@ -216,7 +216,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
     }
     else
     {
-        NSLog(@"[MXKeyBackup] maybeSendKeyBackup: Skip it because state: %@", @(_state));
+        MXLogDebug(@"[MXKeyBackup] maybeSendKeyBackup: Skip it because state: %@", @(_state));
 
         // If not already done, check for a valid backup version on the homeserver.
         // If one, maybeSendKeyBackup will be called again.
@@ -226,12 +226,12 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
 
 - (void)sendKeyBackup
 {
-    NSLog(@"[MXKeyBackup] sendKeyBackup");
+    MXLogDebug(@"[MXKeyBackup] sendKeyBackup");
 
     // Get a chunk of keys to backup
     NSArray<MXOlmInboundGroupSession*> *sessions = [crypto.store inboundGroupSessionsToBackup:kMXKeyBackupSendKeysMaxCount];
 
-    NSLog(@"[MXKeyBackup] sendKeyBackup: 1 - %@ sessions to back up", @(sessions.count));
+    MXLogDebug(@"[MXKeyBackup] sendKeyBackup: 1 - %@ sessions to back up", @(sessions.count));
 
     if (!sessions.count)
     {
@@ -249,7 +249,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
     // Sanity check
     if (!self.enabled || !_backupKey || !_keyBackupVersion)
     {
-        NSLog(@"[MXKeyBackup] sendKeyBackup: Invalid state: %@", @(_state));
+        MXLogDebug(@"[MXKeyBackup] sendKeyBackup: Invalid state: %@", @(_state));
         if (backupAllGroupSessionsFailure)
         {
             NSError *error = [NSError errorWithDomain:MXKeyBackupErrorDomain
@@ -264,7 +264,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
 
     self.state = MXKeyBackupStateBackingUp;
 
-    NSLog(@"[MXKeyBackup] sendKeyBackup: 2 - Encrypting keys");
+    MXLogDebug(@"[MXKeyBackup] sendKeyBackup: 2 - Encrypting keys");
 
     // Gather data to send to the homeserver
     // roomId -> sessionId -> MXKeyBackupData
@@ -285,7 +285,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
         }
     }
 
-    NSLog(@"[MXKeyBackup] sendKeyBackup: 3 - Finalising data to send");
+    MXLogDebug(@"[MXKeyBackup] sendKeyBackup: 3 - Finalising data to send");
 
     // Finalise data to send
     NSMutableDictionary<NSString*, MXRoomKeysBackupData*> *rooms = [NSMutableDictionary dictionary];
@@ -305,26 +305,26 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
     MXKeysBackupData *keysBackupData = [MXKeysBackupData new];
     keysBackupData.rooms = rooms;
 
-    NSLog(@"[MXKeyBackup] sendKeyBackup: 4 - Sending request");
+    MXLogDebug(@"[MXKeyBackup] sendKeyBackup: 4 - Sending request");
 
     // Make the request
     MXWeakify(self);
     [crypto.matrixRestClient sendKeysBackup:keysBackupData version:_keyBackupVersion.version success:^{
         MXStrongifyAndReturnIfNil(self);
 
-        NSLog(@"[MXKeyBackup] sendKeyBackup: 5a - Request complete");
+        MXLogDebug(@"[MXKeyBackup] sendKeyBackup: 5a - Request complete");
 
         // Mark keys as backed up
         [self->crypto.store markBackupDoneForInboundGroupSessions:sessions];
 
         if (sessions.count < kMXKeyBackupSendKeysMaxCount)
         {
-            NSLog(@"[MXKeyBackup] sendKeyBackup: All keys have been backed up");
+            MXLogDebug(@"[MXKeyBackup] sendKeyBackup: All keys have been backed up");
             self.state = MXKeyBackupStateReadyToBackUp;
         }
         else
         {
-            NSLog(@"[MXKeyBackup] sendKeyBackup: Continue to back up keys");
+            MXLogDebug(@"[MXKeyBackup] sendKeyBackup: Continue to back up keys");
             self.state = MXKeyBackupStateWillBackUp;
 
             [self sendKeyBackup];
@@ -333,7 +333,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
     } failure:^(NSError *error) {
         MXStrongifyAndReturnIfNil(self);
 
-        NSLog(@"[MXKeyBackup] sendKeyBackup: 5b - sendKeysBackup failed. Error: %@", error);
+        MXLogDebug(@"[MXKeyBackup] sendKeyBackup: 5b - sendKeysBackup failed. Error: %@", error);
 
         void (^backupAllGroupSessionsFailure)(NSError *error) = self->backupAllGroupSessionsFailure;
 
@@ -359,7 +359,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
 
 - (void)requestPrivateKeys:(void (^)(void))onComplete
 {
-    NSLog(@"[MXKeyBackup] requestPrivateKeys");
+    MXLogDebug(@"[MXKeyBackup] requestPrivateKeys");
           
     [self requestPrivateKeysToDeviceIds:nil success:^{
     } onPrivateKeysReceived:^{
@@ -367,7 +367,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
         [self restoreKeyBackupAutomaticallyWithPrivateKey:onComplete];
         
     } failure:^(NSError * _Nonnull error) {
-        NSLog(@"[MXKeyBackup] requestPrivateKeys. Error for requestPrivateKeys: %@", error);
+        MXLogDebug(@"[MXKeyBackup] requestPrivateKeys. Error for requestPrivateKeys: %@", error);
         onComplete();
     }];
 }
@@ -375,7 +375,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
 - (void)restoreKeyBackupAutomaticallyWithPrivateKey:(void (^)(void))onComplete
 {
     // Check we have alreaded loaded the backup before going further
-    NSLog(@"[MXKeyBackup] restoreKeyBackupAutomatically: Current backup version %@", self.keyBackupVersion);
+    MXLogDebug(@"[MXKeyBackup] restoreKeyBackupAutomatically: Current backup version %@", self.keyBackupVersion);
     if (!self.keyBackupVersion)
     {
         // Backup not yet retrieved?
@@ -386,7 +386,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
                 [self restoreKeyBackupAutomaticallyWithPrivateKey:onComplete];
             }
         } failure:^(NSError * _Nonnull error) {
-            NSLog(@"[MXKeyBackup] restoreKeyBackupAutomatically: Cannot fetch backup version. Error: %@", error);
+            MXLogDebug(@"[MXKeyBackup] restoreKeyBackupAutomatically: Cannot fetch backup version. Error: %@", error);
         }];
         return;
     }
@@ -394,7 +394,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
     // Check private keys
     if (!self.hasPrivateKeyInCryptoStore)
     {
-        NSLog(@"[MXKeyBackup] restoreKeyBackupAutomatically. Error: No private key");
+        MXLogDebug(@"[MXKeyBackup] restoreKeyBackupAutomatically. Error: No private key");
         onComplete();
         return;
     }
@@ -403,7 +403,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
     NSString *pKDecryptionPublicKey = [self pkDecrytionPublicKeyFromCryptoStore];
     if (![self checkPkDecryptionPublicKey:pKDecryptionPublicKey forKeyBackupVersion:self.keyBackupVersion])
     {
-        NSLog(@"[MXKeyBackup] restoreKeyBackupAutomatically. Error: Invalid private key (%@)", pKDecryptionPublicKey);
+        MXLogDebug(@"[MXKeyBackup] restoreKeyBackupAutomatically. Error: Invalid private key (%@)", pKDecryptionPublicKey);
         [crypto.store deleteSecretWithSecretId:MXSecretId.keyBackup];
         onComplete();
         return;
@@ -412,11 +412,11 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
     // Do the restore operation in background
     [self restoreUsingPrivateKeyKeyBackup:self.keyBackupVersion room:nil session:nil success:^(NSUInteger total, NSUInteger imported) {
         
-        NSLog(@"[MXKeyBackup] restoreKeyBackupAutomatically: Restored %@ keys out of %@", @(imported), @(total));
+        MXLogDebug(@"[MXKeyBackup] restoreKeyBackupAutomatically: Restored %@ keys out of %@", @(imported), @(total));
         onComplete();
         
     } failure:^(NSError * _Nonnull error) {
-        NSLog(@"[MXKeyBackup] restoreKeyBackupAutomatically. Error for restoreKeyBackup: %@", error);
+        MXLogDebug(@"[MXKeyBackup] restoreKeyBackupAutomatically. Error for restoreKeyBackup: %@", error);
         onComplete();
     }];
 }
@@ -669,7 +669,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
             }
             else
             {
-                NSLog(@"[MXKeyBackup] forceRefresh: New version detected on the homeserver. New version: %@. Old version: %@", serverKeyBackupVersion.version, self.keyBackupVersion.version);
+                MXLogDebug(@"[MXKeyBackup] forceRefresh: New version detected on the homeserver. New version: %@. Old version: %@", serverKeyBackupVersion.version, self.keyBackupVersion.version);
                 usingLastVersion = NO;
 
                 // Stop current backup or start a new one
@@ -706,7 +706,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
         // Reset previous state if any
         [self resetBackupAllGroupSessionsObjects];
 
-        NSLog(@"[MXKeyBackup] backupAllGroupSessions: backupProgress: %@", backupProgress);
+        MXLogDebug(@"[MXKeyBackup] backupAllGroupSessions: backupProgress: %@", backupProgress);
 
         if (progress)
         {
@@ -715,7 +715,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
 
         if (backupProgress.finished)
         {
-            NSLog(@"[MXKeyBackup] backupAllGroupSessions: complete");
+            MXLogDebug(@"[MXKeyBackup] backupAllGroupSessions: complete");
             if (success)
             {
                 dispatch_async(dispatch_get_main_queue(), ^{
@@ -824,7 +824,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
 {
     MXHTTPOperation *operation = [MXHTTPOperation new];
 
-    NSLog(@"[MXKeyBackup] restoreKeyBackup with recovery key: From backup version: %@", keyBackupVersion.version);
+    MXLogDebug(@"[MXKeyBackup] restoreKeyBackup with recovery key: From backup version: %@", keyBackupVersion.version);
 
     MXWeakify(self);
     dispatch_async(cryptoQueue, ^{
@@ -835,7 +835,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
         [self isValidRecoveryKey:recoveryKey forKeyBackupVersion:keyBackupVersion error:&error];
         if (error)
         {
-            NSLog(@"[MXKeyBackup] restoreKeyBackup: Invalid recovery key. Error: %@", error);
+            MXLogDebug(@"[MXKeyBackup] restoreKeyBackup: Invalid recovery key. Error: %@", error);
             if (failure)
             {
                 dispatch_async(dispatch_get_main_queue(), ^{
@@ -906,13 +906,13 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
             }
         }
         
-        NSLog(@"[MXKeyBackup] restoreKeyBackup: Decrypted %@ keys out of %@ from the backup store on the homeserver", @(sessionDatas.count), @(sessionsFromHSCount));
+        MXLogDebug(@"[MXKeyBackup] restoreKeyBackup: Decrypted %@ keys out of %@ from the backup store on the homeserver", @(sessionDatas.count), @(sessionsFromHSCount));
         
         // Do not trigger a backup for them if they come from the backup version we are using
         BOOL backUp = ![keyBackupVersion.version isEqualToString:self.keyBackupVersion.version];
         if (backUp)
         {
-            NSLog(@"[MXKeyBackup] restoreKeyBackup: Those keys will be backed up to backup version: %@", self.keyBackupVersion.version);
+            MXLogDebug(@"[MXKeyBackup] restoreKeyBackup: Those keys will be backed up to backup version: %@", self.keyBackupVersion.version);
         }
         
         // Import them into the crypto store
@@ -944,7 +944,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
 {
     MXHTTPOperation *operation = [MXHTTPOperation new];
 
-    NSLog(@"[MXKeyBackup] restoreKeyBackup with password: From backup version: %@", keyBackupVersion.version);
+    MXLogDebug(@"[MXKeyBackup] restoreKeyBackup with password: From backup version: %@", keyBackupVersion.version);
 
     MXWeakify(self);
     dispatch_async(cryptoQueue, ^{
@@ -981,7 +981,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
 {
     MXHTTPOperation *operation = [MXHTTPOperation new];
     
-    NSLog(@"[MXKeyBackup] restoreUsingPrivateKeyKeyBackup: From backup version: %@", keyBackupVersion.version);
+    MXLogDebug(@"[MXKeyBackup] restoreUsingPrivateKeyKeyBackup: From backup version: %@", keyBackupVersion.version);
     
     MXWeakify(self);
     dispatch_async(cryptoQueue, ^{
@@ -996,7 +996,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
             NSString *pKDecryptionPublicKey = [self pkDecrytionPublicKeyFromCryptoStore];
             if (![self checkPkDecryptionPublicKey:pKDecryptionPublicKey forKeyBackupVersion:keyBackupVersion])
             {
-                NSLog(@"[MXKeyBackup] restoreUsingPrivateKeyKeyBackup. Error: Invalid private key (%@) for %@", pKDecryptionPublicKey, keyBackupVersion);
+                MXLogDebug(@"[MXKeyBackup] restoreUsingPrivateKeyKeyBackup. Error: Invalid private key (%@) for %@", pKDecryptionPublicKey, keyBackupVersion);
                 decryption = nil;
             }
         }
@@ -1053,14 +1053,14 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
     MXMegolmBackupAuthData *authData = [self megolmBackupAuthDataFromKeyBackupVersion:keyBackupVersion error:&error];
     if (error)
     {
-        NSLog(@"[MXKeyBackup] trustForKeyBackupVersion: Key backup is absent or missing required data");
+        MXLogDebug(@"[MXKeyBackup] trustForKeyBackupVersion: Key backup is absent or missing required data");
         return keyBackupVersionTrust;
     }
 
     NSDictionary *mySigs = authData.signatures[myUserId];
     if (mySigs.count == 0)
     {
-        NSLog(@"[MXKeyBackup] trustForKeyBackupVersion: Ignoring key backup because it lacks any signatures from this user");
+        MXLogDebug(@"[MXKeyBackup] trustForKeyBackupVersion: Ignoring key backup because it lacks any signatures from this user");
         return keyBackupVersionTrust;
     }
 
@@ -1087,7 +1087,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
 
                 if (!valid)
                 {
-                    NSLog(@"[MXKeyBackup] trustForKeyBackupVersion: Bad signature from device %@: %@", device.deviceId, error);
+                    MXLogDebug(@"[MXKeyBackup] trustForKeyBackupVersion: Bad signature from device %@: %@", device.deviceId, error);
                 }
                 else if (device.trustLevel.isVerified)
                 {
@@ -1096,7 +1096,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
             }
             else
             {
-                NSLog(@"[MXKeyBackup] trustForKeyBackupVersion: Signature from unknown key %@", deviceId);
+                MXLogDebug(@"[MXKeyBackup] trustForKeyBackupVersion: Signature from unknown key %@", deviceId);
             }
 
             MXKeyBackupVersionTrustSignature *signature = [MXKeyBackupVersionTrustSignature new];
@@ -1117,7 +1117,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
                                    success:(void (^)(void))success
                                    failure:(void (^)(NSError * _Nonnull))failure
 {
-    NSLog(@"[MXKeyBackup] trustKeyBackupVersion:trust: %@. trust: %@", keyBackupVersion.version, @(trust));
+    MXLogDebug(@"[MXKeyBackup] trustKeyBackupVersion:trust: %@. trust: %@", keyBackupVersion.version, @(trust));
 
     MXHTTPOperation *operation = [MXHTTPOperation new];
 
@@ -1132,7 +1132,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
         MXMegolmBackupAuthData *authData = [self megolmBackupAuthDataFromKeyBackupVersion:keyBackupVersion error:&error];
         if (error)
         {
-            NSLog(@"[MXKeyBackup] trustKeyBackupVersion:trust: Key backup is missing required data");
+            MXLogDebug(@"[MXKeyBackup] trustKeyBackupVersion:trust: Key backup is missing required data");
 
             if (failure)
             {
@@ -1189,7 +1189,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
             }
         } failure:^(NSError *error) {
             
-            NSLog(@"[MXKeyBackup] trustKeyBackupVersion:trust: Error: %@", error);
+            MXLogDebug(@"[MXKeyBackup] trustKeyBackupVersion:trust: Error: %@", error);
             if (failure)
             {
                 dispatch_async(dispatch_get_main_queue(), ^{
@@ -1208,7 +1208,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
                                    success:(void (^)(void))success
                                    failure:(void (^)(NSError * _Nonnull))failure
 {
-    NSLog(@"[MXKeyBackup] trustKeyBackupVersion:withRecoveryKey: %@", keyBackupVersion.version);
+    MXLogDebug(@"[MXKeyBackup] trustKeyBackupVersion:withRecoveryKey: %@", keyBackupVersion.version);
 
     MXHTTPOperation *operation = [MXHTTPOperation new];
 
@@ -1225,7 +1225,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
         }
         else
         {
-            NSLog(@"[MXKeyBackup] trustKeyBackupVersion:withRecoveryKey: Invalid recovery key. Error: %@", error);
+            MXLogDebug(@"[MXKeyBackup] trustKeyBackupVersion:withRecoveryKey: Invalid recovery key. Error: %@", error);
 
             if (failure)
             {
@@ -1244,7 +1244,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
                                    success:(void (^)(void))success
                                    failure:(void (^)(NSError * _Nonnull))failure
 {
-    NSLog(@"[MXKeyBackup] trustKeyBackupVersion:withPassword: %@", keyBackupVersion.version);
+    MXLogDebug(@"[MXKeyBackup] trustKeyBackupVersion:withPassword: %@", keyBackupVersion.version);
 
     MXHTTPOperation *operation = [MXHTTPOperation new];
 
@@ -1283,7 +1283,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
                 onPrivateKeysReceived:(void (^)(void))onPrivateKeysReceived
                               failure:(void (^)(NSError *error))failure
 {
-    NSLog(@"[MXKeyBackup] requestPrivateKeysToDeviceIds: %@", deviceIds);
+    MXLogDebug(@"[MXKeyBackup] requestPrivateKeysToDeviceIds: %@", deviceIds);
 
     MXWeakify(self);
     [crypto.secretShareManager requestSecret:MXSecretId.keyBackup toDeviceIds:deviceIds success:^(NSString * _Nonnull requestId) {
@@ -1293,7 +1293,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
         BOOL isSecretValid = !self.keyBackupVersion     // Accept the secret if the backup is not known yet
         || [self isSecretValid:secret forKeyBackupVersion:self.keyBackupVersion];
         
-        NSLog(@"[MXKeyBackup] requestPrivateKeysToDeviceIds: Got key. isSecretValid: %@", @(isSecretValid));
+        MXLogDebug(@"[MXKeyBackup] requestPrivateKeysToDeviceIds: Got key. isSecretValid: %@", @(isSecretValid));
         if (isSecretValid)
         {
             [self->crypto.store storeSecret:secret withSecretId:MXSecretId.keyBackup];
@@ -1335,7 +1335,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
 
 - (void)setState:(MXKeyBackupState)state
 {
-    NSLog(@"[MXKeyBackup] setState: %@ -> %@", @(_state), @(state));
+    MXLogDebug(@"[MXKeyBackup] setState: %@ -> %@", @(_state), @(state));
 
     _state = state;
 
@@ -1433,7 +1433,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
     OLMPkDecryption *decryption = [self pkDecryptionFromRecoveryKey:recoveryKey error:&error];
     if (!decryption)
     {
-        NSLog(@"[MXKeyBackup] storePrivateKeyWithRecoveryKey] Cannot create OLMPkDecryption. Error: %@", error);
+        MXLogDebug(@"[MXKeyBackup] storePrivateKeyWithRecoveryKey] Cannot create OLMPkDecryption. Error: %@", error);
         return;
     }
     
@@ -1446,7 +1446,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
     NSString *privateKeyBase64 = [self->crypto.store secretWithSecretId:MXSecretId.keyBackup];
     if (!privateKeyBase64)
     {
-        NSLog(@"[MXCrossSigning] privateKeyFromCryptoStore. Error: No secret in crypto store");
+        MXLogDebug(@"[MXCrossSigning] privateKeyFromCryptoStore. Error: No secret in crypto store");
         return nil;
     }
     
@@ -1467,7 +1467,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
         
         if (error)
         {
-            NSLog(@"[MXCrossSigning] pkDecryptionFromCryptoStore failed. Error: %@", error);
+            MXLogDebug(@"[MXCrossSigning] pkDecryptionFromCryptoStore failed. Error: %@", error);
         }
     }
 
@@ -1494,7 +1494,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
         
         if (error)
         {
-            NSLog(@"[MXCrossSigning] pkDecrytionPublicKeyFromPrivateKey failed. Error: %@", error);
+            MXLogDebug(@"[MXCrossSigning] pkDecrytionPublicKeyFromPrivateKey failed. Error: %@", error);
         }
     }
     
@@ -1514,7 +1514,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
     
     if (error)
     {
-        NSLog(@"[MXCrossSigning] checkPkDecryptionPublicKey: Error: %@", error);
+        MXLogDebug(@"[MXCrossSigning] checkPkDecryptionPublicKey: Error: %@", error);
     }
     
     return checkPkDecryptionPublicKey;
@@ -1527,13 +1527,13 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
     NSString *gotPublicKey = [pkSigning doInitWithSeed:privateKey error:&error];
     if (error)
     {
-        NSLog(@"[MXCrossSigning] pkSigningFromPrivateKey failed to build PK signing. Error: %@", error);
+        MXLogDebug(@"[MXCrossSigning] pkSigningFromPrivateKey failed to build PK signing. Error: %@", error);
         return nil;
     }
     
     if (![gotPublicKey isEqualToString:expectedPublicKey])
     {
-        NSLog(@"[MXCrossSigning] pkSigningFromPrivateKey failed. Keys do not match: %@ vs %@", gotPublicKey, expectedPublicKey);
+        MXLogDebug(@"[MXCrossSigning] pkSigningFromPrivateKey failed. Keys do not match: %@ vs %@", gotPublicKey, expectedPublicKey);
         return nil;
     }
     
@@ -1546,7 +1546,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
     MXDeviceInfo *device = [crypto.deviceList deviceWithIdentityKey:session.senderKey andAlgorithm:kMXCryptoMegolmAlgorithm];
     if (!device)
     {
-        NSLog(@"[MXKeyBackup] encryptGroupSession: Error: Cannot find device for %@", session.senderKey);
+        MXLogDebug(@"[MXKeyBackup] encryptGroupSession: Error: Cannot find device for %@", session.senderKey);
         return nil;
     }
 
@@ -1555,7 +1555,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
     MXMegolmSessionData *sessionData = session.exportSessionData;
     if (![self checkMXMegolmSessionData:sessionData])
     {
-        NSLog(@"[MXKeyBackup] encryptGroupSession: Error: Invalid MXMegolmSessionData for %@", session.senderKey);
+        MXLogDebug(@"[MXKeyBackup] encryptGroupSession: Error: Invalid MXMegolmSessionData for %@", session.senderKey);
         return nil;
     }
     
@@ -1569,7 +1569,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
     OLMPkMessage *encryptedSessionBackupData = [_backupKey encryptMessage:[MXTools serialiseJSONObject:sessionBackupData] error:nil];
     if (![self checkOLMPkMessage:encryptedSessionBackupData])
     {
-        NSLog(@"[MXKeyBackup] encryptGroupSession: Error: Invalid OLMPkMessage for %@", session.senderKey);
+        MXLogDebug(@"[MXKeyBackup] encryptGroupSession: Error: Invalid OLMPkMessage for %@", session.senderKey);
         return nil;
     }
 
@@ -1592,22 +1592,22 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
 {
     if (!sessionData.algorithm)
     {
-        NSLog(@"[MXKeyBackup] checkMXMegolmSessionData: missing algorithm");
+        MXLogDebug(@"[MXKeyBackup] checkMXMegolmSessionData: missing algorithm");
         return NO;
     }
     if (!sessionData.senderKey)
     {
-        NSLog(@"[MXKeyBackup] checkMXMegolmSessionData: missing senderKey");
+        MXLogDebug(@"[MXKeyBackup] checkMXMegolmSessionData: missing senderKey");
         return NO;
     }
     if (!sessionData.senderClaimedKeys)
     {
-        NSLog(@"[MXKeyBackup] checkMXMegolmSessionData: missing senderClaimedKeys");
+        MXLogDebug(@"[MXKeyBackup] checkMXMegolmSessionData: missing senderClaimedKeys");
         return NO;
     }
     if (!sessionData.sessionKey)
     {
-        NSLog(@"[MXKeyBackup] checkMXMegolmSessionData: missing sessionKey");
+        MXLogDebug(@"[MXKeyBackup] checkMXMegolmSessionData: missing sessionKey");
         return NO;
     }
     
@@ -1619,17 +1619,17 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
 {
     if (!message.ciphertext)
     {
-        NSLog(@"[MXKeyBackup] checkOLMPkMessage: missing ciphertext");
+        MXLogDebug(@"[MXKeyBackup] checkOLMPkMessage: missing ciphertext");
         return NO;
     }
     if (!message.mac)
     {
-        NSLog(@"[MXKeyBackup] checkOLMPkMessage: missing mac");
+        MXLogDebug(@"[MXKeyBackup] checkOLMPkMessage: missing mac");
         return NO;
     }
     if (!message.ephemeralKey)
     {
-        NSLog(@"[MXKeyBackup] checkOLMPkMessage: missing ephemeralKey");
+        MXLogDebug(@"[MXKeyBackup] checkOLMPkMessage: missing ephemeralKey");
         return NO;
     }
 
@@ -1667,7 +1667,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
         }
         else
         {
-            NSLog(@"[MXKeyBackup] decryptKeyBackupData: Failed to decrypt session from backup. Error: %@", error);
+            MXLogDebug(@"[MXKeyBackup] decryptKeyBackupData: Failed to decrypt session from backup. Error: %@", error);
         }
     }
 
@@ -1690,7 +1690,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
     }
     else
     {
-        NSLog(@"[MXKeyBackup] megolmBackupAuthDataFromKeyBackupVersion: Key backup is missing required data");
+        MXLogDebug(@"[MXKeyBackup] megolmBackupAuthDataFromKeyBackupVersion: Key backup is missing required data");
 
         *error = [NSError errorWithDomain:MXKeyBackupErrorDomain
                                      code:MXKeyBackupErrorMissingAuthDataCode
@@ -1721,7 +1721,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
 
     if (!authData.privateKeySalt || !authData.privateKeyIterations)
     {
-        NSLog(@"[MXKeyBackup] recoveryFromPassword: Salt and/or iterations not found in key backup auth data");
+        MXLogDebug(@"[MXKeyBackup] recoveryFromPassword: Salt and/or iterations not found in key backup auth data");
         *error = [NSError errorWithDomain:MXKeyBackupErrorDomain
                                      code:MXKeyBackupErrorMissingPrivateKeySaltCode
                                  userInfo:@{
@@ -1735,7 +1735,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
     NSData *recoveryKeyData = [MXKeyBackupPassword retrievePrivateKeyWithPassword:password salt:authData.privateKeySalt iterations:authData.privateKeyIterations error:error];
     if (*error)
     {
-        NSLog(@"[MXKeyBackup] recoveryFromPassword: retrievePrivateKeyWithPassword failed: %@", *error);
+        MXLogDebug(@"[MXKeyBackup] recoveryFromPassword: retrievePrivateKeyWithPassword failed: %@", *error);
         return nil;
     }
 
@@ -1756,7 +1756,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
     NSString *publicKey = [self pkPublicKeyFromRecoveryKey:recoveryKey error:error];
     if (*error)
     {
-        NSLog(@"[MXKeyBackup] isValidRecoveryKey: Invalid recovery key. Error: %@", *error);
+        MXLogDebug(@"[MXKeyBackup] isValidRecoveryKey: Invalid recovery key. Error: %@", *error);
 
         // Return a generic error
         *error = [NSError errorWithDomain:MXKeyBackupErrorDomain
@@ -1771,14 +1771,14 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
     MXMegolmBackupAuthData *authData = [self megolmBackupAuthDataFromKeyBackupVersion:keyBackupVersion error:error];
     if (*error)
     {
-        NSLog(@"[MXKeyBackup] isValidRecoveryKey: Key backup is missing required data");
+        MXLogDebug(@"[MXKeyBackup] isValidRecoveryKey: Key backup is missing required data");
         return NO;
     }
 
     // Compare both
     if (![publicKey isEqualToString:authData.publicKey])
     {
-        NSLog(@"[MXKeyBackup] isValidRecoveryKey: Public keys mismatch");
+        MXLogDebug(@"[MXKeyBackup] isValidRecoveryKey: Public keys mismatch");
 
         *error = [NSError errorWithDomain:MXKeyBackupErrorDomain
                                      code:MXKeyBackupErrorInvalidRecoveryKeyCode

--- a/MatrixSDK/Crypto/KeyBackup/MXKeyBackupPassword.m
+++ b/MatrixSDK/Crypto/KeyBackup/MXKeyBackupPassword.m
@@ -80,7 +80,7 @@ static NSUInteger const kDefaultIterations = 500000;
                                    derivedKey.mutableBytes,
                                    derivedKey.length);
 
-    NSLog(@"[MXKeyBackupPassword] deriveKey: %tu iterations took %.0fms", iterations, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+    MXLogDebug(@"[MXKeyBackupPassword] deriveKey: %tu iterations took %.0fms", iterations, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 
     if (result != kCCSuccess)
     {

--- a/MatrixSDK/Crypto/KeySharing/MXOutgoingRoomKeyRequestManager.m
+++ b/MatrixSDK/Crypto/KeySharing/MXOutgoingRoomKeyRequestManager.m
@@ -79,7 +79,7 @@ NSUInteger const SEND_KEY_REQUESTS_DELAY_MS = 500;
 
 - (void)setEnabled:(BOOL)enabled
 {
-    NSLog(@"[MXOutgoingRoomKeyRequestManager] setEnabled: %@ (old: %@)", @(enabled), @(_enabled));
+    MXLogDebug(@"[MXOutgoingRoomKeyRequestManager] setEnabled: %@ (old: %@)", @(enabled), @(_enabled));
     if (enabled == _enabled)
     {
         return;
@@ -126,7 +126,7 @@ NSUInteger const SEND_KEY_REQUESTS_DELAY_MS = 500;
         return;
     }
 
-    NSLog(@"[MXOutgoingRoomKeyRequestManager] cancelRoomKeyRequest:andResend:%@: request.requestId: %@. state: %@", @(resend), request.requestId,  @(request.state));
+    MXLogDebug(@"[MXOutgoingRoomKeyRequestManager] cancelRoomKeyRequest:andResend:%@: request.requestId: %@. state: %@", @(resend), request.requestId,  @(request.state));
 
     switch (request.state)
     {
@@ -143,7 +143,7 @@ NSUInteger const SEND_KEY_REQUESTS_DELAY_MS = 500;
             // may have seen it, so we still need to send a cancellation
             // in that case :/
 
-            NSLog(@"[MXOutgoingRoomKeyRequestManager] cancelRoomKeyRequest: deleting unnecessary room key request %@", request.requestId);
+            MXLogDebug(@"[MXOutgoingRoomKeyRequestManager] cancelRoomKeyRequest: deleting unnecessary room key request %@", request.requestId);
 
             [cryptoStore deleteOutgoingRoomKeyRequestWithRequestId:request.requestId];
             break;
@@ -169,7 +169,7 @@ NSUInteger const SEND_KEY_REQUESTS_DELAY_MS = 500;
             [self sendOutgoingRoomKeyRequestCancellation:request andResend:resend success:nil failure:^(NSError *error) {
                 MXStrongifyAndReturnIfNil(self);
 
-                NSLog(@"[MXOutgoingRoomKeyRequestManager] cancelRoomKeyRequest: Error sending room key request cancellation; will retry later.");
+                MXLogDebug(@"[MXOutgoingRoomKeyRequestManager] cancelRoomKeyRequest: Error sending room key request cancellation; will retry later.");
 
                 [self startTimer];
             }];
@@ -218,7 +218,7 @@ NSUInteger const SEND_KEY_REQUESTS_DELAY_MS = 500;
         }
     }
     
-    NSLog(@"[MXOutgoingRoomKeyRequestManager] checkAllPendingOutgoingRoomKeyRequests: Cleared %@ requests out of %@", @(deleted), @(requests.count));
+    MXLogDebug(@"[MXOutgoingRoomKeyRequestManager] checkAllPendingOutgoingRoomKeyRequests: Cleared %@ requests out of %@", @(deleted), @(requests.count));
 }
 
 - (void)sendOutgoingRoomKeyRequests
@@ -229,11 +229,11 @@ NSUInteger const SEND_KEY_REQUESTS_DELAY_MS = 500;
     // Do not start
     if (!self.isEnabled)
     {
-        NSLog(@"[MXOutgoingRoomKeyRequestManager] startSendingOutgoingRoomKeyRequests: Disabled.");
+        MXLogDebug(@"[MXOutgoingRoomKeyRequestManager] startSendingOutgoingRoomKeyRequests: Disabled.");
         return;
     }
     
-    NSLog(@"[MXOutgoingRoomKeyRequestManager] startSendingOutgoingRoomKeyRequests: Looking for queued outgoing room key requests.");
+    MXLogDebug(@"[MXOutgoingRoomKeyRequestManager] startSendingOutgoingRoomKeyRequests: Looking for queued outgoing room key requests.");
 
     // This method is called on the [NSRunLoop mainRunLoop]. Go to the crypto thread
     MXWeakify(self);
@@ -248,7 +248,7 @@ NSUInteger const SEND_KEY_REQUESTS_DELAY_MS = 500;
 
         if (!request)
         {
-            NSLog(@"[MXOutgoingRoomKeyRequestManager] startSendingOutgoingRoomKeyRequests: No more outgoing room key requests");
+            MXLogDebug(@"[MXOutgoingRoomKeyRequestManager] startSendingOutgoingRoomKeyRequests: No more outgoing room key requests");
             return;
         }
 
@@ -291,7 +291,7 @@ NSUInteger const SEND_KEY_REQUESTS_DELAY_MS = 500;
                            success:(void (^)(void))success
                            failure:(void (^)(NSError *error))failure
 {
-    NSLog(@"[MXOutgoingRoomKeyRequestManager] sendOutgoingRoomKeyRequest: Requesting key %@ using request id %@ to %@: %@", request.sessionId, request.requestId, request.recipients, request.requestBody);
+    MXLogDebug(@"[MXOutgoingRoomKeyRequestManager] sendOutgoingRoomKeyRequest: Requesting key %@ using request id %@ to %@: %@", request.sessionId, request.requestId, request.recipients, request.requestBody);
 
     NSDictionary *requestMessage = @{
                                      @"action": @"request",
@@ -319,7 +319,7 @@ NSUInteger const SEND_KEY_REQUESTS_DELAY_MS = 500;
                                        success:(void (^)(void))success
                                        failure:(void (^)(NSError *error))failure
 {
-    NSLog(@"[MXOutgoingRoomKeyRequestManager] sendOutgoingRoomKeyRequestCancellation: Sending cancellation for key request (request id %@) for key %@ (cancellation id %@)", request.requestId, request.sessionId, request.cancellationTxnId);
+    MXLogDebug(@"[MXOutgoingRoomKeyRequestManager] sendOutgoingRoomKeyRequestCancellation: Sending cancellation for key request (request id %@) for key %@ (cancellation id %@)", request.requestId, request.sessionId, request.cancellationTxnId);
 
     NSDictionary *requestMessage = @{
                                      @"action": @"request_cancellation",
@@ -378,13 +378,13 @@ NSUInteger const SEND_KEY_REQUESTS_DELAY_MS = 500;
     if (outgoingRoomKeyRequest)
     {
         // this entry matches the request - return it.
-        NSLog(@"[MXOutgoingRoomKeyRequestManager] getOrAddOutgoingRoomKeyRequest: already have key request outstanding for %@ / %@: not sending another", requestBody[@"room_id"], requestBody[@"session_id"]);
+        MXLogDebug(@"[MXOutgoingRoomKeyRequestManager] getOrAddOutgoingRoomKeyRequest: already have key request outstanding for %@ / %@: not sending another", requestBody[@"room_id"], requestBody[@"session_id"]);
         return outgoingRoomKeyRequest;
     }
 
     // we got to the end of the list without finding a match
     // - add the new request.
-    NSLog(@"[MXOutgoingRoomKeyRequestManager] getOrAddOutgoingRoomKeyRequest: enqueueing key request for %@ / %@", requestBody[@"room_id"], requestBody[@"session_id"]);
+    MXLogDebug(@"[MXOutgoingRoomKeyRequestManager] getOrAddOutgoingRoomKeyRequest: enqueueing key request for %@ / %@", requestBody[@"room_id"], requestBody[@"session_id"]);
 
     outgoingRoomKeyRequest = [[MXOutgoingRoomKeyRequest alloc] init];
     outgoingRoomKeyRequest.requestBody = requestBody;

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -156,7 +156,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 {
 #ifdef MX_CRYPTO
 
-    NSLog(@"[MXCrypto] checkCryptoWithMatrixSession for %@", mxSession.matrixRestClient.credentials.userId);
+    MXLogDebug(@"[MXCrypto] checkCryptoWithMatrixSession for %@", mxSession.matrixRestClient.credentials.userId);
 
     dispatch_queue_t cryptoQueue = [MXCrypto dispatchQueueForUser:mxSession.matrixRestClient.credentials.userId];
     dispatch_async(cryptoQueue, ^{
@@ -166,14 +166,14 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
         
         if ([MXCryptoStoreClass hasDataForCredentials:mxSession.matrixRestClient.credentials])
         {
-            NSLog(@"[MXCrypto] checkCryptoWithMatrixSession: Crypto store exists");
+            MXLogDebug(@"[MXCrypto] checkCryptoWithMatrixSession: Crypto store exists");
 
             // If it already exists, open and init crypto
             MXCryptoStoreClass *cryptoStore = [[MXCryptoStoreClass alloc] initWithCredentials:mxSession.matrixRestClient.credentials];
 
             [cryptoStore open:^{
 
-                NSLog(@"[MXCrypto] checkCryptoWithMatrixSession: Crypto store opened");
+                MXLogDebug(@"[MXCrypto] checkCryptoWithMatrixSession: Crypto store opened");
 
                 MXCrypto *crypto = [[MXCrypto alloc] initWithMatrixSession:mxSession cryptoQueue:cryptoQueue andStore:cryptoStore];
 
@@ -183,7 +183,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 
             } failure:^(NSError *error) {
 
-                NSLog(@"[MXCrypto] checkCryptoWithMatrixSession: Crypto store failed to open. Error: %@", error);
+                MXLogDebug(@"[MXCrypto] checkCryptoWithMatrixSession: Crypto store failed to open. Error: %@", error);
                 
                 dispatch_async(dispatch_get_main_queue(), ^{
                     complete(nil);
@@ -194,7 +194,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
                  // Without the device id provided by the hs, the crypto does not work
                  && mxSession.matrixRestClient.credentials.deviceId)
         {
-            NSLog(@"[MXCrypto] checkCryptoWithMatrixSession: Need to create the store");
+            MXLogDebug(@"[MXCrypto] checkCryptoWithMatrixSession: Need to create the store");
 
             // Create it
             MXCryptoStoreClass *cryptoStore = [MXCryptoStoreClass createStoreWithCredentials:mxSession.matrixRestClient.credentials];
@@ -244,12 +244,12 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 {
 
 #ifdef MX_CRYPTO
-    NSLog(@"[MXCrypto] start");
+    MXLogDebug(@"[MXCrypto] start");
 
     // The session must be initialised enough before starting this module
     if (!_mxSession.myUser.userId)
     {
-        NSLog(@"[MXCrypto] start. ERROR: mxSession.myUser.userId cannot be nil");
+        MXLogDebug(@"[MXCrypto] start. ERROR: mxSession.myUser.userId cannot be nil");
         failure(nil);
         return;
     }
@@ -270,7 +270,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
             
             // We have no mandatory migration for now
             // We can try again at the next MXCrypto startup
-            NSLog(@"[MXCrypto] start. Migration failed. Ignore it for now");
+            MXLogDebug(@"[MXCrypto] start. Migration failed. Ignore it for now");
             self->cryptoMigration = nil;
             [self start:success failure:failure];
         }];
@@ -302,15 +302,15 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
         [self maybeUploadOneTimeKeys:^{
             MXStrongifyAndReturnIfNil(self);
 
-            NSLog(@"[MXCrypto] start ###########################################################");
-            NSLog(@"[MXCrypto] uploadDeviceKeys done for %@: ", self.mxSession.myUserId);
+            MXLogDebug(@"[MXCrypto] start ###########################################################");
+            MXLogDebug(@"[MXCrypto] uploadDeviceKeys done for %@: ", self.mxSession.myUserId);
 
-            NSLog(@"[MXCrypto]    - device id  : %@", self.store.deviceId);
-            NSLog(@"[MXCrypto]    - ed25519    : %@", self.olmDevice.deviceEd25519Key);
-            NSLog(@"[MXCrypto]    - curve25519 : %@", self.olmDevice.deviceCurve25519Key);
-            NSLog(@"[MXCrypto] ");
-            NSLog(@"[MXCrypto] Store: %@", self.store);
-            NSLog(@"[MXCrypto] ");
+            MXLogDebug(@"[MXCrypto]    - device id  : %@", self.store.deviceId);
+            MXLogDebug(@"[MXCrypto]    - ed25519    : %@", self.olmDevice.deviceEd25519Key);
+            MXLogDebug(@"[MXCrypto]    - curve25519 : %@", self.olmDevice.deviceCurve25519Key);
+            MXLogDebug(@"[MXCrypto] ");
+            MXLogDebug(@"[MXCrypto] Store: %@", self.store);
+            MXLogDebug(@"[MXCrypto] ");
 
             [self->_crossSigning refreshStateWithSuccess:nil failure:nil];
             
@@ -327,7 +327,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
         } failure:^(NSError *error) {
             MXStrongifyAndReturnIfNil(self);
 
-            NSLog(@"[MXCrypto] start. Error in maybeUploadOneTimeKeys: %@", error);
+            MXLogDebug(@"[MXCrypto] start. Error in maybeUploadOneTimeKeys: %@", error);
             dispatch_async(dispatch_get_main_queue(), ^{
                 self->startOperation = nil;
                 failure(error);
@@ -337,7 +337,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     } failure:^(NSError *error) {
         MXStrongifyAndReturnIfNil(self);
 
-        NSLog(@"[MXCrypto] start. Error in uploadDeviceKeys: %@", error);
+        MXLogDebug(@"[MXCrypto] start. Error in uploadDeviceKeys: %@", error);
         dispatch_async(dispatch_get_main_queue(), ^{
             self->startOperation = nil;
             failure(error);
@@ -351,7 +351,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 {
 #ifdef MX_CRYPTO
 
-    NSLog(@"[MXCrypto] close. store: %@", _store);
+    MXLogDebug(@"[MXCrypto] close. store: %@", _store);
 
     [_mxSession removeListener:roomMembershipEventsListener];
 
@@ -392,7 +392,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 
         self->_myDevice = nil;
 
-        NSLog(@"[MXCrypto] close: done");
+        MXLogDebug(@"[MXCrypto] close: done");
     });
 
 #endif
@@ -404,7 +404,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 {
 #ifdef MX_CRYPTO
 
-    NSLog(@"[MXCrypto] encryptEventContent");
+    MXLogDebug(@"[MXCrypto] encryptEventContent");
 
     NSDate *startDate = [NSDate date];
 
@@ -438,7 +438,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
                 NSString *algorithm;
                 id<MXEncrypting> alg = self->roomEncryptors[room.roomId];
 
-                NSLog(@"[MXCrypto] encryptEventContent: with %@ for %@ users", roomState.encryptionAlgorithm, @(userIds.count));
+                MXLogDebug(@"[MXCrypto] encryptEventContent: with %@ for %@ users", roomState.encryptionAlgorithm, @(userIds.count));
 
                 if (!alg)
                 {
@@ -461,12 +461,12 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
                 if (alg && [eventType isEqualToString:kMXEventTypeStringRoomEncrypted] == NO)
                 {
 #ifdef DEBUG
-                    NSLog(@"[MXCrypto] encryptEventContent: content: %@", eventContent);
+                    MXLogDebug(@"[MXCrypto] encryptEventContent: content: %@", eventContent);
 #endif
 
                     MXHTTPOperation *operation2 = [alg encryptEventContent:eventContent eventType:eventType forUsers:userIds success:^(NSDictionary *encryptedContent) {
 
-                        NSLog(@"[MXCrypto] encryptEventContent: Success in %.0fms using sessionId: %@",
+                        MXLogDebug(@"[MXCrypto] encryptEventContent: Success in %.0fms using sessionId: %@",
                               [[NSDate date] timeIntervalSinceDate:startDate] * 1000,
                               encryptedContent[@"session_id"]);
 
@@ -475,7 +475,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
                         });
 
                     } failure:^(NSError *error) {
-                        NSLog(@"[MXCrypto] encryptEventContent: Error: %@", error);
+                        MXLogDebug(@"[MXCrypto] encryptEventContent: Error: %@", error);
 
                         dispatch_async(dispatch_get_main_queue(), ^{
                             failure(error);
@@ -487,7 +487,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
                 }
                 else
                 {
-                    NSLog(@"[MXCrypto] encryptEventContent: Invalid algorithm");
+                    MXLogDebug(@"[MXCrypto] encryptEventContent: Invalid algorithm");
 
                     NSError *error = [NSError errorWithDomain:MXDecryptingErrorDomain
                                                          code:MXDecryptingErrorUnableToEncryptCode
@@ -555,7 +555,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     
     if (!event.content.count)
     {
-        NSLog(@"[MXCrypto] decryptEvent: No content to decrypt in event %@ (isRedacted: %@). Event: %@", event.eventId, @(event.isRedactedEvent), event.JSONDictionary);
+        MXLogDebug(@"[MXCrypto] decryptEvent: No content to decrypt in event %@ (isRedacted: %@). Event: %@", event.eventId, @(event.isRedactedEvent), event.JSONDictionary);
         result = [[MXEventDecryptionResult alloc] init];
         result.clearEvent = event.content;
         return result;
@@ -565,7 +565,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     id<MXDecrypting> alg = [self getRoomDecryptor:event.roomId algorithm:algorithm];
     if (!alg)
     {
-        NSLog(@"[MXCrypto] decryptEvent: Unable to decrypt %@ with algorithm %@. Event: %@", event.eventId, algorithm, event.JSONDictionary);
+        MXLogDebug(@"[MXCrypto] decryptEvent: Unable to decrypt %@ with algorithm %@. Event: %@", event.eventId, algorithm, event.JSONDictionary);
         
         result = [MXEventDecryptionResult new];
         result.error = [NSError errorWithDomain:MXDecryptingErrorDomain
@@ -580,7 +580,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
         result = [alg decryptEvent:event inTimeline:timeline];
         if (result.error)
         {
-            NSLog(@"[MXCrypto] decryptEvent: Error for %@: %@\nEvent: %@", event.eventId, result.error, event.JSONDictionary);
+            MXLogDebug(@"[MXCrypto] decryptEvent: Error for %@: %@\nEvent: %@", event.eventId, result.error, event.JSONDictionary);
             
             if ([result.error.domain isEqualToString:MXDecryptingErrorDomain]
                 && result.error.code == MXDecryptingErrorBadEncryptedMessageCode)
@@ -742,7 +742,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
         return;
     }
 
-    NSLog(@"[MXCrypto] handleDeviceListsChanges (changes: %@, left: %@):\nchanges: %@\nleft: %@", @(deviceLists.changed.count), @(deviceLists.left.count),
+    MXLogDebug(@"[MXCrypto] handleDeviceListsChanges (changes: %@, left: %@):\nchanges: %@\nleft: %@", @(deviceLists.changed.count), @(deviceLists.left.count),
           deviceLists.changed, deviceLists.left);
 
     MXWeakify(self);
@@ -789,7 +789,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
         return;
     }
 
-    NSLog(@"[MXCrypto] handleDeviceOneTimeKeysCount: %@ keys on the homeserver", deviceOneTimeKeysCount[@"signed_curve25519"]);
+    MXLogDebug(@"[MXCrypto] handleDeviceOneTimeKeysCount: %@ keys on the homeserver", deviceOneTimeKeysCount[@"signed_curve25519"]);
 
     MXWeakify(self);
     dispatch_async(_cryptoQueue, ^{
@@ -817,14 +817,14 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 
         if (!oldSyncToken)
         {
-            NSLog(@"[MXCrypto] onSyncCompleted: Completed initial sync");
+            MXLogDebug(@"[MXCrypto] onSyncCompleted: Completed initial sync");
 
             // If we have a deviceSyncToken, we can tell the deviceList to
             // invalidate devices which have changed since then.
             NSString *oldDeviceSyncToken = self.store.deviceSyncToken;
             if (oldDeviceSyncToken)
             {
-                NSLog(@"[MXCrypto] onSyncCompleted: invalidating device list from deviceSyncToken: %@", oldDeviceSyncToken);
+                MXLogDebug(@"[MXCrypto] onSyncCompleted: invalidating device list from deviceSyncToken: %@", oldDeviceSyncToken);
 
                 [self invalidateDeviceListsSince:oldDeviceSyncToken to:nextSyncToken success:^() {
 
@@ -834,7 +834,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
                 } failure:^(NSError *error) {
 
                     // If that failed, we fall back to invalidating everyone.
-                    NSLog(@"[MXCrypto] onSyncCompleted: Error fetching changed device list. Error: %@", error);
+                    MXLogDebug(@"[MXCrypto] onSyncCompleted: Error fetching changed device list. Error: %@", error);
                     [self.deviceList invalidateAllDeviceLists];
                 }];
             }
@@ -842,7 +842,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
             {
                 // Otherwise, we have to invalidate all devices for all users we
                 // are tracking.
-                NSLog(@"[MXCrypto] onSyncCompleted: Completed first initialsync; invalidating all device list caches");
+                MXLogDebug(@"[MXCrypto] onSyncCompleted: Completed first initialsync; invalidating all device list caches");
                 [self.deviceList invalidateAllDeviceLists];
             }
         }
@@ -923,7 +923,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     {
         if (downloadIfNeeded)
         {
-            NSLog(@"[MXCrypto] setDeviceVerificationForDevice: Unknown device. Try to download user's keys for %@:%@", userId, deviceId);
+            MXLogDebug(@"[MXCrypto] setDeviceVerificationForDevice: Unknown device. Try to download user's keys for %@:%@", userId, deviceId);
             [self.deviceList downloadKeys:@[userId] forceDownload:YES success:^(MXUsersDevicesMap<MXDeviceInfo *> *usersDevicesInfoMap, NSDictionary<NSString *,MXCrossSigningInfo *> *crossSigningKeysMap) {
                 [self setDeviceVerification2:verificationStatus forDevice:deviceId ofUser:userId downloadIfNeeded:NO success:success failure:failure];
             } failure:^(NSError *error) {
@@ -937,7 +937,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
         }
         else
         {
-            NSLog(@"[MXCrypto] setDeviceVerificationForDevice: Unknown device %@:%@", userId, deviceId);
+            MXLogDebug(@"[MXCrypto] setDeviceVerificationForDevice: Unknown device %@:%@", userId, deviceId);
             if (failure)
             {
                 dispatch_async(dispatch_get_main_queue(), ^{
@@ -964,14 +964,14 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
         if (verificationStatus == MXDeviceVerified)
         {
             // This is a good time to request all private keys
-            NSLog(@"[MXCrypto] setDeviceVerificationForDevice: Request all private keys");
+            MXLogDebug(@"[MXCrypto] setDeviceVerificationForDevice: Request all private keys");
             [self scheduleRequestsForAllPrivateKeys];
             
             // Check cross-signing
             if (self.crossSigning.canCrossSign)
             {
                 // Cross-sign our own device
-                NSLog(@"[MXCrypto] setDeviceVerificationForDevice: Mark device %@ as self verified", deviceId);
+                MXLogDebug(@"[MXCrypto] setDeviceVerificationForDevice: Mark device %@ as self verified", deviceId);
                 [self.crossSigning crossSignDeviceWithDeviceId:deviceId success:success failure:failure];
                 
                 // Wait the end of cross-sign before returning
@@ -1060,7 +1060,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     {
         if (downloadIfNeeded)
         {
-            NSLog(@"[MXCrypto] setUserVerification: Unknown user. Try to download user's keys for %@", userId);
+            MXLogDebug(@"[MXCrypto] setUserVerification: Unknown user. Try to download user's keys for %@", userId);
             [self.deviceList downloadKeys:@[userId] forceDownload:YES success:^(MXUsersDevicesMap<MXDeviceInfo *> *usersDevicesInfoMap, NSDictionary<NSString *,MXCrossSigningInfo *> *crossSigningKeysMap) {
                 [self setUserVerification2:verificationStatus forUser:userId downloadIfNeeded:NO success:success failure:failure];
             } failure:^(NSError *error) {
@@ -1074,7 +1074,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
         }
         else
         {
-            NSLog(@"[MXCrypto] setUserVerification: Unknown user %@", userId);
+            MXLogDebug(@"[MXCrypto] setUserVerification: Unknown user %@", userId);
             if (failure)
             {
                 dispatch_async(dispatch_get_main_queue(), ^{
@@ -1099,7 +1099,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     {
         if (self.crossSigning.canCrossSign)
         {
-            NSLog(@"[MXCrypto] setUserVerification: Sign user %@ as verified", userId);
+            MXLogDebug(@"[MXCrypto] setUserVerification: Sign user %@ as verified", userId);
             [self.crossSigning signUserWithUserId:userId success:success failure:failure];
             
             // Wait the end of cross-sign before returning
@@ -1108,7 +1108,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
         else
         {
             // Cross-signing ability should have been checked before going into this hole
-            NSLog(@"[MXCrypto] setUserVerification: Cross-signing not enabled. Current state: %@", @(self.crossSigning.state));
+            MXLogDebug(@"[MXCrypto] setUserVerification: Cross-signing not enabled. Current state: %@", @(self.crossSigning.state));
             
         }
     }
@@ -1335,12 +1335,12 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 
 - (void)requestAllPrivateKeys
 {
-    NSLog(@"[MXCrypto] requestAllPrivateKeys");
+    MXLogDebug(@"[MXCrypto] requestAllPrivateKeys");
     
     // Request backup private keys
     if (!self.backup.hasPrivateKeyInCryptoStore || !self.backup.enabled)
     {
-        NSLog(@"[MXCrypto] requestAllPrivateKeys: Request key backup private keys");
+        MXLogDebug(@"[MXCrypto] requestAllPrivateKeys: Request key backup private keys");
         
         MXWeakify(self);
         [self.backup requestPrivateKeys:^{
@@ -1356,7 +1356,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     // Check cross-signing private keys
     if (!self.crossSigning.canCrossSign)
     {
-        NSLog(@"[MXCrypto] requestAllPrivateKeys: Request cross-signing private keys");
+        MXLogDebug(@"[MXCrypto] requestAllPrivateKeys: Request cross-signing private keys");
         [self.crossSigning requestPrivateKeys];
     }
 }
@@ -1394,7 +1394,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
             }
         }
 
-        NSLog(@"[MXCrypto] exportRoomKeys: Exported %tu keys in %.0fms", keys.count, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+        MXLogDebug(@"[MXCrypto] exportRoomKeys: Exported %tu keys in %.0fms", keys.count, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 
         dispatch_async(dispatch_get_main_queue(), ^{
 
@@ -1432,7 +1432,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
             }
         }
 
-        NSLog(@"[MXCrypto] exportRoomKeysWithPassword: Exportion of %tu keys took %.0fms", keys.count, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+        MXLogDebug(@"[MXCrypto] exportRoomKeysWithPassword: Exportion of %tu keys took %.0fms", keys.count, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 
         // Convert them to JSON
         NSData *jsonData = [NSJSONSerialization dataWithJSONObject:keys
@@ -1444,7 +1444,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
             keyFile = [MXMegolmExportEncryption encryptMegolmKeyFile:jsonData withPassword:password kdfRounds:0 error:&error];
         }
 
-        NSLog(@"[MXCrypto] exportRoomKeysWithPassword: Exported and encrypted %tu keys in %.0fms", keys.count, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+        MXLogDebug(@"[MXCrypto] exportRoomKeysWithPassword: Exported and encrypted %tu keys in %.0fms", keys.count, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 
         dispatch_async(dispatch_get_main_queue(), ^{
 
@@ -1457,7 +1457,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
             }
             else
             {
-                NSLog(@"[MXCrypto] exportRoomKeysWithPassword: Error: %@", error);
+                MXLogDebug(@"[MXCrypto] exportRoomKeysWithPassword: Error: %@", error);
                 if (failure)
                 {
                     failure(error);
@@ -1473,7 +1473,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 #ifdef MX_CRYPTO
     dispatch_async(cargoQueue, ^{
 
-        NSLog(@"[MXCrypto] importRoomKeys:");
+        MXLogDebug(@"[MXCrypto] importRoomKeys:");
 
         // Convert JSON to MXMegolmSessionData
         NSArray<MXMegolmSessionData *> *sessionDatas = [MXMegolmSessionData modelsFromJSON:keys];
@@ -1490,14 +1490,14 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     dispatch_async(cargoQueue, ^{
         MXStrongifyAndReturnIfNil(self);
 
-        NSLog(@"[MXCrypto] importMegolmSessionDatas: backUp: %@", @(backUp));
+        MXLogDebug(@"[MXCrypto] importMegolmSessionDatas: backUp: %@", @(backUp));
 
         NSDate *startDate = [NSDate date];
 
         // Import keys
         NSArray<MXOlmInboundGroupSession *>* sessions = [self.olmDevice importInboundGroupSessions:sessionDatas];
 
-        NSLog(@"[MXCrypto] importMegolmSessionDatas: Imported %@ keys in store", @(sessions.count));
+        MXLogDebug(@"[MXCrypto] importMegolmSessionDatas: Imported %@ keys in store", @(sessions.count));
         
         dispatch_async(self.cryptoQueue, ^{
             // Do not back up the key if it comes from a backup recovery
@@ -1511,7 +1511,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
             }
             
             // Notify there are new keys
-            NSLog(@"[MXCrypto] importMegolmSessionDatas: Notifying about new keys...");
+            MXLogDebug(@"[MXCrypto] importMegolmSessionDatas: Notifying about new keys...");
             for (MXOlmInboundGroupSession *session in sessions)
             {
                 id<MXDecrypting> alg = [self getRoomDecryptor:session.roomId algorithm:kMXCryptoMegolmAlgorithm];
@@ -1521,7 +1521,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
             NSUInteger imported = sessions.count;
             NSUInteger totalKeyCount = sessionDatas.count;
             
-            NSLog(@"[MXCrypto] importMegolmSessionDatas: Complete. Imported %tu keys from %tu provided keys in %.0fms", imported, totalKeyCount, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+            MXLogDebug(@"[MXCrypto] importMegolmSessionDatas: Complete. Imported %tu keys from %tu provided keys in %.0fms", imported, totalKeyCount, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
             
             dispatch_async(dispatch_get_main_queue(), ^{
                 
@@ -1541,7 +1541,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 #ifdef MX_CRYPTO
     dispatch_async(cargoQueue, ^{
 
-        NSLog(@"[MXCrypto] importRoomKeys:withPassord:");
+        MXLogDebug(@"[MXCrypto] importRoomKeys:withPassord:");
 
         NSError *error;
         NSDate *startDate = [NSDate date];
@@ -1554,7 +1554,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
             {
                 [self importRoomKeys:keys success:^(NSUInteger total, NSUInteger imported) {
 
-                    NSLog(@"[MXCrypto] importRoomKeys:withPassord: Imported %tu keys from %tu provided keys in %.0fms", imported, total, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+                    MXLogDebug(@"[MXCrypto] importRoomKeys:withPassord: Imported %tu keys from %tu provided keys in %.0fms", imported, total, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 
                     if (success)
                     {
@@ -1568,7 +1568,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 
         dispatch_async(dispatch_get_main_queue(), ^{
 
-            NSLog(@"[MXCrypto] importRoomKeys:withPassord: Error: %@", error);
+            MXLogDebug(@"[MXCrypto] importRoomKeys:withPassord: Error: %@", error);
 
             if (failure)
             {
@@ -1606,7 +1606,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 #ifdef MX_CRYPTO
     dispatch_async(_cryptoQueue, ^{
 
-        NSLog(@"[MXCrypto] acceptKeyRequest: %@", keyRequest);
+        MXLogDebug(@"[MXCrypto] acceptKeyRequest: %@", keyRequest);
         [self acceptKeyRequestFromCryptoThread:keyRequest success:success failure:failure];
     });
 #endif
@@ -1621,7 +1621,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 
         NSArray<MXIncomingRoomKeyRequest *> *requests = [self->incomingRoomKeyRequestManager.pendingKeyRequests objectForDevice:deviceId forUser:userId];
 
-        NSLog(@"[MXCrypto] acceptAllPendingKeyRequestsFromUser from %@:%@. %@ pending requests", userId, deviceId, @(requests.count));
+        MXLogDebug(@"[MXCrypto] acceptAllPendingKeyRequestsFromUser from %@:%@. %@ pending requests", userId, deviceId, @(requests.count));
 
         for (MXIncomingRoomKeyRequest *request in requests)
         {
@@ -1666,7 +1666,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     {
         dispatch_async(dispatch_get_main_queue(), ^{
 
-            NSLog(@"[MXCrypto] acceptPendingKeyRequests: ERROR: unknown alg %@ in room %@", alg, roomId);
+            MXLogDebug(@"[MXCrypto] acceptPendingKeyRequests: ERROR: unknown alg %@ in room %@", alg, roomId);
             if (failure)
             {
                 failure(nil);
@@ -1681,7 +1681,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 #ifdef MX_CRYPTO
     dispatch_async(_cryptoQueue, ^{
 
-        NSLog(@"[MXCrypto] ignoreKeyRequest: %@", keyRequest);
+        MXLogDebug(@"[MXCrypto] ignoreKeyRequest: %@", keyRequest);
         [self ignoreKeyRequestFromCryptoThread:keyRequest];
 
         dispatch_async(dispatch_get_main_queue(), ^{
@@ -1703,7 +1703,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 
         NSArray<MXIncomingRoomKeyRequest *> *requests = [self->incomingRoomKeyRequestManager.pendingKeyRequests objectForDevice:deviceId forUser:userId];
 
-        NSLog(@"[MXCrypto] ignoreAllPendingKeyRequestsFromUser from %@:%@. %@ pending requests", userId, deviceId, @(requests.count));
+        MXLogDebug(@"[MXCrypto] ignoreAllPendingKeyRequestsFromUser from %@:%@. %@ pending requests", userId, deviceId, @(requests.count));
 
         for (MXIncomingRoomKeyRequest *request in requests)
         {
@@ -1764,7 +1764,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     dispatch_async(_cryptoQueue, ^{
         MXStrongifyAndReturnIfNil(self);
 
-        NSLog(@"[MXCrypto] reRequestRoomKeyForEvent: %@", event.eventId);
+        MXLogDebug(@"[MXCrypto] reRequestRoomKeyForEvent: %@", event.eventId);
 
         NSDictionary *wireContent = event.wireContent;
         NSString *algorithm, *senderKey, *sessionId;
@@ -1862,7 +1862,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
             // Generate a device id if the homeserver did not provide it or it was lost
             deviceId = [self generateDeviceId];
 
-            NSLog(@"[MXCrypto] Warning: No device id in MXCredentials. The id %@ was created", deviceId);
+            MXLogDebug(@"[MXCrypto] Warning: No device id in MXCredentials. The id %@ was created", deviceId);
 
             [_store storeDeviceId:deviceId];
         }
@@ -1958,13 +1958,13 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     NSString *claimedKey = event.keysClaimed[@"ed25519"];
     if (!claimedKey)
     {
-        NSLog(@"[MXCrypto] eventSenderDeviceOfEvent: Event %@ claims no ed25519 key. Cannot verify sending device", event.eventId);
+        MXLogDebug(@"[MXCrypto] eventSenderDeviceOfEvent: Event %@ claims no ed25519 key. Cannot verify sending device", event.eventId);
         return nil;
     }
 
     if (![claimedKey isEqualToString:device.fingerprint])
     {
-        NSLog(@"[MXCrypto] eventSenderDeviceOfEvent: Event %@ claims ed25519 key %@. Cannot verify sending device but sender device has key %@", event.eventId, claimedKey, device.fingerprint);
+        MXLogDebug(@"[MXCrypto] eventSenderDeviceOfEvent: Event %@ claims ed25519 key %@. Cannot verify sending device but sender device has key %@", event.eventId, claimedKey, device.fingerprint);
         return nil;
     }
     
@@ -1978,14 +1978,14 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     NSString *existingAlgorithm = [_store algorithmForRoom:roomId];
     if (existingAlgorithm && ![existingAlgorithm isEqualToString:algorithm])
     {
-        NSLog(@"[MXCrypto] setEncryptionInRoom: Ignoring m.room.encryption event which requests a change of config in %@", roomId);
+        MXLogDebug(@"[MXCrypto] setEncryptionInRoom: Ignoring m.room.encryption event which requests a change of config in %@", roomId);
         return NO;
     }
 
     Class encryptionClass = [[MXCryptoAlgorithms sharedAlgorithms] encryptorClassForAlgorithm:algorithm];
     if (!encryptionClass)
     {
-        NSLog(@"[MXCrypto] setEncryptionInRoom: Unable to encrypt with %@", algorithm);
+        MXLogDebug(@"[MXCrypto] setEncryptionInRoom: Unable to encrypt with %@", algorithm);
         return NO;
     }
 
@@ -1999,7 +1999,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     roomEncryptors[roomId] = alg;
 
     // make sure we are tracking the device lists for all users in this room.
-    NSLog(@"[MXCrypto] setEncryptionInRoom: Enabling encryption in %@; starting to track device lists for all users therein", roomId);
+    MXLogDebug(@"[MXCrypto] setEncryptionInRoom: Enabling encryption in %@; starting to track device lists for all users therein", roomId);
 
     for (NSString *userId in members)
     {
@@ -2018,7 +2018,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
                                       success:(void (^)(MXUsersDevicesMap<MXOlmSessionResult*> *results))success
                                       failure:(void (^)(NSError *error))failure
 {
-    NSLog(@"[MXCrypto] ensureOlmSessionsForUsers: %@", users);
+    MXLogDebug(@"[MXCrypto] ensureOlmSessionsForUsers: %@", users);
 
     NSMutableDictionary<NSString* /* userId */, NSMutableArray<MXDeviceInfo*>*> *devicesByUser = [NSMutableDictionary dictionary];
 
@@ -2080,11 +2080,11 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
         }
     }
 
-    NSLog(@"[MXCrypto] ensureOlmSessionsForDevices (users: %tu - devices: %tu - force: %@): %@", devicesByUser.count, count, @(force), devicesByUser);
+    MXLogDebug(@"[MXCrypto] ensureOlmSessionsForDevices (users: %tu - devices: %tu - force: %@): %@", devicesByUser.count, count, @(force), devicesByUser);
 
     if (devicesWithoutSession.count == 0)
     {
-        NSLog(@"[MXCrypto] ensureOlmSessionsForDevices: Have already sessions for all");
+        MXLogDebug(@"[MXCrypto] ensureOlmSessionsForDevices: Have already sessions for all");
         if (success)
         {
             success(results);
@@ -2125,7 +2125,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
         [devicesInProgress addObject:deviceIdentityKey];
     }
     
-    NSLog(@"[MXCrypto] ensureOlmSessionsForDevices: %@ out of %@ sessions to claim one time keys", @(usersDevicesToClaim.count), @(devicesWithoutSession.count));
+    MXLogDebug(@"[MXCrypto] ensureOlmSessionsForDevices: %@ out of %@ sessions to claim one time keys", @(usersDevicesToClaim.count), @(devicesWithoutSession.count));
     
     
     // Wait for the result of claim request(s)
@@ -2143,7 +2143,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
         {
             if (error)
             {
-                NSLog(@"[MXCrypto] ensureOlmSessionsForDevices: Got a notification failure for %@ devices. Fail our current pool of %@ devices", @(devices.count), @(devicesInProgress.count));
+                MXLogDebug(@"[MXCrypto] ensureOlmSessionsForDevices: Got a notification failure for %@ devices. Fail our current pool of %@ devices", @(devices.count), @(devicesInProgress.count));
                 
                 // Consider the failure for all requests of the current pool
                 [self->ensureOlmSessionsInProgress removeObjectsInArray:devices];
@@ -2175,7 +2175,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
                     }
                 }
                 
-                NSLog(@"[MXCrypto] ensureOlmSessionsForDevices: Got olm sessions for %@ devices. Still missing %@ sessions", @(devices.count), @(devicesInProgress.count));
+                MXLogDebug(@"[MXCrypto] ensureOlmSessionsForDevices: Got olm sessions for %@ devices. Still missing %@ sessions", @(devices.count), @(devicesInProgress.count));
                 
                 // If the pool is empty, we are done
                 if (!devicesInProgress.count)
@@ -2193,17 +2193,17 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     
     if (usersDevicesToClaim.count == 0)
     {
-        NSLog(@"[MXCrypto] ensureOlmSessionsForDevices: All missing sessions are already pending");
+        MXLogDebug(@"[MXCrypto] ensureOlmSessionsForDevices: All missing sessions are already pending");
         return nil;
     }
     
 
-    NSLog(@"[MXCrypto] ensureOlmSessionsForDevices: claimOneTimeKeysForUsersDevices (users: %tu - devices: %tu)",
+    MXLogDebug(@"[MXCrypto] ensureOlmSessionsForDevices: claimOneTimeKeysForUsersDevices (users: %tu - devices: %tu)",
           usersDevicesToClaim.map.count, usersDevicesToClaim.count);
 
     return [_matrixRestClient claimOneTimeKeysForUsersDevices:usersDevicesToClaim success:^(MXKeysClaimResponse *keysClaimResponse) {
 
-        NSLog(@"[MXCrypto] ensureOlmSessionsForDevices: claimOneTimeKeysForUsersDevices response (users: %tu - devices: %tu): %@",
+        MXLogDebug(@"[MXCrypto] ensureOlmSessionsForDevices: claimOneTimeKeysForUsersDevices response (users: %tu - devices: %tu): %@",
               keysClaimResponse.oneTimeKeys.map.count, keysClaimResponse.oneTimeKeys.count, keysClaimResponse.oneTimeKeys);
 
         for (NSString *userId in devicesByUser)
@@ -2228,7 +2228,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 
                     if (!oneTimeKey)
                     {
-                        NSLog(@"[MXCrypto] ensureOlmSessionsForDevices: No one-time keys (alg=%@) for device %@:%@", oneTimeKeyAlgorithm, userId, deviceId);
+                        MXLogDebug(@"[MXCrypto] ensureOlmSessionsForDevices: No one-time keys (alg=%@) for device %@:%@", oneTimeKeyAlgorithm, userId, deviceId);
                         continue;
                     }
 
@@ -2246,7 +2246,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 
     } failure:^(NSError *error) {
 
-        NSLog(@"[MXCrypto] ensureOlmSessionsForDevices: claimOneTimeKeysForUsersDevices request failed.");
+        MXLogDebug(@"[MXCrypto] ensureOlmSessionsForDevices: claimOneTimeKeysForUsersDevices request failed.");
 
         // Broadcast the /claim request is done
         [[NSNotificationCenter defaultCenter] postNotificationName:kMXCryptoOneTimeKeyClaimCompleteNotification
@@ -2275,17 +2275,17 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 
         if (sessionId)
         {
-            NSLog(@"[MXCrypto] verifyKeyAndStartSession: Started new olm session id %@ for device %@ (theirOneTimeKey: %@)", sessionId, deviceInfo, oneTimeKey.value);
+            MXLogDebug(@"[MXCrypto] verifyKeyAndStartSession: Started new olm session id %@ for device %@ (theirOneTimeKey: %@)", sessionId, deviceInfo, oneTimeKey.value);
         }
         else
         {
             // Possibly a bad key
-            NSLog(@"[MXCrypto] verifyKeyAndStartSession: Error starting olm session with device %@:%@", userId, deviceId);
+            MXLogDebug(@"[MXCrypto] verifyKeyAndStartSession: Error starting olm session with device %@:%@", userId, deviceId);
         }
     }
     else
     {
-        NSLog(@"[MXCrypto] verifyKeyAndStartSession: Unable to verify signature on one-time key for device %@:%@. Error: %@", userId, deviceId, error.localizedFailureReason);
+        MXLogDebug(@"[MXCrypto] verifyKeyAndStartSession: Unable to verify signature on one-time key for device %@:%@. Error: %@", userId, deviceId, error.localizedFailureReason);
     }
 
     return sessionId;
@@ -2326,7 +2326,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
             NSData *payloadData = [NSJSONSerialization  dataWithJSONObject:payloadJson options:0 error:nil];
             NSString *payloadString = [[NSString alloc] initWithData:payloadData encoding:NSUTF8StringEncoding];
 
-            //NSLog(@"[MXCrypto] encryptMessage: %@\nUsing sessionid %@ for device %@", payloadJson, sessionId, recipientDevice.identityKey);
+            //MXLogDebug(@"[MXCrypto] encryptMessage: %@\nUsing sessionid %@ for device %@", payloadJson, sessionId, recipientDevice.identityKey);
             ciphertext[recipientDevice.identityKey] = [_olmDevice encryptMessage:recipientDevice.identityKey sessionId:sessionId payloadString:payloadString];
         }
     }
@@ -2444,7 +2444,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     {
         @synchronized (dispatchQueues)
         {
-            NSLog(@"[MXCrypto] Create dispatch queue for %@'s crypto", userId);
+            MXLogDebug(@"[MXCrypto] Create dispatch queue for %@'s crypto", userId);
             queue = dispatch_queue_create([NSString stringWithFormat:@"MXCrypto-%@", userId].UTF8String, DISPATCH_QUEUE_SERIAL);
             dispatchQueues[userId] = queue;
         }
@@ -2473,7 +2473,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 {
     [_matrixRestClient keyChangesFrom:oldSyncToken to:lastKnownSyncToken success:^(MXDeviceListResponse *deviceLists) {
 
-        NSLog(@"[MXCrypto] invalidateDeviceListsSince: got key changes since %@: changed: %@\nleft: %@", oldSyncToken, deviceLists.changed, deviceLists.left);
+        MXLogDebug(@"[MXCrypto] invalidateDeviceListsSince: got key changes since %@: changed: %@\nleft: %@", oldSyncToken, deviceLists.changed, deviceLists.left);
 
         [self handleDeviceListsChanges:deviceLists];
 
@@ -2520,7 +2520,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 {
     MXEvent *event = notification.userInfo[kMXSessionNotificationEventKey];
 
-    NSLog(@"[MXCrypto] onToDeviceEvent: event.type: %@", event.type);
+    MXLogDebug(@"[MXCrypto] onToDeviceEvent: event.type: %@", event.type);
 
     if (_cryptoQueue)
     {
@@ -2562,14 +2562,14 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 {
     if (!event.content[@"room_id"] || !event.content[@"algorithm"])
     {
-        NSLog(@"[MXCrypto] onRoomKeyEvent: ERROR: Key event is missing fields");
+        MXLogDebug(@"[MXCrypto] onRoomKeyEvent: ERROR: Key event is missing fields");
         return;
     }
 
     id<MXDecrypting> alg = [self getRoomDecryptor:event.content[@"room_id"] algorithm:event.content[@"algorithm"]];
     if (!alg)
     {
-        NSLog(@"[MXCrypto] onRoomKeyEvent: ERROR: Unable to handle keys for %@", event.content[@"algorithm"]);
+        MXLogDebug(@"[MXCrypto] onRoomKeyEvent: ERROR: Unable to handle keys for %@", event.content[@"algorithm"]);
         return;
     }
 
@@ -2632,7 +2632,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     {
         if (member.membership == MXMembershipJoin)
         {
-            NSLog(@"[MXCrypto] onRoomMembership: Join event for %@ in %@", member.userId, event.roomId);
+            MXLogDebug(@"[MXCrypto] onRoomMembership: Join event for %@ in %@", member.userId, event.roomId);
             shouldTrack = YES;
         }
         // Check whether we should encrypt for the invited members too
@@ -2643,7 +2643,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
             // know what other servers are in the room at the time they've been invited.
             // They therefore will not send device updates if a user logs in whilst
             // their state is invite.
-            NSLog(@"[MXCrypto] onRoomMembership: Invite event for %@ in %@", member.userId, event.roomId);
+            MXLogDebug(@"[MXCrypto] onRoomMembership: Invite event for %@ in %@", member.userId, event.roomId);
             shouldTrack = YES;
         }
     }
@@ -2668,7 +2668,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     // Sanity check
     if (!_matrixRestClient.credentials.userId)
     {
-        NSLog(@"[MXCrypto] uploadDeviceKeys. ERROR: _matrixRestClient.credentials.userId cannot be nil");
+        MXLogDebug(@"[MXCrypto] uploadDeviceKeys. ERROR: _matrixRestClient.credentials.userId cannot be nil");
         failure(nil);
         return nil;
     }
@@ -2694,7 +2694,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 {
     if (uploadOneTimeKeysOperation)
     {
-        NSLog(@"[MXCrypto] maybeUploadOneTimeKeys: already in progress");
+        MXLogDebug(@"[MXCrypto] maybeUploadOneTimeKeys: already in progress");
         if (success)
         {
             success();
@@ -2719,7 +2719,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     {
         // We already have the current one_time_key count from a /sync response.
         // Use this value instead of asking the server for the current key count.
-        NSLog(@"[MXCrypto] maybeUploadOneTimeKeys: there are %tu one-time keys on the homeserver", oneTimeKeyCount);
+        MXLogDebug(@"[MXCrypto] maybeUploadOneTimeKeys: there are %tu one-time keys on the homeserver", oneTimeKeyCount);
         
         MXWeakify(self);
         uploadOneTimeKeysOperation = [self generateAndUploadOneTimeKeys:oneTimeKeyCount retry:YES success:^{
@@ -2734,7 +2734,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
         } failure:^(NSError *error) {
             MXStrongifyAndReturnIfNil(self);
             
-            NSLog(@"[MXCrypto] maybeUploadOneTimeKeys: Failed to publish one-time keys. Error: %@", error);
+            MXLogDebug(@"[MXCrypto] maybeUploadOneTimeKeys: Failed to publish one-time keys. Error: %@", error);
             self->uploadOneTimeKeysOperation = nil;
             
             if (failure)
@@ -2780,7 +2780,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
             } failure:^(NSError *error) {
                 MXStrongifyAndReturnIfNil(self);
                 
-                NSLog(@"[MXCrypto] maybeUploadOneTimeKeys: Failed to publish one-time keys. Error: %@", error);
+                MXLogDebug(@"[MXCrypto] maybeUploadOneTimeKeys: Failed to publish one-time keys. Error: %@", error);
                 self->uploadOneTimeKeysOperation = nil;
                 
                 if (failure)
@@ -2805,7 +2805,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
         } failure:^(NSError *error) {
             MXStrongifyAndReturnIfNil(self);
 
-            NSLog(@"[MXCrypto] maybeUploadOneTimeKeys: Get published one-time keys count failed. Error: %@", error);
+            MXLogDebug(@"[MXCrypto] maybeUploadOneTimeKeys: Get published one-time keys count failed. Error: %@", error);
             self->uploadOneTimeKeysOperation = nil;
 
             if (failure)
@@ -2818,7 +2818,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 
 - (MXHTTPOperation *)generateAndUploadOneTimeKeys:(NSUInteger)keyCount retry:(BOOL)retry success:(void (^)(void))success failure:(void (^)(NSError *))failure
 {
-    NSLog(@"[MXCrypto] generateAndUploadOneTimeKeys: %@ one time keys are available on the homeserver", @(keyCount));
+    MXLogDebug(@"[MXCrypto] generateAndUploadOneTimeKeys: %@ one time keys are available on the homeserver", @(keyCount));
           
     MXHTTPOperation *operation;
     
@@ -2827,7 +2827,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
         operation = [self uploadOneTimeKeys:^(MXKeysUploadResponse *keysUploadResponse) {
             success();
         } failure:^(NSError *error) {
-            NSLog(@"[MXCrypto] generateAndUploadOneTimeKeys: Failed to publish one-time keys. Error: %@", error);
+            MXLogDebug(@"[MXCrypto] generateAndUploadOneTimeKeys: Failed to publish one-time keys. Error: %@", error);
             
             if ([MXError isMXError:error] && retry)
             {
@@ -2835,7 +2835,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
                 // Reset local OTKs we tried to push and retry
                 // There is no matrix specific error but we really want to detect the error described at
                 // https://github.com/vector-im/element-ios/issues/3721
-                NSLog(@"[MXCrypto] uploadOneTimeKeys: Reset local OTKs because the server does not like them");
+                MXLogDebug(@"[MXCrypto] uploadOneTimeKeys: Reset local OTKs because the server does not like them");
                 [self.olmDevice markOneTimeKeysAsPublished];
                 
                 [self generateAndUploadOneTimeKeys:keyCount retry:NO success:success failure:failure];
@@ -2870,7 +2870,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     // So we need some kind of enginering compromise to balance all of
     // these factors.
 
-    NSLog(@"[MXCrypto] generateOneTimeKeys: %tu one-time keys on the homeserver", keyCount);
+    MXLogDebug(@"[MXCrypto] generateOneTimeKeys: %tu one-time keys on the homeserver", keyCount);
 
     // First check how many keys we can store in the Account object.
     NSUInteger maxOneTimeKeys = _olmDevice.maxNumberOfOneTimeKeys;
@@ -2893,14 +2893,14 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     }
 
 
-    NSLog(@"[MXCrypto] generateOneTimeKeys: Generate %tu keys", numberToGenerate);
+    MXLogDebug(@"[MXCrypto] generateOneTimeKeys: Generate %tu keys", numberToGenerate);
 
     if (numberToGenerate)
     {
         // Ask olm to generate new one time keys, then upload them to synapse.
         NSDate *startDate = [NSDate date];
         [_olmDevice generateOneTimeKeys:numberToGenerate];
-        NSLog(@"[MXCrypto] generateOneTimeKeys: Keys generated in %.0fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+        MXLogDebug(@"[MXCrypto] generateOneTimeKeys: Keys generated in %.0fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
     }
 
     return (numberToGenerate > 0);
@@ -2924,7 +2924,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
         oneTimeJson[[NSString stringWithFormat:@"signed_curve25519:%@", keyId]] = k;
     }
 
-    NSLog(@"[MXCrypto] uploadOneTimeKeys: Upload %tu keys", ((NSDictionary*)oneTimeKeys[@"curve25519"]).count);
+    MXLogDebug(@"[MXCrypto] uploadOneTimeKeys: Upload %tu keys", ((NSDictionary*)oneTimeKeys[@"curve25519"]).count);
 
     // For now, we set the device id explicitly, as we may not be using the
     // same one as used in login.
@@ -2936,7 +2936,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
         success(keysUploadResponse);
 
     } failure:^(NSError *error) {
-        NSLog(@"[MXCrypto] uploadOneTimeKeys fails.");
+        MXLogDebug(@"[MXCrypto] uploadOneTimeKeys fails.");
         failure(error);
     }];
 }
@@ -2948,12 +2948,12 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
         
         NSUInteger publishedkeyCount = [keysUploadResponse oneTimeKeyCountsForAlgorithm:@"signed_curve25519"];
         
-        NSLog(@"[MXCrypto] publishedOneTimeKeysCount: %@ OTKs on the homeserver", @(publishedkeyCount));
+        MXLogDebug(@"[MXCrypto] publishedOneTimeKeysCount: %@ OTKs on the homeserver", @(publishedkeyCount));
         
         success(publishedkeyCount);
         
     } failure:^(NSError *error) {
-        NSLog(@"[MXCrypto] publishedOneTimeKeysCount failed. Error: %@", error);
+        MXLogDebug(@"[MXCrypto] publishedOneTimeKeysCount failed. Error: %@", error);
         failure(error);
     }];
 }
@@ -2968,7 +2968,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     MXJSONModelSetString(deviceKey, event.content[@"sender_key"]);
     MXJSONModelSetString(algorithm, event.content[@"algorithm"]);
     
-    NSLog(@"[MXCrypto] markOlmSessionForUnwedging from %@:%@", sender, deviceKey);
+    MXLogDebug(@"[MXCrypto] markOlmSessionForUnwedging from %@:%@", sender, deviceKey);
 
     if (!sender || !deviceKey || !algorithm)
     {
@@ -2978,7 +2978,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     if ([sender isEqualToString:_mxSession.myUserId]
         && [deviceKey isEqualToString:self.olmDevice.deviceCurve25519Key])
     {
-        NSLog(@"[MXCrypto] markOlmSessionForUnwedging: Do not unwedge ourselves");
+        MXLogDebug(@"[MXCrypto] markOlmSessionForUnwedging: Do not unwedge ourselves");
         return;
     }
     
@@ -2988,7 +2988,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     if (lastNewSessionForcedDate
         && -[lastNewSessionForcedDate timeIntervalSinceNow] < kMXCryptoMinForceSessionPeriod)
     {
-        NSLog(@"[MXCrypto] markOlmSessionForUnwedging: New session already forced with device at %@. Not forcing another", lastNewSessionForcedDate);
+        MXLogDebug(@"[MXCrypto] markOlmSessionForUnwedging: New session already forced with device at %@. Not forcing another", lastNewSessionForcedDate);
         return;
     }
 
@@ -2997,11 +2997,11 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     MXDeviceInfo *device = [_store deviceWithIdentityKey:deviceKey];
     if (!device)
     {
-        NSLog(@"[MXCrypto] markOlmSessionForUnwedgingInEvent: Couldn't find device for identity key %@: not re-establishing session", deviceKey);
+        MXLogDebug(@"[MXCrypto] markOlmSessionForUnwedgingInEvent: Couldn't find device for identity key %@: not re-establishing session", deviceKey);
         return;
     }
     
-    NSLog(@"[MXCrypto] markOlmSessionForUnwedging from %@:%@", sender, device.deviceId);
+    MXLogDebug(@"[MXCrypto] markOlmSessionForUnwedging from %@:%@", sender, device.deviceId);
     
     [lastNewSessionForcedDates setObject:[NSDate date] forUser:sender andDevice:deviceKey];
     
@@ -3025,11 +3025,11 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
         [contentMap setObject:encryptedContent forUser:sender andDevice:device.deviceId];
         
         [self.matrixRestClient sendToDevice:kMXEventTypeStringRoomEncrypted contentMap:contentMap txnId:nil success:nil failure:^(NSError *error) {
-            NSLog(@"[MXCrypto] markOlmSessionForUnwedgingInEvent: ERROR for sendToDevice: %@", error);
+            MXLogDebug(@"[MXCrypto] markOlmSessionForUnwedgingInEvent: ERROR for sendToDevice: %@", error);
         }];
         
     } failure:^(NSError *error) {
-        NSLog(@"[MXCrypto] markOlmSessionForUnwedgingInEvent: ERROR for ensureOlmSessionsForDevices: %@", error);
+        MXLogDebug(@"[MXCrypto] markOlmSessionForUnwedgingInEvent: ERROR for ensureOlmSessionsForDevices: %@", error);
     }];
 }
 

--- a/MatrixSDK/Crypto/MXOlmDevice.m
+++ b/MatrixSDK/Crypto/MXOlmDevice.m
@@ -71,7 +71,7 @@
         // Else, libolm will create pickle keys internally.
         if ([MXKeyProvider.sharedInstance hasKeyForDataOfType:MXCryptoOlmPickleKeyDataType isMandatory:NO])
         {
-            NSLog(@"[MXOlmDevice] initWithStore: Use a global pickle key for libolm");
+            MXLogDebug(@"[MXOlmDevice] initWithStore: Use a global pickle key for libolm");
             OLMKit.sharedInstance.pickleKeyDelegate = self;
         }
 
@@ -79,7 +79,7 @@
         OLMAccount *olmAccount = store.account;
         if (!olmAccount)
         {
-            NSLog(@"[MXOlmDevice] initWithStore: Create new OLMAccount");
+            MXLogDebug(@"[MXOlmDevice] initWithStore: Create new OLMAccount");
 
             // Else, create it
             olmAccount = [[OLMAccount alloc] initNewAccount];
@@ -88,7 +88,7 @@
         }
         else
         {
-            NSLog(@"[MXOlmDevice] initWithStore: Reuse OLMAccount from store");
+            MXLogDebug(@"[MXOlmDevice] initWithStore: Reuse OLMAccount from store");
         }
 
         olmUtility = [[OLMUtility alloc] init];
@@ -144,11 +144,11 @@
 {
     NSError *error;
 
-    NSLog(@"[MXOlmDevice] createOutboundSession: theirIdentityKey: %@. theirOneTimeKey: %@", theirIdentityKey, theirOneTimeKey);
+    MXLogDebug(@"[MXOlmDevice] createOutboundSession: theirIdentityKey: %@. theirOneTimeKey: %@", theirIdentityKey, theirOneTimeKey);
 
     OLMSession *olmSession = [[OLMSession alloc] initOutboundSessionWithAccount:store.account theirIdentityKey:theirIdentityKey theirOneTimeKey:theirOneTimeKey error:&error];
 
-    NSLog(@"[MXOlmDevice] createOutboundSession: Olm Session id: %@", olmSession.sessionIdentifier);
+    MXLogDebug(@"[MXOlmDevice] createOutboundSession: Olm Session id: %@", olmSession.sessionIdentifier);
 
     if (olmSession)
     {
@@ -164,7 +164,7 @@
     }
     else if (error)
     {
-        NSLog(@"[MXOlmDevice] createOutboundSession. Error: %@", error);
+        MXLogDebug(@"[MXOlmDevice] createOutboundSession. Error: %@", error);
     }
 
     return nil;
@@ -172,7 +172,7 @@
 
 - (NSString*)createInboundSession:(NSString*)theirDeviceIdentityKey messageType:(NSUInteger)messageType cipherText:(NSString*)ciphertext payload:(NSString**)payload
 {
-    NSLog(@"[MXOlmDevice] createInboundSession: theirIdentityKey: %@", theirDeviceIdentityKey);
+    MXLogDebug(@"[MXOlmDevice] createInboundSession: theirIdentityKey: %@", theirDeviceIdentityKey);
 
     __block OLMSession *olmSession;
     
@@ -180,7 +180,7 @@
         NSError *error;
         olmSession = [[OLMSession alloc] initInboundSessionWithAccount:olmAccount theirIdentityKey:theirDeviceIdentityKey oneTimeKeyMessage:ciphertext error:&error];
         
-        NSLog(@"[MXOlmDevice] createInboundSession: Olm Session id: %@", olmSession.sessionIdentifier);
+        MXLogDebug(@"[MXOlmDevice] createInboundSession: Olm Session id: %@", olmSession.sessionIdentifier);
         
         if (olmSession)
         {
@@ -188,7 +188,7 @@
         }
         else if (error)
         {
-            NSLog(@"[MXOlmDevice] createInboundSession. Error: %@", error);
+            MXLogDebug(@"[MXOlmDevice] createInboundSession. Error: %@", error);
         }
     }];
     
@@ -198,7 +198,7 @@
         *payload = [olmSession decryptMessage:[[OLMMessage alloc] initWithCiphertext:ciphertext type:messageType] error:&error];
         if (error)
         {
-            NSLog(@"[MXOlmDevice] createInboundSession. decryptMessage error: %@", error);
+            MXLogDebug(@"[MXOlmDevice] createInboundSession. decryptMessage error: %@", error);
         }
         
         MXOlmSession *mxOlmSession = [[MXOlmSession alloc] initWithOlmSession:olmSession];
@@ -237,7 +237,7 @@
 {
     __block OLMMessage *olmMessage;
 
-    NSLog(@"[MXOlmDevice] encryptMessage: Olm Session id %@ to %@", sessionId, theirDeviceIdentityKey);
+    MXLogDebug(@"[MXOlmDevice] encryptMessage: Olm Session id %@ to %@", sessionId, theirDeviceIdentityKey);
     
     [store performSessionOperationWithDevice:theirDeviceIdentityKey andSessionId:sessionId block:^(MXOlmSession *mxOlmSession) {
         
@@ -248,7 +248,7 @@
             
             if (error)
             {
-                NSLog(@"[MXOlmDevice] encryptMessage failed for session id %@ and sender %@: %@", sessionId, theirDeviceIdentityKey, error);
+                MXLogDebug(@"[MXOlmDevice] encryptMessage failed for session id %@ and sender %@: %@", sessionId, theirDeviceIdentityKey, error);
             }
         }
     }];
@@ -263,7 +263,7 @@
 {
     __block NSString *payloadString;
     
-    NSLog(@"[MXOlmDevice] decryptMessage: Olm Session id %@(%@) from %@" ,sessionId, @(messageType), theirDeviceIdentityKey);
+    MXLogDebug(@"[MXOlmDevice] decryptMessage: Olm Session id %@(%@) from %@" ,sessionId, @(messageType), theirDeviceIdentityKey);
     
     [store performSessionOperationWithDevice:theirDeviceIdentityKey andSessionId:sessionId block:^(MXOlmSession *mxOlmSession) {
         if (mxOlmSession)
@@ -273,7 +273,7 @@
             
             if (error)
             {
-                NSLog(@"[MXOlmDevice] decryptMessage. Error: %@", error);
+                MXLogDebug(@"[MXOlmDevice] decryptMessage. Error: %@", error);
             }
             
             [mxOlmSession didReceiveMessage];
@@ -305,7 +305,7 @@
 
 - (void)storeOutboundGroupSession:(MXOlmOutboundGroupSession *)session
 {
-    NSLog(@"[MXOlmDevice] storing Outbound Group Session For Room With ID %@", session.roomId);
+    MXLogDebug(@"[MXOlmDevice] storing Outbound Group Session For Room With ID %@", session.roomId);
     [store storeOutboundGroupSession:session.session withRoomId:session.roomId];
 }
 
@@ -347,21 +347,21 @@
     if (existingSession)
     {
         // If we already have this session, consider updating it
-        NSLog(@"[MXOlmDevice] addInboundGroupSession: Update for megolm session %@|%@", senderKey, sessionId);
+        MXLogDebug(@"[MXOlmDevice] addInboundGroupSession: Update for megolm session %@|%@", senderKey, sessionId);
 
         // If our existing session is better, we keep it
         if (existingSession.session.firstKnownIndex <= session.session.firstKnownIndex)
         {
-            NSLog(@"[MXOlmDevice] addInboundGroupSession: Skip it. The index of the incoming session is higher (%@ vs %@)", @(session.session.firstKnownIndex), @(existingSession.session.firstKnownIndex));
+            MXLogDebug(@"[MXOlmDevice] addInboundGroupSession: Skip it. The index of the incoming session is higher (%@ vs %@)", @(session.session.firstKnownIndex), @(existingSession.session.firstKnownIndex));
             return NO;
         }
     }
 
-    NSLog(@"[MXOlmDevice] addInboundGroupSession: Add megolm session %@|%@ (import: %@)", senderKey, sessionId, exportFormat ? @"YES" : @"NO");
+    MXLogDebug(@"[MXOlmDevice] addInboundGroupSession: Add megolm session %@|%@ (import: %@)", senderKey, sessionId, exportFormat ? @"YES" : @"NO");
 
     if (![session.session.sessionIdentifier isEqualToString:sessionId])
     {
-        NSLog(@"[MXOlmDevice] addInboundGroupSession: ERROR: Mismatched group session ID from senderKey: %@", senderKey);
+        MXLogDebug(@"[MXOlmDevice] addInboundGroupSession: ERROR: Mismatched group session ID from senderKey: %@", senderKey);
         return NO;
     }
 
@@ -383,7 +383,7 @@
     {
         if (!sessionData.roomId || !sessionData.algorithm)
         {
-            NSLog(@"[MXOlmDevice] importInboundGroupSessions: ignoring session entry with missing fields: %@", sessionData);
+            MXLogDebug(@"[MXOlmDevice] importInboundGroupSessions: ignoring session entry with missing fields: %@", sessionData);
             continue;
         }
 
@@ -398,12 +398,12 @@
         if (existingSession)
         {
             // If we already have this session, consider updating it
-            NSLog(@"[MXOlmDevice] importInboundGroupSessions: Update for megolm session %@|%@", sessionData.senderKey, sessionData.sessionId);
+            MXLogDebug(@"[MXOlmDevice] importInboundGroupSessions: Update for megolm session %@|%@", sessionData.senderKey, sessionData.sessionId);
 
             // If our existing session is better, we keep it
             if (existingSession.session.firstKnownIndex <= session.session.firstKnownIndex)
             {
-                NSLog(@"[MXOlmDevice] importInboundGroupSessions: Skip it. The index of the incoming session is higher (%@ vs %@)", @(session.session.firstKnownIndex), @(existingSession.session.firstKnownIndex));
+                MXLogDebug(@"[MXOlmDevice] importInboundGroupSessions: Skip it. The index of the incoming session is higher (%@ vs %@)", @(session.session.firstKnownIndex), @(existingSession.session.firstKnownIndex));
                 continue;
             }
         }
@@ -433,7 +433,7 @@
         *error = [self checkInboundGroupSession:session roomId:roomId];
         if (*error)
         {
-            NSLog(@"[MXOlmDevice] decryptGroupMessage: Cannot decrypt in room %@ with session %@|%@. Error: %@", roomId, senderKey, sessionId, *error);
+            MXLogDebug(@"[MXOlmDevice] decryptGroupMessage: Cannot decrypt in room %@ with session %@|%@. Error: %@", roomId, senderKey, sessionId, *error);
             session = nil;
         }
         else
@@ -458,7 +458,7 @@
             NSString *messageIndexKey = [NSString stringWithFormat:@"%@|%@|%tu", senderKey, sessionId, messageIndex];
             if (inboundGroupSessionMessageIndexes[timeline][messageIndexKey])
             {
-                NSLog(@"[MXOlmDevice] decryptGroupMessage: Warning: Possible replay attack %@", messageIndexKey);
+                MXLogDebug(@"[MXOlmDevice] decryptGroupMessage: Warning: Possible replay attack %@", messageIndexKey);
                 
                 if (error)
                 {
@@ -506,7 +506,7 @@
         // the HS pretending a message was targeting a different room.
         if (![roomId isEqualToString:session.roomId])
         {
-            NSLog(@"[MXOlmDevice] inboundGroupSessionWithId: ERROR: Mismatched room_id for inbound group session (expected %@, was %@)", roomId, session.roomId);
+            MXLogDebug(@"[MXOlmDevice] inboundGroupSessionWithId: ERROR: Mismatched room_id for inbound group session (expected %@, was %@)", roomId, session.roomId);
 
             NSString *errorDescription = [NSString stringWithFormat:MXDecryptingErrorInboundSessionMismatchRoomIdReason, roomId, session.roomId];
 
@@ -539,7 +539,7 @@
 
     if (![session.roomId isEqualToString:roomId])
     {
-        NSLog(@"[MXOlmDevice] hasInboundSessionKeys: requested keys for inbound group session %@|%@`, with incorrect room_id (expected %@, was %@)", senderKey, sessionId, session.roomId, roomId);
+        MXLogDebug(@"[MXOlmDevice] hasInboundSessionKeys: requested keys for inbound group session %@|%@`, with incorrect room_id (expected %@, was %@)", senderKey, sessionId, session.roomId, roomId);
 
         return NO;
     }
@@ -555,7 +555,7 @@
     NSError *error = [self checkInboundGroupSession:session roomId:roomId];
     if (error)
     {
-        NSLog(@"[MXOlmDevice] getInboundGroupSessionKey in room %@ with session %@|%@. Error: %@", roomId, senderKey, sessionId, error);
+        MXLogDebug(@"[MXOlmDevice] getInboundGroupSessionKey in room %@ with session %@|%@. Error: %@", roomId, senderKey, sessionId, error);
         session = nil;
     }
     

--- a/MatrixSDK/Crypto/Recovery/MXRecoveryService.m
+++ b/MatrixSDK/Crypto/Recovery/MXRecoveryService.m
@@ -98,7 +98,7 @@ NSString *const MXRecoveryServiceErrorDomain = @"org.matrix.sdk.recoveryService"
                                         success:(void (^)(void))success
                                         failure:(void (^)(NSError *error))failure
 {
-    NSLog(@"[MXRecoveryService] deleteRecovery: deleteServicesBackups: %@", @(deleteServicesBackups));
+    MXLogDebug(@"[MXRecoveryService] deleteRecovery: deleteServicesBackups: %@", @(deleteServicesBackups));
     
     if (deleteServicesBackups)
     {
@@ -121,12 +121,12 @@ NSString *const MXRecoveryServiceErrorDomain = @"org.matrix.sdk.recoveryService"
     {
         dispatch_group_enter(dispatchGroup);
         
-        NSLog(@"[MXRecoveryService] deleteRecovery: Remove secret %@", secretId);
+        MXLogDebug(@"[MXRecoveryService] deleteRecovery: Remove secret %@", secretId);
         
         [_secretStorage deleteSecretWithSecretId:secretId success:^{
             dispatch_group_leave(dispatchGroup);
         } failure:^(NSError * _Nonnull anError) {
-            NSLog(@"[MXRecoveryService] deleteRecovery: Failed to remove %@. Error: %@", secretId, anError);
+            MXLogDebug(@"[MXRecoveryService] deleteRecovery: Failed to remove %@. Error: %@", secretId, anError);
             
             error = anError;
             dispatch_group_leave(dispatchGroup);
@@ -135,7 +135,7 @@ NSString *const MXRecoveryServiceErrorDomain = @"org.matrix.sdk.recoveryService"
     
     dispatch_group_notify(dispatchGroup, dispatch_get_main_queue(), ^{
         
-        NSLog(@"[MXRecoveryService] deleteRecovery: Completed");
+        MXLogDebug(@"[MXRecoveryService] deleteRecovery: Completed");
         
         if (error)
         {
@@ -145,7 +145,7 @@ NSString *const MXRecoveryServiceErrorDomain = @"org.matrix.sdk.recoveryService"
         {
             // Delete the associated SSSS
             NSString *ssssKeyId = self.recoveryId;
-            NSLog(@"[MXRecoveryService] deleteRecovery: Delete SSSS %@", ssssKeyId);
+            MXLogDebug(@"[MXRecoveryService] deleteRecovery: Delete SSSS %@", ssssKeyId);
             
             if (ssssKeyId)
             {
@@ -162,7 +162,7 @@ NSString *const MXRecoveryServiceErrorDomain = @"org.matrix.sdk.recoveryService"
 - (void)deleteKeyBackupWithSuccess:(void (^)(void))success
                            failure:(void (^)(NSError *error))failure
 {
-    NSLog(@"[MXRecoveryService] deleteKeyBackup");
+    MXLogDebug(@"[MXRecoveryService] deleteKeyBackup");
     
     MXKeyBackup *keyBackup = self.crypto.backup;
     if (!keyBackup)
@@ -238,11 +238,11 @@ NSString *const MXRecoveryServiceErrorDomain = @"org.matrix.sdk.recoveryService"
                          success:(void (^)(MXSecretStorageKeyCreationInfo *keyCreationInfo))success
                          failure:(void (^)(NSError *error))failure
 {
-    NSLog(@"[MXRecoveryService] createRecovery: secrets: %@. createServicesBackups: %@", secrets, @(createServicesBackups));
+    MXLogDebug(@"[MXRecoveryService] createRecovery: secrets: %@. createServicesBackups: %@", secrets, @(createServicesBackups));
     
     if (self.hasRecovery)
     {
-        NSLog(@"[MXRecoveryService] createRecovery: Error: A recovery already exists.");
+        MXLogDebug(@"[MXRecoveryService] createRecovery: Error: A recovery already exists.");
         NSError *error = [NSError errorWithDomain:MXRecoveryServiceErrorDomain
                                              code:MXRecoveryServiceSSSSAlreadyExistsErrorCode
                                          userInfo:@{
@@ -271,11 +271,11 @@ NSString *const MXRecoveryServiceErrorDomain = @"org.matrix.sdk.recoveryService"
                          success:(void (^)(MXSecretStorageKeyCreationInfo *keyCreationInfo))success
                          failure:(void (^)(NSError *error))failure
 {
-    NSLog(@"[MXRecoveryService] createRecovery: secrets: %@. createServicesBackups: %@", secrets, @(createServicesBackups));
+    MXLogDebug(@"[MXRecoveryService] createRecovery: secrets: %@. createServicesBackups: %@", secrets, @(createServicesBackups));
     
     if (self.hasRecovery)
     {
-        NSLog(@"[MXRecoveryService] createRecovery: Error: A recovery already exists.");
+        MXLogDebug(@"[MXRecoveryService] createRecovery: Error: A recovery already exists.");
         NSError *error = [NSError errorWithDomain:MXRecoveryServiceErrorDomain
                                              code:MXRecoveryServiceSSSSAlreadyExistsErrorCode
                                          userInfo:@{
@@ -317,7 +317,7 @@ NSString *const MXRecoveryServiceErrorDomain = @"org.matrix.sdk.recoveryService"
         } failure:failure];
         
     } failure:^(NSError * _Nonnull error) {
-        NSLog(@"[MXRecoveryService] createRecovery: Failed to create SSSS. Error: %@", error);
+        MXLogDebug(@"[MXRecoveryService] createRecovery: Failed to create SSSS. Error: %@", error);
         failure(error);
     }];
 }
@@ -341,7 +341,7 @@ NSString *const MXRecoveryServiceErrorDomain = @"org.matrix.sdk.recoveryService"
         } failure:failure];
         
     } failure:^(NSError * _Nonnull error) {
-        NSLog(@"[MXRecoveryService] createRecovery: Failed to create SSSS. Error: %@", error);
+        MXLogDebug(@"[MXRecoveryService] createRecovery: Failed to create SSSS. Error: %@", error);
         failure(error);
     }];
 }
@@ -349,7 +349,7 @@ NSString *const MXRecoveryServiceErrorDomain = @"org.matrix.sdk.recoveryService"
 - (void)createKeyBackupWithSuccess:(void (^)(void))success
                            failure:(void (^)(NSError *error))failure
 {
-    NSLog(@"[MXRecoveryService] createKeyBackup");
+    MXLogDebug(@"[MXRecoveryService] createKeyBackup");
     
     MXKeyBackup *keyBackup = self.crypto.backup;
     if (!keyBackup)
@@ -365,12 +365,12 @@ NSString *const MXRecoveryServiceErrorDomain = @"org.matrix.sdk.recoveryService"
         {
             if ([self.cryptoStore secretWithSecretId:MXSecretId.keyBackup])
             {
-                NSLog(@"[MXRecoveryService] createKeyBackup: Reuse private key of existing one");
+                MXLogDebug(@"[MXRecoveryService] createKeyBackup: Reuse private key of existing one");
                 success();
             }
             else
             {
-                NSLog(@"[MXRecoveryService] createKeyBackup: Error: A key backup already exists");
+                MXLogDebug(@"[MXRecoveryService] createKeyBackup: Error: A key backup already exists");
                 NSError *error = [NSError errorWithDomain:MXRecoveryServiceErrorDomain
                                                      code:MXRecoveryServiceKeyBackupExistsButNoPrivateKeyErrorCode
                                                  userInfo:@{
@@ -401,13 +401,13 @@ NSString *const MXRecoveryServiceErrorDomain = @"org.matrix.sdk.recoveryService"
                          success:(void (^)(void))success
                          failure:(void (^)(NSError *error))failure
 {
-    NSLog(@"[MXRecoveryService] updateRecovery: secrets: %@", secrets);
+    MXLogDebug(@"[MXRecoveryService] updateRecovery: secrets: %@", secrets);
     
     NSString *ssssKeyId = self.recoveryId;
     if (!ssssKeyId)
     {
         // No recovery
-        NSLog(@"[MXRecoveryService] updateRecovery: Error: No existing SSSS");
+        MXLogDebug(@"[MXRecoveryService] updateRecovery: Error: No existing SSSS");
         NSError *error = [NSError errorWithDomain:MXRecoveryServiceErrorDomain
                                              code:MXRecoveryServiceNoSSSSErrorCode
                                          userInfo:@{
@@ -426,7 +426,7 @@ NSString *const MXRecoveryServiceErrorDomain = @"org.matrix.sdk.recoveryService"
     NSArray *secretsStoredLocally = self.secretsStoredLocally;
     NSArray<NSString*> *secretsToStore = [secretsStoredLocally mx_intersectArray:secrets];
     
-    NSLog(@"[MXRecoveryService] updateRecovery: Backup secrets: %@", secretsToStore);
+    MXLogDebug(@"[MXRecoveryService] updateRecovery: Backup secrets: %@", secretsToStore);
     
     // Build the key to encrypt secret
     NSDictionary<NSString*, NSData*> *keys = @{
@@ -446,7 +446,7 @@ NSString *const MXRecoveryServiceErrorDomain = @"org.matrix.sdk.recoveryService"
             [self.secretStorage storeSecret:secret withSecretId:secretId withSecretStorageKeys:keys success:^(NSString * _Nonnull secretId) {
                 dispatch_group_leave(dispatchGroup);
             } failure:^(NSError * _Nonnull anError) {
-                NSLog(@"[MXRecoveryService] updateRecovery: Failed to store %@. Error: %@", secretId, anError);
+                MXLogDebug(@"[MXRecoveryService] updateRecovery: Failed to store %@. Error: %@", secretId, anError);
                 
                 error = anError;
                 dispatch_group_leave(dispatchGroup);
@@ -456,7 +456,7 @@ NSString *const MXRecoveryServiceErrorDomain = @"org.matrix.sdk.recoveryService"
     
     dispatch_group_notify(dispatchGroup, dispatch_get_main_queue(), ^{
         
-        NSLog(@"[MXRecoveryService] updateRecovery: Completed");
+        MXLogDebug(@"[MXRecoveryService] updateRecovery: Completed");
         
         if (error)
         {
@@ -484,7 +484,7 @@ NSString *const MXRecoveryServiceErrorDomain = @"org.matrix.sdk.recoveryService"
         secrets = _supportedSecrets;
     }
     
-    NSLog(@"[MXRecoveryService] recoverSecrets: %@", secrets);
+    MXLogDebug(@"[MXRecoveryService] recoverSecrets: %@", secrets);
     
     NSMutableArray<NSString*> *updatedSecrets = [NSMutableArray array];
     NSMutableArray<NSString*> *invalidSecrets = [NSMutableArray array];
@@ -493,14 +493,14 @@ NSString *const MXRecoveryServiceErrorDomain = @"org.matrix.sdk.recoveryService"
     NSArray<NSString*> *secretsToRecover = [secretsStoredInRecovery mx_intersectArray:secrets];
     if (!secretsToRecover.count)
     {
-        NSLog(@"[MXRecoveryService] recoverSecrets: No secrets to recover. secretsStoredInRecovery: %@", secretsStoredInRecovery);
+        MXLogDebug(@"[MXRecoveryService] recoverSecrets: No secrets to recover. secretsStoredInRecovery: %@", secretsStoredInRecovery);
         
         // No recovery at all
         success([MXSecretRecoveryResult new]);
         return;
     }
     
-    NSLog(@"[MXRecoveryService] recoverSecrets: secretsToRecover: %@", secretsToRecover);
+    MXLogDebug(@"[MXRecoveryService] recoverSecrets: secretsToRecover: %@", secretsToRecover);
     
     NSString *secretStorageKeyId = self.recoveryId;
     
@@ -520,26 +520,26 @@ NSString *const MXRecoveryServiceErrorDomain = @"org.matrix.sdk.recoveryService"
             {
                 if (![secret isEqualToString:[self.cryptoStore secretWithSecretId:secretId]])
                 {
-                    NSLog(@"[MXRecoveryService] recoverSecrets: Recovered secret %@", secretId);
+                    MXLogDebug(@"[MXRecoveryService] recoverSecrets: Recovered secret %@", secretId);
                     
                     [updatedSecrets addObject:secretId];
                     [self.cryptoStore storeSecret:secret withSecretId:secretId];
                 }
                 else
                 {
-                    NSLog(@"[MXRecoveryService] recoverSecrets: Secret %@ was already known", secretId);
+                    MXLogDebug(@"[MXRecoveryService] recoverSecrets: Secret %@ was already known", secretId);
                 }
             }
             else
             {
-                NSLog(@"[MXRecoveryService] recoverSecrets: Secret %@ is invalid", secretId);
+                MXLogDebug(@"[MXRecoveryService] recoverSecrets: Secret %@ is invalid", secretId);
                 [invalidSecrets addObject:secretId];
             }
             
             dispatch_group_leave(dispatchGroup);
             
         } failure:^(NSError * _Nonnull anError) {
-            NSLog(@"[MXRecoveryService] recoverSecrets: Failed to restore %@. Error: %@", secretId, anError);
+            MXLogDebug(@"[MXRecoveryService] recoverSecrets: Failed to restore %@. Error: %@", secretId, anError);
             
             error = [self domainErrorFromError:anError];
             
@@ -551,7 +551,7 @@ NSString *const MXRecoveryServiceErrorDomain = @"org.matrix.sdk.recoveryService"
         
         if (error)
         {
-            NSLog(@"[MXRecoveryService] recoverSecrets: Completed with error.");
+            MXLogDebug(@"[MXRecoveryService] recoverSecrets: Completed with error.");
             failure(error);
         }
         else
@@ -561,7 +561,7 @@ NSString *const MXRecoveryServiceErrorDomain = @"org.matrix.sdk.recoveryService"
             recoveryResult.updatedSecrets = updatedSecrets;
             recoveryResult.invalidSecrets = invalidSecrets;
             
-            NSLog(@"[MXRecoveryService] recoverSecrets: Completed. secrets: %@. updatedSecrets: %@. invalidSecrets: %@", secretsToRecover, updatedSecrets, invalidSecrets);
+            MXLogDebug(@"[MXRecoveryService] recoverSecrets: Completed. secrets: %@. updatedSecrets: %@. invalidSecrets: %@", secretsToRecover, updatedSecrets, invalidSecrets);
             
             // Recover services if required
             if (recoverServices)
@@ -585,7 +585,7 @@ NSString *const MXRecoveryServiceErrorDomain = @"org.matrix.sdk.recoveryService"
                                      success:(void (^)(void))success
                                      failure:(void (^)(NSError *error))failure
 {
-    NSLog(@"[MXRecoveryService] startServicesAssociatedWithSecrets: %@", secrets);
+    MXLogDebug(@"[MXRecoveryService] startServicesAssociatedWithSecrets: %@", secrets);
     
     if (!secrets)
     {
@@ -596,7 +596,7 @@ NSString *const MXRecoveryServiceErrorDomain = @"org.matrix.sdk.recoveryService"
     NSArray *secretsStoredLocally = self.secretsStoredLocally;
     NSArray<NSString*> *servicesToRecover = [secretsStoredLocally mx_intersectArray:secrets];
     
-    NSLog(@"[MXRecoveryService] startServicesAssociatedWithSecrets: servicesToRecover: %@", servicesToRecover);
+    MXLogDebug(@"[MXRecoveryService] startServicesAssociatedWithSecrets: servicesToRecover: %@", servicesToRecover);
     
     
     dispatch_group_t dispatchGroup = dispatch_group_create();
@@ -614,7 +614,7 @@ NSString *const MXRecoveryServiceErrorDomain = @"org.matrix.sdk.recoveryService"
         [self recoverKeyBackupWithSuccess:^{
             dispatch_group_leave(dispatchGroup);
         } failure:^(NSError *anError) {
-            NSLog(@"[MXRecoveryService] startServicesAssociatedWithSecrets: Failed to restore key backup. Error: %@", anError);
+            MXLogDebug(@"[MXRecoveryService] startServicesAssociatedWithSecrets: Failed to restore key backup. Error: %@", anError);
             
             error = anError;
             dispatch_group_leave(dispatchGroup);
@@ -628,7 +628,7 @@ NSString *const MXRecoveryServiceErrorDomain = @"org.matrix.sdk.recoveryService"
         [self recoverCrossSigningWithSuccess:^{
             dispatch_group_leave(dispatchGroup);
         } failure:^(NSError *anError) {
-            NSLog(@"[MXRecoveryService] startServicesAssociatedWithSecrets: Failed to restore cross-signing. Error: %@", anError);
+            MXLogDebug(@"[MXRecoveryService] startServicesAssociatedWithSecrets: Failed to restore cross-signing. Error: %@", anError);
             
             error = anError;
             dispatch_group_leave(dispatchGroup);
@@ -639,12 +639,12 @@ NSString *const MXRecoveryServiceErrorDomain = @"org.matrix.sdk.recoveryService"
         
         if (error)
         {
-            NSLog(@"[MXRecoveryService] startServicesAssociatedWithSecrets: Completed with error.");
+            MXLogDebug(@"[MXRecoveryService] startServicesAssociatedWithSecrets: Completed with error.");
             failure(error);
         }
         else
         {
-            NSLog(@"[MXRecoveryService] startServicesAssociatedWithSecrets: Completed for secrets: %@", servicesToRecover);
+            MXLogDebug(@"[MXRecoveryService] startServicesAssociatedWithSecrets: Completed for secrets: %@", servicesToRecover);
             success();
         }
     });
@@ -654,7 +654,7 @@ NSString *const MXRecoveryServiceErrorDomain = @"org.matrix.sdk.recoveryService"
 - (void)recoverKeyBackupWithSuccess:(void (^)(void))success
                             failure:(void (^)(NSError *error))failure
 {
-    NSLog(@"[MXRecoveryService] recoverKeyBackup: %@", self.crypto.backup.keyBackupVersion.version);
+    MXLogDebug(@"[MXRecoveryService] recoverKeyBackup: %@", self.crypto.backup.keyBackupVersion.version);
     
     MXKeyBackupVersion *keyBackupVersion = self.crypto.backup.keyBackupVersion;
     NSString *secret = [self.crypto.store secretWithSecretId:MXSecretId.keyBackup];
@@ -665,30 +665,30 @@ NSString *const MXRecoveryServiceErrorDomain = @"org.matrix.sdk.recoveryService"
         // Restore the backup in background
         // It will take time
         [self.crypto.backup restoreUsingPrivateKeyKeyBackup:keyBackupVersion room:nil session:nil success:^(NSUInteger total, NSUInteger imported) {
-            NSLog(@"[MXRecoveryService] recoverKeyBackup: Backup is restored!");
+            MXLogDebug(@"[MXRecoveryService] recoverKeyBackup: Backup is restored!");
         } failure:^(NSError * _Nonnull error) {
-            NSLog(@"[MXRecoveryService] recoverKeyBackup: restoreUsingPrivateKeyKeyBackup failed: %@", error);
+            MXLogDebug(@"[MXRecoveryService] recoverKeyBackup: restoreUsingPrivateKeyKeyBackup failed: %@", error);
         }];
         
         // Check if the service really needs to be started
         if (self.crypto.backup.enabled)
         {
-            NSLog(@"[MXRecoveryService] recoverKeyBackup: Key backup is already running");
+            MXLogDebug(@"[MXRecoveryService] recoverKeyBackup: Key backup is already running");
             success();
             return;
         }
         
         // Trust the current backup to start backuping keys to it
         [self.crypto.backup trustKeyBackupVersion:keyBackupVersion trust:YES success:^{
-            NSLog(@"[MXRecoveryService] recoverKeyBackup: Current backup is now trusted");
+            MXLogDebug(@"[MXRecoveryService] recoverKeyBackup: Current backup is now trusted");
             success();
         } failure:^(NSError * _Nonnull error) {
-            NSLog(@"[MXRecoveryService] recoverKeyBackup: trustKeyBackupVersion failed: %@", error);
+            MXLogDebug(@"[MXRecoveryService] recoverKeyBackup: trustKeyBackupVersion failed: %@", error);
         }];
     }
     else
     {
-        NSLog(@"[MXRecoveryService] recoverKeyBackup: can't start backup");
+        MXLogDebug(@"[MXRecoveryService] recoverKeyBackup: can't start backup");
         success();
     }
 }
@@ -696,14 +696,14 @@ NSString *const MXRecoveryServiceErrorDomain = @"org.matrix.sdk.recoveryService"
 - (void)recoverCrossSigningWithSuccess:(void (^)(void))success
                                failure:(void (^)(NSError *error))failure
 {
-    NSLog(@"[MXRecoveryService] recoverCrossSigning");
+    MXLogDebug(@"[MXRecoveryService] recoverCrossSigning");
     
     [self.crypto.crossSigning refreshStateWithSuccess:^(BOOL stateUpdated) {
         
         // Check if the service really needs to be started
         if (self.crypto.crossSigning.canCrossSign)
         {
-            NSLog(@"[MXRecoveryService] recoverCrossSigning: Cross-signing is already up");
+            MXLogDebug(@"[MXRecoveryService] recoverCrossSigning: Cross-signing is already up");
             success();
             return;
         }
@@ -716,25 +716,25 @@ NSString *const MXRecoveryServiceErrorDomain = @"org.matrix.sdk.recoveryService"
                 
                 // And update the state
                 [self.crypto.crossSigning refreshStateWithSuccess:^(BOOL stateUpdated) {
-                    NSLog(@"[MXRecoveryService] recoverCrossSigning: Cross-signing is up. State: %@", @(self.crypto.crossSigning.state));
+                    MXLogDebug(@"[MXRecoveryService] recoverCrossSigning: Cross-signing is up. State: %@", @(self.crypto.crossSigning.state));
                     success();
                 } failure:^(NSError *error) {
-                    NSLog(@"[MXRecoveryService] recoverCrossSigning: refreshStateWithSuccess 2 failed: %@", error);
+                    MXLogDebug(@"[MXRecoveryService] recoverCrossSigning: refreshStateWithSuccess 2 failed: %@", error);
                     failure(error);
                 }];
                 
             } failure:^(NSError * _Nonnull error) {
-                NSLog(@"[MXRecoveryService] recoverCrossSigning: crossSignDeviceWithDeviceId failed: %@", error);
+                MXLogDebug(@"[MXRecoveryService] recoverCrossSigning: crossSignDeviceWithDeviceId failed: %@", error);
                 failure(error);
             }];
             
         } failure:^(NSError *error) {
-            NSLog(@"[MXRecoveryService] recoverCrossSigning: setUserVerification failed: %@", error);
+            MXLogDebug(@"[MXRecoveryService] recoverCrossSigning: setUserVerification failed: %@", error);
             failure(error);
         }];
         
     } failure:^(NSError * _Nonnull error) {
-        NSLog(@"[MXRecoveryService] recoverCrossSigning: refreshStateWithSuccess 1 failed: %@", error);
+        MXLogDebug(@"[MXRecoveryService] recoverCrossSigning: refreshStateWithSuccess 1 failed: %@", error);
         failure(error);
     }];
 }
@@ -824,7 +824,7 @@ NSString *const MXRecoveryServiceErrorDomain = @"org.matrix.sdk.recoveryService"
         }
         else
         {
-            NSLog(@"[MXRecoveryService] checkSecret: Backup is not enabled yet. Accept the secret by default");
+            MXLogDebug(@"[MXRecoveryService] checkSecret: Backup is not enabled yet. Accept the secret by default");
         }
     }
     else if ([secretId isEqualToString:MXSecretId.crossSigningMaster])
@@ -836,7 +836,7 @@ NSString *const MXRecoveryServiceErrorDomain = @"org.matrix.sdk.recoveryService"
         }
         else
         {
-            NSLog(@"[MXRecoveryService] checkSecret: Cross-signing is not enabled yet. Accept the secret by default");
+            MXLogDebug(@"[MXRecoveryService] checkSecret: Cross-signing is not enabled yet. Accept the secret by default");
         }
     }
     else if ([secretId isEqualToString:MXSecretId.crossSigningSelfSigning])
@@ -848,7 +848,7 @@ NSString *const MXRecoveryServiceErrorDomain = @"org.matrix.sdk.recoveryService"
         }
         else
         {
-            NSLog(@"[MXRecoveryService] checkSecret: Cross-signing is not enabled yet. Accept the secret by default");
+            MXLogDebug(@"[MXRecoveryService] checkSecret: Cross-signing is not enabled yet. Accept the secret by default");
         }
     }
     else if ([secretId isEqualToString:MXSecretId.crossSigningUserSigning])
@@ -860,11 +860,11 @@ NSString *const MXRecoveryServiceErrorDomain = @"org.matrix.sdk.recoveryService"
         }
         else
         {
-            NSLog(@"[MXRecoveryService] checkSecret: Cross-signing is not enabled yet. Accept the secret by default");
+            MXLogDebug(@"[MXRecoveryService] checkSecret: Cross-signing is not enabled yet. Accept the secret by default");
         }
     }
     
-    NSLog(@"[MXRecoveryService] checkSecret: Secret for %@ is %@", secretId, valid ? @"valid" :  @"invalid");
+    MXLogDebug(@"[MXRecoveryService] checkSecret: Secret for %@ is %@", secretId, valid ? @"valid" :  @"invalid");
 
     return valid;
 }

--- a/MatrixSDK/Crypto/SecretStorage/JSONModels/MXSecretStorageKeyContent.m
+++ b/MatrixSDK/Crypto/SecretStorage/JSONModels/MXSecretStorageKeyContent.m
@@ -41,7 +41,7 @@ const struct MXSecretStorageKeyAlgorithm MXSecretStorageKeyAlgorithm = {
     
     if (![algorithm isEqualToString:MXSecretStorageKeyAlgorithm.aesHmacSha2])
     {
-        NSLog(@"[MXSecretStorageKeyContent] modelFromJSON: ERROR: Unsupported algorithm: %@", JSONDictionary);
+        MXLogDebug(@"[MXSecretStorageKeyContent] modelFromJSON: ERROR: Unsupported algorithm: %@", JSONDictionary);
         return nil;
     }
     

--- a/MatrixSDK/Crypto/SecretStorage/MXSecretStorage.m
+++ b/MatrixSDK/Crypto/SecretStorage/MXSecretStorage.m
@@ -229,7 +229,7 @@ static NSString* const kSecretStorageZeroString = @"\0\0\0\0\0\0\0\0\0\0\0\0\0\0
     }
     if (!keyId)
     {
-        NSLog(@"[MXSecretStorage] deleteKeyWithKeyId: ERROR: No key id provided and no default key id");
+        MXLogDebug(@"[MXSecretStorage] deleteKeyWithKeyId: ERROR: No key id provided and no default key id");
         failure([self errorWithCode:MXSecretStorageUnknownKeyCode reason:@"No key id"]);
         return operation;
     }
@@ -371,7 +371,7 @@ static NSString* const kSecretStorageZeroString = @"\0\0\0\0\0\0\0\0\0\0\0\0\0\0
             MXSecretStorageKeyContent *key = [self keyWithKeyId:keyId];
             if (!key)
             {
-                NSLog(@"[MXSecretStorage] storeSecret: ERROR: No key for with id %@", keyId);
+                MXLogDebug(@"[MXSecretStorage] storeSecret: ERROR: No key for with id %@", keyId);
                 dispatch_async(dispatch_get_main_queue(), ^{
                     failure([self errorWithCode:MXSecretStorageUnknownKeyCode reason:[NSString stringWithFormat:@"Unknown key %@", keyId]]);
                 });
@@ -380,7 +380,7 @@ static NSString* const kSecretStorageZeroString = @"\0\0\0\0\0\0\0\0\0\0\0\0\0\0
             
             if (![key.algorithm isEqualToString:MXSecretStorageKeyAlgorithm.aesHmacSha2])
             {
-                NSLog(@"[MXSecretStorage] storeSecret: ERROR: Unsupported algorihthm %@", key.algorithm);
+                MXLogDebug(@"[MXSecretStorage] storeSecret: ERROR: Unsupported algorihthm %@", key.algorithm);
                 dispatch_async(dispatch_get_main_queue(), ^{
                     failure([self errorWithCode:MXSecretStorageUnsupportedAlgorithmCode reason:[NSString stringWithFormat:@"Unknown algorithm %@", key.algorithm]]);
                 });
@@ -391,7 +391,7 @@ static NSString* const kSecretStorageZeroString = @"\0\0\0\0\0\0\0\0\0\0\0\0\0\0
             NSData *secret = [MXBase64Tools dataFromBase64:unpaddedBase64Secret];
             if (!secret)
             {
-                NSLog(@"[MXSecretStorage] storeSecret: ERROR: The secret string is not in unpadded Base64 format");
+                MXLogDebug(@"[MXSecretStorage] storeSecret: ERROR: The secret string is not in unpadded Base64 format");
                 dispatch_async(dispatch_get_main_queue(), ^{
                     failure([self errorWithCode:MXSecretStorageBadSecretFormatCode reason:@"Bad secret format"]);
                 });
@@ -404,7 +404,7 @@ static NSString* const kSecretStorageZeroString = @"\0\0\0\0\0\0\0\0\0\0\0\0\0\0
             MXEncryptedSecretContent *encryptedSecretContent = [self encryptSecret:unpaddedBase64Secret withSecretId:secretId privateKey:privateKey iv:nil error:&error];
             if (error)
             {
-                NSLog(@"[MXSecretStorage] storeSecret: ERROR: Cannot encrypt. Error: %@", error);
+                MXLogDebug(@"[MXSecretStorage] storeSecret: ERROR: Cannot encrypt. Error: %@", error);
                 dispatch_async(dispatch_get_main_queue(), ^{
                     failure(error);
                 });
@@ -439,7 +439,7 @@ static NSString* const kSecretStorageZeroString = @"\0\0\0\0\0\0\0\0\0\0\0\0\0\0
     NSDictionary *accountData = [_mxSession.accountData accountDataForEventType:secretId];
     if (!accountData)
     {
-        NSLog(@"[MXSecretStorage] secretStorageKeysUsedForSecretWithSecretId: ERROR: No Secret for secret id %@", secretId);
+        MXLogDebug(@"[MXSecretStorage] secretStorageKeysUsedForSecretWithSecretId: ERROR: No Secret for secret id %@", secretId);
         return nil;
     }
     
@@ -468,7 +468,7 @@ static NSString* const kSecretStorageZeroString = @"\0\0\0\0\0\0\0\0\0\0\0\0\0\0
     NSDictionary *accountData = [_mxSession.accountData accountDataForEventType:secretId];
     if (!accountData)
     {
-        NSLog(@"[MXSecretStorage] secretWithSecretId: ERROR: Unknown secret id %@", secretId);
+        MXLogDebug(@"[MXSecretStorage] secretWithSecretId: ERROR: Unknown secret id %@", secretId);
         failure([self errorWithCode:MXSecretStorageUnknownSecretCode reason:[NSString stringWithFormat:@"Unknown secret %@", secretId]]);
         return;
     }
@@ -479,7 +479,7 @@ static NSString* const kSecretStorageZeroString = @"\0\0\0\0\0\0\0\0\0\0\0\0\0\0
     }
     if (!keyId)
     {
-        NSLog(@"[MXSecretStorage] secretWithSecretId: ERROR: No key id provided and no default key id");
+        MXLogDebug(@"[MXSecretStorage] secretWithSecretId: ERROR: No key id provided and no default key id");
         failure([self errorWithCode:MXSecretStorageUnknownKeyCode reason:@"No key id"]);
         return;
     }
@@ -487,7 +487,7 @@ static NSString* const kSecretStorageZeroString = @"\0\0\0\0\0\0\0\0\0\0\0\0\0\0
     MXSecretStorageKeyContent *key = [self keyWithKeyId:keyId];
     if (!key)
     {
-        NSLog(@"[MXSecretStorage] secretWithSecretId: ERROR: No key for with id %@", keyId);
+        MXLogDebug(@"[MXSecretStorage] secretWithSecretId: ERROR: No key for with id %@", keyId);
         failure([self errorWithCode:MXSecretStorageUnknownKeyCode reason:[NSString stringWithFormat:@"Unknown key %@", keyId]]);
         return;
     }
@@ -496,7 +496,7 @@ static NSString* const kSecretStorageZeroString = @"\0\0\0\0\0\0\0\0\0\0\0\0\0\0
     MXJSONModelSetDictionary(encryptedContent, accountData[@"encrypted"]);
     if (!encryptedContent)
     {
-        NSLog(@"[MXSecretStorage] secretWithSecretId: ERROR: No encrypted data for the secret");
+        MXLogDebug(@"[MXSecretStorage] secretWithSecretId: ERROR: No encrypted data for the secret");
         failure([self errorWithCode:MXSecretStorageSecretNotEncryptedCode reason:[NSString stringWithFormat:@"Missing content for secret %@", secretId]]);
         return;
     }
@@ -505,14 +505,14 @@ static NSString* const kSecretStorageZeroString = @"\0\0\0\0\0\0\0\0\0\0\0\0\0\0
     MXJSONModelSetMXJSONModel(secretContent, MXEncryptedSecretContent.class, encryptedContent[keyId]);
     if (!secretContent)
     {
-        NSLog(@"[MXSecretStorage] secretWithSecretId: ERROR: No content for secret %@ with key %@: %@", secretId, keyId, encryptedContent);
+        MXLogDebug(@"[MXSecretStorage] secretWithSecretId: ERROR: No content for secret %@ with key %@: %@", secretId, keyId, encryptedContent);
         failure([self errorWithCode:MXSecretStorageSecretNotEncryptedWithKeyCode reason:[NSString stringWithFormat:@"Missing content for secret %@ with key %@", secretId, keyId]]);
         return;
     }
     
     if (![key.algorithm isEqualToString:MXSecretStorageKeyAlgorithm.aesHmacSha2])
     {
-        NSLog(@"[MXSecretStorage] secretWithSecretId: ERROR: Unsupported algorihthm %@", key.algorithm);
+        MXLogDebug(@"[MXSecretStorage] secretWithSecretId: ERROR: Unsupported algorihthm %@", key.algorithm);
         failure([self errorWithCode:MXSecretStorageUnsupportedAlgorithmCode reason:[NSString stringWithFormat:@"Unknown algorithm %@", key.algorithm]]);
         return;
     }
@@ -563,7 +563,7 @@ static NSString* const kSecretStorageZeroString = @"\0\0\0\0\0\0\0\0\0\0\0\0\0\0
     NSDictionary *accountData = [_mxSession.accountData accountDataForEventType:secretId];
     if (!accountData)
     {
-        NSLog(@"[MXSecretStorage] removeSecretWithSecretId: ERROR: Unknown secret id %@", secretId);
+        MXLogDebug(@"[MXSecretStorage] removeSecretWithSecretId: ERROR: Unknown secret id %@", secretId);
         failure([self errorWithCode:MXSecretStorageUnknownSecretCode reason:[NSString stringWithFormat:@"Unknown secret %@", secretId]]);
         return nil;
     }
@@ -650,7 +650,7 @@ static NSString* const kSecretStorageZeroString = @"\0\0\0\0\0\0\0\0\0\0\0\0\0\0
     NSData *cipher = [MXAesHmacSha2 encrypt:secret aesKey:aesKey iv:iv hmacKey:hmacKey hmac:&hmac error:error];
     if (*error)
     {
-        NSLog(@"[MXSecretStorage] encryptSecret: Encryption failed. Error: %@", *error);
+        MXLogDebug(@"[MXSecretStorage] encryptSecret: Encryption failed. Error: %@", *error);
         return nil;
     }
     
@@ -694,7 +694,7 @@ static NSString* const kSecretStorageZeroString = @"\0\0\0\0\0\0\0\0\0\0\0\0\0\0
     NSData *hmac = secretContent.mac ? [MXBase64Tools dataFromBase64:secretContent.mac] : nil;
     if (!hmac)
     {
-        NSLog(@"[MXSecretStorage] decryptSecret: ERROR: Bad base64 format for MAC: %@", secretContent.mac);
+        MXLogDebug(@"[MXSecretStorage] decryptSecret: ERROR: Bad base64 format for MAC: %@", secretContent.mac);
         *error = [self errorWithCode:MXSecretStorageBadMacCode reason:[NSString stringWithFormat:@"Bad base64 format for MAC: %@", secretContent.mac]];
         return nil;
     }
@@ -702,7 +702,7 @@ static NSString* const kSecretStorageZeroString = @"\0\0\0\0\0\0\0\0\0\0\0\0\0\0
     NSData *cipher = secretContent.ciphertext ? [MXBase64Tools dataFromBase64:secretContent.ciphertext] : nil;
     if (!cipher)
     {
-        NSLog(@"[MXSecretStorage] decryptSecret: ERROR: Bad base64 format for ciphertext: %@", secretContent.ciphertext);
+        MXLogDebug(@"[MXSecretStorage] decryptSecret: ERROR: Bad base64 format for ciphertext: %@", secretContent.ciphertext);
         *error = [self errorWithCode:MXSecretStorageBadCiphertextCode reason:[NSString stringWithFormat:@"Bad base64 format for ciphertext: %@", secretContent.ciphertext]];
         return nil;
     }
@@ -714,14 +714,14 @@ static NSString* const kSecretStorageZeroString = @"\0\0\0\0\0\0\0\0\0\0\0\0\0\0
     
     if (*error)
     {
-        NSLog(@"[MXSecretStorage] decryptSecret: Decryption failed. Error: %@", *error);
+        MXLogDebug(@"[MXSecretStorage] decryptSecret: Decryption failed. Error: %@", *error);
         return nil;
     }
     
     NSString *unpaddedBase64Secret = [[NSString alloc] initWithData:decrypted encoding:NSUTF8StringEncoding];
     if (!unpaddedBase64Secret)
     {
-        NSLog(@"[MXSecretStorage] decryptSecret: ERROR: Bad secret format. Can't convert to string");
+        MXLogDebug(@"[MXSecretStorage] decryptSecret: ERROR: Bad secret format. Can't convert to string");
         *error = [self errorWithCode:MXSecretStorageBadSecretFormatCode reason:@"Bad secret format"];
         return nil;
     }

--- a/MatrixSDK/Crypto/Utils/MXAes.m
+++ b/MatrixSDK/Crypto/Utils/MXAes.m
@@ -19,6 +19,8 @@
 #import <CommonCrypto/CommonKeyDerivation.h>
 #import <CommonCrypto/CommonCryptor.h>
 
+#import "MXLog.h"
+
 
 #pragma mark - Constants
 
@@ -34,7 +36,7 @@ NSString *const MXAesErrorDomain = @"org.matrix.sdk.MXAes";
     int result = SecRandomCopyBytes(kSecRandomDefault, ivLength, iv.mutableBytes);
     if (result != 0)
     {
-        NSLog(@"[MXAes] iv failed. result: %@", @(result));
+        MXLogDebug(@"[MXAes] iv failed. result: %@", @(result));
     }
     
     // Clear bit 63 of the IV to stop us hitting the 64-bit counter boundary

--- a/MatrixSDK/Crypto/Utils/MXMegolmExportEncryption.m
+++ b/MatrixSDK/Crypto/Utils/MXMegolmExportEncryption.m
@@ -21,6 +21,8 @@
 #import <CommonCrypto/CommonCryptor.h>
 #import <CommonCrypto/CommonKeyDerivation.h>
 
+#import "MXLog.h"
+
 NSString *const MXMegolmExportEncryptionErrorDomain = @"org.matrix.sdk.megolm.export";
 
 NSString *const MXMegolmExportEncryptionHeaderLine = @"-----BEGIN MEGOLM SESSION DATA-----";
@@ -153,7 +155,7 @@ NSString *const MXMegolmExportEncryptionTrailerLine = @"-----END MEGOLM SESSION 
         }
     }
 
-    NSLog(@"[MXMegolmExportEncryption] decryptMegolmKeyFile: decrypted %tu bytes in %.0fms", data.length, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+    MXLogDebug(@"[MXMegolmExportEncryption] decryptMegolmKeyFile: decrypted %tu bytes in %.0fms", data.length, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 
     return result;
 }
@@ -260,7 +262,7 @@ NSString *const MXMegolmExportEncryptionTrailerLine = @"-----END MEGOLM SESSION 
 
             NSData *keyFile = [MXMegolmExportEncryption packMegolmKeyFile:result];
 
-            NSLog(@"[MXMegolmExportEncryption] encryptMegolmKeyFile: encrypted %tu bytes in %.0fms", data.length, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+            MXLogDebug(@"[MXMegolmExportEncryption] encryptMegolmKeyFile: encrypted %tu bytes in %.0fms", data.length, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 
             return keyFile;
         }
@@ -346,7 +348,7 @@ NSString *const MXMegolmExportEncryptionTrailerLine = @"-----END MEGOLM SESSION 
     *aesKey = [derivedKey subdataWithRange:NSMakeRange(0, 32)];
     *hmacKey = [derivedKey subdataWithRange:NSMakeRange(32, derivedKey.length - 32)];
 
-    NSLog(@"[MXMegolmExportEncryption] deriveKeys: %tu iterations took %.0fms", iterations, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+    MXLogDebug(@"[MXMegolmExportEncryption] deriveKeys: %tu iterations took %.0fms", iterations, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 
     return result;
 }
@@ -468,7 +470,7 @@ NSString *const MXMegolmExportEncryptionTrailerLine = @"-----END MEGOLM SESSION 
         [s appendFormat:@"%hhu, ", bytes[i]];
     }
 
-    NSLog(@"%tu bytes:\n%@", data.length, s);
+    MXLogDebug(@"%tu bytes:\n%@", data.length, s);
 }
 
 @end

--- a/MatrixSDK/Crypto/Verification/Data/MXQRCodeDataBuilder.m
+++ b/MatrixSDK/Crypto/Verification/Data/MXQRCodeDataBuilder.m
@@ -18,6 +18,8 @@
 
 #import "MXBase64Tools.h"
 
+#import "MXLog.h"
+
 static NSUInteger const kKeyBytesCount = 32;
 static NSUInteger const kSharedSecretBytesCount = 8;
 
@@ -33,19 +35,19 @@ static NSUInteger const kSharedSecretBytesCount = 8;
 {
     if (![self isKeyValid:firstKey])
     {
-        NSLog(@"[MXQRCodeDataBuilder] buildQRCodeDataWithVerificationMode, First key is invalid");
+        MXLogDebug(@"[MXQRCodeDataBuilder] buildQRCodeDataWithVerificationMode, First key is invalid");
         return nil;
     }
     
     if (![self isKeyValid:secondKey])
     {
-        NSLog(@"[MXQRCodeDataBuilder] buildQRCodeDataWithVerificationMode, Second key is invalid");
+        MXLogDebug(@"[MXQRCodeDataBuilder] buildQRCodeDataWithVerificationMode, Second key is invalid");
         return nil;
     }
     
     if (![self isSharedSecretValid:sharedSecret])
     {
-        NSLog(@"[MXQRCodeDataBuilder] buildQRCodeDataWithVerificationMode, Shared secret is invalid");
+        MXLogDebug(@"[MXQRCodeDataBuilder] buildQRCodeDataWithVerificationMode, Shared secret is invalid");
         return nil;
     }
     

--- a/MatrixSDK/Crypto/Verification/Data/MXQRCodeDataCoder.m
+++ b/MatrixSDK/Crypto/Verification/Data/MXQRCodeDataCoder.m
@@ -22,6 +22,8 @@
 
 #import "MXVerifyingAnotherUserQRCodeData.h"
 
+#import "MXLog.h"
+
 static NSString* const kQRCodeFormatPrefix = @"MATRIX";
 static NSUInteger const kQRCodeFormatVersion = 2;
 
@@ -60,7 +62,7 @@ static NSUInteger const kQRCodeFormatMinimumSharedSecretByteCount = 8;
     
     if (dataByteCount < kQRCodeFormatMinimumDataByteCount)
     {
-        NSLog(@"[MXQRCodeDataCoder] Data byte count is too short");
+        MXLogDebug(@"[MXQRCodeDataCoder] Data byte count is too short");
         return nil;
     }
     
@@ -78,7 +80,7 @@ static NSUInteger const kQRCodeFormatMinimumSharedSecretByteCount = 8;
     
     if (currenReadBytesCount < 0)
     {
-        NSLog(@"inputStream.streamError: %@", inputStream.streamError);
+        MXLogDebug(@"inputStream.streamError: %@", inputStream.streamError);
         return nil;
     }
     
@@ -88,7 +90,7 @@ static NSUInteger const kQRCodeFormatMinimumSharedSecretByteCount = 8;
     
     if (![self.prefixData isEqualToData:foundPrefixData])
     {
-        NSLog(@"[MXQRCodeDataCoder] decode: Invalid prefix");        
+        MXLogDebug(@"[MXQRCodeDataCoder] decode: Invalid prefix");        
         return nil;
     }
     
@@ -99,7 +101,7 @@ static NSUInteger const kQRCodeFormatMinimumSharedSecretByteCount = 8;
     
     if (currenReadBytesCount < 0)
     {
-        NSLog(@"[MXQRCodeDataCoder] Fail to parse QR code version with inputStream.streamError: %@", inputStream.streamError);
+        MXLogDebug(@"[MXQRCodeDataCoder] Fail to parse QR code version with inputStream.streamError: %@", inputStream.streamError);
         return nil;
     }
     
@@ -109,7 +111,7 @@ static NSUInteger const kQRCodeFormatMinimumSharedSecretByteCount = 8;
     
     if (version != self.supportedQRCodeVersion)
     {
-        NSLog(@"[MXQRCodeDataCoder] Unsupported QR code version: %@", @(version));
+        MXLogDebug(@"[MXQRCodeDataCoder] Unsupported QR code version: %@", @(version));
         return nil;
     }
     
@@ -120,7 +122,7 @@ static NSUInteger const kQRCodeFormatMinimumSharedSecretByteCount = 8;
     
     if (currenReadBytesCount < 0)
     {
-        NSLog(@"[MXQRCodeDataCoder] Fail to parse verification mode with inputStream.streamError: %@", inputStream.streamError);
+        MXLogDebug(@"[MXQRCodeDataCoder] Fail to parse verification mode with inputStream.streamError: %@", inputStream.streamError);
         return nil;
     }
     
@@ -135,7 +137,7 @@ static NSUInteger const kQRCodeFormatMinimumSharedSecretByteCount = 8;
     }
     else
     {
-        NSLog(@"[MXQRCodeDataCoder] Invalid verification mode %ld", (long)verificationModeRawValue);
+        MXLogDebug(@"[MXQRCodeDataCoder] Invalid verification mode %ld", (long)verificationModeRawValue);
         return nil;
     }
     
@@ -147,7 +149,7 @@ static NSUInteger const kQRCodeFormatMinimumSharedSecretByteCount = 8;
     
     if (currenReadBytesCount < 0)
     {
-        NSLog(@"[MXQRCodeDataCoder] Fail to parse transaction id length with inputStream.streamError: %@", inputStream.streamError);
+        MXLogDebug(@"[MXQRCodeDataCoder] Fail to parse transaction id length with inputStream.streamError: %@", inputStream.streamError);
         return nil;
     }
     
@@ -161,7 +163,7 @@ static NSUInteger const kQRCodeFormatMinimumSharedSecretByteCount = 8;
     
     if (transactionIdLength == 0)
     {
-        NSLog(@"[MXQRCodeDataCoder] Transaction id length is equal to zero");
+        MXLogDebug(@"[MXQRCodeDataCoder] Transaction id length is equal to zero");
         return nil;
     }
     
@@ -172,7 +174,7 @@ static NSUInteger const kQRCodeFormatMinimumSharedSecretByteCount = 8;
     
     if (currenReadBytesCount < 0)
     {
-        NSLog(@"[MXQRCodeDataCoder] Fail to parse transaction id length with inputStream.streamError: %@", inputStream.streamError);
+        MXLogDebug(@"[MXQRCodeDataCoder] Fail to parse transaction id length with inputStream.streamError: %@", inputStream.streamError);
         return nil;
     }
     
@@ -187,7 +189,7 @@ static NSUInteger const kQRCodeFormatMinimumSharedSecretByteCount = 8;
     
     if (currenReadBytesCount < 0)
     {
-        NSLog(@"[MXQRCodeDataCoder] Fail to parse first key inputStream.streamError: %@", inputStream.streamError);
+        MXLogDebug(@"[MXQRCodeDataCoder] Fail to parse first key inputStream.streamError: %@", inputStream.streamError);
         return nil;
     }
     
@@ -203,7 +205,7 @@ static NSUInteger const kQRCodeFormatMinimumSharedSecretByteCount = 8;
     
     if (currenReadBytesCount < 0)
     {
-        NSLog(@"[MXQRCodeDataCoder] Fail to parse second key inputStream.streamError: %@", inputStream.streamError);
+        MXLogDebug(@"[MXQRCodeDataCoder] Fail to parse second key inputStream.streamError: %@", inputStream.streamError);
         return nil;
     }
     
@@ -218,7 +220,7 @@ static NSUInteger const kQRCodeFormatMinimumSharedSecretByteCount = 8;
     // Shared secret should be 8 bytes length minimum
     if (remainingBytesCount < kQRCodeFormatMinimumSharedSecretByteCount)
     {
-        NSLog(@"[MXQRCodeDataCoder] Fail to parse shared secret");
+        MXLogDebug(@"[MXQRCodeDataCoder] Fail to parse shared secret");
         return nil;
     }
     

--- a/MatrixSDK/Crypto/Verification/JSONModels/MXKeyVerificationAccept.m
+++ b/MatrixSDK/Crypto/Verification/JSONModels/MXKeyVerificationAccept.m
@@ -71,7 +71,7 @@
         || _shortAuthenticationString.count == 0
         || _commitment.length == 0)
    {
-        NSLog(@"[MXKeyVerification] Invalid MXKeyVerificationAccept: %@", self);
+        MXLogDebug(@"[MXKeyVerification] Invalid MXKeyVerificationAccept: %@", self);
         isValid = NO;
     }
 

--- a/MatrixSDK/Crypto/Verification/JSONModels/MXKeyVerificationKey.m
+++ b/MatrixSDK/Crypto/Verification/JSONModels/MXKeyVerificationKey.m
@@ -48,7 +48,7 @@
 
     if (_key.length == 0)
     {
-        NSLog(@"[MXKeyVerification] Invalid MXKeyVerificationKey: %@", self);
+        MXLogDebug(@"[MXKeyVerification] Invalid MXKeyVerificationKey: %@", self);
         isValid = NO;
     }
 

--- a/MatrixSDK/Crypto/Verification/JSONModels/MXKeyVerificationMac.m
+++ b/MatrixSDK/Crypto/Verification/JSONModels/MXKeyVerificationMac.m
@@ -53,7 +53,7 @@
 
     if (_mac.count == 0 || _keys.length == 0)
     {
-        NSLog(@"[MXKeyVerification] Invalid MXKeyVerificationMac: %@", self);
+        MXLogDebug(@"[MXKeyVerification] Invalid MXKeyVerificationMac: %@", self);
         isValid = NO;
     }
 

--- a/MatrixSDK/Crypto/Verification/JSONModels/MXKeyVerificationReady.m
+++ b/MatrixSDK/Crypto/Verification/JSONModels/MXKeyVerificationReady.m
@@ -59,7 +59,7 @@
 
     if (_methods.count == 0)
     {
-        NSLog(@"[MXKeyVerification] Invalid MXKeyVerificationReady: %@", self);
+        MXLogDebug(@"[MXKeyVerification] Invalid MXKeyVerificationReady: %@", self);
         isValid = NO;
     }
 

--- a/MatrixSDK/Crypto/Verification/JSONModels/MXQRCodeKeyVerificationStart.m
+++ b/MatrixSDK/Crypto/Verification/JSONModels/MXQRCodeKeyVerificationStart.m
@@ -54,7 +54,7 @@
         || ![self.method isEqualToString:MXKeyVerificationMethodReciprocate]
         || self.sharedSecret.length == 0)
     {
-        NSLog(@"[MXKeyVerification] Invalid MXQRCodeKeyVerificationStart: %@", self);
+        MXLogDebug(@"[MXKeyVerification] Invalid MXQRCodeKeyVerificationStart: %@", self);
         return NO;
     }
     

--- a/MatrixSDK/Crypto/Verification/JSONModels/MXSASKeyVerificationStart.m
+++ b/MatrixSDK/Crypto/Verification/JSONModels/MXSASKeyVerificationStart.m
@@ -71,7 +71,7 @@
         || _shortAuthenticationString.count == 0
         || [_shortAuthenticationString containsObject:MXKeyVerificationSASModeDecimal] == NO)
     {
-        NSLog(@"[MXKeyVerification] Invalid MXSASKeyVerificationStart: %@", self);
+        MXLogDebug(@"[MXKeyVerification] Invalid MXSASKeyVerificationStart: %@", self);
         isValid = NO;
     }
     

--- a/MatrixSDK/Crypto/Verification/MXKeyVerificationManager.m
+++ b/MatrixSDK/Crypto/Verification/MXKeyVerificationManager.m
@@ -93,7 +93,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
                                         success:(void(^)(MXKeyVerificationRequest *request))success
                                         failure:(void(^)(NSError *error))failure
 {
-    NSLog(@"[MXKeyVerification] requestVerificationByToDeviceWithUserId: %@. deviceIds: %@", userId, deviceIds);
+    MXLogDebug(@"[MXKeyVerification] requestVerificationByToDeviceWithUserId: %@. deviceIds: %@", userId, deviceIds);
     if (deviceIds.count)
     {
         [self requestVerificationByToDeviceWithUserId2:userId deviceIds:deviceIds methods:methods success:success failure:failure];
@@ -221,7 +221,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
                                    success:(void(^)(MXKeyVerificationRequest *request))success
                                    failure:(void(^)(NSError *error))failure
 {
-    NSLog(@"[MXKeyVerification] requestVerificationByDMWithUserId: %@. RoomId: %@", userId, roomId);
+    MXLogDebug(@"[MXKeyVerification] requestVerificationByDMWithUserId: %@. RoomId: %@", userId, roomId);
     
     MXKeyVerificationRequestByDMJSONModel *request = [MXKeyVerificationRequestByDMJSONModel new];
     request.body = fallbackText;
@@ -267,7 +267,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
                                 success:(void(^)(MXKeyVerificationTransaction *transaction))success
                                 failure:(void(^)(NSError *error))failure
 {
-    NSLog(@"[MXKeyVerification] beginKeyVerificationFromRequest: event: %@", request.requestId);
+    MXLogDebug(@"[MXKeyVerification] beginKeyVerificationFromRequest: event: %@", request.requestId);
     
     // Sanity checks
     if (!request.otherDevice)
@@ -323,7 +323,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
                                success:(void(^)(MXKeyVerificationTransaction *transaction))success
                                failure:(void(^)(NSError *error))failure
 {
-    NSLog(@"[MXKeyVerification] beginKeyVerification: device: %@:%@ roomId: %@ method:%@", userId, deviceId, dmRoomId, method);
+    MXLogDebug(@"[MXKeyVerification] beginKeyVerification: device: %@:%@ roomId: %@ method:%@", userId, deviceId, dmRoomId, method);
 
     // Make sure we have other device keys
     [self loadDeviceWithDeviceId:deviceId andUserId:userId success:^(MXDeviceInfo *otherDevice) {
@@ -372,7 +372,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
         });
 
     } failure:^(NSError *error) {
-        NSLog(@"[MXKeyVerification] beginKeyVerification: Error: %@", error);
+        MXLogDebug(@"[MXKeyVerification] beginKeyVerification: Error: %@", error);
         failure(error);
     }];
 }
@@ -382,7 +382,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
                                    success:(void(^)(MXQRCodeTransaction *transaction))success
                                    failure:(void(^)(NSError *error))failure
 {
-    NSLog(@"[MXKeyVerification] createQRCodeTransactionFromRequest: event: %@", request.requestId);
+    MXLogDebug(@"[MXKeyVerification] createQRCodeTransactionFromRequest: event: %@", request.requestId);
     
     // Sanity checks
     if (!request.otherDevice)
@@ -444,7 +444,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
                                       success:(void(^)(MXQRCodeTransaction *transaction))success
                                       failure:(void(^)(NSError *error))failure
 {
-    NSLog(@"[MXKeyVerification] createQRCodeTransaction: device: %@:%@ roomId: %@", userId, deviceId, dmRoomId);
+    MXLogDebug(@"[MXKeyVerification] createQRCodeTransaction: device: %@:%@ roomId: %@", userId, deviceId, dmRoomId);
     
     // Make sure we have other device keys
     [self loadDeviceWithDeviceId:deviceId andUserId:userId success:^(MXDeviceInfo *otherDevice) {
@@ -485,7 +485,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
         });
         
     } failure:^(NSError *error) {
-        NSLog(@"[MXKeyVerification] createQRCodeTransaction: Error: %@", error);
+        MXLogDebug(@"[MXKeyVerification] createQRCodeTransaction: Error: %@", error);
         dispatch_async(dispatch_get_main_queue(), ^{
             failure(error);
         });
@@ -645,7 +645,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
                                  success:(dispatch_block_t)success
                                  failure:(void (^)(NSError *error))failure
 {
-    NSLog(@"[MXKeyVerification] sendToOtherInRequest: eventType: %@\n%@",
+    MXLogDebug(@"[MXKeyVerification] sendToOtherInRequest: eventType: %@\n%@",
           eventType, content);
     
     MXHTTPOperation *operation;
@@ -720,7 +720,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
                                      success:(void (^)(void))success
                                      failure:(void (^)(NSError *error))failure
 {
-    NSLog(@"[MXKeyVerification] sendToOtherInTransaction%@: eventType: %@\n%@",
+    MXLogDebug(@"[MXKeyVerification] sendToOtherInTransaction%@: eventType: %@\n%@",
           transaction.dmEventId ? @"(DM)" : @"",
           eventType, content);
 
@@ -743,7 +743,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
                   success:(void (^)(void))success
                   failure:(void (^)(NSError *error))failure
 {
-    NSLog(@"[MXKeyVerification] cancelTransaction. code: %@", code.value);
+    MXLogDebug(@"[MXKeyVerification] cancelTransaction. code: %@", code.value);
     
     MXKeyVerificationCancel *cancel = [MXKeyVerificationCancel new];
     cancel.transactionId = transaction.transactionId;
@@ -761,7 +761,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
         
     } failure:^(NSError *error) {
         
-        NSLog(@"[MXKeyVerification] cancelTransaction. Error: %@", error);
+        MXLogDebug(@"[MXKeyVerification] cancelTransaction. Error: %@", error);
         if (failure)
         {
             failure(error);
@@ -774,7 +774,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
 // Special handling for incoming requests that are not yet valid transactions
 - (void)cancelTransactionFromStartEvent:(MXEvent*)event code:(MXTransactionCancelCode*)code
 {
-    NSLog(@"[MXKeyVerification] cancelTransactionFromStartEvent. code: %@", code.value);
+    MXLogDebug(@"[MXKeyVerification] cancelTransactionFromStartEvent. code: %@", code.value);
 
     MXKeyVerificationStart *keyVerificationStart;
     MXJSONModelSetMXJSONModel(keyVerificationStart, MXKeyVerificationStart, event.content);
@@ -791,14 +791,14 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
         {
             [self sendMessage:event.sender roomId:event.roomId eventType:kMXEventTypeStringKeyVerificationCancel relatedTo:keyVerificationStart.relatedEventId content:cancel.JSONDictionary success:nil failure:^(NSError *error) {
 
-                NSLog(@"[MXKeyVerification] cancelTransactionFromStartEvent. Error: %@", error);
+                MXLogDebug(@"[MXKeyVerification] cancelTransactionFromStartEvent. Error: %@", error);
             }];
         }
         else
         {
             [self sendToDevice:event.sender deviceId:keyVerificationStart.fromDevice eventType:kMXEventTypeStringKeyVerificationCancel content:cancel.JSONDictionary success:nil failure:^(NSError *error) {
 
-                NSLog(@"[MXKeyVerification] cancelTransactionFromStartEvent. Error: %@", error);
+                MXLogDebug(@"[MXKeyVerification] cancelTransactionFromStartEvent. Error: %@", error);
             }];
         }
 
@@ -816,7 +816,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
         BOOL eventFromMyUser = [event.sender isEqualToString:self.crypto.mxSession.myUserId];
         BOOL isEventIntendedForMyDevice = isToDeviceEvent || !eventFromMyUser;
 
-        NSLog(@"[MXKeyVerification] handleKeyVerificationEvent(from my user: %@, isToDeviceEvent: %@, intendedForMyDevice: %@): eventType: %@ \n%@",
+        MXLogDebug(@"[MXKeyVerification] handleKeyVerificationEvent(from my user: %@, isToDeviceEvent: %@, intendedForMyDevice: %@): eventType: %@ \n%@",
               eventFromMyUser ? @"YES": @"NO",
               isToDeviceEvent ? @"YES": @"NO",
               isEventIntendedForMyDevice ? @"MAYBE": @"NO",     // MAYBE because it depends on the type of event
@@ -883,7 +883,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
 
 - (void)handleToDeviceRequestEvent:(MXEvent*)event
 {
-    NSLog(@"[MXKeyVerification] handleToDeviceRequestEvent");
+    MXLogDebug(@"[MXKeyVerification] handleToDeviceRequestEvent");
     
     MXKeyVerificationByToDeviceRequest *keyVerificationRequest = [[MXKeyVerificationByToDeviceRequest alloc] initWithEvent:event andManager:self to:self.crypto.mxSession.myUserId requestedOtherDeviceIds:@[]];
     
@@ -897,7 +897,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
 
 - (void)handleReadyEvent:(MXEvent*)event isToDeviceEvent:(BOOL)isToDeviceEvent
 {
-    NSLog(@"[MXKeyVerification] handleReadyEvent");
+    MXLogDebug(@"[MXKeyVerification] handleReadyEvent");
     
     MXKeyVerificationReady *keyVerificationReady;
     MXJSONModelSetMXJSONModel(keyVerificationReady, MXKeyVerificationReady, event.content);
@@ -928,7 +928,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
             {
                 // This is a ready response to a request the user made from another device
                 // Remove it from pending requests will ignore any other events related to this request id
-                NSLog(@"[MXKeyVerification] handleReadyEvent: The request (%@) has been accepted on another device. Ignore it.", requestId);
+                MXLogDebug(@"[MXKeyVerification] handleReadyEvent: The request (%@) has been accepted on another device. Ignore it.", requestId);
                 [self removePendingRequestWithRequestId:request.requestId];
             }
         }
@@ -937,7 +937,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
 
 - (void)handleCancelEvent:(MXEvent*)event
 {
-    NSLog(@"[MXKeyVerification] handleCancelEvent");
+    MXLogDebug(@"[MXKeyVerification] handleCancelEvent");
 
     MXKeyVerificationCancel *cancelContent;
     MXJSONModelSetMXJSONModel(cancelContent, MXKeyVerificationCancel, event.content);
@@ -960,13 +960,13 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
     }
     else
     {
-        NSLog(@"[MXKeyVerification] handleCancelEvent. Invalid event: %@", event.JSONDictionary);
+        MXLogDebug(@"[MXKeyVerification] handleCancelEvent. Invalid event: %@", event.JSONDictionary);
     }
 }
 
 - (void)handleStartEvent:(MXEvent*)event
 {
-    NSLog(@"[MXKeyVerification] handleStartEvent");
+    MXLogDebug(@"[MXKeyVerification] handleStartEvent");
     
     MXSASKeyVerificationStart *keyVerificationSASStart;
     MXJSONModelSetMXJSONModel(keyVerificationSASStart, MXSASKeyVerificationStart, event.content);
@@ -986,7 +986,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
         return;
     }
     
-    NSLog(@"[MXKeyVerification] handleStartEvent: Unknown start event %@", event);
+    MXLogDebug(@"[MXKeyVerification] handleStartEvent: Unknown start event %@", event);
     [self cancelTransactionFromStartEvent:event code:MXTransactionCancelCode.unknownMethod];
 }
 
@@ -994,7 +994,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
 
 - (void)handleSASKeyVerificationStart:(MXSASKeyVerificationStart*)keyVerificationStart withEvent:(MXEvent*)event
 {
-    NSLog(@"[MXKeyVerification] handleSASKeyVerificationStart");
+    MXLogDebug(@"[MXKeyVerification] handleSASKeyVerificationStart");
     
     if (!keyVerificationStart)
     {
@@ -1015,7 +1015,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
             || (request.isFromMyUser && !request.isFromMyDevice))
         {
             // This is a start response to a request we did not make. Ignore it
-            NSLog(@"[MXKeyVerification] handleStartEvent: Start event for verification by DM(%@) not triggered by this device. Ignore it", requestId);
+            MXLogDebug(@"[MXKeyVerification] handleStartEvent: Start event for verification by DM(%@) not triggered by this device. Ignore it", requestId);
             return;
         }
     }
@@ -1050,7 +1050,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
 
         if (existingTransaction)
         {
-            NSLog(@"[MXKeyVerification] handleStartEvent: already existing transaction. Cancel both");
+            MXLogDebug(@"[MXKeyVerification] handleStartEvent: already existing transaction. Cancel both");
             
             [existingTransaction cancelWithCancelCode:MXTransactionCancelCode.invalidMessage];
             [self cancelTransactionFromStartEvent:event code:MXTransactionCancelCode.invalidMessage];
@@ -1061,7 +1061,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
         NSArray<MXKeyVerificationTransaction*> *transactionsWithUser = [self transactionsWithUser:event.sender];
         if (transactionsWithUser.count)
         {
-            NSLog(@"[MXKeyVerification] handleStartEvent: already existing transaction with the user. Cancel both");
+            MXLogDebug(@"[MXKeyVerification] handleStartEvent: already existing transaction with the user. Cancel both");
             
             [transactionsWithUser[0] cancelWithCancelCode:MXTransactionCancelCode.invalidMessage];
             [self cancelTransactionFromStartEvent:event code:MXTransactionCancelCode.invalidMessage];
@@ -1077,31 +1077,31 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
                 
                 if (request)
                 {
-                    NSLog(@"[MXKeyVerification] handleStartEvent: auto accept incoming transaction in response of a request");
+                    MXLogDebug(@"[MXKeyVerification] handleStartEvent: auto accept incoming transaction in response of a request");
                     [transaction accept];
                 }
             }
             else
             {
-                NSLog(@"[MXKeyVerification] handleStartEvent: Expired transaction: %@", transaction);
+                MXLogDebug(@"[MXKeyVerification] handleStartEvent: Expired transaction: %@", transaction);
                 [self cancelTransactionFromStartEvent:event code:MXTransactionCancelCode.timeout];
             }
         }
         else
         {
-            NSLog(@"[MXKeyVerification] handleStartEvent: Unsupported transaction method: %@", event);
+            MXLogDebug(@"[MXKeyVerification] handleStartEvent: Unsupported transaction method: %@", event);
             [self cancelTransactionFromStartEvent:event code:MXTransactionCancelCode.unknownMethod];
         }
         
     } failure:^(NSError *error) {
-        NSLog(@"[MXKeyVerification] handleStartEvent: Failed to get other device keys: %@", event);
+        MXLogDebug(@"[MXKeyVerification] handleStartEvent: Failed to get other device keys: %@", event);
         [self cancelTransactionFromStartEvent:event code:MXTransactionCancelCode.invalidMessage];
     }];
 }
 
 - (void)handleAcceptEvent:(MXEvent*)event
 {
-    NSLog(@"[MXKeyVerification] handleAcceptEvent");
+    MXLogDebug(@"[MXKeyVerification] handleAcceptEvent");
 
     MXKeyVerificationAccept *acceptContent;
     MXJSONModelSetMXJSONModel(acceptContent, MXKeyVerificationAccept, event.content);
@@ -1115,18 +1115,18 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
         }
         else
         {
-            NSLog(@"[MXKeyVerification] handleAcceptEvent. Unknown SAS transaction: %@", event);
+            MXLogDebug(@"[MXKeyVerification] handleAcceptEvent. Unknown SAS transaction: %@", event);
         }
     }
     else
     {
-        NSLog(@"[MXKeyVerification] handleAcceptEvent. Invalid event: %@", event);
+        MXLogDebug(@"[MXKeyVerification] handleAcceptEvent. Invalid event: %@", event);
     }
 }
 
 - (void)handleKeyEvent:(MXEvent*)event
 {
-    NSLog(@"[MXKeyVerification] handleKeyEvent");
+    MXLogDebug(@"[MXKeyVerification] handleKeyEvent");
 
     MXKeyVerificationKey *keyContent;
     MXJSONModelSetMXJSONModel(keyContent, MXKeyVerificationKey, event.content);
@@ -1140,18 +1140,18 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
         }
         else
         {
-            NSLog(@"[MXKeyVerification] handleKeyEvent. Unknown SAS transaction: %@", event);
+            MXLogDebug(@"[MXKeyVerification] handleKeyEvent. Unknown SAS transaction: %@", event);
         }
     }
     else
     {
-        NSLog(@"[MXKeyVerification] handleKeyEvent. Invalid event: %@", event);
+        MXLogDebug(@"[MXKeyVerification] handleKeyEvent. Invalid event: %@", event);
     }
 }
 
 - (void)handleMacEvent:(MXEvent*)event
 {
-    NSLog(@"[MXKeyVerification] handleMacEvent");
+    MXLogDebug(@"[MXKeyVerification] handleMacEvent");
 
     MXKeyVerificationMac *macContent;
     MXJSONModelSetMXJSONModel(macContent, MXKeyVerificationMac, event.content);
@@ -1165,12 +1165,12 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
         }
         else
         {
-            NSLog(@"[MXKeyVerification] handleMacEvent. Unknown SAS transaction: %@", event);
+            MXLogDebug(@"[MXKeyVerification] handleMacEvent. Unknown SAS transaction: %@", event);
         }
     }
     else
     {
-        NSLog(@"[MXKeyVerification] handleMacEvent. Invalid event: %@", event);
+        MXLogDebug(@"[MXKeyVerification] handleMacEvent. Invalid event: %@", event);
     }
 }
 
@@ -1188,7 +1188,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
         }
         else
         {
-            NSLog(@"[MXKeyVerification] handleDoneEvent. Not handled for SAS transaction: %@", event);
+            MXLogDebug(@"[MXKeyVerification] handleDoneEvent. Not handled for SAS transaction: %@", event);
         }
         
         MXKeyVerificationTransaction *transaction = [self transactionWithTransactionId:doneEvent.transactionId];
@@ -1197,7 +1197,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
             BOOL eventFromMyDevice = [transaction.otherDeviceId isEqualToString:self.crypto.mxSession.myDeviceId];
             if (!eventFromMyDevice)
             {
-                NSLog(@"[MXKeyVerification] handleDoneEvent: requestAllPrivateKeys");
+                MXLogDebug(@"[MXKeyVerification] handleDoneEvent: requestAllPrivateKeys");
                 [self.crypto requestAllPrivateKeys];
             }
         }
@@ -1205,13 +1205,13 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
         {
             // The done event from the other can happen long time after.
             // That means the transaction can be no more in memory. In this case, request private keys with no condition
-            NSLog(@"[MXKeyVerification] handleDoneEvent: requestAllPrivateKeys anyway");
+            MXLogDebug(@"[MXKeyVerification] handleDoneEvent: requestAllPrivateKeys anyway");
             [self.crypto requestAllPrivateKeys];
         }
     }
     else
     {
-        NSLog(@"[MXKeyVerification] handleMacEvent. Invalid event: %@", event);
+        MXLogDebug(@"[MXKeyVerification] handleMacEvent. Invalid event: %@", event);
     }
 }
 
@@ -1219,7 +1219,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
 
 - (void)handleQRCodeKeyVerificationStart:(MXQRCodeKeyVerificationStart*)keyVerificationStart withEvent:(MXEvent*)event
 {
-    NSLog(@"[MXKeyVerification] handleQRCodeKeyVerificationStart");
+    MXLogDebug(@"[MXKeyVerification] handleQRCodeKeyVerificationStart");
     
     if (!keyVerificationStart)
     {
@@ -1240,7 +1240,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
             || (request.isFromMyUser && !request.isFromMyDevice))
         {
             // This is a start response to a request we did not make. Ignore it
-            NSLog(@"[MXKeyVerification] handleStartEvent: Start event for verification by DM(%@) not triggered by this device. Ignore it", requestId);
+            MXLogDebug(@"[MXKeyVerification] handleStartEvent: Start event for verification by DM(%@) not triggered by this device. Ignore it", requestId);
             return;
         }
     }
@@ -1256,7 +1256,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
     // Verify existing transaction
     if (!qrCodeTransaction)
     {
-        NSLog(@"[MXKeyVerification] handleStartEvent: Start event for verification not triggered by this device no existing transaction. Start event: %@", event);
+        MXLogDebug(@"[MXKeyVerification] handleStartEvent: Start event for verification not triggered by this device no existing transaction. Start event: %@", event);
         [self cancelTransactionFromStartEvent:event code:MXTransactionCancelCode.userMismatchError];
         return;
     }
@@ -1264,7 +1264,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
     // Verify sender user match
     if (![qrCodeTransaction.otherUserId isEqualToString:event.sender])
     {
-        NSLog(@"[MXKeyVerification] handleStartEvent: Invalid start event sender user mismatch. Start event: %@.", event);
+        MXLogDebug(@"[MXKeyVerification] handleStartEvent: Invalid start event sender user mismatch. Start event: %@.", event);
         [self cancelTransactionFromStartEvent:event code:MXTransactionCancelCode.userMismatchError];
         return;
     }
@@ -1272,7 +1272,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
     // Verify sender device match
     if (![qrCodeTransaction.otherDevice.deviceId isEqualToString:keyVerificationStart.fromDevice])
     {
-        NSLog(@"[MXKeyVerification] handleStartEvent: Invalid start event sender device mismatch. Start event: %@.", event);
+        MXLogDebug(@"[MXKeyVerification] handleStartEvent: Invalid start event sender device mismatch. Start event: %@.", event);
         [self cancelTransactionFromStartEvent:event code:MXTransactionCancelCode.userMismatchError];
         return;
     }
@@ -1392,11 +1392,11 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
 
 - (void)handleKeyVerificationRequestByDM:(MXKeyVerificationByDMRequest*)request event:(MXEvent*)event
 {
-    NSLog(@"[MXKeyVerification] handleKeyVerificationRequestByDM: %@", request);
+    MXLogDebug(@"[MXKeyVerification] handleKeyVerificationRequestByDM: %@", request);
 
     if (![request.request.to isEqualToString:self.crypto.mxSession.myUserId])
     {
-        NSLog(@"[MXKeyVerification] handleKeyVerificationRequestByDM: Request for another user: %@", request.request.to);
+        MXLogDebug(@"[MXKeyVerification] handleKeyVerificationRequestByDM: Request for another user: %@", request.request.to);
         return;
     }
 
@@ -1413,7 +1413,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
             }
 
         } failure:^(NSError *error) {
-            NSLog(@"[MXKeyVerificationRequest] handleKeyVerificationRequestByDM: Failed to resolve state: %@", request.requestId);
+            MXLogDebug(@"[MXKeyVerificationRequest] handleKeyVerificationRequestByDM: Failed to resolve state: %@", request.requestId);
         }];
     });
 }
@@ -1509,7 +1509,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
     
     if (!keyVerificationRequest)
     {
-        NSLog(@"[MXKeyVerification] computeReadyMethodsFromVerificationRequestWithId: Failed to find request with ID: %@", transactionId);
+        MXLogDebug(@"[MXKeyVerification] computeReadyMethodsFromVerificationRequestWithId: Failed to find request with ID: %@", transactionId);
     }
     
     NSMutableSet<NSString*> *readyMethods = [NSMutableSet new];
@@ -1574,13 +1574,13 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
         // verifyingAnotherUserQRCodeData.otherUserCrossSigningMasterKeyPublic -> Current user master key public
         if (![verifyingAnotherUserQRCodeData.otherUserCrossSigningMasterKeyPublic isEqualToString:masterKeyPublic])
         {
-            NSLog(@"[MXKeyVerification] checkOtherQRCodeData: Invalid other master key %@", verifyingAnotherUserQRCodeData.otherUserCrossSigningMasterKeyPublic);
+            MXLogDebug(@"[MXKeyVerification] checkOtherQRCodeData: Invalid other master key %@", verifyingAnotherUserQRCodeData.otherUserCrossSigningMasterKeyPublic);
             isOtherQRCodeDataValid = NO;
         }
         // verifyingAnotherUserQRCodeData.userCrossSigningMasterKeyPublic -> Other user master key public
         else if (![verifyingAnotherUserQRCodeData.userCrossSigningMasterKeyPublic isEqualToString:otherUserMasterKeyPublic])
         {
-            NSLog(@"[MXKeyVerification] checkOtherQRCodeData: Invalid user master key %@", verifyingAnotherUserQRCodeData.userCrossSigningMasterKeyPublic);
+            MXLogDebug(@"[MXKeyVerification] checkOtherQRCodeData: Invalid user master key %@", verifyingAnotherUserQRCodeData.userCrossSigningMasterKeyPublic);
             isOtherQRCodeDataValid = NO;
         }
     }
@@ -1593,13 +1593,13 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
         // selfVerifyingMasterKeyTrustedQRCodeData.userCrossSigningMasterKeyPublic -> Current user master key public
         if (![selfVerifyingMasterKeyTrustedQRCodeData.userCrossSigningMasterKeyPublic isEqualToString:masterKeyPublic])
         {
-            NSLog(@"[MXKeyVerification] checkOtherQRCodeData: Invalid user master key %@", selfVerifyingMasterKeyTrustedQRCodeData.userCrossSigningMasterKeyPublic);
+            MXLogDebug(@"[MXKeyVerification] checkOtherQRCodeData: Invalid user master key %@", selfVerifyingMasterKeyTrustedQRCodeData.userCrossSigningMasterKeyPublic);
             isOtherQRCodeDataValid = NO;
         }
         // selfVerifyingMasterKeyTrustedQRCodeData.otherDeviceKey -> Current device key
         else if (![selfVerifyingMasterKeyTrustedQRCodeData.otherDeviceKey isEqualToString:currentDeviceKey])
         {
-            NSLog(@"[MXKeyVerification] checkOtherQRCodeData: Invalid other device key %@", selfVerifyingMasterKeyTrustedQRCodeData.otherDeviceKey);
+            MXLogDebug(@"[MXKeyVerification] checkOtherQRCodeData: Invalid other device key %@", selfVerifyingMasterKeyTrustedQRCodeData.otherDeviceKey);
             isOtherQRCodeDataValid = NO;
         }
     }
@@ -1611,13 +1611,13 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
         // selfVerifyingMasterKeyNotTrustedQRCodeData.currentDeviceKey -> other device key
         if (![selfVerifyingMasterKeyNotTrustedQRCodeData.currentDeviceKey isEqualToString:otherDeviceKey])
         {
-            NSLog(@"[MXKeyVerification] checkOtherQRCodeData: Current device key %@", selfVerifyingMasterKeyNotTrustedQRCodeData.currentDeviceKey);
+            MXLogDebug(@"[MXKeyVerification] checkOtherQRCodeData: Current device key %@", selfVerifyingMasterKeyNotTrustedQRCodeData.currentDeviceKey);
             isOtherQRCodeDataValid = NO;
         }
         // selfVerifyingMasterKeyNotTrustedQRCodeData.userCrossSigningMasterKeyPublic -> Current user master key public
         else if (![selfVerifyingMasterKeyNotTrustedQRCodeData.userCrossSigningMasterKeyPublic isEqualToString:masterKeyPublic])
         {
-            NSLog(@"[MXKeyVerification] checkOtherQRCodeData: Invalid user master key %@", selfVerifyingMasterKeyNotTrustedQRCodeData.userCrossSigningMasterKeyPublic);
+            MXLogDebug(@"[MXKeyVerification] checkOtherQRCodeData: Invalid user master key %@", selfVerifyingMasterKeyNotTrustedQRCodeData.userCrossSigningMasterKeyPublic);
             isOtherQRCodeDataValid = NO;
         }
     }
@@ -1699,7 +1699,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
     {
         if (!pendingRequestsMap.count)
         {
-            NSLog(@"[MXKeyVerificationRequest] scheduleTimeoutTimer: Disable timer as there is no more requests");
+            MXLogDebug(@"[MXKeyVerificationRequest] scheduleTimeoutTimer: Disable timer as there is no more requests");
             [requestTimeoutTimer invalidate];
             requestTimeoutTimer = nil;
         }
@@ -1710,7 +1710,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
     NSDate *oldestRequestDate = [self oldestRequestDate];
     if (oldestRequestDate)
     {
-        NSLog(@"[MXKeyVerificationRequest] scheduleTimeoutTimer: Create timer");
+        MXLogDebug(@"[MXKeyVerificationRequest] scheduleTimeoutTimer: Create timer");
 
         NSDate *timeoutDate = [oldestRequestDate dateByAddingTimeInterval:self.requestTimeout];
         requestTimeoutTimer = [[NSTimer alloc] initWithFireDate:timeoutDate
@@ -1725,7 +1725,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
 
 - (void)onRequestTimeoutTimer
 {
-    NSLog(@"[MXKeyVerificationRequest] onTimeoutTimer");
+    MXLogDebug(@"[MXKeyVerificationRequest] onTimeoutTimer");
     requestTimeoutTimer = nil;
 
     [self checkRequestTimeoutsWithCompletion:^{
@@ -1740,7 +1740,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
     {
         if (![self isRequestStillValid:request])
         {
-            NSLog(@"[MXKeyVerificationRequest] checkTimeouts: timeout %@", request);
+            MXLogDebug(@"[MXKeyVerificationRequest] checkTimeouts: timeout %@", request);
             
             dispatch_group_enter(group);
             [request cancelWithCancelCode:MXTransactionCancelCode.timeout success:^{
@@ -1861,7 +1861,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
     {
         if (!transactions.count)
         {
-            NSLog(@"[MXKeyVerification] scheduleTimeoutTimer: Disable timer as there is no more transactions");
+            MXLogDebug(@"[MXKeyVerification] scheduleTimeoutTimer: Disable timer as there is no more transactions");
             [transactionTimeoutTimer invalidate];
             transactionTimeoutTimer = nil;
         }
@@ -1881,7 +1881,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
                 return;
             }
 
-            NSLog(@"[MXKeyVerification] scheduleTimeoutTimer: Create timer");
+            MXLogDebug(@"[MXKeyVerification] scheduleTimeoutTimer: Create timer");
 
             NSDate *timeoutDate = [oldestCreationDate dateByAddingTimeInterval:MXTransactionTimeout];
             self->transactionTimeoutTimer = [[NSTimer alloc] initWithFireDate:timeoutDate
@@ -1897,7 +1897,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
 
 - (void)onTransactionTimeoutTimer
 {
-    NSLog(@"[MXKeyVerification] onTimeoutTimer");
+    MXLogDebug(@"[MXKeyVerification] onTimeoutTimer");
     self->transactionTimeoutTimer = nil;
 
     if (cryptoQueue)
@@ -1915,7 +1915,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
     {
         if (![self isCreationDateValid:transaction])
         {
-            NSLog(@"[MXKeyVerification] checkTimeouts: timeout %@", transaction);
+            MXLogDebug(@"[MXKeyVerification] checkTimeouts: timeout %@", transaction);
             [transaction cancelWithCancelCode:MXTransactionCancelCode.timeout];
         }
     }
@@ -1962,7 +1962,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
 
     if (!userCrossSigningMasterKeyPublic || !otherUserCrossSigningMasterKeyPublic)
     {
-        NSLog(@"[MXKeyVerification] createVerifyingAnotherUserQRCodeData fails to get userCrossSigningMasterKeyPublic or otherUserCrossSigningMasterKeyPublic");
+        MXLogDebug(@"[MXKeyVerification] createVerifyingAnotherUserQRCodeData fails to get userCrossSigningMasterKeyPublic or otherUserCrossSigningMasterKeyPublic");
         return nil;
     }
 
@@ -1984,7 +1984,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
     
     if (!userCrossSigningMasterKeyPublic || !otherDeviceKey)
     {
-        NSLog(@"[MXKeyVerification] createSelfVerifyingMasterKeyTrustedQRCodeData fails to get userCrossSigningMasterKeyPublic or otherDeviceKey");
+        MXLogDebug(@"[MXKeyVerification] createSelfVerifyingMasterKeyTrustedQRCodeData fails to get userCrossSigningMasterKeyPublic or otherDeviceKey");
         return nil;
     }
     
@@ -2003,7 +2003,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
 
     if (!userCrossSigningMasterKeyPublic || !currentDeviceKey)
     {
-        NSLog(@"[MXKeyVerification] createSelfVerifyingMasterKeyNotTrustedQRCodeData fails to get userCrossSigningMasterKeyPublic or currentDeviceKey");
+        MXLogDebug(@"[MXKeyVerification] createSelfVerifyingMasterKeyNotTrustedQRCodeData fails to get userCrossSigningMasterKeyPublic or currentDeviceKey");
         return nil;
     }
 

--- a/MatrixSDK/Crypto/Verification/Requests/MXKeyVerificationRequest.m
+++ b/MatrixSDK/Crypto/Verification/Requests/MXKeyVerificationRequest.m
@@ -100,12 +100,12 @@ NSString * const MXKeyVerificationRequestDidChangeNotification = @"MXKeyVerifica
                     });
                 } failure:^(NSError * _Nonnull error) {
                     
-                    NSLog(@"[MXKeyVerificationRequest] acceptWithMethods fail to create qrCodeData.");
+                    MXLogDebug(@"[MXKeyVerificationRequest] acceptWithMethods fail to create qrCodeData.");
                     
                     [self cancelWithCancelCode:MXTransactionCancelCode.unexpectedMessage success:^{
                         
                     } failure:^(NSError * _Nonnull error) {
-                        NSLog(@"[MXKeyVerificationRequest] acceptWithMethods fail to cancel request");
+                        MXLogDebug(@"[MXKeyVerificationRequest] acceptWithMethods fail to cancel request");
                     }];
                     
                     dispatch_async(dispatch_get_main_queue(), ^{
@@ -189,7 +189,7 @@ NSString * const MXKeyVerificationRequestDidChangeNotification = @"MXKeyVerifica
             [self cancelWithCancelCode:MXTransactionCancelCode.unexpectedMessage success:^{
                 
             } failure:^(NSError * _Nonnull error) {
-                NSLog(@"[MXKeyVerificationRequest] handleReady fail to cancel request");
+                MXLogDebug(@"[MXKeyVerificationRequest] handleReady fail to cancel request");
             }];
         }];
     }

--- a/MatrixSDK/Crypto/Verification/Transactions/QRCode/MXQRCodeTransaction.m
+++ b/MatrixSDK/Crypto/Verification/Transactions/QRCode/MXQRCodeTransaction.m
@@ -65,7 +65,7 @@ NSString * const MXKeyVerificationMethodReciprocate = @"m.reciprocate.v1";
 
 - (void)setState:(MXQRCodeTransactionState)state
 {
-    NSLog(@"[MXKeyVerification][MXQRCodeTransaction] setState: %@ -> %@", @(_state), @(state));
+    MXLogDebug(@"[MXKeyVerification][MXQRCodeTransaction] setState: %@ -> %@", @(_state), @(state));
     
     _state = state;
     [self didUpdateState];
@@ -77,7 +77,7 @@ NSString * const MXKeyVerificationMethodReciprocate = @"m.reciprocate.v1";
 {
     if (self.state != MXQRCodeTransactionStateQRScannedByOther)
     {
-        NSLog(@"[MXQRCodeTransaction]: otherUserScannedMyQrCode: QR code has not been scanned");
+        MXLogDebug(@"[MXQRCodeTransaction]: otherUserScannedMyQrCode: QR code has not been scanned");
         [self cancelWithCancelCode:MXTransactionCancelCode.unexpectedMessage];
         return;
     }
@@ -102,7 +102,7 @@ NSString * const MXKeyVerificationMethodReciprocate = @"m.reciprocate.v1";
     }
     else
     {
-        NSLog(@"[MXKeyVerification][MXQRCodeTransaction] userHasScannedOtherQrCodeRawData: Invalid QR code data: %@", otherQRCodeRawData);
+        MXLogDebug(@"[MXKeyVerification][MXQRCodeTransaction] userHasScannedOtherQrCodeRawData: Invalid QR code data: %@", otherQRCodeRawData);
         [self cancelWithCancelCode:MXTransactionCancelCode.qrCodeInvalid];
     }
 }
@@ -141,7 +141,7 @@ NSString * const MXKeyVerificationMethodReciprocate = @"m.reciprocate.v1";
     [self cancelWithCancelCode:code success:^{
         self.state = MXQRCodeTransactionStateCancelledByMe;
     } failure:^(NSError * _Nonnull error) {
-        NSLog(@"[MXKeyVerification][MXSASTransaction] Fail to cancel with error: %@", error);
+        MXLogDebug(@"[MXKeyVerification][MXSASTransaction] Fail to cancel with error: %@", error);
     }];
 }
 
@@ -151,21 +151,21 @@ NSString * const MXKeyVerificationMethodReciprocate = @"m.reciprocate.v1";
 {
     if (self.state != MXQRCodeTransactionStateUnknown)
     {
-        NSLog(@"[MXQRCodeTransaction]: ERROR: A start event was already retrieved");
+        MXLogDebug(@"[MXQRCodeTransaction]: ERROR: A start event was already retrieved");
         [self cancelWithCancelCode:MXTransactionCancelCode.unexpectedMessage];
         return;
     }
     
     if (!start || !start.isValid)
     {
-        NSLog(@"[MXQRCodeTransaction]: ERROR: Invalid start: %@", start);
+        MXLogDebug(@"[MXQRCodeTransaction]: ERROR: Invalid start: %@", start);
         [self cancelWithCancelCode:MXTransactionCancelCode.unexpectedMessage];
         return;
     }
     
     if (!self.qrCodeData)
     {
-        NSLog(@"[MXQRCodeTransaction]: ERROR: Invalid start, no QR code to scan: %@", start);
+        MXLogDebug(@"[MXQRCodeTransaction]: ERROR: Invalid start, no QR code to scan: %@", start);
         [self cancelWithCancelCode:MXTransactionCancelCode.unexpectedMessage];
         return;
     }
@@ -175,7 +175,7 @@ NSString * const MXKeyVerificationMethodReciprocate = @"m.reciprocate.v1";
     
     if (![startSharedSecretData isEqualToData:self.qrCodeData.sharedSecret])
     {
-        NSLog(@"[MXQRCodeTransaction]: ERROR: Invalid start, mismatch shared secret: %@", start);
+        MXLogDebug(@"[MXQRCodeTransaction]: ERROR: Invalid start, mismatch shared secret: %@", start);
         [self cancelWithCancelCode:MXTransactionCancelCode.mismatchedKeys];
         return;
     }
@@ -196,13 +196,13 @@ NSString * const MXKeyVerificationMethodReciprocate = @"m.reciprocate.v1";
             else
             {
                 [self cancelWithCancelCode:MXTransactionCancelCode.unexpectedMessage];
-                NSLog(@"[MXQRCodeTransaction]: ERROR: Done event was already retrieved");
+                MXLogDebug(@"[MXQRCodeTransaction]: ERROR: Done event was already retrieved");
             }
         }
             break;
         case MXQRCodeTransactionStateScannedOtherQR:
             [self cancelWithCancelCode:MXTransactionCancelCode.unexpectedMessage];
-            NSLog(@"[MXQRCodeTransaction]: ERROR: Unexpected state for done event");
+            MXLogDebug(@"[MXQRCodeTransaction]: ERROR: Unexpected state for done event");
         default:
             break;
     }
@@ -212,11 +212,11 @@ NSString * const MXKeyVerificationMethodReciprocate = @"m.reciprocate.v1";
 
 - (void)startWithOtherQRCodeSharedSecret:(NSData*)otherQRCodeSharedSecret success:(dispatch_block_t)success failure:(void (^)(NSError* error))failure;
 {
-    NSLog(@"[MXKeyVerification][MXQRCodeTransaction] start");
+    MXLogDebug(@"[MXKeyVerification][MXQRCodeTransaction] start");
     
     if (self.state != MXQRCodeTransactionStateUnknown)
     {
-        NSLog(@"[MXKeyVerification][MXQRCodeTransaction] start: wrong state: %@", self);
+        MXLogDebug(@"[MXKeyVerification][MXQRCodeTransaction] start: wrong state: %@", self);
         self.state = MXQRCodeTransactionStateCancelled;
         return;
     }
@@ -238,10 +238,10 @@ NSString * const MXKeyVerificationMethodReciprocate = @"m.reciprocate.v1";
         self.state = MXQRCodeTransactionStateScannedOtherQR;
         
         [self sendToOther:kMXEventTypeStringKeyVerificationStart content:startContent.JSONDictionary success:^{
-            NSLog(@"[MXKeyVerification][MXQRCodeTransaction] start: sendToOther:kMXEventTypeStringKeyVerificationStart succeeds");
+            MXLogDebug(@"[MXKeyVerification][MXQRCodeTransaction] start: sendToOther:kMXEventTypeStringKeyVerificationStart succeeds");
             success();
         } failure:^(NSError * _Nonnull error) {
-            NSLog(@"[MXKeyVerification][MXQRCodeTransaction] start: sendToOther:kMXEventTypeStringKeyVerificationStart failed. Error: %@", error);
+            MXLogDebug(@"[MXKeyVerification][MXQRCodeTransaction] start: sendToOther:kMXEventTypeStringKeyVerificationStart failed. Error: %@", error);
             self.error = error;
             self.state = MXQRCodeTransactionStateError;
             failure(error);
@@ -249,7 +249,7 @@ NSString * const MXKeyVerificationMethodReciprocate = @"m.reciprocate.v1";
     }
     else
     {
-        NSLog(@"[MXKeyVerification][MXQRCodeTransaction] start: Invalid startContent: %@", startContent);
+        MXLogDebug(@"[MXKeyVerification][MXQRCodeTransaction] start: Invalid startContent: %@", startContent);
         self.state = MXQRCodeTransactionStateCancelled;
     }
 }
@@ -258,7 +258,7 @@ NSString * const MXKeyVerificationMethodReciprocate = @"m.reciprocate.v1";
 {
     if (self.state != MXQRCodeTransactionStateWaitingOtherConfirm)
     {
-        NSLog(@"[MXKeyVerification][MXQRCodeTransaction] trustOtherWithOtherQRCodeData: wrong state: %@", self);
+        MXLogDebug(@"[MXKeyVerification][MXQRCodeTransaction] trustOtherWithOtherQRCodeData: wrong state: %@", self);
         [self cancelWithCancelCode:MXTransactionCancelCode.unexpectedMessage];
         return;
     }
@@ -284,7 +284,7 @@ NSString * const MXKeyVerificationMethodReciprocate = @"m.reciprocate.v1";
     }
     else
     {
-        NSLog(@"[MXKeyVerification][MXQRCodeTransaction] trustOtherWithOtherQRCodeData: QR code is invalid");
+        MXLogDebug(@"[MXKeyVerification][MXQRCodeTransaction] trustOtherWithOtherQRCodeData: QR code is invalid");
         [self cancelWithCancelCode:MXTransactionCancelCode.qrCodeInvalid];
     }
 }
@@ -293,14 +293,14 @@ NSString * const MXKeyVerificationMethodReciprocate = @"m.reciprocate.v1";
 {
     if (self.state != MXQRCodeTransactionStateQRScannedByOther)
     {
-        NSLog(@"[MXKeyVerification][MXQRCodeTransaction] trustOtherWithMyQRCodeData: wrong state: %@", self);
+        MXLogDebug(@"[MXKeyVerification][MXQRCodeTransaction] trustOtherWithMyQRCodeData: wrong state: %@", self);
         [self cancelWithCancelCode:MXTransactionCancelCode.unexpectedMessage];
         return;
     }
     
     if (!self.qrCodeData)
     {
-        NSLog(@"[MXKeyVerification][MXQRCodeTransaction] start: wrong state: %@", self);
+        MXLogDebug(@"[MXKeyVerification][MXQRCodeTransaction] start: wrong state: %@", self);
         [self cancelWithCancelCode:MXTransactionCancelCode.unexpectedMessage];
         return;
     }
@@ -328,14 +328,14 @@ NSString * const MXKeyVerificationMethodReciprocate = @"m.reciprocate.v1";
     }
     else
     {
-        NSLog(@"[MXKeyVerification][MXQRCodeTransaction] trustOtherWithMyQRCodeData: My QR code is invalid");
+        MXLogDebug(@"[MXKeyVerification][MXQRCodeTransaction] trustOtherWithMyQRCodeData: My QR code is invalid");
         [self cancelWithCancelCode:MXTransactionCancelCode.invalidMessage];
     }
 }
 
 - (void)trustOtherUserWithId:(NSString*)otherUserId andDeviceId:(NSString*)otherDeviceId
 {
-    NSLog(@"[MXKeyVerification][MXQRCodeTransaction] trustOtherUserWithId: Mark user %@:%@ as verified", otherUserId, otherDeviceId);
+    MXLogDebug(@"[MXKeyVerification][MXQRCodeTransaction] trustOtherUserWithId: Mark user %@:%@ as verified", otherUserId, otherDeviceId);
     
     // Mark the device as locally verified
     [self.manager.crypto setDeviceVerification:MXDeviceVerified forDevice:otherDeviceId ofUser:otherUserId success:^{
@@ -345,12 +345,12 @@ NSString * const MXKeyVerificationMethodReciprocate = @"m.reciprocate.v1";
             [self sendVerified];
             
         } failure:^(NSError *error) {
-            NSLog(@"[MXKeyVerification][MXQRCodeTransaction] trustOtherWithQRCodeData: Fail to cross sign user %@", otherUserId);
+            MXLogDebug(@"[MXKeyVerification][MXQRCodeTransaction] trustOtherWithQRCodeData: Fail to cross sign user %@", otherUserId);
             [self cancelWithCancelCode:MXTransactionCancelCode.mismatchedKeys];
         }];
         
     } failure:^(NSError *error) {
-        NSLog(@"[MXKeyVerification][MXQRCodeTransaction] trustOtherWithQRCodeData: Fail to mark device %@:%@ as locally verified", otherUserId, otherDeviceId);
+        MXLogDebug(@"[MXKeyVerification][MXQRCodeTransaction] trustOtherWithQRCodeData: Fail to mark device %@:%@ as locally verified", otherUserId, otherDeviceId);
         [self cancelWithCancelCode:MXTransactionCancelCode.mismatchedKeys];
     }];
 }

--- a/MatrixSDK/Crypto/Verification/Transactions/SAS/MXIncomingSASTransaction.m
+++ b/MatrixSDK/Crypto/Verification/Transactions/SAS/MXIncomingSASTransaction.m
@@ -29,11 +29,11 @@
 
 - (void)accept;
 {
-    NSLog(@"[MXKeyVerification][MXIncomingSASTransaction] accept");
+    MXLogDebug(@"[MXKeyVerification][MXIncomingSASTransaction] accept");
 
     if (self.state != MXSASTransactionStateIncomingShowAccept)
     {
-        NSLog(@"[MXKeyVerification][MXIncomingSASTransaction] accept: wrong state: %@", self);
+        MXLogDebug(@"[MXKeyVerification][MXIncomingSASTransaction] accept: wrong state: %@", self);
         [self cancelWithCancelCode:MXTransactionCancelCode.unexpectedMessage];
         return;
     }
@@ -66,14 +66,14 @@
             self.state = MXSASTransactionStateWaitForPartnerKey;
         } failure:^(NSError * _Nonnull error) {
 
-            NSLog(@"[MXKeyVerification][MXIncomingSASTransaction] accept: sendToOther:kMXEventTypeStringKeyVerificationAccept failed. Error: %@", error);
+            MXLogDebug(@"[MXKeyVerification][MXIncomingSASTransaction] accept: sendToOther:kMXEventTypeStringKeyVerificationAccept failed. Error: %@", error);
             self.error = error;
             self.state = MXSASTransactionStateError;
         }];
     }
     else
     {
-        NSLog(@"[MXKeyVerification][MXIncomingSASTransaction] accept: Failed to find agreement");
+        MXLogDebug(@"[MXKeyVerification][MXIncomingSASTransaction] accept: Failed to find agreement");
         [self cancelWithCancelCode:MXTransactionCancelCode.unknownMethod];
         return;
     }
@@ -88,7 +88,7 @@
     MXJSONModelSetMXJSONModel(startContent, MXSASKeyVerificationStart, event.content);
     if (!startContent || !startContent.isValid)
     {
-        NSLog(@"[MXKeyVerificationTransaction]: ERROR: Invalid start event: %@", event);
+        MXLogDebug(@"[MXKeyVerificationTransaction]: ERROR: Invalid start event: %@", event);
         return nil;
     }
     
@@ -113,7 +113,7 @@
         if (![self.startContent.method isEqualToString:MXKeyVerificationMethodSAS]
             || ![self.startContent.shortAuthenticationString containsObject:MXKeyVerificationSASModeDecimal])
         {
-            NSLog(@"[MXKeyVerification][MXIncomingSASTransaction]: ERROR: Invalid start event: %@", event);
+            MXLogDebug(@"[MXKeyVerification][MXIncomingSASTransaction]: ERROR: Invalid start event: %@", event);
             return nil;
         }
 
@@ -129,25 +129,25 @@
 
 - (void)handleAccept:(MXKeyVerificationAccept*)acceptContent
 {
-    NSLog(@"[MXKeyVerification][MXIncomingSASTransaction] handleAccept");
+    MXLogDebug(@"[MXKeyVerification][MXIncomingSASTransaction] handleAccept");
 
     [self cancelWithCancelCode:MXTransactionCancelCode.unexpectedMessage];
 }
 
 - (void)handleKey:(MXKeyVerificationKey *)keyContent
 {
-    NSLog(@"[MXKeyVerification][MXIncomingSASTransaction] handleKey");
+    MXLogDebug(@"[MXKeyVerification][MXIncomingSASTransaction] handleKey");
 
     if (self.state != MXSASTransactionStateWaitForPartnerKey)
     {
-        NSLog(@"[MXKeyVerification][MXIncomingSASTransaction] handleKey: wrong state: %@. keyContent: %@", self, keyContent);
+        MXLogDebug(@"[MXKeyVerification][MXIncomingSASTransaction] handleKey: wrong state: %@. keyContent: %@", self, keyContent);
         [self cancelWithCancelCode:MXTransactionCancelCode.unexpectedMessage];
         return;
     }
     
     if (!keyContent.isValid)
     {
-        NSLog(@"[MXKeyVerification][MXIncomingSASTransaction] handleKey: key content is invalid. keyContent: %@", keyContent);
+        MXLogDebug(@"[MXKeyVerification][MXIncomingSASTransaction] handleKey: key content is invalid. keyContent: %@", keyContent);
         [self cancelWithCancelCode:MXTransactionCancelCode.unexpectedMessage];
         return;
     }
@@ -169,14 +169,14 @@
                                                 requestingDevice:self.otherDevice sasPublicKey:keyContent.key
                                                      otherDevice:self.manager.crypto.myDevice otherSasPublicKey:self.olmSAS.publicKey];
 
-//        NSLog(@"[MXKeyVerification][MXIncomingSASTransaction] handleKey: BOB CODE: %@", self.sasDecimal);
-//        NSLog(@"[MXKeyVerification][MXIncomingSASTransaction] handleKey: BOB EMOJI CODE: %@", self.sasEmoji);
+//        MXLogDebug(@"[MXKeyVerification][MXIncomingSASTransaction] handleKey: BOB CODE: %@", self.sasDecimal);
+//        MXLogDebug(@"[MXKeyVerification][MXIncomingSASTransaction] handleKey: BOB EMOJI CODE: %@", self.sasEmoji);
 
         self.state = MXSASTransactionStateShowSAS;
 
     } failure:^(NSError * _Nonnull error) {
 
-        NSLog(@"[MXKeyVerification][MXIncomingSASTransaction] handleKey: sendToOther:kMXEventTypeStringKeyVerificationKey failed. Error: %@", error);
+        MXLogDebug(@"[MXKeyVerification][MXIncomingSASTransaction] handleKey: sendToOther:kMXEventTypeStringKeyVerificationKey failed. Error: %@", error);
         self.error = error;
         self.state = MXSASTransactionStateError;
     }];

--- a/MatrixSDK/Crypto/Verification/Transactions/SAS/MXOutgoingSASTransaction.m
+++ b/MatrixSDK/Crypto/Verification/Transactions/SAS/MXOutgoingSASTransaction.m
@@ -31,11 +31,11 @@
 
 - (void)start;
 {
-    NSLog(@"[MXKeyVerification][MXOutgoingSASTransaction] start");
+    MXLogDebug(@"[MXKeyVerification][MXOutgoingSASTransaction] start");
 
     if (self.state != MXSASTransactionStateUnknown)
     {
-        NSLog(@"[MXKeyVerification][MXOutgoingSASTransaction] start: wrong state: %@", self);
+        MXLogDebug(@"[MXKeyVerification][MXOutgoingSASTransaction] start: wrong state: %@", self);
         self.state = MXSASTransactionStateCancelled;
         return;
     }
@@ -60,16 +60,16 @@
         self.state = MXSASTransactionStateOutgoingWaitForPartnerToAccept;
 
         [self sendToOther:kMXEventTypeStringKeyVerificationStart content:startContent.JSONDictionary success:^{
-            NSLog(@"[MXKeyVerification][MXOutgoingSASTransaction] start: sendToOther:kMXEventTypeStringKeyVerificationStart succeeds");
+            MXLogDebug(@"[MXKeyVerification][MXOutgoingSASTransaction] start: sendToOther:kMXEventTypeStringKeyVerificationStart succeeds");
         } failure:^(NSError * _Nonnull error) {
-            NSLog(@"[MXKeyVerification][MXOutgoingSASTransaction] start: sendToOther:kMXEventTypeStringKeyVerificationStart failed. Error: %@", error);
+            MXLogDebug(@"[MXKeyVerification][MXOutgoingSASTransaction] start: sendToOther:kMXEventTypeStringKeyVerificationStart failed. Error: %@", error);
             self.error = error;
             self.state = MXSASTransactionStateError;
         }];
     }
     else
     {
-        NSLog(@"[MXKeyVerification][MXOutgoingSASTransaction] start: Invalid startContent: %@", startContent);
+        MXLogDebug(@"[MXKeyVerification][MXOutgoingSASTransaction] start: Invalid startContent: %@", startContent);
         self.state = MXSASTransactionStateCancelled;
     }
 }
@@ -95,11 +95,11 @@
 - (void)handleAccept:(MXKeyVerificationAccept*)acceptContent
 {
     // Alice's POV
-    NSLog(@"[MXKeyVerification][MXOutgoingSASTransaction] handleAccept");
+    MXLogDebug(@"[MXKeyVerification][MXOutgoingSASTransaction] handleAccept");
 
     if (self.state != MXSASTransactionStateOutgoingWaitForPartnerToAccept)
     {
-        NSLog(@"[MXKeyVerification][MXOutgoingSASTransaction] handleAccept: wrong state: %@. acceptContent: %@", self, acceptContent);
+        MXLogDebug(@"[MXKeyVerification][MXOutgoingSASTransaction] handleAccept: wrong state: %@. acceptContent: %@", self, acceptContent);
         [self cancelWithCancelCode:MXTransactionCancelCode.unexpectedMessage];
         return;
     }
@@ -110,7 +110,7 @@
         || ![kKnownMacs containsObject:acceptContent.messageAuthenticationCode]
         || ![acceptContent.shortAuthenticationString mx_intersectArray:kKnownShortCodes].count)
     {
-        NSLog(@"[MXKeyVerification][MXOutgoingSASTransaction] handleAccept: wrong method: %@. acceptContent: %@", self, acceptContent);
+        MXLogDebug(@"[MXKeyVerification][MXOutgoingSASTransaction] handleAccept: wrong method: %@. acceptContent: %@", self, acceptContent);
         [self cancelWithCancelCode:MXTransactionCancelCode.unknownMethod];
         return;
     }
@@ -132,7 +132,7 @@
         self.state = MXSASTransactionStateWaitForPartnerKey;
 
     } failure:^(NSError * _Nonnull error) {
-        NSLog(@"[MXKeyVerification][MXOutgoingSASTransaction] handleAccept: sendToOther:kMXEventTypeStringKeyVerificationKey failed. Error: %@", error);
+        MXLogDebug(@"[MXKeyVerification][MXOutgoingSASTransaction] handleAccept: sendToOther:kMXEventTypeStringKeyVerificationKey failed. Error: %@", error);
         self.error = error;
         self.state = MXSASTransactionStateError;
     }];
@@ -140,18 +140,18 @@
 
 - (void)handleKey:(MXKeyVerificationKey *)keyContent
 {
-    NSLog(@"[MXKeyVerification][MXOutgoingSASTransaction] handleKey");
+    MXLogDebug(@"[MXKeyVerification][MXOutgoingSASTransaction] handleKey");
 
     if (self.state != MXSASTransactionStateWaitForPartnerKey)
     {
-        NSLog(@"[MXKeyVerification][MXOutgoingSASTransaction] handleKey: wrong state: %@. keyContent: %@", self, keyContent);
+        MXLogDebug(@"[MXKeyVerification][MXOutgoingSASTransaction] handleKey: wrong state: %@. keyContent: %@", self, keyContent);
         [self cancelWithCancelCode:MXTransactionCancelCode.unexpectedMessage];
         return;
     }
     
     if (!keyContent.isValid)
     {
-        NSLog(@"[MXKeyVerification][MXOutgoingSASTransaction] handleKey: key content is invalid. keyContent: %@", keyContent);
+        MXLogDebug(@"[MXKeyVerification][MXOutgoingSASTransaction] handleKey: key content is invalid. keyContent: %@", keyContent);
         [self cancelWithCancelCode:MXTransactionCancelCode.unexpectedMessage];
         return;
     }
@@ -173,14 +173,14 @@
                                                 requestingDevice:self.manager.crypto.myDevice sasPublicKey:self.olmSAS.publicKey
                                                      otherDevice:self.otherDevice otherSasPublicKey:keyContent.key];
 
-//        NSLog(@"[MXKeyVerification][MXOutgoingSASTransaction] handleKey: ALICE CODE: %@", self.sasDecimal);
-//        NSLog(@"[MXKeyVerification][MXOutgoingSASTransaction] handleKey: ALICE EMOJI CODE: %@", self.sasEmoji);
+//        MXLogDebug(@"[MXKeyVerification][MXOutgoingSASTransaction] handleKey: ALICE CODE: %@", self.sasDecimal);
+//        MXLogDebug(@"[MXKeyVerification][MXOutgoingSASTransaction] handleKey: ALICE EMOJI CODE: %@", self.sasEmoji);
 
         self.state = MXSASTransactionStateShowSAS;
     }
     else
     {
-        NSLog(@"[MXKeyVerification][MXOutgoingSASTransaction] handleKey: Bad commitment:\n%@\n%@", self.accepted.commitment, otherCommitment);
+        MXLogDebug(@"[MXKeyVerification][MXOutgoingSASTransaction] handleKey: Bad commitment:\n%@\n%@", self.accepted.commitment, otherCommitment);
 
         [self cancelWithCancelCode:MXTransactionCancelCode.mismatchedCommitment];
     }

--- a/MatrixSDK/Crypto/Verification/Transactions/SAS/MXSASTransaction.m
+++ b/MatrixSDK/Crypto/Verification/Transactions/SAS/MXSASTransaction.m
@@ -75,7 +75,7 @@ static NSArray<MXEmojiRepresentation*> *kSasEmojis;
     if (self.state != MXSASTransactionStateShowSAS)
     {
         // Ignore and cancel
-        NSLog(@"[MXKeyVerification][MXSASTransaction] accept: Accepted short code from invalid state (%@)", @(self.state));
+        MXLogDebug(@"[MXKeyVerification][MXSASTransaction] accept: Accepted short code from invalid state (%@)", @(self.state));
         [self cancelWithCancelCode:MXTransactionCancelCode.unexpectedMessage];
 
         return;
@@ -92,7 +92,7 @@ static NSArray<MXEmojiRepresentation*> *kSasEmojis;
         [self sendToOther:kMXEventTypeStringKeyVerificationMac content:macContent.JSONDictionary success:^{
 
         } failure:^(NSError * _Nonnull error) {
-            NSLog(@"[MXKeyVerification][MXSASTransaction] accept: sendToOther:kMXEventTypeStringKeyVerificationAccept failed. Error: %@", error);
+            MXLogDebug(@"[MXKeyVerification][MXSASTransaction] accept: sendToOther:kMXEventTypeStringKeyVerificationAccept failed. Error: %@", error);
             self.error = error;
             self.state = MXSASTransactionStateError;
         }];
@@ -105,7 +105,7 @@ static NSArray<MXEmojiRepresentation*> *kSasEmojis;
     }
     else
     {
-        NSLog(@"[MXKeyVerification][MXSASTransaction] confirmSASMatch: Failed to send KeyMac, empty key hashes");
+        MXLogDebug(@"[MXKeyVerification][MXSASTransaction] confirmSASMatch: Failed to send KeyMac, empty key hashes");
         [self cancelWithCancelCode:MXTransactionCancelCode.unexpectedMessage];
     }
 }
@@ -157,7 +157,7 @@ static NSArray<MXEmojiRepresentation*> *kSasEmojis;
     }
     else
     {
-        NSLog(@"[MXKeyVerification][MXSASTransaction] hashUsingAgreedHashMethod: Unsupported hash: %@", _accepted.hashAlgorithm);
+        MXLogDebug(@"[MXKeyVerification][MXSASTransaction] hashUsingAgreedHashMethod: Unsupported hash: %@", _accepted.hashAlgorithm);
     }
 
     return hashUsingAgreedHashMethod;
@@ -217,12 +217,12 @@ static NSArray<MXEmojiRepresentation*> *kSasEmojis;
     }
     else
     {
-        NSLog(@"[MXKeyVerification][MXSASTransaction] macUsingAgreedMethod: Unsupported MAC format: %@", _accepted.messageAuthenticationCode);
+        MXLogDebug(@"[MXKeyVerification][MXSASTransaction] macUsingAgreedMethod: Unsupported MAC format: %@", _accepted.messageAuthenticationCode);
     }
 
     if (error)
     {
-        NSLog(@"[MXKeyVerification][MXSASTransaction] macUsingAgreedMethod: Error with MAC format: %@. Error: %@", _accepted.messageAuthenticationCode, error);
+        MXLogDebug(@"[MXKeyVerification][MXSASTransaction] macUsingAgreedMethod: Error with MAC format: %@. Error: %@", _accepted.messageAuthenticationCode, error);
     }
 
     return macUsingAgreedMethod;
@@ -233,7 +233,7 @@ static NSArray<MXEmojiRepresentation*> *kSasEmojis;
     [self cancelWithCancelCode:code success:^{
         self.state = MXSASTransactionStateCancelledByMe;
     } failure:^(NSError * _Nonnull error) {
-        NSLog(@"[MXKeyVerification][MXSASTransaction] Fail to cancel with error: %@", error);
+        MXLogDebug(@"[MXKeyVerification][MXSASTransaction] Fail to cancel with error: %@", error);
     }];
 }
 
@@ -244,7 +244,7 @@ static NSArray<MXEmojiRepresentation*> *kSasEmojis;
     if (self.state != MXSASTransactionStateWaitForPartnerToConfirm
         && self.state != MXSASTransactionStateShowSAS)
     {
-        NSLog(@"[MXKeyVerification] handleMac: wrong state: %@", self);
+        MXLogDebug(@"[MXKeyVerification] handleMac: wrong state: %@", self);
         [self cancelWithCancelCode:MXTransactionCancelCode.unexpectedMessage];
         return;
     }
@@ -266,7 +266,7 @@ static NSArray<MXEmojiRepresentation*> *kSasEmojis;
 
 - (void)setState:(MXSASTransactionState)state
 {
-    NSLog(@"[MXKeyVerification][MXSASTransaction] setState: %@ -> %@", @(_state), @(state));
+    MXLogDebug(@"[MXKeyVerification][MXSASTransaction] setState: %@ -> %@", @(_state), @(state));
 
     _state = state;
     [self didUpdateState];
@@ -331,9 +331,9 @@ static NSArray<MXEmojiRepresentation*> *kSasEmojis;
         macContent.keys = keyStrings;
         
         // TODO: To remove
-        NSLog(@"keyListIds: %@", keyListIds);
-        NSLog(@"otherUserMasterKeys: %@", myUserCrossSigningKeys.masterKeys.keys);
-        NSLog(@"info: %@", [NSString stringWithFormat:@"%@%@", baseInfo, deviceKey.keyFullId]);
+        MXLogDebug(@"keyListIds: %@", keyListIds);
+        MXLogDebug(@"otherUserMasterKeys: %@", myUserCrossSigningKeys.masterKeys.keys);
+        MXLogDebug(@"info: %@", [NSString stringWithFormat:@"%@%@", baseInfo, deviceKey.keyFullId]);
     }
 
     return macContent;
@@ -373,7 +373,7 @@ static NSArray<MXEmojiRepresentation*> *kSasEmojis;
                                                                      info:[NSString stringWithFormat:@"%@%@", baseInfo, keyFullId]]])
                 {
                     // Mark device as verified
-                    NSLog(@"[MXKeyVerification][MXSASTransaction] verifyMacs: Mark device %@ as verified", device);
+                    MXLogDebug(@"[MXKeyVerification][MXSASTransaction] verifyMacs: Mark device %@ as verified", device);
                     dispatch_group_enter(group);
                     [self.manager.crypto setDeviceVerification:MXDeviceVerified forDevice:self.otherDeviceId ofUser:self.otherUserId success:^{
                         dispatch_group_leave(group);
@@ -387,7 +387,7 @@ static NSArray<MXEmojiRepresentation*> *kSasEmojis;
                 }
                 else
                 {
-                    NSLog(@"[MXKeyVerification][MXSASTransaction] verifyMacs: ERROR: mac for device keys do not match: %@\vs %@", self.theirMac.JSONDictionary, self.myMac.JSONDictionary);
+                    MXLogDebug(@"[MXKeyVerification][MXSASTransaction] verifyMacs: ERROR: mac for device keys do not match: %@\vs %@", self.theirMac.JSONDictionary, self.myMac.JSONDictionary);
                     cancelCode = MXTransactionCancelCode.mismatchedKeys;
                     break;
                 }
@@ -403,7 +403,7 @@ static NSArray<MXEmojiRepresentation*> *kSasEmojis;
                                                                          info:[NSString stringWithFormat:@"%@%@", baseInfo, keyFullId]]])
                     {
                         // Mark user as verified
-                        NSLog(@"[MXKeyVerification][MXSASTransaction] verifyMacs: Mark user %@ as verified", self.otherDevice.userId);
+                        MXLogDebug(@"[MXKeyVerification][MXSASTransaction] verifyMacs: Mark user %@ as verified", self.otherDevice.userId);
                         dispatch_group_enter(group);
                         [self.manager.crypto setUserVerification:YES forUser:self.otherDevice.userId success:^{
                             dispatch_group_leave(group);
@@ -417,10 +417,10 @@ static NSArray<MXEmojiRepresentation*> *kSasEmojis;
                     }
                     else
                     {
-                        NSLog(@"[MXKeyVerification][MXSASTransaction] verifyMacs: ERROR: mac for master keys do not match: %@\vs %@", self.theirMac.JSONDictionary, self.myMac.JSONDictionary);
-                        NSLog(@"keyListIds: %@", keyListIds);
-                        NSLog(@"otherUserMasterKeys: %@", otherUserMasterKeys.keys);
-                        NSLog(@"info: %@", [NSString stringWithFormat:@"%@%@", baseInfo, keyFullId]);
+                        MXLogDebug(@"[MXKeyVerification][MXSASTransaction] verifyMacs: ERROR: mac for master keys do not match: %@\vs %@", self.theirMac.JSONDictionary, self.myMac.JSONDictionary);
+                        MXLogDebug(@"keyListIds: %@", keyListIds);
+                        MXLogDebug(@"otherUserMasterKeys: %@", otherUserMasterKeys.keys);
+                        MXLogDebug(@"info: %@", [NSString stringWithFormat:@"%@%@", baseInfo, keyFullId]);
                         
                         cancelCode = MXTransactionCancelCode.mismatchedKeys;
                         break;
@@ -429,7 +429,7 @@ static NSArray<MXEmojiRepresentation*> *kSasEmojis;
                 else
                 {
                     // Unknown key
-                    NSLog(@"[MXKeyVerification][MXSASTransaction] verifyMacs: Could not find keys %@ to verify", keyFullId);
+                    MXLogDebug(@"[MXKeyVerification][MXSASTransaction] verifyMacs: Could not find keys %@ to verify", keyFullId);
                 }
             }
         }

--- a/MatrixSDK/Data/AutoDiscovery/MXAutoDiscovery.m
+++ b/MatrixSDK/Data/AutoDiscovery/MXAutoDiscovery.m
@@ -57,14 +57,14 @@
 - (MXHTTPOperation *)findClientConfig:(void (^)(MXDiscoveredClientConfig * _Nonnull))complete
                               failure:(void (^)(NSError * _Nonnull))failure
 {
-    NSLog(@"[MXAutoDiscovery] findClientConfig: %@", restClient.homeserver);
+    MXLogDebug(@"[MXAutoDiscovery] findClientConfig: %@", restClient.homeserver);
 
     MXHTTPOperation *operation;
     operation = [self wellKnow:^(MXWellKnown *wellKnown) {
 
         if (!wellKnown.homeServer.baseUrl)
         {
-            NSLog(@"[MXAutoDiscovery] findClientConfig: FAIL_PROMPT");
+            MXLogDebug(@"[MXAutoDiscovery] findClientConfig: FAIL_PROMPT");
             complete([[MXDiscoveredClientConfig alloc] initWithAction:MXDiscoveredClientConfigActionFailPrompt]);
         }
         else
@@ -77,7 +77,7 @@
             }
             else
             {
-                NSLog(@"[MXAutoDiscovery] findClientConfig: FAIL_ERROR (invalid homeserver base_url)");
+                MXLogDebug(@"[MXAutoDiscovery] findClientConfig: FAIL_ERROR (invalid homeserver base_url)");
                 complete([[MXDiscoveredClientConfig alloc] initWithAction:MXDiscoveredClientConfigActionFailError]);
             }
         }
@@ -89,18 +89,18 @@
         {
             if (urlResponse.statusCode == 404)
             {
-                NSLog(@"[MXAutoDiscovery] findClientConfig: IGNORE (HTTP code: 404)");
+                MXLogDebug(@"[MXAutoDiscovery] findClientConfig: IGNORE (HTTP code: 404)");
                 complete([[MXDiscoveredClientConfig alloc] initWithAction:MXDiscoveredClientConfigActionIgnore]);
             }
             else
             {
-                NSLog(@"[MXAutoDiscovery] findClientConfig: FAIL_PROMPT (HTTP code: %@)", @(urlResponse.statusCode));
+                MXLogDebug(@"[MXAutoDiscovery] findClientConfig: FAIL_PROMPT (HTTP code: %@)", @(urlResponse.statusCode));
                 complete([[MXDiscoveredClientConfig alloc] initWithAction:MXDiscoveredClientConfigActionFailPrompt]);
             }
         }
         else
         {
-            NSLog(@"[MXAutoDiscovery] findClientConfig: IGNORE. Error: %@", error);
+            MXLogDebug(@"[MXAutoDiscovery] findClientConfig: IGNORE. Error: %@", error);
             complete([[MXDiscoveredClientConfig alloc] initWithAction:MXDiscoveredClientConfigActionIgnore]);
         }
     }];
@@ -111,7 +111,7 @@
 - (MXHTTPOperation*)wellKnow:(void (^)(MXWellKnown *wellKnown))success
                      failure:(void (^)(NSError *error))failure
 {
-    NSLog(@"[MXAutoDiscovery] wellKnow: %@", restClient.homeserver);
+    MXLogDebug(@"[MXAutoDiscovery] wellKnow: %@", restClient.homeserver);
     return [restClient wellKnow:success failure:failure];
 }
 
@@ -140,7 +140,7 @@
 
         if (!wellKnown.identityServer)
         {
-            NSLog(@"[MXAutoDiscovery] validateHomeserverAndProceed: PROMPT. wellKnown: %@", wellKnown);
+            MXLogDebug(@"[MXAutoDiscovery] validateHomeserverAndProceed: PROMPT. wellKnown: %@", wellKnown);
             complete([[MXDiscoveredClientConfig alloc] initWithAction:MXDiscoveredClientConfigActionPrompt andWellKnown:wellKnown]);
         }
         else
@@ -148,7 +148,7 @@
             // If m.identity_server is present, it must be valid
             if (!wellKnown.identityServer.baseUrl)
             {
-                NSLog(@"[MXAutoDiscovery] validateHomeserverAndProceed: FAIL_ERROR (No identity server base_url)");
+                MXLogDebug(@"[MXAutoDiscovery] validateHomeserverAndProceed: FAIL_ERROR (No identity server base_url)");
                 complete([[MXDiscoveredClientConfig alloc] initWithAction:MXDiscoveredClientConfigActionFailError]);
             }
             else if ([self isValidURL:wellKnown.identityServer.baseUrl])
@@ -158,7 +158,7 @@
             }
             else
             {
-                NSLog(@"[MXAutoDiscovery] validateHomeserverAndProceed: FAIL_ERROR (invalid identity server base_url)");
+                MXLogDebug(@"[MXAutoDiscovery] validateHomeserverAndProceed: FAIL_ERROR (invalid identity server base_url)");
                 complete([[MXDiscoveredClientConfig alloc] initWithAction:MXDiscoveredClientConfigActionFailError]);
             }
         }
@@ -176,12 +176,12 @@
     MXHTTPOperation *operation;
     operation = [self.identityService pingIdentityServer:^{
         
-        NSLog(@"[MXAutoDiscovery] validateIdentityServerAndFinish: PROMPT. wellKnown: %@", wellKnown);
+        MXLogDebug(@"[MXAutoDiscovery] validateIdentityServerAndFinish: PROMPT. wellKnown: %@", wellKnown);
         complete([[MXDiscoveredClientConfig alloc] initWithAction:MXDiscoveredClientConfigActionPrompt andWellKnown:wellKnown]);
         
     } failure:^(NSError *error) {
         
-        NSLog(@"[MXAutoDiscovery] validateIdentityServerAndFinish: FAIL_ERROR (invalid identity server not responding)");
+        MXLogDebug(@"[MXAutoDiscovery] validateIdentityServerAndFinish: FAIL_ERROR (invalid identity server not responding)");
         complete([[MXDiscoveredClientConfig alloc] initWithAction:MXDiscoveredClientConfigActionFailError]);
     }];
     

--- a/MatrixSDK/Data/MXEventTimeline.m
+++ b/MatrixSDK/Data/MXEventTimeline.m
@@ -262,7 +262,7 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
         
         [self decryptEvents:eventsFromStore onComplete:^{
             
-            NSLog(@"[MXEventTimeline] paginateFromStore %tu messages in %@ (%tu are retrieved from the store)", numItems, self.state.roomId, eventsFromStore.count);
+            MXLogDebug(@"[MXEventTimeline] paginateFromStore %tu messages in %@ (%tu are retrieved from the store)", numItems, self.state.roomId, eventsFromStore.count);
 
             onComplete(eventsFromStore);
         }];
@@ -302,7 +302,7 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
             if (onlyFromStore && eventsFromStoreCount)
             {
                 dispatch_async(dispatch_get_main_queue(), ^{
-                    NSLog(@"[MXEventTimeline] paginate : is done from the store");
+                    MXLogDebug(@"[MXEventTimeline] paginate : is done from the store");
                     complete();
                 });
 
@@ -313,7 +313,7 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
             {
                 dispatch_async(dispatch_get_main_queue(), ^{
                     // Nothing more to do
-                    NSLog(@"[MXEventTimeline] paginate: is done");
+                    MXLogDebug(@"[MXEventTimeline] paginate: is done");
                     complete();
                 });
                 
@@ -326,7 +326,7 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
         {
             dispatch_async(dispatch_get_main_queue(), ^{
                 // Nothing more to do
-                NSLog(@"[MXEventTimeline] paginate: is done");
+                MXLogDebug(@"[MXEventTimeline] paginate: is done");
                 complete();
             });
 
@@ -350,20 +350,20 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
             paginationToken = self->forwardsPaginationToken;
         }
 
-        NSLog(@"[MXEventTimeline] paginate : request %tu messages from the server", remainingNumItems);
+        MXLogDebug(@"[MXEventTimeline] paginate : request %tu messages from the server", remainingNumItems);
 
         MXWeakify(self);
         MXHTTPOperation *operation2 = [self->room.mxSession.matrixRestClient messagesForRoom:self.state.roomId from:paginationToken direction:direction limit:remainingNumItems filter:self.roomEventFilter success:^(MXPaginationResponse *paginatedResponse) {
             MXStrongifyAndReturnIfNil(self);
 
-            NSLog(@"[MXEventTimeline] paginate : got %tu messages from the server", paginatedResponse.chunk.count);
+            MXLogDebug(@"[MXEventTimeline] paginate : got %tu messages from the server", paginatedResponse.chunk.count);
 
             // Check if the room has not been left while waiting for the response
             if ([self->room.mxSession hasRoomWithRoomId:self->room.roomId]
                 || [self->room.mxSession isPeekingInRoomWithRoomId:self->room.roomId])
             {
                 [self handlePaginationResponse:paginatedResponse direction:direction onComplete:^{
-                    NSLog(@"[MXEventTimeline] paginate: is done");
+                    MXLogDebug(@"[MXEventTimeline] paginate: is done");
                     
                     // Inform the method caller
                     complete();
@@ -371,7 +371,7 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
             }
             else
             {
-                NSLog(@"[MXEventTimeline] paginate: is done");
+                MXLogDebug(@"[MXEventTimeline] paginate: is done");
                 // Inform the method caller
                 complete();
             }
@@ -393,14 +393,14 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
                     self->hasReachedHomeServerForwardsPaginationEnd = YES;
                 }
 
-                NSLog(@"[MXEventTimeline] paginate: pagination end has been reached");
+                MXLogDebug(@"[MXEventTimeline] paginate: pagination end has been reached");
 
                 // Ignore the error
                 complete();
                 return;
             }
 
-            NSLog(@"[MXEventTimeline] paginate failed");
+            MXLogDebug(@"[MXEventTimeline] paginate failed");
             if (failure)
             {
                 failure(error);
@@ -436,7 +436,7 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
     if (room.summary.membership == MXMembershipInvite)
     {
         // Reset the storage of this room. An initial sync of the room will be done with the provided 'roomSync'.
-        NSLog(@"[MXEventTimeline] handleJoinedRoomSync: clean invited room from the store (%@).", self.state.roomId);
+        MXLogDebug(@"[MXEventTimeline] handleJoinedRoomSync: clean invited room from the store (%@).", self.state.roomId);
         [store deleteRoom:self.state.roomId];
     }
 
@@ -709,7 +709,7 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
 #pragma mark - Specific events Handling
 - (void)handleRedaction:(MXEvent*)redactionEvent
 {
-    NSLog(@"[MXEventTimeline] handleRedaction: handle an event redaction");
+    MXLogDebug(@"[MXEventTimeline] handleRedaction: handle an event redaction");
     
     // Check whether the redacted event is stored in room messages
     MXEvent *redactedEvent = [store eventWithEventId:redactionEvent.redacts inRoom:_state.roomId];
@@ -734,7 +734,7 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
             
             if ([stateEvent.eventId isEqualToString:redactionEvent.redacts])
             {
-                NSLog(@"[MXEventTimeline] handleRedaction: the current room state has been modified by the event redaction.");
+                MXLogDebug(@"[MXEventTimeline] handleRedaction: the current room state has been modified by the event redaction.");
                 
                 // Redact the stored event
                 redactedEvent = [stateEvent prune];
@@ -767,11 +767,11 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
     if (redactedEvent.isState)
     {
         // TODO
-        NSLog(@"[MXEventTimeline] handleRedaction: the redacted event is a former state event. TODO: prune prev_content of the current state event");
+        MXLogDebug(@"[MXEventTimeline] handleRedaction: the redacted event is a former state event. TODO: prune prev_content of the current state event");
     }
     else if (!redactedEvent)
     {
-        NSLog(@"[MXEventTimeline] handleRedaction: the redacted event is unknown. Fetch it from the homeserver");
+        MXLogDebug(@"[MXEventTimeline] handleRedaction: the redacted event is unknown. Fetch it from the homeserver");
 
         // Retrieve the event from the HS to check whether the redacted event is a state event or not
         MXWeakify(self);
@@ -781,11 +781,11 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
             if (event.isState)
             {
                 // TODO
-                NSLog(@"[MXEventTimeline] handleRedaction: the redacted event is a state event in the past. TODO: prune prev_content of the current state event");
+                MXLogDebug(@"[MXEventTimeline] handleRedaction: the redacted event is a state event in the past. TODO: prune prev_content of the current state event");
             }
             else
             {
-                NSLog(@"[MXEventTimeline] handleRedaction: the redacted event is a not state event -> job is done");
+                MXLogDebug(@"[MXEventTimeline] handleRedaction: the redacted event is a not state event -> job is done");
             }
 
             if (!self->httpOperation)
@@ -805,7 +805,7 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
 
             self->httpOperation = nil;
 
-            NSLog(@"[MXEventTimeline] handleRedaction: failed to retrieved the redacted event");
+            MXLogDebug(@"[MXEventTimeline] handleRedaction: failed to retrieved the redacted event");
         }];
     }
 }
@@ -850,7 +850,7 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
         {
             // If there is no lazy loading of room members, consider we have fetched
             // all of them
-            NSLog(@"[MXEventTimeline] handleStateEvents: syncWithLazyLoadOfRoomMembers disabled. Mark all room members loaded for room %@",  room.roomId);
+            MXLogDebug(@"[MXEventTimeline] handleStateEvents: syncWithLazyLoadOfRoomMembers disabled. Mark all room members loaded for room %@",  room.roomId);
             
             // XXX: Optimisation removed because of https://github.com/vector-im/element-ios/issues/3807
             // There can be a race on mxSession.syncWithLazyLoadOfRoomMembers. Its value may be not set yet.

--- a/MatrixSDK/Data/MXRoomSummary.m
+++ b/MatrixSDK/Data/MXRoomSummary.m
@@ -230,7 +230,7 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
     
     if (!lastMessageEvent)
     {
-        NSLog(@"[MXRoomSummary] loadLastEvent: Cannot find event %@ in store", _lastMessageEventId);
+        MXLogDebug(@"[MXRoomSummary] loadLastEvent: Cannot find event %@ in store", _lastMessageEventId);
         onComplete();
         return;
     }
@@ -238,7 +238,7 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
     [_mxSession decryptEvents:@[lastMessageEvent] inTimeline:nil onComplete:^(NSArray<MXEvent *> *failedEvents) {
         if (failedEvents.count)
         {
-            NSLog(@"[MXRoomSummary] loadLastEvent: Warning: Unable to decrypt event. Error: %@", self.lastMessageEvent.decryptionError);
+            MXLogDebug(@"[MXRoomSummary] loadLastEvent: Warning: Unable to decrypt event. Error: %@", self.lastMessageEvent.decryptionError);
         }
         onComplete();
     }];
@@ -372,7 +372,7 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
         // If requested, get messages from the homeserver
         // Fetch them by batch of 50 messages
         NSUInteger paginationCount = MIN(maxServerPaginationCount, MXRoomSummaryPaginationChunkSize);
-        NSLog(@"[MXRoomSummary] fetchLastMessage: paginate %@ (%@) messages from the server in %@", @(paginationCount), @(maxServerPaginationCount), _roomId);
+        MXLogDebug(@"[MXRoomSummary] fetchLastMessage: paginate %@ (%@) messages from the server in %@", @(paginationCount), @(maxServerPaginationCount), _roomId);
         
         MXHTTPOperation *newOperation = [timeline paginate:paginationCount direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^{
             if (lastMessageUpdated)
@@ -383,13 +383,13 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
             }
             else if (maxServerPaginationCount > MXRoomSummaryPaginationChunkSize)
             {
-                NSLog(@"[MXRoomSummary] fetchLastMessage: Failed to find last message in %@. Paginate more...", self.roomId);
+                MXLogDebug(@"[MXRoomSummary] fetchLastMessage: Failed to find last message in %@. Paginate more...", self.roomId);
                 NSUInteger newMaxServerPaginationCount = maxServerPaginationCount - MXRoomSummaryPaginationChunkSize;
                 [self fetchLastMessageWithMaxServerPaginationCount:newMaxServerPaginationCount onComplete:onComplete failure:failure timeline:timeline operation:operation commit:commit];
             }
             else
             {
-                NSLog(@"[MXRoomSummary] fetchLastMessage: Failed to find last message in %@. Stop paginating.", self.roomId);
+                MXLogDebug(@"[MXRoomSummary] fetchLastMessage: Failed to find last message in %@. Stop paginating.", self.roomId);
                 onComplete();
             }
             
@@ -399,7 +399,7 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
     }
     else
     {
-        NSLog(@"[MXRoomSummary] fetchLastMessage: Failed to find last message in %@.", self.roomId);
+        MXLogDebug(@"[MXRoomSummary] fetchLastMessage: Failed to find last message in %@.", self.roomId);
         onComplete();
     }
     
@@ -435,7 +435,7 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
     MXRoom *room = notif.object;
     if (_mxSession == room.mxSession && [_roomId isEqualToString:room.roomId])
     {
-        NSLog(@"[MXRoomSummary] roomDidFlushData: %@", _roomId);
+        MXLogDebug(@"[MXRoomSummary] roomDidFlushData: %@", _roomId);
 
         [self resetRoomStateData];
     }
@@ -480,7 +480,7 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
             return;
         }
         
-        NSLog(@"[MXRoomSummary] enableTrustTracking: YES");
+        MXLogDebug(@"[MXRoomSummary] enableTrustTracking: YES");
         
         // Bootstrap trust computation
         [self registerTrustLevelDidChangeNotifications];
@@ -488,7 +488,7 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
     }
     else
     {
-        NSLog(@"[MXRoomSummary] enableTrustTracking: NO");
+        MXLogDebug(@"[MXRoomSummary] enableTrustTracking: NO");
         [self unregisterTrustLevelDidChangeNotifications];
         _trust = nil;
     }
@@ -572,7 +572,7 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
         }
         
     } failure:^(NSError *error) {
-        NSLog(@"[MXRoomSummary] trustLevelDidChangeRelatedToUserId fails to retrieve room members");
+        MXLogDebug(@"[MXRoomSummary] trustLevelDidChangeRelatedToUserId fails to retrieve room members");
     }];
 }
 
@@ -592,7 +592,7 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
         }
         
         // Skip this request. Wait for the current one to finish
-        NSLog(@"[MXRoomSummary] triggerComputeTrust: Skip it. A request is pending");
+        MXLogDebug(@"[MXRoomSummary] triggerComputeTrust: Skip it. A request is pending");
         return;
     }
     
@@ -625,7 +625,7 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
         [self save:YES];
         
     } failure:^(NSError *error) {
-        NSLog(@"[MXRoomSummary] computeTrust: fails to retrieve room members trusted progress");
+        MXLogDebug(@"[MXRoomSummary] computeTrust: fails to retrieve room members trusted progress");
     }];
 }
 
@@ -985,7 +985,7 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
     }
     else if (status == errSecItemNotFound)
     {
-        NSLog(@"[MXRoomSummary] encryptionKey: Generate the key and store it to the keychain");
+        MXLogDebug(@"[MXRoomSummary] encryptionKey: Generate the key and store it to the keychain");
 
         // There is not yet a key in the keychain
         // Generate an AES key
@@ -1004,17 +1004,17 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
             {
                 // TODO: The iOS 10 simulator returns the -34018 (errSecMissingEntitlement) error.
                 // We need to fix it but there is no issue with the app on real device nor with iOS 9 simulator.
-                NSLog(@"[MXRoomSummary] encryptionKey: SecItemAdd failed. status: %i", (int)status);
+                MXLogDebug(@"[MXRoomSummary] encryptionKey: SecItemAdd failed. status: %i", (int)status);
             }
         }
         else
         {
-            NSLog(@"[MXRoomSummary] encryptionKey: Cannot generate key. retval: %i", retval);
+            MXLogDebug(@"[MXRoomSummary] encryptionKey: Cannot generate key. retval: %i", retval);
         }
     }
     else
     {
-        NSLog(@"[MXRoomSummary] encryptionKey: Keychain failed. OSStatus: %i", (int)status);
+        MXLogDebug(@"[MXRoomSummary] encryptionKey: Keychain failed. OSStatus: %i", (int)status);
     }
     
     if (foundKey)
@@ -1058,12 +1058,12 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
         }
         else
         {
-            NSLog(@"[MXRoomSummary] encrypt: CCCryptorUpdate failed. status: %i", status);
+            MXLogDebug(@"[MXRoomSummary] encrypt: CCCryptorUpdate failed. status: %i", status);
         }
     }
     else
     {
-        NSLog(@"[MXRoomSummary] encrypt: CCCryptorCreateWithMode failed. status: %i", status);
+        MXLogDebug(@"[MXRoomSummary] encrypt: CCCryptorCreateWithMode failed. status: %i", status);
     }
 
     return encryptedData;
@@ -1102,12 +1102,12 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
         }
         else
         {
-            NSLog(@"[MXRoomSummary] decrypt: CCCryptorUpdate failed. status: %i", status);
+            MXLogDebug(@"[MXRoomSummary] decrypt: CCCryptorUpdate failed. status: %i", status);
         }
     }
     else
     {
-        NSLog(@"[MXRoomSummary] decrypt: CCCryptorCreateWithMode failed. status: %i", status);
+        MXLogDebug(@"[MXRoomSummary] decrypt: CCCryptorCreateWithMode failed. status: %i", status);
     }
     
     return data;

--- a/MatrixSDK/Data/MXRoomSummaryUpdater.m
+++ b/MatrixSDK/Data/MXRoomSummaryUpdater.m
@@ -91,7 +91,7 @@
         if ([event.redacts isEqualToString:summary.lastMessageEventId])
         {
             [summary resetLastMessage:nil failure:^(NSError *error) {
-                NSLog(@"[MXRoomSummaryUpdater] updateRoomSummary: Cannot reset last message after redaction. Room: %@", summary.roomId);
+                MXLogDebug(@"[MXRoomSummaryUpdater] updateRoomSummary: Cannot reset last message after redaction. Room: %@", summary.roomId);
             } commit:YES];
         }
         return NO;
@@ -437,7 +437,7 @@
             && (!displayname || [displayname isEqualToString:_roomNameStringLocalizations.emptyRoom]))
         {
             // Data are missing to compute the display name
-            NSLog(@"[MXRoomSummaryUpdater] updateSummaryDisplayname: Warning: Computed an unexpected \"Empty Room\" name. memberCount: %@", @(memberCount));
+            MXLogDebug(@"[MXRoomSummaryUpdater] updateSummaryDisplayname: Warning: Computed an unexpected \"Empty Room\" name. memberCount: %@", @(memberCount));
             displayname = [self fixUnexpectedEmptyRoomDisplayname:memberCount session:session roomState:roomState];
         }
     }
@@ -477,24 +477,24 @@
         }
     }
 
-    NSLog(@"[MXRoomSummaryUpdater] fixUnexpectedEmptyRoomDisplayname: Found %@ loaded members for %@ known other members", @(otherMembers.count), @(memberCount - 1));
+    MXLogDebug(@"[MXRoomSummaryUpdater] fixUnexpectedEmptyRoomDisplayname: Found %@ loaded members for %@ known other members", @(otherMembers.count), @(memberCount - 1));
 
     switch (memberNames.count)
     {
         case 0:
-            NSLog(@"[MXRoomSummaryUpdater] fixUnexpectedEmptyRoomDisplayname: No luck");
+            MXLogDebug(@"[MXRoomSummaryUpdater] fixUnexpectedEmptyRoomDisplayname: No luck");
             displayname = _roomNameStringLocalizations.emptyRoom;
             break;
 
         case 1:
             if (memberCount == 2)
             {
-                NSLog(@"[MXRoomSummaryUpdater] fixUnexpectedEmptyRoomDisplayname: Fixed 1");
+                MXLogDebug(@"[MXRoomSummaryUpdater] fixUnexpectedEmptyRoomDisplayname: Fixed 1");
                 displayname = memberNames[0];
             }
             else
             {
-                NSLog(@"[MXRoomSummaryUpdater] fixUnexpectedEmptyRoomDisplayname: Half fixed 1");
+                MXLogDebug(@"[MXRoomSummaryUpdater] fixUnexpectedEmptyRoomDisplayname: Half fixed 1");
                 displayname = [NSString stringWithFormat:_roomNameStringLocalizations.moreThanTwoMembers,
                                memberNames[0],
                                @(memberCount - 1)];
@@ -504,14 +504,14 @@
         case 2:
             if (memberCount == 3)
             {
-                NSLog(@"[MXRoomSummaryUpdater] fixUnexpectedEmptyRoomDisplayname: Fixed 2");
+                MXLogDebug(@"[MXRoomSummaryUpdater] fixUnexpectedEmptyRoomDisplayname: Fixed 2");
                 displayname = [NSString stringWithFormat:_roomNameStringLocalizations.twoMembers,
                                memberNames[0],
                                memberNames[1]];
             }
             else
             {
-                NSLog(@"[MXRoomSummaryUpdater] fixUnexpectedEmptyRoomDisplayname: Half fixed 2");
+                MXLogDebug(@"[MXRoomSummaryUpdater] fixUnexpectedEmptyRoomDisplayname: Half fixed 2");
                 displayname = [NSString stringWithFormat:_roomNameStringLocalizations.moreThanTwoMembers,
                                memberNames[0],
                                @(memberCount - 2)];
@@ -519,7 +519,7 @@
             break;
 
         default:
-            NSLog(@"[MXRoomSummaryUpdater] fixUnexpectedEmptyRoomDisplayname: Fixed 3");
+            MXLogDebug(@"[MXRoomSummaryUpdater] fixUnexpectedEmptyRoomDisplayname: Fixed 3");
             displayname = [NSString stringWithFormat:_roomNameStringLocalizations.moreThanTwoMembers,
                            memberNames[0],
                            @(memberCount - 2)];

--- a/MatrixSDK/Data/MXUser.m
+++ b/MatrixSDK/Data/MXUser.m
@@ -148,12 +148,12 @@
 
         } failure:^(NSError *error) {
 
-            NSLog(@"[MXUser] updateFromHomeserverOfMatrixSession failed to get avatar");
+            MXLogDebug(@"[MXUser] updateFromHomeserverOfMatrixSession failed to get avatar");
             failure(error);
         }];
     } failure:^(NSError *error) {
 
-        NSLog(@"[MXUser] updateFromHomeserverOfMatrixSession failed to get display name");
+        MXLogDebug(@"[MXUser] updateFromHomeserverOfMatrixSession failed to get display name");
         failure(error);
     }];
 }

--- a/MatrixSDK/Data/ReplyEvent/Parser/MXReplyEventParser.m
+++ b/MatrixSDK/Data/ReplyEvent/Parser/MXReplyEventParser.m
@@ -61,7 +61,7 @@ static NSString* const kFormattedBodyRegexPattern = @"(^<mx-reply>.+</mx-reply>)
     
     if (error)
     {
-        NSLog(@"[MXReplyEventParser] Regex pattern %@ is not valid. Error: %@", kBodyReplyTextRegexPattern, error);
+        MXLogDebug(@"[MXReplyEventParser] Regex pattern %@ is not valid. Error: %@", kBodyReplyTextRegexPattern, error);
     }
     else if(match && match.numberOfRanges == 2)
     {
@@ -97,7 +97,7 @@ static NSString* const kFormattedBodyRegexPattern = @"(^<mx-reply>.+</mx-reply>)
     
     if (error)
     {
-        NSLog(@"[MXReplyEventParser] Regex pattern %@ is not valid. Error: %@", kFormattedBodyRegexPattern, error);
+        MXLogDebug(@"[MXReplyEventParser] Regex pattern %@ is not valid. Error: %@", kFormattedBodyRegexPattern, error);
     }
     else if(match && match.numberOfRanges == 3)
     {        

--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
@@ -189,7 +189,7 @@ static NSUInteger preloadOptions;
 
 #if DEBUG
     [self diskUsageWithBlock:^(NSUInteger diskUsage) {
-        NSLog(@"[MXFileStore] diskUsage: %@", [NSByteCountFormatter stringFromByteCount:diskUsage countStyle:NSByteCountFormatterCountStyleFile]);
+        MXLogDebug(@"[MXFileStore] diskUsage: %@", [NSByteCountFormatter stringFromByteCount:diskUsage countStyle:NSByteCountFormatterCountStyleFile]);
     }];
 #endif
 
@@ -207,11 +207,11 @@ static NSUInteger preloadOptions;
             // Check store version
             if (self->metaData && kMXFileVersion != self->metaData.version)
             {
-                NSLog(@"[MXFileStore] New MXFileStore version detected");
+                MXLogDebug(@"[MXFileStore] New MXFileStore version detected");
 
                 if (self->metaData.version <= 35)
                 {
-                    NSLog(@"[MXFileStore] Matrix SDK until the version of 35 of MXFileStore caches all NSURLRequests unnecessarily. Clear NSURLCache");
+                    MXLogDebug(@"[MXFileStore] Matrix SDK until the version of 35 of MXFileStore caches all NSURLRequests unnecessarily. Clear NSURLCache");
                     [[NSURLCache sharedURLCache] removeAllCachedResponses];
                 }
 
@@ -223,7 +223,7 @@ static NSUInteger preloadOptions;
             {                
                 MXTaskProfile *taskProfile = [MXSDKOptions.sharedInstance.profiler startMeasuringTaskWithName:kMXAnalyticsStartupStorePreload category:kMXAnalyticsStartupCategory];
                 
-                NSLog(@"[MXFileStore] Start data loading from files");
+                MXLogDebug(@"[MXFileStore] Start data loading from files");
 
                 [self loadRoomsMessages];
                 if (preloadOptions & MXFileStorePreloadOptionRoomState)
@@ -244,7 +244,7 @@ static NSUInteger preloadOptions;
 
                 taskProfile.units = self->roomStores.count;
                 [MXSDKOptions.sharedInstance.profiler stopMeasuringTaskWithProfile:taskProfile];
-                NSLog(@"[MXFileStore] Data loaded from files in %.0fms", taskProfile.duration * 1000);
+                MXLogDebug(@"[MXFileStore] Data loaded from files in %.0fms", taskProfile.duration * 1000);
             }
 
             // Else, if credentials is valid, create and store it
@@ -295,7 +295,7 @@ static NSUInteger preloadOptions;
 
 - (void)logFiles
 {
-    NSLog(@"[MXFileStore] logFiles: Files in %@:", self->storePath);
+    MXLogDebug(@"[MXFileStore] logFiles: Files in %@:", self->storePath);
     NSArray *contents = [[NSFileManager defaultManager] subpathsOfDirectoryAtPath:self->storePath error:nil];
     NSEnumerator *contentsEnumurator = [contents objectEnumerator];
     
@@ -307,12 +307,12 @@ static NSUInteger preloadOptions;
         NSDictionary *fileAttributes = [[NSFileManager defaultManager] attributesOfItemAtPath:[self->storePath stringByAppendingPathComponent:file] error:nil];
         NSUInteger fileSize = [[fileAttributes objectForKey:NSFileSize] intValue];
         
-        NSLog(@"[MXFileStore] logFiles:     - %@: %@", file, [NSByteCountFormatter stringFromByteCount:fileSize countStyle:NSByteCountFormatterCountStyleFile]);
+        MXLogDebug(@"[MXFileStore] logFiles:     - %@: %@", file, [NSByteCountFormatter stringFromByteCount:fileSize countStyle:NSByteCountFormatterCountStyleFile]);
         diskUsage += fileSize;
         fileCount++;
     }
     
-    NSLog(@"[MXFileStore] logFiles:  %@ files: %@", @(fileCount), [NSByteCountFormatter stringFromByteCount:diskUsage countStyle:NSByteCountFormatterCountStyleFile]);
+    MXLogDebug(@"[MXFileStore] logFiles:  %@ files: %@", @(fileCount), [NSByteCountFormatter stringFromByteCount:diskUsage countStyle:NSByteCountFormatterCountStyleFile]);
 }
 
 + (void)setPreloadOptions:(MXFileStorePreloadOptions)thePreloadOptions
@@ -370,7 +370,7 @@ static NSUInteger preloadOptions;
 
 - (void)deleteAllData
 {
-    NSLog(@"[MXFileStore] Delete all data");
+    MXLogDebug(@"[MXFileStore] Delete all data");
 
     [super deleteAllData];
 
@@ -423,7 +423,7 @@ static NSUInteger preloadOptions;
 - (void)storeHasLoadedAllRoomMembersForRoom:(NSString *)roomId andValue:(BOOL)value
 {
     // XXX: To remove once https://github.com/vector-im/element-ios/issues/3807 is fixed
-    NSLog(@"[MXFileStore] storeHasLoadedAllRoomMembersForRoom: %@ value: %@", roomId, @(value));
+    MXLogDebug(@"[MXFileStore] storeHasLoadedAllRoomMembersForRoom: %@ value: %@", roomId, @(value));
           
     [super storeHasLoadedAllRoomMembersForRoom:roomId andValue:value];
 
@@ -697,7 +697,7 @@ static NSUInteger preloadOptions;
         // we are sure that it will be done on the second pass.
         if (pendingCommits >= 2)
         {
-            NSLog(@"[MXFileStore commit] Ignore it. There are already pending commits");
+            MXLogDebug(@"[MXFileStore commit] Ignore it. There are already pending commits");
             return;
         }
 
@@ -710,7 +710,7 @@ static NSUInteger preloadOptions;
         // Create a bg task if none is available
         if (self.commitBackgroundTask.isRunning)
         {
-            NSLog(@"[MXFileStore commit] Background task %@ reused", self.commitBackgroundTask);
+            MXLogDebug(@"[MXFileStore commit] Background task %@ reused", self.commitBackgroundTask);
         }
         else
         {
@@ -724,7 +724,7 @@ static NSUInteger preloadOptions;
                 self.commitBackgroundTask = [handler startBackgroundTaskWithName:@"[MXFileStore commit]" expirationHandler:^{
                     MXStrongifyAndReturnIfNil(self);
                     
-                    NSLog(@"[MXFileStore commit] Background task %@ is going to expire - ending it. pendingCommits: %tu", self.commitBackgroundTask, self->pendingCommits);
+                    MXLogDebug(@"[MXFileStore commit] Background task %@ is going to expire - ending it. pendingCommits: %tu", self.commitBackgroundTask, self->pendingCommits);
                 }];
             }
         }
@@ -741,7 +741,7 @@ static NSUInteger preloadOptions;
             // Release the background task if there is no more pending commits
             dispatch_async(dispatch_get_main_queue(), ^(void){
 
-                NSLog(@"[MXFileStore commit] lasted %.0fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+                MXLogDebug(@"[MXFileStore commit] lasted %.0fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 
                 self->pendingCommits--;
                 
@@ -752,7 +752,7 @@ static NSUInteger preloadOptions;
                 }
                 else if (self.commitBackgroundTask.isRunning)
                 {
-                    NSLog(@"[MXFileStore commit] Background task %@ is kept - running since %.0fms", self.commitBackgroundTask, [[NSDate date] timeIntervalSinceDate:self->backgroundTaskStartDate] * 1000);
+                    MXLogDebug(@"[MXFileStore commit] Background task %@ is kept - running since %.0fms", self.commitBackgroundTask, [[NSDate date] timeIntervalSinceDate:self->backgroundTaskStartDate] * 1000);
                 }
                 
                 if (completion)
@@ -782,7 +782,7 @@ static NSUInteger preloadOptions;
 
 - (void)close
 {
-    NSLog(@"[MXFileStore] close: %tu pendingCommits", pendingCommits);
+    MXLogDebug(@"[MXFileStore] close: %tu pendingCommits", pendingCommits);
 
     // Flush pending commits
     if (pendingCommits)
@@ -1000,7 +1000,7 @@ static NSUInteger preloadOptions;
     // Check whether the previous commit was interrupted or not.
     if ([fileManager fileExistsAtPath:storeBackupPath])
     {
-        NSLog(@"[MXFileStore] Warning: The previous commit was interrupted. Try to repair the store.");
+        MXLogDebug(@"[MXFileStore] Warning: The previous commit was interrupted. Try to repair the store.");
 
         // Get the previous sync token from the folder name
         NSArray *backupFolderContent = [fileManager contentsOfDirectoryAtPath:storeBackupPath error:nil];
@@ -1008,7 +1008,7 @@ static NSUInteger preloadOptions;
         {
             NSString *prevSyncToken = backupFolderContent[0];
 
-            NSLog(@"[MXFileStore] Restore data from sync token: %@", prevSyncToken);
+            MXLogDebug(@"[MXFileStore] Restore data from sync token: %@", prevSyncToken);
 
             NSDate *startDate = [NSDate date];
 
@@ -1028,7 +1028,7 @@ static NSUInteger preloadOptions;
                                      toPath:[storePath stringByAppendingString:file]
                                       error:&error])
                 {
-                    NSLog(@"MXFileStore] Restore data: ERROR: Cannot copy file: %@", error);
+                    MXLogDebug(@"MXFileStore] Restore data: ERROR: Cannot copy file: %@", error);
 
                     checkStorageValidity = NO;
                     break;
@@ -1037,7 +1037,7 @@ static NSUInteger preloadOptions;
 
             if (checkStorageValidity)
             {
-                NSLog(@"[MXFileStore] Restore data: %tu files have been successfully restored in %.0fms", backupFiles.count, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+                MXLogDebug(@"[MXFileStore] Restore data: %tu files have been successfully restored in %.0fms", backupFiles.count, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
                 
                 // Load the event stream token.
                 [self loadMetaData];
@@ -1051,13 +1051,13 @@ static NSUInteger preloadOptions;
         }
         else
         {
-            NSLog(@"MXFileStore] Restore data: ERROR: Cannot find the previous sync token: %@", backupFolderContent);
+            MXLogDebug(@"MXFileStore] Restore data: ERROR: Cannot find the previous sync token: %@", backupFolderContent);
             checkStorageValidity = NO;
         }
 
         if (!checkStorageValidity)
         {
-            NSLog(@"[MXFileStore] Restore data: Cannot restore previous data. Reset the store");
+            MXLogDebug(@"[MXFileStore] Restore data: Cannot restore previous data. Reset the store");
             [self logFiles];
             [self deleteAllData];
         }
@@ -1091,17 +1091,17 @@ static NSUInteger preloadOptions;
         }
         @catch (NSException *exception)
         {
-            NSLog(@"[MXFileStore] Warning: MXFileRoomStore file for room %@ has been corrupted. Exception: %@", roomId, exception);
+            MXLogDebug(@"[MXFileStore] Warning: MXFileRoomStore file for room %@ has been corrupted. Exception: %@", roomId, exception);
         }
 
         if (roomStore)
         {
-            //NSLog(@"   - %@: %@", roomId, roomStore);
+            //MXLogDebug(@"   - %@: %@", roomId, roomStore);
             roomStores[roomId] = roomStore;
         }
         else
         {
-            NSLog(@"[MXFileStore] Warning: MXFileStore has been reset due to room file corruption. Room id: %@. File path: %@",
+            MXLogDebug(@"[MXFileStore] Warning: MXFileStore has been reset due to room file corruption. Room id: %@. File path: %@",
                   roomId, roomFile);
             
             [self logFiles];
@@ -1110,7 +1110,7 @@ static NSUInteger preloadOptions;
         }
     }
 
-    NSLog(@"[MXFileStore] Loaded room messages of %tu rooms in %.0fms", roomStores.allKeys.count, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+    MXLogDebug(@"[MXFileStore] Loaded room messages of %tu rooms in %.0fms", roomStores.allKeys.count, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 }
 
 - (void)saveRoomsMessages
@@ -1121,7 +1121,7 @@ static NSUInteger preloadOptions;
         [roomsToCommitForMessages removeAllObjects];
 
 #if DEBUG
-        NSLog(@"[MXFileStore commit] queuing saveRoomsMessages for %tu rooms", roomsToCommit.count);
+        MXLogDebug(@"[MXFileStore commit] queuing saveRoomsMessages for %tu rooms", roomsToCommit.count);
 #endif
 
         MXWeakify(self);
@@ -1154,7 +1154,7 @@ static NSUInteger preloadOptions;
             }
 
 #if DEBUG
-            NSLog(@"[MXFileStore commit] lasted %.0fms for %tu rooms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000, roomsToCommit.count);
+            MXLogDebug(@"[MXFileStore commit] lasted %.0fms for %tu rooms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000, roomsToCommit.count);
 #endif
         });
     }
@@ -1178,7 +1178,7 @@ static NSUInteger preloadOptions;
         preloadedRoomsStates[roomId] = [self stateOfRoom:roomId];
     }
 
-    NSLog(@"[MXFileStore] Loaded room states of %tu rooms in %.0fms", roomIDs.count, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+    MXLogDebug(@"[MXFileStore] Loaded room states of %tu rooms in %.0fms", roomIDs.count, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 }
 
 - (void)saveRoomsState
@@ -1189,7 +1189,7 @@ static NSUInteger preloadOptions;
         NSDictionary *roomsToCommit = [NSDictionary dictionaryWithDictionary:roomsToCommitForState];
         [roomsToCommitForState removeAllObjects];
 #if DEBUG
-        NSLog(@"[MXFileStore commit] queuing saveRoomsState for %tu rooms", roomsToCommit.count);
+        MXLogDebug(@"[MXFileStore commit] queuing saveRoomsState for %tu rooms", roomsToCommit.count);
 #endif
         dispatch_async(dispatchQueue, ^(void){
 #if DEBUG
@@ -1214,7 +1214,7 @@ static NSUInteger preloadOptions;
                 [NSKeyedArchiver archiveRootObject:stateEvents toFile:file];
             }
 #if DEBUG
-            NSLog(@"[MXFileStore commit] lasted %.0fms for %tu rooms state", [[NSDate date] timeIntervalSinceDate:startDate] * 1000, roomsToCommit.count);
+            MXLogDebug(@"[MXFileStore commit] lasted %.0fms for %tu rooms state", [[NSDate date] timeIntervalSinceDate:startDate] * 1000, roomsToCommit.count);
 #endif
         });
     }
@@ -1238,7 +1238,7 @@ static NSUInteger preloadOptions;
         preloadedRoomSummary[roomId] = [self summaryOfRoom:roomId];
     }
 
-    NSLog(@"[MXFileStore] Loaded rooms summaries data of %tu rooms in %.0fms", roomIDs.count, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+    MXLogDebug(@"[MXFileStore] Loaded rooms summaries data of %tu rooms in %.0fms", roomIDs.count, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 }
 
 - (void)saveRoomsSummaries
@@ -1249,7 +1249,7 @@ static NSUInteger preloadOptions;
         NSDictionary *roomsToCommit = [NSDictionary dictionaryWithDictionary:roomsToCommitForSummary];
         [roomsToCommitForSummary removeAllObjects];
 #if DEBUG
-        NSLog(@"[MXFileStore commit] queuing saveRoomsSummaries for %tu rooms", roomsToCommit.count);
+        MXLogDebug(@"[MXFileStore commit] queuing saveRoomsSummaries for %tu rooms", roomsToCommit.count);
 #endif
         dispatch_async(dispatchQueue, ^(void){
 #if DEBUG
@@ -1274,7 +1274,7 @@ static NSUInteger preloadOptions;
                 [NSKeyedArchiver archiveRootObject:summary toFile:file];
             }
 #if DEBUG
-            NSLog(@"[MXFileStore commit] lasted %.0fms for summaries for %tu rooms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000, roomsToCommit.count);
+            MXLogDebug(@"[MXFileStore commit] lasted %.0fms for summaries for %tu rooms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000, roomsToCommit.count);
 #endif
         });
     }
@@ -1298,7 +1298,7 @@ static NSUInteger preloadOptions;
         preloadedRoomAccountData[roomId] = [self accountDataOfRoom:roomId];
     }
 
-    NSLog(@"[MXFileStore] Loaded rooms account data of %tu rooms in %.0fms", roomIDs.count, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+    MXLogDebug(@"[MXFileStore] Loaded rooms account data of %tu rooms in %.0fms", roomIDs.count, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 }
 
 - (void)saveRoomsAccountData
@@ -1309,7 +1309,7 @@ static NSUInteger preloadOptions;
         NSDictionary *roomsToCommit = [NSDictionary dictionaryWithDictionary:roomsToCommitForAccountData];
         [roomsToCommitForAccountData removeAllObjects];
 #if DEBUG
-        NSLog(@"[MXFileStore commit] queuing saveRoomsAccountData for %tu rooms", roomsToCommit.count);
+        MXLogDebug(@"[MXFileStore commit] queuing saveRoomsAccountData for %tu rooms", roomsToCommit.count);
 #endif
         dispatch_async(dispatchQueue, ^(void){
 #if DEBUG
@@ -1334,7 +1334,7 @@ static NSUInteger preloadOptions;
                 [NSKeyedArchiver archiveRootObject:roomAccountData toFile:file];
             }
 #if DEBUG
-            NSLog(@"[MXFileStore commit] lasted %.0fms for account data for %tu rooms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000, roomsToCommit.count);
+            MXLogDebug(@"[MXFileStore commit] lasted %.0fms for account data for %tu rooms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000, roomsToCommit.count);
 #endif
         });
     }
@@ -1349,7 +1349,7 @@ static NSUInteger preloadOptions;
         NSArray *roomsToCommit = [[NSArray alloc] initWithArray:roomsToCommitForDeletion copyItems:YES];
         [roomsToCommitForDeletion removeAllObjects];
 #if DEBUG
-        NSLog(@"[MXFileStore commit] queuing saveRoomsDeletion for %tu rooms", roomsToCommit.count);
+        MXLogDebug(@"[MXFileStore commit] queuing saveRoomsDeletion for %tu rooms", roomsToCommit.count);
 #endif
         dispatch_async(dispatchQueue, ^(void){
             
@@ -1376,7 +1376,7 @@ static NSUInteger preloadOptions;
 
             }
 #if DEBUG
-            NSLog(@"[MXFileStore commit] lasted %.0fms for %tu rooms deletion", [[NSDate date] timeIntervalSinceDate:startDate] * 1000, roomsToCommit.count);
+            MXLogDebug(@"[MXFileStore commit] lasted %.0fms for %tu rooms deletion", [[NSDate date] timeIntervalSinceDate:startDate] * 1000, roomsToCommit.count);
 #endif
         });
     }
@@ -1426,12 +1426,12 @@ static NSUInteger preloadOptions;
     }
     @catch (NSException *exception)
     {
-        NSLog(@"[MXFileStore] loadMetaData: Warning: MXFileStore metadata has been corrupted");
+        MXLogDebug(@"[MXFileStore] loadMetaData: Warning: MXFileStore metadata has been corrupted");
     }
     
     if (metaData && ![metaData isKindOfClass:MXFileStoreMetaData.class])
     {
-        NSLog(@"[MXFileStore] loadMetaData: Warning: Bad MXFileStore metadata type: %@", metaData);
+        MXLogDebug(@"[MXFileStore] loadMetaData: Warning: Bad MXFileStore metadata type: %@", metaData);
         metaData = nil;
     }
     
@@ -1442,7 +1442,7 @@ static NSUInteger preloadOptions;
     }
     else
     {
-        NSLog(@"[MXFileStore] loadMetaData: event stream token is missing");
+        MXLogDebug(@"[MXFileStore] loadMetaData: event stream token is missing");
         [self logFiles];
         [self deleteAllData];
     }
@@ -1456,7 +1456,7 @@ static NSUInteger preloadOptions;
         metaDataHasChanged = NO;
 
 #if DEBUG
-        NSLog(@"[MXFileStore commit] queuing saveMetaData");
+        MXLogDebug(@"[MXFileStore commit] queuing saveMetaData");
 #endif
 
         MXWeakify(self);
@@ -1489,7 +1489,7 @@ static NSUInteger preloadOptions;
             [NSKeyedArchiver archiveRootObject:self->metaData toFile:file];
 
 #if DEBUG
-            NSLog(@"[MXFileStore commit] lasted %.0fms for metadata", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+            MXLogDebug(@"[MXFileStore commit] lasted %.0fms for metadata", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 #endif
         });
     }
@@ -1570,11 +1570,11 @@ static NSUInteger preloadOptions;
         }
         @catch (NSException *exception)
         {
-            NSLog(@"[MXFileStore] Warning: MXFileRoomStore file for users group %@ has been corrupted", group);
+            MXLogDebug(@"[MXFileStore] Warning: MXFileRoomStore file for users group %@ has been corrupted", group);
         }
     }
     
-    NSLog(@"[MXFileStore] Loaded %tu MXUsers in %.0fms", users.count, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+    MXLogDebug(@"[MXFileStore] Loaded %tu MXUsers in %.0fms", users.count, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 }
 
 - (NSArray<MXUser *> *)loadUsersWithUserIds:(NSArray<NSString *> *)userIds
@@ -1617,7 +1617,7 @@ static NSUInteger preloadOptions;
             }
             @catch (NSException *exception)
             {
-                NSLog(@"[MXFileStore] Warning: MXFileRoomStore file for users group %@ has been corrupted", group);
+                MXLogDebug(@"[MXFileStore] Warning: MXFileRoomStore file for users group %@ has been corrupted", group);
             }
         }
     }
@@ -1634,7 +1634,7 @@ static NSUInteger preloadOptions;
         NSMutableDictionary *theUsersToCommit = [[NSMutableDictionary alloc] initWithDictionary:usersToCommit copyItems:YES];
         [usersToCommit removeAllObjects];
 #if DEBUG
-        NSLog(@"[MXFileStore commit] queuing saveUsers");
+        MXLogDebug(@"[MXFileStore commit] queuing saveUsers");
 #endif
         dispatch_async(dispatchQueue, ^(void){
 
@@ -1698,7 +1698,7 @@ static NSUInteger preloadOptions;
             }
 
 #if DEBUG
-            NSLog(@"[MXFileStore] saveUsers in %.0fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+            MXLogDebug(@"[MXFileStore] saveUsers in %.0fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 #endif
         });
     }
@@ -1732,11 +1732,11 @@ static NSUInteger preloadOptions;
         }
         @catch (NSException *exception)
         {
-            NSLog(@"[MXFileStore] Warning: File for group %@ has been corrupted", groupId);
+            MXLogDebug(@"[MXFileStore] Warning: File for group %@ has been corrupted", groupId);
         }
     }
     
-    NSLog(@"[MXFileStore] Loaded %tu MXGroups in %.0fms", groups.count, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+    MXLogDebug(@"[MXFileStore] Loaded %tu MXGroups in %.0fms", groups.count, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 }
 
 - (void)saveGroupsDeletion
@@ -1746,7 +1746,7 @@ static NSUInteger preloadOptions;
         NSArray *groupsToCommit = [[NSArray alloc] initWithArray:groupsToCommitForDeletion copyItems:YES];
         [groupsToCommitForDeletion removeAllObjects];
 #if DEBUG
-        NSLog(@"[MXFileStore commit] queuing saveGroupsDeletion for %tu rooms", groupsToCommit.count);
+        MXLogDebug(@"[MXFileStore commit] queuing saveGroupsDeletion for %tu rooms", groupsToCommit.count);
 #endif
         dispatch_async(dispatchQueue, ^(void){
             
@@ -1765,7 +1765,7 @@ static NSUInteger preloadOptions;
                 }
             }
 #if DEBUG
-            NSLog(@"[MXFileStore commit] lasted %.0fms for %tu groups deletion", [[NSDate date] timeIntervalSinceDate:startDate] * 1000, groupsToCommit.count);
+            MXLogDebug(@"[MXFileStore commit] lasted %.0fms for %tu groups deletion", [[NSDate date] timeIntervalSinceDate:startDate] * 1000, groupsToCommit.count);
 #endif
         });
     }
@@ -1780,7 +1780,7 @@ static NSUInteger preloadOptions;
         NSMutableDictionary *theGroupsToCommit = [[NSMutableDictionary alloc] initWithDictionary:groupsToCommit copyItems:YES];
         [groupsToCommit removeAllObjects];
 #if DEBUG
-        NSLog(@"[MXFileStore commit] queuing saveGroups");
+        MXLogDebug(@"[MXFileStore commit] queuing saveGroups");
 #endif
         dispatch_async(dispatchQueue, ^(void){
             
@@ -1804,7 +1804,7 @@ static NSUInteger preloadOptions;
                 [NSKeyedArchiver archiveRootObject:group toFile:file];
             }
 #if DEBUG
-            NSLog(@"[MXFileStore] saveGroups in %.0fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+            MXLogDebug(@"[MXFileStore] saveGroups in %.0fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 #endif
         });
     }
@@ -1850,17 +1850,17 @@ static NSUInteger preloadOptions;
         }
         @catch (NSException *exception)
         {
-            NSLog(@"[MXFileStore] Warning: loadReceipts file for room %@ has been corrupted", roomId);
+            MXLogDebug(@"[MXFileStore] Warning: loadReceipts file for room %@ has been corrupted", roomId);
         }
 
         if (receiptsDict)
         {
-            //NSLog(@"   - %@: %tu", roomId, receiptsDict.count);
+            //MXLogDebug(@"   - %@: %tu", roomId, receiptsDict.count);
             receiptsByRoomId[roomId] = receiptsDict;
         }
         else
         {
-            NSLog(@"[MXFileStore] Warning: MXFileStore has no receipts file for room %@", roomId);
+            MXLogDebug(@"[MXFileStore] Warning: MXFileStore has no receipts file for room %@", roomId);
 
             // We used to reset the store and force a full initial sync but this makes the app
             // start very slowly.
@@ -1873,7 +1873,7 @@ static NSUInteger preloadOptions;
         }
     }
 
-    NSLog(@"[MXFileStore] Loaded read receipts of %tu rooms in %.0fms", receiptsByRoomId.count, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+    MXLogDebug(@"[MXFileStore] Loaded read receipts of %tu rooms in %.0fms", receiptsByRoomId.count, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 }
 
 - (void)saveReceipts
@@ -1884,7 +1884,7 @@ static NSUInteger preloadOptions;
         [roomsToCommitForReceipts removeAllObjects];
 
 #if DEBUG
-        NSLog(@"[MXFileStore commit] queuing saveReceipts for %tu rooms", roomsToCommit.count);
+        MXLogDebug(@"[MXFileStore commit] queuing saveReceipts for %tu rooms", roomsToCommit.count);
 #endif
         MXWeakify(self);
         dispatch_async(dispatchQueue, ^(void){
@@ -1919,7 +1919,7 @@ static NSUInteger preloadOptions;
             }
             
 #if DEBUG
-            NSLog(@"[MXFileStore commit] lasted %.0fms for receipts in %tu rooms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000, roomsToCommit.count);
+            MXLogDebug(@"[MXFileStore commit] lasted %.0fms for receipts in %tu rooms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000, roomsToCommit.count);
 #endif
         });
     }
@@ -2011,7 +2011,7 @@ static NSUInteger preloadOptions;
     }
     @catch (NSException *exception)
     {
-        NSLog(@"[MXFileStore] roomStoreForRoom = Warning: MXFileRoomStore file for room %@ seems corrupted", roomId);
+        MXLogDebug(@"[MXFileStore] roomStoreForRoom = Warning: MXFileRoomStore file for room %@ seems corrupted", roomId);
     }
     
     return roomStore;

--- a/MatrixSDK/JSONModels/MXJSONModel.h
+++ b/MatrixSDK/JSONModels/MXJSONModel.h
@@ -16,6 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
+#import "MXLog.h"
 
 /**
  A class that inherits from `MXJSONModel` represents the response to a request
@@ -154,6 +155,6 @@
  */
 #define MXJSONModelSetLogError(theClass, value) \
     { \
-        NSLog(@"[MXJSONModelSet] ERROR: Unexpected type for parsing at %@:%d. Expected: %@. Got: %@ (%@)", \
+        MXLogDebug(@"[MXJSONModelSet] ERROR: Unexpected type for parsing at %@:%d. Expected: %@. Got: %@ (%@)", \
             @(__FILE__).lastPathComponent, __LINE__, theClass, value, NSStringFromClass([value class])); \
     }

--- a/MatrixSDK/JSONModels/MXJSONModels.m
+++ b/MatrixSDK/JSONModels/MXJSONModels.m
@@ -68,7 +68,7 @@ static NSString* const kMXLoginFlowTypeKey = @"type";
         }
         else
         {
-            NSLog(@"[MXPublicRoom] Warning: room id leak for %@", self.roomId);
+            MXLogDebug(@"[MXPublicRoom] Warning: room id leak for %@", self.roomId);
             displayname = self.roomId;
         }
     }
@@ -375,7 +375,7 @@ NSString *const kMXRoomTagServerNotice = @"m.server_notice";
             // Do some cleaning if the order is a number (and do nothing if the order is a string)
             if ([order isKindOfClass:NSNumber.class])
             {
-                NSLog(@"[MXRoomTag] Warning: the room tag order is an number value not a string in this event: %@", event);
+                MXLogDebug(@"[MXRoomTag] Warning: the room tag order is an number value not a string in this event: %@", event);
 
                 NSNumberFormatter *formatter = [[NSNumberFormatter alloc] init];
                 [formatter setMaximumFractionDigits:16];

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -213,7 +213,7 @@ MXAuthAction;
     }
     else
     {
-        NSLog(@"[MXRestClient] Warning: the userId is not correctly formatted: %@", credentials.userId);
+        MXLogDebug(@"[MXRestClient] Warning: the userId is not correctly formatted: %@", credentials.userId);
     }
 
     return homeserverSuffix;
@@ -1079,7 +1079,7 @@ MXAuthAction;
                     }
                     else
                     {
-                        NSLog(@"[MXRestClient] addIdentityAccessTokenToParameters: Error: identityServerAccessTokenHandler returned no token");
+                        MXLogDebug(@"[MXRestClient] addIdentityAccessTokenToParameters: Error: identityServerAccessTokenHandler returned no token");
                         NSError *error = [NSError errorWithDomain:kMXRestClientErrorDomain code:MXRestClientErrorMissingIdentityServerAccessToken userInfo:nil];
                         [self dispatchFailure:error inBlock:failure];
                     }
@@ -1090,7 +1090,7 @@ MXAuthAction;
             }
             else
             {
-                NSLog(@"[MXRestClient] addIdentityAccessTokenToParameters: Error: No identityServerAccessTokenHandler");
+                MXLogDebug(@"[MXRestClient] addIdentityAccessTokenToParameters: Error: No identityServerAccessTokenHandler");
                 NSError *error = [NSError errorWithDomain:kMXRestClientErrorDomain code:MXRestClientErrorMissingIdentityServerAccessToken userInfo:nil];
                 [self dispatchFailure:error inBlock:failure];
             }
@@ -1126,7 +1126,7 @@ MXAuthAction;
     {
         NSError *error = [NSError errorWithDomain:kMXRestClientErrorDomain code:MXRestClientErrorInvalidParameters userInfo:nil];
 
-        NSLog(@"[MXRestClient] setPusherWithPushkey: Error: Invalid params: ");
+        MXLogDebug(@"[MXRestClient] setPusherWithPushkey: Error: Invalid params: ");
 
         [self dispatchFailure:error inBlock:failure];
         return nil;
@@ -2554,7 +2554,7 @@ MXAuthAction;
                                           MXError *mxError = [[MXError alloc] initWithNSError:error];
                                           if (mxError && [mxError.errcode isEqualToString:kMXErrCodeStringUnrecognized])
                                           {
-                                              NSLog(@"[MXRestClient] eventWithEventId: The homeserver does not support `/rooms/{roomId}/event/{eventId}` API. Try with `/context`");
+                                              MXLogDebug(@"[MXRestClient] eventWithEventId: The homeserver does not support `/rooms/{roomId}/event/{eventId}` API. Try with `/context`");
 
                                               MXHTTPOperation *operation2 = [self contextOfEvent:eventId inRoom:roomId limit:1 filter:nil success:^(MXEventContext *eventContext) {
 
@@ -2977,7 +2977,7 @@ MXAuthAction;
 {
     if (!self.identityServer)
     {
-        NSLog(@"[MXRestClient] add3PID: Error: Missing identityServer");
+        MXLogDebug(@"[MXRestClient] add3PID: Error: Missing identityServer");
         NSError *error = [NSError errorWithDomain:kMXRestClientErrorDomain code:MXRestClientErrorMissingIdentityServer userInfo:nil];
         [self dispatchFailure:error inBlock:failure];
         return nil;
@@ -3102,7 +3102,7 @@ MXAuthAction;
 
     if (!self.identityServer)
     {
-        NSLog(@"[MXRestClient] bind3PidWithSessionId: Error: Missing identityServer");
+        MXLogDebug(@"[MXRestClient] bind3PidWithSessionId: Error: Missing identityServer");
         NSError *error = [NSError errorWithDomain:kMXRestClientErrorDomain code:MXRestClientErrorMissingIdentityServer userInfo:nil];
         [self dispatchFailure:error inBlock:failure];
         return nil;
@@ -3156,7 +3156,7 @@ MXAuthAction;
 
     if (!self.identityServer)
     {
-        NSLog(@"[MXRestClient] add3PID: Error: Missing identityServer");
+        MXLogDebug(@"[MXRestClient] add3PID: Error: Missing identityServer");
         NSError *error = [NSError errorWithDomain:kMXRestClientErrorDomain code:MXRestClientErrorMissingIdentityServer userInfo:nil];
         [self dispatchFailure:error inBlock:failure];
         return nil;
@@ -4292,7 +4292,7 @@ MXAuthAction;
     NSString *path = [self keyBackupPath:roomId session:sessionId version:version];
     if (!path || !keyBackupData || !roomId || !sessionId)
     {
-        NSLog(@"[MXRestClient] sendKeyBackup: ERROR: Bad parameters");
+        MXLogDebug(@"[MXRestClient] sendKeyBackup: ERROR: Bad parameters");
         [self dispatchFailure:nil inBlock:failure];
         return nil;
     }
@@ -4309,7 +4309,7 @@ MXAuthAction;
     NSString *path = [self keyBackupPath:roomId session:nil version:version];
     if (!path || !roomKeysBackupData || !roomId)
     {
-        NSLog(@"[MXRestClient] sendRoomKeysBackup: ERROR: Bad parameters");
+        MXLogDebug(@"[MXRestClient] sendRoomKeysBackup: ERROR: Bad parameters");
         [self dispatchFailure:nil inBlock:failure];
         return nil;
     }
@@ -4325,7 +4325,7 @@ MXAuthAction;
     NSString *path = [self keyBackupPath:nil session:nil version:version];
     if (!path || !keysBackupData)
     {
-        NSLog(@"[MXRestClient] sendKeysBackup: ERROR: Bad parameters");
+        MXLogDebug(@"[MXRestClient] sendKeysBackup: ERROR: Bad parameters");
         [self dispatchFailure:nil inBlock:failure];
         return nil;
     }
@@ -4367,7 +4367,7 @@ MXAuthAction;
     NSString *path = [self keyBackupPath:roomId session:sessionId version:version];
     if (!path || !roomId || !sessionId)
     {
-        NSLog(@"[MXRestClient] keyBackup: ERROR: Bad parameters");
+        MXLogDebug(@"[MXRestClient] keyBackup: ERROR: Bad parameters");
         [self dispatchFailure:nil inBlock:failure];
         return nil;
     }
@@ -4402,7 +4402,7 @@ MXAuthAction;
     NSString *path = [self keyBackupPath:roomId session:nil version:version];
     if (!path || !roomId)
     {
-        NSLog(@"[MXRestClient] roomKeysBackup: ERROR: Bad parameters");
+        MXLogDebug(@"[MXRestClient] roomKeysBackup: ERROR: Bad parameters");
         [self dispatchFailure:nil inBlock:failure];
         return nil;
     }
@@ -4436,7 +4436,7 @@ MXAuthAction;
     NSString *path = [self keyBackupPath:nil session:nil version:version];
     if (!path)
     {
-        NSLog(@"[MXRestClient] keysBackup: ERROR: Bad parameters");
+        MXLogDebug(@"[MXRestClient] keysBackup: ERROR: Bad parameters");
         [self dispatchFailure:nil inBlock:failure];
         return nil;
     }
@@ -4472,7 +4472,7 @@ MXAuthAction;
     NSString *path = [self keyBackupPath:roomId session:sessionId version:version];
     if (!path || !roomId || !sessionId)
     {
-        NSLog(@"[MXRestClient] deleteKeyFromBackup: ERROR: Bad parameters");
+        MXLogDebug(@"[MXRestClient] deleteKeyFromBackup: ERROR: Bad parameters");
         [self dispatchFailure:nil inBlock:failure];
         return nil;
     }
@@ -4505,7 +4505,7 @@ MXAuthAction;
     NSString *path = [self keyBackupPath:roomId session:nil version:version];
     if (!path || !roomId)
     {
-        NSLog(@"[MXRestClient] deleteKeysInRoomFromBackup: ERROR: Bad parameters");
+        MXLogDebug(@"[MXRestClient] deleteKeysInRoomFromBackup: ERROR: Bad parameters");
         [self dispatchFailure:nil inBlock:failure];
         return nil;
     }
@@ -4537,7 +4537,7 @@ MXAuthAction;
     NSString *path = [self keyBackupPath:nil session:nil version:version];
     if (!path)
     {
-        NSLog(@"[MXRestClient] keysBackup: ERROR: Bad parameters");
+        MXLogDebug(@"[MXRestClient] keysBackup: ERROR: Bad parameters");
         [self dispatchFailure:nil inBlock:failure];
         return nil;
     }
@@ -4575,7 +4575,7 @@ MXAuthAction;
     {
         if (!roomId)
         {
-            NSLog(@"[MXRestClient] keyBackupPath: ERROR: Null version");
+            MXLogDebug(@"[MXRestClient] keyBackupPath: ERROR: Null version");
             return nil;
         }
         [path appendString:@"/"];
@@ -4717,7 +4717,7 @@ MXAuthAction;
                                  success:^(NSDictionary *JSONResponse) {
                                      MXStrongifyAndReturnIfNil(self);
                                      
-                                     NSLog(@"[MXRestClient] Warning: get an authentication session to delete a device failed");
+                                     MXLogDebug(@"[MXRestClient] Warning: get an authentication session to delete a device failed");
                                      if (success)
                                      {
                                          [self dispatchProcessing:nil
@@ -5180,7 +5180,7 @@ MXAuthAction;
                               parameters:parameters
                                  success:^(NSDictionary *JSONResponse) {
 
-                                     NSLog(@"[MXRestClient] authSessionForRequestWithMethod: No authentication is needed");
+                                     MXLogDebug(@"[MXRestClient] authSessionForRequestWithMethod: No authentication is needed");
                                      if (success)
                                      {
                                          [self dispatchProcessing:nil
@@ -5199,7 +5199,7 @@ MXAuthAction;
                                          // If a grace period is active or the endpoint do not requires authentication and waiting for parameters do not fail and give a nil auth session.
                                          if (matrixError && matrixError.httpResponse.statusCode == 400)
                                          {
-                                             NSLog(@"[MXRestClient] authSessionForRequestWithMethod: No authentication is needed. Ignore invalid parameters error");
+                                             MXLogDebug(@"[MXRestClient] authSessionForRequestWithMethod: No authentication is needed. Ignore invalid parameters error");
                                              isAuthenticationNeeded = NO;
                                          }
                                          else if (error.userInfo[MXHTTPClientErrorResponseDataKey])

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -296,7 +296,7 @@ typedef void (^MXOnResumeDone)(void);
 {
     if (_state != state)
     {
-        NSLog(@"[MXSession] setState: %@ (was %@)", @(state), @(_state));
+        MXLogDebug(@"[MXSession] setState: %@ (was %@)", @(state), @(_state));
         
         _state = state;
 
@@ -360,7 +360,7 @@ typedef void (^MXOnResumeDone)(void);
             if (self.store.isPermanent && self.isEventStreamInitialised)
             {
                 // Mount data from the permanent store
-                NSLog(@"[MXSession] Loading room state events to build MXRoom objects...");
+                MXLogDebug(@"[MXSession] Loading room state events to build MXRoom objects...");
 
                 // Create myUser from the store
                 MXUser *myUser = [self.store userWithUserId:self->matrixRestClient.credentials.userId];
@@ -384,7 +384,7 @@ typedef void (^MXOnResumeDone)(void);
                     }
                 }
 
-                NSLog(@"[MXSession] Built %lu MXRoomSummaries in %.0fms", (unsigned long)self->roomsSummaries.allKeys.count, [[NSDate date] timeIntervalSinceDate:startDate2] * 1000);
+                MXLogDebug(@"[MXSession] Built %lu MXRoomSummaries in %.0fms", (unsigned long)self->roomsSummaries.allKeys.count, [[NSDate date] timeIntervalSinceDate:startDate2] * 1000);
 
                 // Create MXRooms from their states stored in the store
                 NSDate *startDate3 = [NSDate date];
@@ -393,16 +393,16 @@ typedef void (^MXOnResumeDone)(void);
                     [self loadRoom:roomId];
                 }
 
-                NSLog(@"[MXSession] Built %lu MXRooms in %.0fms", (unsigned long)self->rooms.count, [[NSDate date] timeIntervalSinceDate:startDate3] * 1000);
+                MXLogDebug(@"[MXSession] Built %lu MXRooms in %.0fms", (unsigned long)self->rooms.count, [[NSDate date] timeIntervalSinceDate:startDate3] * 1000);
                 
                 NSDate *startDate4 = [NSDate date];
                 [self loadRoomSummaryLastEvents:^{
-                    NSLog(@"[MXSession] Loaded %lu MXRoomSummaries last events in  in %.0fms", (unsigned long)self->roomsSummaries.count, [[NSDate date] timeIntervalSinceDate:startDate4] * 1000);
+                    MXLogDebug(@"[MXSession] Loaded %lu MXRoomSummaries last events in  in %.0fms", (unsigned long)self->roomsSummaries.count, [[NSDate date] timeIntervalSinceDate:startDate4] * 1000);
                     
                     taskProfile.units = self->rooms.count;
                     [MXSDKOptions.sharedInstance.profiler stopMeasuringTaskWithProfile:taskProfile];
                     
-                    NSLog(@"[MXSession] Total time to mount SDK data from MXStore: %.0fms", taskProfile.duration * 1000);
+                    MXLogDebug(@"[MXSession] Total time to mount SDK data from MXStore: %.0fms", taskProfile.duration * 1000);
                     
                     [self setState:MXSessionStateStoreDataReady];
                     
@@ -416,7 +416,7 @@ typedef void (^MXOnResumeDone)(void);
                 self->_myUser = [[MXMyUser alloc] initWithUserId:self->matrixRestClient.credentials.userId];
                 self->_myUser.mxSession = self;
                 
-                NSLog(@"[MXSession] Total time to mount SDK data from MXStore: %.0fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+                MXLogDebug(@"[MXSession] Total time to mount SDK data from MXStore: %.0fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
                 
                 [self setState:MXSessionStateStoreDataReady];
                 
@@ -460,7 +460,7 @@ typedef void (^MXOnResumeDone)(void);
                 completion:(void (^)(void))completion
            storeCompletion:(void (^)(void))storeCompletion
 {
-    NSLog(@"[MXSession] handleSyncResponse: Received %tu joined rooms, %tu invited rooms, %tu left rooms, %tu toDevice events.", syncResponse.rooms.join.count, syncResponse.rooms.invite.count, syncResponse.rooms.leave.count, syncResponse.toDevice.events.count);
+    MXLogDebug(@"[MXSession] handleSyncResponse: Received %tu joined rooms, %tu invited rooms, %tu left rooms, %tu toDevice events.", syncResponse.rooms.join.count, syncResponse.rooms.invite.count, syncResponse.rooms.leave.count, syncResponse.toDevice.events.count);
     
     // Check whether this is the initial sync
     BOOL isInitialSync = !self.isEventStreamInitialised;
@@ -666,7 +666,7 @@ typedef void (^MXOnResumeDone)(void);
         }
 
         // Update live event stream token
-            NSLog(@"[MXSession] Next sync token: %@", syncResponse.nextBatch);
+            MXLogDebug(@"[MXSession] Next sync token: %@", syncResponse.nextBatch);
             self.store.eventStreamToken = syncResponse.nextBatch;
             
             if (completion)
@@ -692,7 +692,7 @@ typedef void (^MXOnResumeDone)(void);
 
 - (void)setIdentityServer:(NSString *)identityServer andAccessToken:(NSString *)accessToken
 {
-    NSLog(@"[MXSession] setIdentityServer: %@", identityServer);
+    MXLogDebug(@"[MXSession] setIdentityServer: %@", identityServer);
     
     matrixRestClient.identityServer = identityServer;
 
@@ -722,7 +722,7 @@ typedef void (^MXOnResumeDone)(void);
            onServerSyncDone:(void (^)(void))onServerSyncDone
                     failure:(void (^)(NSError *error))failure;
 {
-    NSLog(@"[MXSession] startWithSyncFilter: %@", syncFilter);
+    MXLogDebug(@"[MXSession] startWithSyncFilter: %@", syncFilter);
 
     if (syncFilter)
     {
@@ -736,7 +736,7 @@ typedef void (^MXOnResumeDone)(void);
         } failure:^(NSError *error) {
             MXStrongifyAndReturnIfNil(self);
 
-            NSLog(@"[MXSession] startWithSyncFilter: WARNING: Impossible to create the filter. Use no filter in /sync");
+            MXLogDebug(@"[MXSession] startWithSyncFilter: WARNING: Impossible to create the filter. Use no filter in /sync");
             [self startWithSyncFilterId:nil onServerSyncDone:onServerSyncDone failure:failure];
         }];
     }
@@ -785,7 +785,7 @@ typedef void (^MXOnResumeDone)(void);
     {
         if (_store.eventStreamToken)
         {
-            NSLog(@"[MXSesssion] startWithSyncFilterId: WARNING: Changing the sync filter while there is existing data in the store is not recommended");
+            MXLogDebug(@"[MXSesssion] startWithSyncFilterId: WARNING: Changing the sync filter while there is existing data in the store is not recommended");
         }
 
         // Store the passed filter id
@@ -801,7 +801,7 @@ typedef void (^MXOnResumeDone)(void);
 
             if (filter.room.state.lazyLoadMembers)
             {
-                NSLog(@"[MXSession] Set syncWithLazyLoadOfRoomMembers to YES");
+                MXLogDebug(@"[MXSession] Set syncWithLazyLoadOfRoomMembers to YES");
                 self->_syncWithLazyLoadOfRoomMembers = YES;
             }
         } failure:nil];
@@ -811,19 +811,19 @@ typedef void (^MXOnResumeDone)(void);
     if (_store.isPermanent && self.isEventStreamInitialised && 0 < _store.rooms.count)
     {
         // Resume the stream (presence will be retrieved during server sync)
-        NSLog(@"[MXSession] Resuming the events stream from %@...", self.store.eventStreamToken);
+        MXLogDebug(@"[MXSession] Resuming the events stream from %@...", self.store.eventStreamToken);
         NSDate *startDate2 = [NSDate date];
         [self resume:^{
-            NSLog(@"[MXSession] Events stream resumed in %.0fms", [[NSDate date] timeIntervalSinceDate:startDate2] * 1000);
+            MXLogDebug(@"[MXSession] Events stream resumed in %.0fms", [[NSDate date] timeIntervalSinceDate:startDate2] * 1000);
 
             onServerSyncDone();
         }];
 
         // Start crypto if enabled
         [self startCrypto:^{
-            NSLog(@"[MXSession] Crypto has been started");
+            MXLogDebug(@"[MXSession] Crypto has been started");
         }  failure:^(NSError *error) {
-            NSLog(@"[MXSession] Crypto failed to start. Error: %@", error);
+            MXLogDebug(@"[MXSession] Crypto failed to start. Error: %@", error);
         }];
     }
     else
@@ -846,7 +846,7 @@ typedef void (^MXOnResumeDone)(void);
             // Start crypto if enabled
             [self startCrypto:^{
 
-                NSLog(@"[MXSession] Do an initial /sync");
+                MXLogDebug(@"[MXSession] Do an initial /sync");
 
                 // Initial server sync
                 [self serverSyncWithServerTimeout:0 success:onServerSyncDone failure:^(NSError *error) {
@@ -858,7 +858,7 @@ typedef void (^MXOnResumeDone)(void);
 
             } failure:^(NSError *error) {
 
-                NSLog(@"[MXSession] Crypto failed to start. Error: %@", error);
+                MXLogDebug(@"[MXSession] Crypto failed to start. Error: %@", error);
                 
                 // Check whether the token is valid
                 if ([self isUnknownTokenError:error])
@@ -874,7 +874,7 @@ typedef void (^MXOnResumeDone)(void);
 
         } failure:^(NSError *error) {
             
-            NSLog(@"[MXSession] Get the user's profile information failed");
+            MXLogDebug(@"[MXSession] Get the user's profile information failed");
             
             // Check whether the token is valid
             if ([self isUnknownTokenError:error])
@@ -902,7 +902,7 @@ typedef void (^MXOnResumeDone)(void);
 
 - (void)pause
 {
-    NSLog(@"[MXSession] pause the event stream in state %tu", _state);
+    MXLogDebug(@"[MXSession] pause the event stream in state %tu", _state);
 
     if (_state == MXSessionStateRunning || _state == MXSessionStateBackgroundSyncInProgress || _state == MXSessionStatePauseRequested)
     {
@@ -910,7 +910,7 @@ typedef void (^MXOnResumeDone)(void);
         // background
         if (_preventPauseCount)
         {
-            NSLog(@"[MXSession pause] Prevent the session from being paused. preventPauseCount: %tu", _preventPauseCount);
+            MXLogDebug(@"[MXSession pause] Prevent the session from being paused. preventPauseCount: %tu", _preventPauseCount);
             
             id<MXBackgroundModeHandler> handler = [MXSDKOptions sharedInstance].backgroundModeHandler;
             
@@ -949,7 +949,7 @@ typedef void (^MXOnResumeDone)(void);
     }
     else
     {
-        NSLog(@"[MXSession] pause skipped because of wrong state of MXSession");
+        MXLogDebug(@"[MXSession] pause skipped because of wrong state of MXSession");
     }
 }
 
@@ -962,7 +962,7 @@ typedef void (^MXOnResumeDone)(void);
 
 - (void)_resume:(void (^)(void))resumeDone
 {
-    NSLog(@"[MXSession] _resume: resume the event stream from state %tu", _state);
+    MXLogDebug(@"[MXSession] _resume: resume the event stream from state %tu", _state);
     
     if (self.backgroundTask.isRunning)
     {
@@ -993,7 +993,7 @@ typedef void (^MXOnResumeDone)(void);
     
     if (!onResumeDone && resumeDone)
     {
-        NSLog(@"[MXSession] _resume: the event stream is already running. Nothing to resume");
+        MXLogDebug(@"[MXSession] _resume: the event stream is already running. Nothing to resume");
         resumeDone();
     }
 }
@@ -1011,14 +1011,14 @@ typedef void (^MXOnResumeDone)(void);
     {
         if (!ignoreSessionState && MXSessionStatePaused != _state)
         {
-            NSLog(@"[MXSession] background Sync cannot be done in the current state %tu", _state);
+            MXLogDebug(@"[MXSession] background Sync cannot be done in the current state %tu", _state);
             dispatch_async(dispatch_get_main_queue(), ^{
                 backgroundSyncfails(nil);
             });
         }
         else
         {
-            NSLog(@"[MXSession] start a background Sync");
+            MXLogDebug(@"[MXSession] start a background Sync");
             [self setState:MXSessionStateBackgroundSyncInProgress];
             
             // BackgroundSync from the latest known token
@@ -1030,7 +1030,7 @@ typedef void (^MXOnResumeDone)(void);
     }
     else
     {
-        NSLog(@"[MXSession] background Sync already ongoing");
+        MXLogDebug(@"[MXSession] background Sync already ongoing");
         dispatch_async(dispatch_get_main_queue(), ^{
             backgroundSyncfails(nil);
         });
@@ -1041,7 +1041,7 @@ typedef void (^MXOnResumeDone)(void);
 {
     if (eventStreamRequest)
     {
-        NSLog(@"[MXSession] Reconnect starts");
+        MXLogDebug(@"[MXSession] Reconnect starts");
         [eventStreamRequest cancel];
         eventStreamRequest = nil;
         
@@ -1053,7 +1053,7 @@ typedef void (^MXOnResumeDone)(void);
     }
     else
     {
-        NSLog(@"[MXSession] Reconnect fails.");
+        MXLogDebug(@"[MXSession] Reconnect fails.");
     }
     
     return NO;
@@ -1191,17 +1191,17 @@ typedef void (^MXOnResumeDone)(void);
         MXError *mxError = [[MXError alloc] initWithNSError:error];
         if ([mxError.errcode isEqualToString:kMXErrCodeStringUnknownToken])
         {
-            NSLog(@"[MXSession] isUnknownTokenError: The access token is no more valid.");
+            MXLogDebug(@"[MXSession] isUnknownTokenError: The access token is no more valid.");
 
             if (mxError.httpResponse.statusCode == 401
                 && [mxError.userInfo[kMXErrorSoftLogoutKey] isEqual:@(YES)])
             {
-                NSLog(@"[MXSession] isUnknownTokenError: Go to MXSessionStateSoftLogout state.");
+                MXLogDebug(@"[MXSession] isUnknownTokenError: Go to MXSessionStateSoftLogout state.");
                 [self setState:MXSessionStateSoftLogout];
             }
             else
             {
-                NSLog(@"[MXSession] isUnknownTokenError: Go to MXSessionStateUnknownToken state.");
+                MXLogDebug(@"[MXSession] isUnknownTokenError: Go to MXSessionStateUnknownToken state.");
                 [self setState:MXSessionStateUnknownToken];
             }
 
@@ -1233,14 +1233,14 @@ typedef void (^MXOnResumeDone)(void);
 {
     _preventPauseCount = preventPauseCount;
 
-    NSLog(@"[MXSession] setPreventPauseCount: %tu. MXSession state: %tu", _preventPauseCount, _state);
+    MXLogDebug(@"[MXSession] setPreventPauseCount: %tu. MXSession state: %tu", _preventPauseCount, _state);
 
     if (_preventPauseCount == 0)
     {
         // The background task can be released
         if (self.backgroundTask.isRunning)
         {
-            NSLog(@"[MXSession pause] Stop background task %@", self.backgroundTask);
+            MXLogDebug(@"[MXSession pause] Stop background task %@", self.backgroundTask);
             [self.backgroundTask stop];
             self.backgroundTask = nil;
         }
@@ -1248,7 +1248,7 @@ typedef void (^MXOnResumeDone)(void);
         // And the session can be paused for real if it was not resumed before
         if (_state == MXSessionStatePauseRequested)
         {
-            NSLog(@"[MXSession] setPreventPauseCount: Actually pause the session");
+            MXLogDebug(@"[MXSession] setPreventPauseCount: Actually pause the session");
             [self pause];
         }
     }
@@ -1281,7 +1281,7 @@ typedef void (^MXOnResumeDone)(void);
         syncResponse = cachedResponse.syncResponse;
         useLiveResponse = NO;
         
-        NSLog(@"[MXSession] serverSync: Use cached initial sync response");
+        MXLogDebug(@"[MXSession] serverSync: Use cached initial sync response");
         
         dispatch_group_leave(initialSyncDispatchGroup);
     }
@@ -1304,7 +1304,7 @@ typedef void (^MXOnResumeDone)(void);
         // Determine if we are catching up
         _catchingUp = (0 == serverTimeout);
         
-        NSLog(@"[MXSession] Do a server sync%@ from token: %@", _catchingUp ? @" (catching up)" : @"", streamToken);
+        MXLogDebug(@"[MXSession] Do a server sync%@ from token: %@", _catchingUp ? @" (catching up)" : @"", streamToken);
         
         MXWeakify(self);
         eventStreamRequest = [matrixRestClient syncFromToken:streamToken serverTimeout:serverTimeout clientTimeout:clientTimeout setPresence:setPresence filter:self.syncFilterId success:^(MXSyncResponse *liveResponse) {
@@ -1317,7 +1317,7 @@ typedef void (^MXOnResumeDone)(void);
             }
             
             NSTimeInterval duration = [[NSDate date] timeIntervalSinceDate:startDate];
-            NSLog(@"[MXSession] Received sync response in %.0fms", duration * 1000);
+            MXLogDebug(@"[MXSession] Received sync response in %.0fms", duration * 1000);
             
             syncResponse = liveResponse;
             useLiveResponse = YES;
@@ -1357,7 +1357,7 @@ typedef void (^MXOnResumeDone)(void);
         {
             // We may have not received all to-device events in a single /sync response
             // Pursue /sync with short timeout
-            NSLog(@"[MXSession] Continue /sync with short timeout to get all to-device events (%@)", self.myUser.userId);
+            MXLogDebug(@"[MXSession] Continue /sync with short timeout to get all to-device events (%@)", self.myUser.userId);
             nextServerTimeout = 0;
         }
         
@@ -1381,7 +1381,7 @@ typedef void (^MXOnResumeDone)(void);
             // there is a pending backgroundSync
             if (self->onBackgroundSyncDone)
             {
-                NSLog(@"[MXSession] Events stream background Sync succeeded");
+                MXLogDebug(@"[MXSession] Events stream background Sync succeeded");
 
                 // Operations on session may occur during this block. For example, [MXSession close] may be triggered.
                 // We run a copy of the block to prevent app from crashing if the block is released by one of these operations.
@@ -1400,7 +1400,7 @@ typedef void (^MXOnResumeDone)(void);
                     }
                     else
                     {
-                        NSLog(@"[MXSession] go to paused ");
+                        MXLogDebug(@"[MXSession] go to paused ");
                         self->eventStreamRequest = nil;
                         [self setState:MXSessionStatePaused];
                         return;
@@ -1408,14 +1408,14 @@ typedef void (^MXOnResumeDone)(void);
                 }
                 else
                 {
-                    NSLog(@"[MXSession] resume after a background Sync");
+                    MXLogDebug(@"[MXSession] resume after a background Sync");
                 }
             }
 
             // If we are resuming inform the app that it received the last uptodate data
             if (self->onResumeDone)
             {
-                NSLog(@"[MXSession] Events stream resumed");
+                MXLogDebug(@"[MXSession] Events stream resumed");
 
                 // Operations on session may occur during this block. For example, [MXSession close] or [MXSession pause] may be triggered.
                 // We run a copy of the block to prevent app from crashing if the block is released by one of these operations.
@@ -1474,7 +1474,7 @@ typedef void (^MXOnResumeDone)(void);
     // Handle failure during catch up first
     if (self->onBackgroundSyncFail)
     {
-        NSLog(@"[MXSession] background Sync fails %@", error);
+        MXLogDebug(@"[MXSession] background Sync fails %@", error);
 
         // Operations on session may occur during this block. For example, [MXSession close] may be triggered.
         // We run a copy of the block to prevent app from crashing if the block is released by one of these operations.
@@ -1493,7 +1493,7 @@ typedef void (^MXOnResumeDone)(void);
             }
             else
             {
-                NSLog(@"[MXSession] go to paused ");
+                MXLogDebug(@"[MXSession] go to paused ");
                 self->eventStreamRequest = nil;
                 [self setState:MXSessionStatePaused];
                 return;
@@ -1501,7 +1501,7 @@ typedef void (^MXOnResumeDone)(void);
         }
         else
         {
-            NSLog(@"[MXSession] resume after a background Sync");
+            MXLogDebug(@"[MXSession] resume after a background Sync");
         }
     }
 
@@ -1519,12 +1519,12 @@ typedef void (^MXOnResumeDone)(void);
         if ([error.domain isEqualToString:NSURLErrorDomain]
             && code == kCFURLErrorCancelled)
         {
-            NSLog(@"[MXSession] The connection has been cancelled.");
+            MXLogDebug(@"[MXSession] The connection has been cancelled.");
         }
         else if ([error.domain isEqualToString:NSURLErrorDomain]
                  && code == kCFURLErrorTimedOut && serverTimeout == 0)
         {
-            NSLog(@"[MXSession] The connection has been timeout.");
+            MXLogDebug(@"[MXSession] The connection has been timeout.");
             // The reconnection attempt failed on timeout: there is no data to retrieve from server
             [self->eventStreamRequest cancel];
             self->eventStreamRequest = nil;
@@ -1553,7 +1553,7 @@ typedef void (^MXOnResumeDone)(void);
 
                     if (self->eventStreamRequest)
                     {
-                        NSLog(@"[MXSession] Retry resuming events stream after error %@", mxError.errcode);
+                        MXLogDebug(@"[MXSession] Retry resuming events stream after error %@", mxError.errcode);
                         [self serverSyncWithServerTimeout:0 success:success failure:failure clientTimeout:CLIENT_TIMEOUT_MS setPresence:nil];
                     }
                 });
@@ -1565,7 +1565,7 @@ typedef void (^MXOnResumeDone)(void);
 
                 // Check if it is a network connectivity issue
                 AFNetworkReachabilityManager *networkReachabilityManager = [AFNetworkReachabilityManager sharedManager];
-                NSLog(@"[MXSession] events stream broken. Network reachability: %d", networkReachabilityManager.isReachable);
+                MXLogDebug(@"[MXSession] events stream broken. Network reachability: %d", networkReachabilityManager.isReachable);
 
                 if (networkReachabilityManager.isReachable)
                 {
@@ -1578,7 +1578,7 @@ typedef void (^MXOnResumeDone)(void);
 
                         if (self->eventStreamRequest)
                         {
-                            NSLog(@"[MXSession] Retry resuming events stream");
+                            MXLogDebug(@"[MXSession] Retry resuming events stream");
                             [self setState:MXSessionStateSyncInProgress];
                             [self serverSyncWithServerTimeout:0 success:success failure:nil clientTimeout:CLIENT_TIMEOUT_MS setPresence:nil];
                         }
@@ -1594,7 +1594,7 @@ typedef void (^MXOnResumeDone)(void);
                         {
                             [[NSNotificationCenter defaultCenter] removeObserver:reachabilityObserver];
 
-                            NSLog(@"[MXSession] Retry resuming events stream");
+                            MXLogDebug(@"[MXSession] Retry resuming events stream");
                             [self setState:MXSessionStateSyncInProgress];
                             [self serverSyncWithServerTimeout:0 success:success failure:nil clientTimeout:CLIENT_TIMEOUT_MS setPresence:nil];
                         }
@@ -1706,7 +1706,7 @@ typedef void (^MXOnResumeDone)(void);
                 if (identityServer != self.identityService.identityServer
                     && ![identityServer isEqualToString:self.identityService.identityServer])
                 {
-                    NSLog(@"[MXSession] handleAccountData: Update identity server: %@ -> %@", self.identityService.identityServer, identityServer);
+                    MXLogDebug(@"[MXSession] handleAccountData: Update identity server: %@ -> %@", self.identityService.identityServer, identityServer);
 
                     // Use the IS from the account data
                     [self setIdentityServer:identityServer andAccessToken:nil];
@@ -1776,7 +1776,7 @@ typedef void (^MXOnResumeDone)(void);
             }
             else
             {
-                NSLog(@"[MXSession] handleToDeviceEvents: Warning: Unable to decrypt to-device event: %@\nError: %@", event.wireContent[@"body"], event.decryptionError);
+                MXLogDebug(@"[MXSession] handleToDeviceEvents: Warning: Unable to decrypt to-device event: %@\nError: %@", event.wireContent[@"body"], event.decryptionError);
             }
         }
         
@@ -1839,12 +1839,12 @@ typedef void (^MXOnResumeDone)(void);
     NSMutableArray<NSString *> *outdatedSyncResponseIds = [syncResponseStore.outdatedSyncResponseIds mutableCopy];
     NSArray<NSString *> *syncResponseIds = syncResponseStore.syncResponseIds;
 
-    NSLog(@"[MXSession] handleBackgroundSyncCacheIfRequired: state %tu. outdatedSyncResponseIds: %@. syncResponseIds: %@. syncResponseStoreSyncToken: %@",
+    MXLogDebug(@"[MXSession] handleBackgroundSyncCacheIfRequired: state %tu. outdatedSyncResponseIds: %@. syncResponseIds: %@. syncResponseStoreSyncToken: %@",
           _state, @(outdatedSyncResponseIds.count), @(syncResponseIds.count) , syncResponseStoreSyncToken);
     
     if (![syncResponseStoreSyncToken isEqualToString:eventStreamToken])
     {
-        NSLog(@"[MXSession] handleBackgroundSyncCacheIfRequired: ");
+        MXLogDebug(@"[MXSession] handleBackgroundSyncCacheIfRequired: ");
         [outdatedSyncResponseIds addObjectsFromArray:syncResponseIds];
         syncResponseIds = @[];
     }
@@ -1905,7 +1905,7 @@ typedef void (^MXOnResumeDone)(void);
 - (void)handleOutdatedSyncResponse:(MXSyncResponse *)syncResponse
                         completion:(void (^)(void))completion
 {
-    NSLog(@"[MXSession] handleOutdatedSyncResponse: %tu joined rooms, %tu invited rooms, %tu left rooms, %tu toDevice events.", syncResponse.rooms.join.count, syncResponse.rooms.invite.count, syncResponse.rooms.leave.count, syncResponse.toDevice.events.count);
+    MXLogDebug(@"[MXSession] handleOutdatedSyncResponse: %tu joined rooms, %tu invited rooms, %tu left rooms, %tu toDevice events.", syncResponse.rooms.join.count, syncResponse.rooms.invite.count, syncResponse.rooms.leave.count, syncResponse.toDevice.events.count);
     
     // Handle only to_device events. They are sent only once by the homeserver
     [self handleToDeviceEvents:syncResponse.toDevice.events onComplete:completion];
@@ -1923,7 +1923,7 @@ typedef void (^MXOnResumeDone)(void);
 
 - (void)enableCrypto:(BOOL)enableCrypto success:(void (^)(void))success failure:(void (^)(NSError *))failure
 {
-    NSLog(@"[MXSesion] enableCrypto: %@", @(enableCrypto));
+    MXLogDebug(@"[MXSesion] enableCrypto: %@", @(enableCrypto));
 
     if (enableCrypto && !_crypto)
     {
@@ -1935,7 +1935,7 @@ typedef void (^MXOnResumeDone)(void);
         }
         else
         {
-            NSLog(@"[MXSesion] enableCrypto: crypto module will be start later (MXSession.state: %@)", @(_state));
+            MXLogDebug(@"[MXSesion] enableCrypto: crypto module will be start later (MXSession.state: %@)", @(_state));
 
             if (success)
             {
@@ -2050,7 +2050,7 @@ typedef void (^MXOnResumeDone)(void);
             
             // TODO: Find a way to handle direct tag failure and report this error in room creation failure block.
             
-            NSLog(@"[MXSession] Failed to tag the room (%@) as a direct chat", response.roomId);
+            MXLogDebug(@"[MXSession] Failed to tag the room (%@) as a direct chat", response.roomId);
             
             if (success)
             {
@@ -2253,7 +2253,7 @@ typedef void (^MXOnResumeDone)(void);
 {
     if (!self.identityService)
     {
-        NSLog(@"[MXSession] Missing identity service");
+        MXLogDebug(@"[MXSession] Missing identity service");
         failure([NSError errorWithDomain:kMXNSErrorDomain code:0 userInfo:@{
                                                                             NSLocalizedDescriptionKey: @"Missing identity service"
                                                                             }]);
@@ -2578,7 +2578,7 @@ typedef void (^MXOnResumeDone)(void);
     }
     else
     {
-        NSLog(@"[MXSession] runOrQueueDirectRoomOperation: Queue operation %p", directRoomsOperationsQueue.lastObject);
+        MXLogDebug(@"[MXSession] runOrQueueDirectRoomOperation: Queue operation %p", directRoomsOperationsQueue.lastObject);
     }
 }
 
@@ -2593,7 +2593,7 @@ typedef void (^MXOnResumeDone)(void);
     // And run the next one if any
     if (directRoomsOperationsQueue.firstObject)
     {
-        NSLog(@"[MXSession] runOrQueueDirectRoomOperation: Execute queued operation %p", directRoomsOperationsQueue.firstObject);
+        MXLogDebug(@"[MXSession] runOrQueueDirectRoomOperation: Execute queued operation %p", directRoomsOperationsQueue.firstObject);
         directRoomsOperationsQueue.firstObject();
     }
 }
@@ -2711,7 +2711,7 @@ typedef void (^MXOnResumeDone)(void);
 
 - (void)preloadRoomsData:(NSArray<NSString*> *)roomIds onComplete:(dispatch_block_t)onComplete
 {
-    NSLog(@"[MXSession] preloadRooms: %@ rooms", @(roomIds.count));
+    MXLogDebug(@"[MXSession] preloadRooms: %@ rooms", @(roomIds.count));
 
     dispatch_group_t group = dispatch_group_create();
     for (NSString *roomId in roomIds)
@@ -2726,12 +2726,12 @@ typedef void (^MXOnResumeDone)(void);
         }
         else
         {
-            NSLog(@"[MXSession] preloadRoomsData: Unkown room id: %@", roomId);
+            MXLogDebug(@"[MXSession] preloadRoomsData: Unkown room id: %@", roomId);
         }
     }
 
     dispatch_group_notify(group, dispatch_get_main_queue(), ^{
-        NSLog(@"[MXSession] preloadRoomsForSyncResponse: DONE");
+        MXLogDebug(@"[MXSession] preloadRoomsForSyncResponse: DONE");
         onComplete();
     });
 }
@@ -2798,12 +2798,12 @@ typedef void (^MXOnResumeDone)(void);
 
 -(void)resetRoomsSummariesLastMessage
 {
-    NSLog(@"[MXSession] resetRoomsSummariesLastMessage");
+    MXLogDebug(@"[MXSession] resetRoomsSummariesLastMessage");
 
     for (MXRoomSummary *summary in self.roomsSummaries)
     {
         [summary resetLastMessage:nil failure:^(NSError *error) {
-            NSLog(@"[MXSession] Cannot reset last message for room %@", summary.roomId);
+            MXLogDebug(@"[MXSession] Cannot reset last message for room %@", summary.roomId);
         } commit:NO];
     }
     
@@ -2825,12 +2825,12 @@ typedef void (^MXOnResumeDone)(void);
     {
         if (!summary.lastMessageEventId)
         {
-            NSLog(@"[MXSession] fixRoomsSummariesLastMessage: Fixing last message for room %@", summary.roomId);
+            MXLogDebug(@"[MXSession] fixRoomsSummariesLastMessage: Fixing last message for room %@", summary.roomId);
             
             [summary resetLastMessageWithMaxServerPaginationCount:maxServerPaginationCount onComplete:^{
-                NSLog(@"[MXSession] fixRoomsSummariesLastMessage:Fixing last message operation for room %@ has complete. lastMessageEventId: %@", summary.roomId, summary.lastMessageEventId);
+                MXLogDebug(@"[MXSession] fixRoomsSummariesLastMessage:Fixing last message operation for room %@ has complete. lastMessageEventId: %@", summary.roomId, summary.lastMessageEventId);
             } failure:^(NSError *error) {
-                NSLog(@"[MXSession] fixRoomsSummariesLastMessage: Cannot fix last message for room %@ with maxServerPaginationCount: %@", summary.roomId, @(maxServerPaginationCount));
+                MXLogDebug(@"[MXSession] fixRoomsSummariesLastMessage: Cannot fix last message for room %@ with maxServerPaginationCount: %@", summary.roomId, @(maxServerPaginationCount));
             }
                                                            commit:NO];
         }
@@ -2853,7 +2853,7 @@ typedef void (^MXOnResumeDone)(void);
     }
     else
     {
-        NSLog(@"[MXSession] updateRoomSummaryWitRoomId:withMembershipState: Failed to find roomSummary with roomId: %@ roomId and update membership transition state: %ld", roomId, (long)membershipTransitionState);
+        MXLogDebug(@"[MXSession] updateRoomSummaryWitRoomId:withMembershipState: Failed to find roomSummary with roomId: %@ roomId and update membership transition state: %ld", roomId, (long)membershipTransitionState);
     }
 }
 
@@ -2873,7 +2873,7 @@ typedef void (^MXOnResumeDone)(void);
                               success:(void (^)(void))success
                               failure:(void (^)(NSError *error))failure
 {
-    NSLog(@"[MXSession] acceptGroupInvite %@", groupId);
+    MXLogDebug(@"[MXSession] acceptGroupInvite %@", groupId);
     
     MXWeakify(self);
     return [matrixRestClient acceptGroupInvite:groupId success:^{
@@ -2892,7 +2892,7 @@ typedef void (^MXOnResumeDone)(void);
                        success:(void (^)(void))success
                        failure:(void (^)(NSError *error))failure
 {
-    NSLog(@"[MXSession] leaveGroup %@", groupId);
+    MXLogDebug(@"[MXSession] leaveGroup %@", groupId);
     
     MXWeakify(self);
     return [matrixRestClient leaveGroup:groupId success:^{
@@ -2927,7 +2927,7 @@ typedef void (^MXOnResumeDone)(void);
         return nil;
     }
     
-    NSLog(@"[MXSession] updateGroupPublicity %@", group.groupId);
+    MXLogDebug(@"[MXSession] updateGroupPublicity %@", group.groupId);
     
     MXWeakify(self);
     return [matrixRestClient updateGroupPublicity:group.groupId isPublicised:isPublicised success:^(void) {
@@ -2988,7 +2988,7 @@ typedef void (^MXOnResumeDone)(void);
         return nil;
     }
     
-    NSLog(@"[MXSession] updateGroupProfile %@", group.groupId);
+    MXLogDebug(@"[MXSession] updateGroupProfile %@", group.groupId);
 
     MXWeakify(self);
     return [matrixRestClient getGroupProfile:group.groupId success:^(MXGroupProfile *groupProfile) {
@@ -3040,7 +3040,7 @@ typedef void (^MXOnResumeDone)(void);
         return nil;
     }
     
-    NSLog(@"[MXSession] updateGroupSummary %@", group.groupId);
+    MXLogDebug(@"[MXSession] updateGroupSummary %@", group.groupId);
 
     MXWeakify(self);
     return [matrixRestClient getGroupSummary:group.groupId success:^(MXGroupSummary *groupSummary) {
@@ -3092,7 +3092,7 @@ typedef void (^MXOnResumeDone)(void);
         return nil;
     }
     
-    NSLog(@"[MXSession] updateGroupUsers %@", group.groupId);
+    MXLogDebug(@"[MXSession] updateGroupUsers %@", group.groupId);
 
     MXWeakify(self);
     return [matrixRestClient getGroupUsers:group.groupId success:^(MXGroupUsers *groupUsers) {
@@ -3144,7 +3144,7 @@ typedef void (^MXOnResumeDone)(void);
         return nil;
     }
     
-    NSLog(@"[MXSession] updateGroupInvitedUsers %@", group.groupId);
+    MXLogDebug(@"[MXSession] updateGroupInvitedUsers %@", group.groupId);
 
     MXWeakify(self);
     return [matrixRestClient getGroupInvitedUsers:group.groupId success:^(MXGroupUsers *invitedUsers) {
@@ -3196,7 +3196,7 @@ typedef void (^MXOnResumeDone)(void);
         return nil;
     }
     
-    NSLog(@"[MXSession] updateGroupRooms %@", group.groupId);
+    MXLogDebug(@"[MXSession] updateGroupRooms %@", group.groupId);
 
     MXWeakify(self);
     return [matrixRestClient getGroupRooms:group.groupId success:^(MXGroupRooms *groupRooms) {
@@ -3239,7 +3239,7 @@ typedef void (^MXOnResumeDone)(void);
 
 - (MXGroup *)didJoinGroupWithId:(NSString *)groupId notify:(BOOL)notify
 {
-    NSLog(@"[MXSession] didJoinGroupWithId %@", groupId);
+    MXLogDebug(@"[MXSession] didJoinGroupWithId %@", groupId);
     
     MXGroup *group = [self groupWithGroupId:groupId];
     if (nil == group)
@@ -3254,7 +3254,7 @@ typedef void (^MXOnResumeDone)(void);
     
     // Update the group summary from server.
     [self updateGroupSummary:group success:nil failure:^(NSError *error) {
-        NSLog(@"[MXKSession] didJoinGroupWithId: group summary update failed %@", groupId);
+        MXLogDebug(@"[MXKSession] didJoinGroupWithId: group summary update failed %@", groupId);
     }];
     
     if (notify)
@@ -3272,7 +3272,7 @@ typedef void (^MXOnResumeDone)(void);
 
 - (MXGroup *)createGroupInviteWithId:(NSString *)groupId profile:(MXGroupSyncProfile*)profile andInviter:(NSString*)inviter notify:(BOOL)notify
 {
-    NSLog(@"[MXSession] createGroupInviteWithId %@", groupId);
+    MXLogDebug(@"[MXSession] createGroupInviteWithId %@", groupId);
     MXGroup *group = [[MXGroup alloc] initWithGroupId:groupId];
     
     MXGroupSummary *summary = [[MXGroupSummary alloc] init];
@@ -3291,7 +3291,7 @@ typedef void (^MXOnResumeDone)(void);
     
     // Retrieve the group summary from server.
     [self updateGroupSummary:group success:nil failure:^(NSError *error) {
-        NSLog(@"[MXKSession] createGroupInviteWithId: group summary update failed %@", group.groupId);
+        MXLogDebug(@"[MXKSession] createGroupInviteWithId: group summary update failed %@", group.groupId);
     }];
     
     if (notify)
@@ -3309,7 +3309,7 @@ typedef void (^MXOnResumeDone)(void);
 
 - (void)removeGroup:(NSString *)groupId
 {
-    NSLog(@"[MXSession] removeGroup %@", groupId);
+    MXLogDebug(@"[MXSession] removeGroup %@", groupId);
     // Clean the store
     [_store deleteGroup:groupId];
     
@@ -3403,7 +3403,7 @@ typedef void (^MXOnResumeDone)(void);
         [self->peekingRooms removeObject:peekingRoom];
         [peekingRoom close];
         
-        NSLog(@"[MXSession] The room is not peekable");
+        MXLogDebug(@"[MXSession] The room is not peekable");
 
         if (failure)
         {
@@ -3799,7 +3799,7 @@ typedef void (^MXOnResumeDone)(void);
             MXRoomTag *prevTag = roomsWithTag[prevIndex - 1].accountData.tags[tag];
             if (!prevTag.order)
             {
-                NSLog(@"[MXSession] computeTagOrderForRoom: Previous room in sublist has no ordering metadata. This should never happen.");
+                MXLogDebug(@"[MXSession] computeTagOrderForRoom: Previous room in sublist has no ordering metadata. This should never happen.");
             }
             else
             {
@@ -3815,7 +3815,7 @@ typedef void (^MXOnResumeDone)(void);
             MXRoomTag *nextTag = roomsWithTag[index ].accountData.tags[tag];
             if (!nextTag.order)
             {
-                NSLog(@"[MXSession] computeTagOrderForRoom: Next room in sublist has no ordering metadata. This should never happen.");
+                MXLogDebug(@"[MXSession] computeTagOrderForRoom: Next room in sublist has no ordering metadata. This should never happen.");
             }
             else
             {
@@ -3884,7 +3884,7 @@ typedef void (^MXOnResumeDone)(void);
         }
     }
 
-    NSLog(@"[MXSession] setAccountDataIdentityServer: %@", identityServer);
+    MXLogDebug(@"[MXSession] setAccountDataIdentityServer: %@", identityServer);
 
     MXHTTPOperation *operation;
     if (identityServer)
@@ -3906,7 +3906,7 @@ typedef void (^MXOnResumeDone)(void);
         } failure:^(NSError * _Nonnull error) {
             identityService = nil;
 
-            NSLog(@"[MXSession] setAccountDataIdentityServer: Invalid identity server. Error: %@", error);
+            MXLogDebug(@"[MXSession] setAccountDataIdentityServer: Invalid identity server. Error: %@", error);
 
             if (failure)
             {
@@ -3951,7 +3951,7 @@ typedef void (^MXOnResumeDone)(void);
 - (MXHTTPOperation *)refreshHomeserverWellknown:(void (^)(MXWellKnown *))success
                                         failure:(void (^)(NSError *))failure
 {
-    NSLog(@"[MXSession] refreshHomeserverWellknown");
+    MXLogDebug(@"[MXSession] refreshHomeserverWellknown");
     if (!autoDiscovery)
     {
         NSString *homeServer;
@@ -4095,7 +4095,7 @@ typedef void (^MXOnResumeDone)(void);
 - (void)startCrypto:(void (^)(void))success
             failure:(void (^)(NSError *error))failure
 {
-    NSLog(@"[MXSession] Start crypto");
+    MXLogDebug(@"[MXSession] Start crypto");
 
     if (_crypto)
     {
@@ -4103,7 +4103,7 @@ typedef void (^MXOnResumeDone)(void);
     }
     else
     {
-        NSLog(@"[MXSession] Start crypto -> No crypto");
+        MXLogDebug(@"[MXSession] Start crypto -> No crypto");
         success();
     }
 }

--- a/MatrixSDK/MatrixSDK.h
+++ b/MatrixSDK/MatrixSDK.h
@@ -40,6 +40,7 @@ FOUNDATION_EXPORT NSString *MatrixSDKVersion;
 #import "MXEventsByTypesEnumeratorOnArray.h"
 
 #import "MXLogger.h"
+#import "MXLog.h"
 
 #import "MXTools.h"
 #import "MXThrottler.h"

--- a/MatrixSDK/NotificationCenter/MXNotificationCenter.m
+++ b/MatrixSDK/NotificationCenter/MXNotificationCenter.m
@@ -119,7 +119,7 @@ NSString *const kMXNotificationCenterAllOtherRoomMessagesRuleID = @".m.rule.mess
         }
         
     } failure:^(NSError *error) {
-        NSLog(@"[MXNotificationCenter] Cannot retrieve push rules from the home server");
+        MXLogDebug(@"[MXNotificationCenter] Cannot retrieve push rules from the home server");
 
         if (failure)
         {
@@ -205,7 +205,7 @@ NSString *const kMXNotificationCenterAllOtherRoomMessagesRuleID = @".m.rule.mess
                             }
                             else
                             {
-                                NSLog(@"[MXNotificationCenter] Warning: There is no MXPushRuleConditionChecker to check condition of kind: %@", condition.kind);
+                                MXLogDebug(@"[MXNotificationCenter] Warning: There is no MXPushRuleConditionChecker to check condition of kind: %@", condition.kind);
                                 conditionsOk = NO;
                             }
                         }

--- a/MatrixSDK/NotificationCenter/ServiceTerms/MXServiceTerms.m
+++ b/MatrixSDK/NotificationCenter/ServiceTerms/MXServiceTerms.m
@@ -87,12 +87,12 @@ NSString *const MXServiceTermsErrorDomain = @"org.matrix.sdk.MXServiceTermsError
         NSHTTPURLResponse *urlResponse = [MXHTTPOperation urlResponseFromError:error];
         if (urlResponse.statusCode == 404)
         {
-            NSLog(@"[MXServiceTerms] areAllTermsAgreed: No terms (404).");
+            MXLogDebug(@"[MXServiceTerms] areAllTermsAgreed: No terms (404).");
             success([NSProgress new]);
             return;
         }
         
-        NSLog(@"[MXServiceTerms] areAllTermsAgreed: Error");
+        MXLogDebug(@"[MXServiceTerms] areAllTermsAgreed: Error");
         failure(error);
     }];
 }

--- a/MatrixSDK/Space/MXSpaceChildContent.m
+++ b/MatrixSDK/Space/MXSpaceChildContent.m
@@ -60,7 +60,7 @@ static NSString* const kOrderTextRegexPattern = @"[ -~]+";
     }
     else
     {
-        NSLog(@"[MXSpaceChildContent] JSONDictionary: order is not valid");
+        MXLogDebug(@"[MXSpaceChildContent] JSONDictionary: order is not valid");
     }
     
     if (self.via)

--- a/MatrixSDK/ThreePidAdd/MX3PidAddManager.m
+++ b/MatrixSDK/ThreePidAdd/MX3PidAddManager.m
@@ -44,7 +44,7 @@ NSString *const MX3PidAddManagerErrorDomain = @"org.matrix.sdk.MX3PidAddManagerE
 
 - (void)cancel3PidAddSession:(MX3PidAddSession*)threePidAddSession
 {
-    NSLog(@"[MX3PidAddManager] cancel3PidAddSession: threePid: %@", threePidAddSession);
+    MXLogDebug(@"[MX3PidAddManager] cancel3PidAddSession: threePid: %@", threePidAddSession);
 
     [threePidAddSession.httpOperation cancel];
     threePidAddSession.httpOperation = nil;
@@ -104,13 +104,13 @@ NSString *const MX3PidAddManagerErrorDomain = @"org.matrix.sdk.MX3PidAddManagerE
 {
     MX3PidAddSession *threePidAddSession = [[MX3PidAddSession alloc] initWithMedium:kMX3PIDMediumEmail andAddress:email];
 
-    NSLog(@"[MX3PidAddManager] startAddEmailSessionWithEmail: threePid: %@", threePidAddSession);
+    MXLogDebug(@"[MX3PidAddManager] startAddEmailSessionWithEmail: threePid: %@", threePidAddSession);
 
     threePidAddSession.httpOperation = [self checkIdentityServerRequirementForAdding3PidWithSuccess:^{
 
         MXHTTPOperation *operation = [self->mxSession.matrixRestClient requestTokenForEmail:email isDuringRegistration:NO clientSecret:threePidAddSession.clientSecret sendAttempt:threePidAddSession.sendAttempt++ nextLink:nextLink success:^(NSString *sid) {
 
-            NSLog(@"[MX3PidAddManager] startAddEmailSessionWithEmail: DONE: threePid: %@", threePidAddSession);
+            MXLogDebug(@"[MX3PidAddManager] startAddEmailSessionWithEmail: DONE: threePid: %@", threePidAddSession);
 
             threePidAddSession.httpOperation = nil;
 
@@ -168,7 +168,7 @@ NSString *const MX3PidAddManagerErrorDomain = @"org.matrix.sdk.MX3PidAddManagerE
                            success:(void (^)(void))success
                            failure:(void (^)(NSError * _Nonnull))failure
 {
-    NSLog(@"[MX3PidAddManager] tryFinaliseAddEmailSession: threePid: %@", threePidAddSession);
+    MXLogDebug(@"[MX3PidAddManager] tryFinaliseAddEmailSession: threePid: %@", threePidAddSession);
 
     NSParameterAssert([threePidAddSession.medium isEqualToString:kMX3PIDMediumEmail]);
 
@@ -186,7 +186,7 @@ NSString *const MX3PidAddManagerErrorDomain = @"org.matrix.sdk.MX3PidAddManagerE
         // https://gist.github.com/jryans/839a09bf0c5a70e2f36ed990d50ed928#2b-adding-a-3pid-to-hs-account-after-registration-post-msc2290
         threePidAddSession.httpOperation = [mxSession.matrixRestClient add3PIDOnlyWithSessionId:threePidAddSession.sid clientSecret:threePidAddSession.clientSecret authParams:authParams success:^{
 
-            NSLog(@"[MX3PidAddManager] tryFinaliseAddEmailSession: DONE: threePid: %@", threePidAddSession);
+            MXLogDebug(@"[MX3PidAddManager] tryFinaliseAddEmailSession: DONE: threePid: %@", threePidAddSession);
 
             threePidAddSession.httpOperation = nil;
             success();
@@ -202,7 +202,7 @@ NSString *const MX3PidAddManagerErrorDomain = @"org.matrix.sdk.MX3PidAddManagerE
         threePidAddSession.httpOperation = [mxSession.matrixRestClient add3PID:threePidAddSession.sid clientSecret:threePidAddSession.clientSecret bind:NO success:^{
             threePidAddSession.httpOperation = nil;
 
-            NSLog(@"[MX3PidAddManager] tryFinaliseAddEmailSession: DONE: threePid: %@", threePidAddSession);
+            MXLogDebug(@"[MX3PidAddManager] tryFinaliseAddEmailSession: DONE: threePid: %@", threePidAddSession);
 
             success();
 
@@ -224,13 +224,13 @@ NSString *const MX3PidAddManagerErrorDomain = @"org.matrix.sdk.MX3PidAddManagerE
     MX3PidAddSession *threePidAddSession = [[MX3PidAddSession alloc] initWithMedium:kMX3PIDMediumMSISDN andAddress:phoneNumber];
     threePidAddSession.countryCode = countryCode;
 
-    NSLog(@"[MX3PidAddManager] startAddPhoneNumberSessionWithPhoneNumber: threePid: %@", threePidAddSession);
+    MXLogDebug(@"[MX3PidAddManager] startAddPhoneNumberSessionWithPhoneNumber: threePid: %@", threePidAddSession);
 
     threePidAddSession.httpOperation = [self checkIdentityServerRequirementForAdding3PidWithSuccess:^{
 
         MXHTTPOperation *operation = [self->mxSession.matrixRestClient requestTokenForPhoneNumber:phoneNumber isDuringRegistration:NO countryCode:countryCode clientSecret:threePidAddSession.clientSecret sendAttempt:threePidAddSession.sendAttempt++ nextLink:nil success:^(NSString *sid, NSString *msisdn, NSString *submitUrl) {
 
-            NSLog(@"[MX3PidAddManager] startAddPhoneNumberSessionWithPhoneNumber: DONE: threePid: %@", threePidAddSession);
+            MXLogDebug(@"[MX3PidAddManager] startAddPhoneNumberSessionWithPhoneNumber: DONE: threePid: %@", threePidAddSession);
 
             threePidAddSession.httpOperation = nil;
 
@@ -291,7 +291,7 @@ NSString *const MX3PidAddManagerErrorDomain = @"org.matrix.sdk.MX3PidAddManagerE
                               success:(void (^)(void))success
                               failure:(void (^)(NSError * _Nonnull))failure
 {
-    NSLog(@"[MX3PidAddManager] finaliseAddPhoneNumberSession: threePid: %@", threePidAddSession);
+    MXLogDebug(@"[MX3PidAddManager] finaliseAddPhoneNumberSession: threePid: %@", threePidAddSession);
 
     NSParameterAssert([threePidAddSession.medium isEqualToString:kMX3PIDMediumMSISDN]);
 
@@ -314,7 +314,7 @@ NSString *const MX3PidAddManagerErrorDomain = @"org.matrix.sdk.MX3PidAddManagerE
             // https://gist.github.com/jryans/839a09bf0c5a70e2f36ed990d50ed928#2b-adding-a-3pid-to-hs-account-after-registration-post-msc2290
             operation = [self->mxSession.matrixRestClient add3PIDOnlyWithSessionId:threePidAddSession.sid clientSecret:threePidAddSession.clientSecret authParams:authParams success:^{
 
-                NSLog(@"[MX3PidAddManager] finaliseAddPhoneNumberSession: DONE: threePid: %@", threePidAddSession);
+                MXLogDebug(@"[MX3PidAddManager] finaliseAddPhoneNumberSession: DONE: threePid: %@", threePidAddSession);
 
                 threePidAddSession.httpOperation = nil;
                 success();
@@ -329,7 +329,7 @@ NSString *const MX3PidAddManagerErrorDomain = @"org.matrix.sdk.MX3PidAddManagerE
             // https://gist.github.com/jryans/839a09bf0c5a70e2f36ed990d50ed928#2a-adding-a-3pid-to-hs-account-after-registration-pre-msc2290
             operation = [self->mxSession.matrixRestClient add3PID:threePidAddSession.sid clientSecret:threePidAddSession.clientSecret bind:NO success:^{
 
-                NSLog(@"[MX3PidAddManager] finaliseAddPhoneNumberSession: DONE: threePid: %@", threePidAddSession);
+                MXLogDebug(@"[MX3PidAddManager] finaliseAddPhoneNumberSession: DONE: threePid: %@", threePidAddSession);
 
                 threePidAddSession.httpOperation = nil;
                 success();
@@ -359,7 +359,7 @@ NSString *const MX3PidAddManagerErrorDomain = @"org.matrix.sdk.MX3PidAddManagerE
     MX3PidAddSession *threePidAddSession = [[MX3PidAddSession alloc] initWithMedium:kMX3PIDMediumEmail andAddress:email];
     threePidAddSession.bind = bind;
 
-    NSLog(@"[MX3PidAddManager] startIdentityServerEmailSessionWithEmail (bind:%@) : threePid: %@", @(bind), threePidAddSession);
+    MXLogDebug(@"[MX3PidAddManager] startIdentityServerEmailSessionWithEmail (bind:%@) : threePid: %@", @(bind), threePidAddSession);
 
     [self startIdentityServer3PidSession:threePidAddSession success:success failure:failure];
 
@@ -370,7 +370,7 @@ NSString *const MX3PidAddManagerErrorDomain = @"org.matrix.sdk.MX3PidAddManagerE
                                       success:(void (^)(void))success
                                       failure:(void (^)(NSError * _Nonnull))failure
 {
-    NSLog(@"[MX3PidAddManager] tryFinaliseIdentityServerEmailSession: threePid: %@", threePidAddSession);
+    MXLogDebug(@"[MX3PidAddManager] tryFinaliseIdentityServerEmailSession: threePid: %@", threePidAddSession);
 
     NSParameterAssert([threePidAddSession.medium isEqualToString:kMX3PIDMediumEmail]);
 
@@ -397,7 +397,7 @@ NSString *const MX3PidAddManagerErrorDomain = @"org.matrix.sdk.MX3PidAddManagerE
     threePidAddSession.countryCode = countryCode;
     threePidAddSession.bind = bind;
 
-    NSLog(@"[MX3PidAddManager] startIdentityServerPhoneNumberSessionWithPhoneNumber (bind: %@): threePid: %@", @(bind), threePidAddSession);
+    MXLogDebug(@"[MX3PidAddManager] startIdentityServerPhoneNumberSessionWithPhoneNumber (bind: %@): threePid: %@", @(bind), threePidAddSession);
 
     [self startIdentityServer3PidSession:threePidAddSession success:success failure:failure];
 
@@ -409,7 +409,7 @@ NSString *const MX3PidAddManagerErrorDomain = @"org.matrix.sdk.MX3PidAddManagerE
                                          success:(void (^)(void))success
                                          failure:(void (^)(NSError * _Nonnull))failure
 {
-    NSLog(@"[MX3PidAddManager] finaliseIdentityServerPhoneNumberSession: threePid: %@", threePidAddSession);
+    MXLogDebug(@"[MX3PidAddManager] finaliseIdentityServerPhoneNumberSession: threePid: %@", threePidAddSession);
 
     NSParameterAssert([threePidAddSession.medium isEqualToString:kMX3PIDMediumMSISDN]);
 
@@ -434,9 +434,9 @@ NSString *const MX3PidAddManagerErrorDomain = @"org.matrix.sdk.MX3PidAddManagerE
     return [mxSession.matrixRestClient supportedMatrixVersions:^(MXMatrixVersions *matrixVersions) {
         MXStrongifyAndReturnIfNil(self);
 
-        NSLog(@"[MX3PidAddManager] checkIdentityServerRequirement: %@", matrixVersions.doesServerRequireIdentityServerParam ? @"YES": @"NO");
+        MXLogDebug(@"[MX3PidAddManager] checkIdentityServerRequirement: %@", matrixVersions.doesServerRequireIdentityServerParam ? @"YES": @"NO");
 
-        NSLog(@"[MX3PidAddManager] doesServerSupportSeparateAddAndBind: %@", matrixVersions.doesServerSupportSeparateAddAndBind ? @"YES": @"NO");
+        MXLogDebug(@"[MX3PidAddManager] doesServerSupportSeparateAddAndBind: %@", matrixVersions.doesServerSupportSeparateAddAndBind ? @"YES": @"NO");
         self->doesServerSupportSeparateAddAndBind = matrixVersions.doesServerSupportSeparateAddAndBind;
 
         if (matrixVersions.doesServerRequireIdentityServerParam
@@ -474,7 +474,7 @@ NSString *const MX3PidAddManagerErrorDomain = @"org.matrix.sdk.MX3PidAddManagerE
             {
                 MXHTTPOperation *operation2 = [self->mxSession.matrixRestClient supportedMatrixVersions:^(MXMatrixVersions *matrixVersions) {
 
-                    NSLog(@"[MX3PidAddManager] doesServerSupportSeparateAddAndBind: %@", matrixVersions.doesServerSupportSeparateAddAndBind ? @"YES": @"NO");
+                    MXLogDebug(@"[MX3PidAddManager] doesServerSupportSeparateAddAndBind: %@", matrixVersions.doesServerSupportSeparateAddAndBind ? @"YES": @"NO");
                     self->doesServerSupportSeparateAddAndBind = matrixVersions.doesServerSupportSeparateAddAndBind;
                     success(self->doesServerSupportSeparateAddAndBind);
 
@@ -485,7 +485,7 @@ NSString *const MX3PidAddManagerErrorDomain = @"org.matrix.sdk.MX3PidAddManagerE
             else
             {
                 // If the IS does not support v2, use legacy APIs
-                NSLog(@"[MX3PidAddManager] doesServerSupportSeparateAddAndBind: NO because v1 identity server");
+                MXLogDebug(@"[MX3PidAddManager] doesServerSupportSeparateAddAndBind: NO because v1 identity server");
                 success(NO);
             }
 
@@ -500,7 +500,7 @@ NSString *const MX3PidAddManagerErrorDomain = @"org.matrix.sdk.MX3PidAddManagerE
                                             success:(void (^)(void))success
                                             failure:(void (^)(NSError * _Nonnull))failure
 {
-    NSLog(@"[MX3PidAddManager] submitValidationToken: for3PidAddSession: %@", threePidAddSession);
+    MXLogDebug(@"[MX3PidAddManager] submitValidationToken: for3PidAddSession: %@", threePidAddSession);
 
     MXHTTPOperation *operation;
     if ([threePidAddSession.medium isEqualToString:kMX3PIDMediumMSISDN]
@@ -525,7 +525,7 @@ NSString *const MX3PidAddManagerErrorDomain = @"org.matrix.sdk.MX3PidAddManagerE
     }
     else
     {
-        NSLog(@"[MX3PidAddManager] submitValidationToken: ERROR: Failed to submit validation token for 3PID: %@, identity service is not set", threePidAddSession);
+        MXLogDebug(@"[MX3PidAddManager] submitValidationToken: ERROR: Failed to submit validation token for 3PID: %@, identity service is not set", threePidAddSession);
 
         NSError *error = [NSError errorWithDomain:MX3PidAddManagerErrorDomain
                                              code:MX3PidAddManagerErrorDomainIdentityServerRequired
@@ -562,7 +562,7 @@ NSString *const MX3PidAddManagerErrorDomain = @"org.matrix.sdk.MX3PidAddManagerE
                                        success:(void (^)(void))success
                                        failure:(void (^)(NSError *))failure
 {
-    NSLog(@"[MX3PidAddManager] submitMsisdnTokenOtherUrl: %@", url);
+    MXLogDebug(@"[MX3PidAddManager] submitMsisdnTokenOtherUrl: %@", url);
 
     NSDictionary *parameters = @{
                                  @"sid": sid,
@@ -659,7 +659,7 @@ NSString *const MX3PidAddManagerErrorDomain = @"org.matrix.sdk.MX3PidAddManagerE
 
                     threePidAddSession.httpOperation = nil;
 
-                    NSLog(@"[MX3PidAddManager] startIdentityServer3PidSession: DONE: threePid: %@", threePidAddSession);
+                    MXLogDebug(@"[MX3PidAddManager] startIdentityServer3PidSession: DONE: threePid: %@", threePidAddSession);
                     success(NO);
 
                 } failure:^(NSError *error) {
@@ -698,13 +698,13 @@ NSString *const MX3PidAddManagerErrorDomain = @"org.matrix.sdk.MX3PidAddManagerE
     {
         operation = [identityService requestEmailValidation:threePidAddSession.address clientSecret:threePidAddSession.clientSecret sendAttempt:threePidAddSession.sendAttempt++ nextLink:nil success:^(NSString * _Nonnull sid) {
 
-            NSLog(@"[MX3PidAddManager] startIdentityServer3PidSessionWithNewHomeserver: DONE: threePid: %@", threePidAddSession);
+            MXLogDebug(@"[MX3PidAddManager] startIdentityServer3PidSessionWithNewHomeserver: DONE: threePid: %@", threePidAddSession);
 
             threePidAddSession.sid = sid;
             success();
 
         } failure:^(NSError *error) {
-            NSLog(@"[MX3PidAddManager] startIdentityServer3PidSessionWithNewHomeserver: threePid: %@. ERROR: requestTokenForEmail failed: %@", threePidAddSession, error);
+            MXLogDebug(@"[MX3PidAddManager] startIdentityServer3PidSessionWithNewHomeserver: threePid: %@. ERROR: requestTokenForEmail failed: %@", threePidAddSession, error);
             failure(error);
         }];
     }
@@ -712,13 +712,13 @@ NSString *const MX3PidAddManagerErrorDomain = @"org.matrix.sdk.MX3PidAddManagerE
     {
         operation = [identityService requestPhoneNumberValidation:threePidAddSession.address countryCode:threePidAddSession.countryCode clientSecret:threePidAddSession.clientSecret sendAttempt:threePidAddSession.sendAttempt++ nextLink:nil success:^(NSString * _Nonnull sid, NSString * _Nonnull msisdn) {
 
-            NSLog(@"[MX3PidAddManager] startIdentityServer3PidSessionWithNewHomeserver: DONE: threePid: %@", threePidAddSession);
+            MXLogDebug(@"[MX3PidAddManager] startIdentityServer3PidSessionWithNewHomeserver: DONE: threePid: %@", threePidAddSession);
 
             threePidAddSession.sid = sid;
             success();
 
         } failure:^(NSError *error) {
-            NSLog(@"[MX3PidAddManager] startIdentityServer3PidSessionWithNewHomeserver: threePid: %@. ERROR: requestTokenForEmail failed: %@", threePidAddSession, error);
+            MXLogDebug(@"[MX3PidAddManager] startIdentityServer3PidSessionWithNewHomeserver: threePid: %@. ERROR: requestTokenForEmail failed: %@", threePidAddSession, error);
             failure(error);
         }];
     }
@@ -731,7 +731,7 @@ NSString *const MX3PidAddManagerErrorDomain = @"org.matrix.sdk.MX3PidAddManagerE
                                                       success:(void (^)(void))success
                                                       failure:(void (^)(NSError * _Nonnull))failure
 {
-    NSLog(@"[MX3PidAddManager] tryFinaliseIdentityServer3PidSessionWithNewHomeserver: threePid: %@", threePidAddSession);
+    MXLogDebug(@"[MX3PidAddManager] tryFinaliseIdentityServer3PidSessionWithNewHomeserver: threePid: %@", threePidAddSession);
 
     NSParameterAssert(threePidAddSession.bind);
 
@@ -750,7 +750,7 @@ NSString *const MX3PidAddManagerErrorDomain = @"org.matrix.sdk.MX3PidAddManagerE
 
             threePidAddSession.httpOperation = nil;
 
-            NSLog(@"[MX3PidAddManager] tryFinaliseIdentityServer3PidSessionWithNewHomeserver: DONE: threePid: %@", threePidAddSession);
+            MXLogDebug(@"[MX3PidAddManager] tryFinaliseIdentityServer3PidSessionWithNewHomeserver: DONE: threePid: %@", threePidAddSession);
             success();
 
         } failure:^(NSError *error) {
@@ -766,7 +766,7 @@ NSString *const MX3PidAddManagerErrorDomain = @"org.matrix.sdk.MX3PidAddManagerE
 
             MXHTTPOperation *operation = [self->mxSession.matrixRestClient bind3PidWithSessionId:threePidAddSession.sid clientSecret:threePidAddSession.clientSecret success:^{
 
-                NSLog(@"[MX3PidAddManager] tryFinaliseIdentityServer3PidSessionWithNewHomeserver: DONE: threePid: %@", threePidAddSession);
+                MXLogDebug(@"[MX3PidAddManager] tryFinaliseIdentityServer3PidSessionWithNewHomeserver: DONE: threePid: %@", threePidAddSession);
 
                 threePidAddSession.httpOperation = nil;
                 success();
@@ -796,7 +796,7 @@ NSString *const MX3PidAddManagerErrorDomain = @"org.matrix.sdk.MX3PidAddManagerE
                                                    success:(void (^)(void))success
                                                    failure:(void (^)(NSError * _Nonnull))failure
 {
-    NSLog(@"[MX3PidAddManager] startBind3PidSessionWithOldHomeserver: threePid: %@", threePidAddSession);
+    MXLogDebug(@"[MX3PidAddManager] startBind3PidSessionWithOldHomeserver: threePid: %@", threePidAddSession);
 
     MXWeakify(self);
     MXHTTPOperation *operation;
@@ -808,13 +808,13 @@ NSString *const MX3PidAddManagerErrorDomain = @"org.matrix.sdk.MX3PidAddManagerE
         {
             operation2 = [self->mxSession.matrixRestClient requestTokenForEmail:threePidAddSession.address isDuringRegistration:NO clientSecret:threePidAddSession.clientSecret sendAttempt:threePidAddSession.sendAttempt++ nextLink:nil success:^(NSString *sid) {
 
-                NSLog(@"[MX3PidAddManager] startBind3PidSessionWithOldHomeserver: DONE: threePid: %@", threePidAddSession);
+                MXLogDebug(@"[MX3PidAddManager] startBind3PidSessionWithOldHomeserver: DONE: threePid: %@", threePidAddSession);
 
                 threePidAddSession.sid = sid;
                 success();
 
             } failure:^(NSError *error) {
-                NSLog(@"[MX3PidAddManager] startBind3PidSessionWithOldHomeserver: threePid: %@. ERROR: requestTokenForEmail failed: %@", threePidAddSession, error);
+                MXLogDebug(@"[MX3PidAddManager] startBind3PidSessionWithOldHomeserver: threePid: %@. ERROR: requestTokenForEmail failed: %@", threePidAddSession, error);
                 failure(error);
             }];
         }
@@ -822,13 +822,13 @@ NSString *const MX3PidAddManagerErrorDomain = @"org.matrix.sdk.MX3PidAddManagerE
         {
             operation2 = [self->mxSession.matrixRestClient requestTokenForPhoneNumber:threePidAddSession.address isDuringRegistration:NO countryCode:threePidAddSession.countryCode clientSecret:threePidAddSession.clientSecret sendAttempt:threePidAddSession.sendAttempt++ nextLink:nil success:^(NSString *sid, NSString *msisdn, NSString *submitUrl) {
 
-                NSLog(@"[MX3PidAddManager] startBind3PidSessionWithOldHomeserver: DONE: threePid: %@", threePidAddSession);
+                MXLogDebug(@"[MX3PidAddManager] startBind3PidSessionWithOldHomeserver: DONE: threePid: %@", threePidAddSession);
 
                 threePidAddSession.sid = sid;
                 success();
 
             } failure:^(NSError *error) {
-                NSLog(@"[MX3PidAddManager] startBind3PidSessionWithOldHomeserver: threePid: %@. ERROR: requestTokenForEmail failed: %@", threePidAddSession, error);
+                MXLogDebug(@"[MX3PidAddManager] startBind3PidSessionWithOldHomeserver: threePid: %@. ERROR: requestTokenForEmail failed: %@", threePidAddSession, error);
                 failure(error);
             }];
         }
@@ -837,7 +837,7 @@ NSString *const MX3PidAddManagerErrorDomain = @"org.matrix.sdk.MX3PidAddManagerE
 
     } failure:^(NSError *error) {
 
-        NSLog(@"[MX3PidAddManager] startBind3PidSessionWithOldHomeserver: threePid: %@. ERROR: remove3PID failed: %@", threePidAddSession, error);
+        MXLogDebug(@"[MX3PidAddManager] startBind3PidSessionWithOldHomeserver: threePid: %@. ERROR: remove3PID failed: %@", threePidAddSession, error);
         failure(error);
     }];
 
@@ -849,7 +849,7 @@ NSString *const MX3PidAddManagerErrorDomain = @"org.matrix.sdk.MX3PidAddManagerE
                                                       success:(void (^)(void))success
                                                       failure:(void (^)(NSError * _Nonnull))failure
 {
-    NSLog(@"[MX3PidAddManager] tryFinaliseIdentityServer3PidSessionWithOldHomeserver: threePid: %@", threePidAddSession);
+    MXLogDebug(@"[MX3PidAddManager] tryFinaliseIdentityServer3PidSessionWithOldHomeserver: threePid: %@", threePidAddSession);
 
     if (threePidAddSession.httpOperation || !threePidAddSession.sid)
     {
@@ -865,7 +865,7 @@ NSString *const MX3PidAddManagerErrorDomain = @"org.matrix.sdk.MX3PidAddManagerE
         threePidAddSession.httpOperation = [mxSession.matrixRestClient add3PID:threePidAddSession.sid clientSecret:threePidAddSession.clientSecret bind:threePidAddSession.bind success:^{
             threePidAddSession.httpOperation = nil;
 
-            NSLog(@"[MX3PidAddManager] tryFinaliseIdentityServer3PidSessionWithOldHomeserver: DONE: threePid: %@", threePidAddSession);
+            MXLogDebug(@"[MX3PidAddManager] tryFinaliseIdentityServer3PidSessionWithOldHomeserver: DONE: threePid: %@", threePidAddSession);
             success();
 
         } failure:^(NSError *error) {
@@ -881,7 +881,7 @@ NSString *const MX3PidAddManagerErrorDomain = @"org.matrix.sdk.MX3PidAddManagerE
 
             MXHTTPOperation *operation = [self->mxSession.matrixRestClient add3PID:threePidAddSession.sid clientSecret:threePidAddSession.clientSecret bind:threePidAddSession.bind success:^{
 
-                NSLog(@"[MX3PidAddManager] tryFinaliseIdentityServer3PidSessionWithOldHomeserver: DONE: threePid: %@", threePidAddSession);
+                MXLogDebug(@"[MX3PidAddManager] tryFinaliseIdentityServer3PidSessionWithOldHomeserver: DONE: threePid: %@", threePidAddSession);
 
                 threePidAddSession.httpOperation = nil;
                 success();

--- a/MatrixSDK/Utils/MXBugReportRestClient.m
+++ b/MatrixSDK/Utils/MXBugReportRestClient.m
@@ -102,7 +102,7 @@
 {
     if (_state != MXBugReportStateReady)
     {
-        NSLog(@"[MXBugReport] sendBugReport failed. There is already a submission in progress. state: %@", @(_state));
+        MXLogDebug(@"[MXBugReport] sendBugReport failed. There is already a submission in progress. state: %@", @(_state));
 
         if (failure)
         {
@@ -227,7 +227,7 @@
 
     if (error)
     {
-        NSLog(@"[MXBugReport] sendBugReport: multipartFormRequestWithMethod failed. Error: %@", error);
+        MXLogDebug(@"[MXBugReport] sendBugReport: multipartFormRequestWithMethod failed. Error: %@", error);
 
         _state = MXBugReportStateReady;
 
@@ -244,7 +244,7 @@
                                           progress:^(NSProgress * _Nonnull uploadProgress) {
                                               MXStrongifyAndReturnIfNil(self);
 
-                                              NSLog(@"[MXBugReport] sendBugReport: uploadProgress: %@", @(uploadProgress.fractionCompleted));
+                                              MXLogDebug(@"[MXBugReport] sendBugReport: uploadProgress: %@", @(uploadProgress.fractionCompleted));
 
                                               if (progress)
                                               {
@@ -266,7 +266,7 @@
 
                                               if (error)
                                               {
-                                                  NSLog(@"[MXBugReport] sendBugReport: report failed. Error: %@", error);
+                                                  MXLogDebug(@"[MXBugReport] sendBugReport: report failed. Error: %@", error);
 
                                                   if (failure)
                                                   {
@@ -275,7 +275,7 @@
                                               }
                                               else
                                               {
-                                                  NSLog(@"[MXBugReport] sendBugReport: report done in %.3fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+                                                  MXLogDebug(@"[MXBugReport] sendBugReport: report done in %.3fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 
                                                   if (success)
                                                   {
@@ -352,7 +352,7 @@
                 }
                 else
                 {
-                    NSLog(@"[MXBugReport] zipLogFiles: Failed to zip %@", logFile);
+                    MXLogDebug(@"[MXBugReport] zipLogFiles: Failed to zip %@", logFile);
                 }
 
                 if (progress)
@@ -365,7 +365,7 @@
                 }
             }
 
-            NSLog(@"[MXBugReport] zipLogFiles: Zipped %tu logs (%@ to %@) in %.3fms", logFiles.count,
+            MXLogDebug(@"[MXBugReport] zipLogFiles: Zipped %tu logs (%@ to %@) in %.3fms", logFiles.count,
                   [NSByteCountFormatter stringFromByteCount:size countStyle:NSByteCountFormatterCountStyleFile],
                   [NSByteCountFormatter stringFromByteCount:zipSize countStyle:NSByteCountFormatterCountStyleFile],
                   [[NSDate date] timeIntervalSinceDate:startDate] * 1000);

--- a/MatrixSDK/Utils/MXLog.h
+++ b/MatrixSDK/Utils/MXLog.h
@@ -1,0 +1,37 @@
+//
+// Copyright 2021 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import "MXLogObjcWrapper.h"
+
+#define MXLogVerbose(message, ...) { \
+    [MXLogObjcWrapper logVerbose:[NSString stringWithFormat: message, ##__VA_ARGS__] file:@__FILE__ function:[NSString stringWithFormat:@"%s", __FUNCTION__] line:__LINE__]; \
+}
+
+#define MXLogDebug(message, ...) { \
+    [MXLogObjcWrapper logDebug:[NSString stringWithFormat: message, ##__VA_ARGS__] file:@__FILE__ function:[NSString stringWithFormat:@"%s", __FUNCTION__] line:__LINE__]; \
+}
+
+#define MXLogInfo(message, ...) { \
+    [MXLogObjcWrapper logInfo:[NSString stringWithFormat: message, ##__VA_ARGS__] file:@__FILE__ function:[NSString stringWithFormat:@"%s", __FUNCTION__] line:__LINE__]; \
+}
+
+#define MXLogWarning(message, ...) { \
+    [MXLogObjcWrapper logWarning:[NSString stringWithFormat: message, ##__VA_ARGS__] file:@__FILE__ function:[NSString stringWithFormat:@"%s", __FUNCTION__] line:__LINE__]; \
+}
+
+#define MXLogError(message, ...) { \
+    [MXLogObjcWrapper logError:[NSString stringWithFormat: message, ##__VA_ARGS__] file:@__FILE__ function:[NSString stringWithFormat:@"%s", __FUNCTION__] line:__LINE__]; \
+}

--- a/MatrixSDK/Utils/MXLog.swift
+++ b/MatrixSDK/Utils/MXLog.swift
@@ -1,0 +1,167 @@
+//
+// Copyright 2021 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import SwiftyBeaver
+
+/// Various MXLog configuration options. Used in conjunction with `MXLog.configure()`
+@objc public class MXLogConfiguration: NSObject {
+    
+    /// the desired log level. `.verbose` by default.
+    @objc public var logLevel: MXLogLevel = MXLogLevel.verbose
+    
+    /// whether logs should be written directly to files. `false` by default.
+    @objc public var redirectLogsToFiles: Bool = false
+    
+    /// the maximum total space to use for log files in bytes. `100MB` by default.
+    @objc public var logFilesSizeLimit: UInt = 100 * 1024 * 1024 // 100MB
+    
+    /// the maximum number of log files to use before rolling. `50` by default.
+    @objc public var maxLogFilesCount: UInt = 50
+    
+    /// the subname for log files. Files will be named as 'console-[subLogName].log'. `nil` by default
+    @objc public var subLogName: String? = nil
+    
+    /// whether logging runs asyncronously. `true` by default.
+    @objc public var asynchronous: Bool = true
+}
+
+/// MXLog logging levels. Use .none to disable logging entirely.
+@objc public enum MXLogLevel: UInt {
+    case none
+    case verbose
+    case debug
+    case info
+    case warning
+    case error
+}
+
+private var logger: SwiftyBeaver.Type = {
+    let logger = SwiftyBeaver.self
+    MXLog.configureLogger(logger, withConfiguration:MXLogConfiguration())
+    return logger
+}()
+
+/**
+ Logging utility that provies multiple logging levels as well as file output and rolling.
+ Its purpose is to provide a common entry for customizing logging and should be used throughout the code.
+ Please see `MXLog.h` for Objective-C options.
+ */
+@objc public class MXLog: NSObject {
+    
+    /// Method used to customize MXLog's behavior.
+    /// Called automatically when first accessing the logger with the default values.
+    /// Please see `MXLogConfiguration` for all available options.
+    /// - Parameters:
+    ///     - configuration: the `MXLogConfiguration` instance to use
+    @objc static public func configure(_ configuration: MXLogConfiguration) {
+        configureLogger(logger, withConfiguration: configuration)
+    }
+    
+    public static func verbose(_ message: @autoclosure () -> Any, _
+                                file: String = #file, _ function: String = #function, line: Int = #line, context: Any? = nil) {
+        logger.verbose(message(), file, function, line: line, context: context)
+    }
+    
+    @available(swift, obsoleted: 5.4)
+    @objc public static func logVerbose(_ message: String, file: String, function: String, line: Int) {
+        logger.verbose(message, file, function, line: line)
+    }
+    
+    public static func debug(_ message: @autoclosure () -> Any, _
+                                file: String = #file, _ function: String = #function, line: Int = #line, context: Any? = nil) {
+        logger.debug(message(), file, function, line: line, context: context)
+    }
+    
+    @available(swift, obsoleted: 5.4)
+    @objc public static func logDebug(_ message: String, file: String, function: String, line: Int) {
+        logger.debug(message, file, function, line: line)
+    }
+    
+    public static func info(_ message: @autoclosure () -> Any, _
+                                file: String = #file, _ function: String = #function, line: Int = #line, context: Any? = nil) {
+        logger.info(message(), file, function, line: line, context: context)
+    }
+    
+    @available(swift, obsoleted: 5.4)
+    @objc public static func logInfo(_ message: String, file: String, function: String, line: Int) {
+        logger.info(message, file, function, line: line)
+    }
+    
+    public static func warning(_ message: @autoclosure () -> Any, _
+                                file: String = #file, _ function: String = #function, line: Int = #line, context: Any? = nil) {
+        logger.warning(message(), file, function, line: line, context: context)
+    }
+    
+    @available(swift, obsoleted: 5.4)
+    @objc public static func logWarning(_ message: String, file: String, function: String, line: Int) {
+        logger.warning(message, file, function, line: line)
+    }
+    
+    public static func error(_ message: @autoclosure () -> Any, _
+                                file: String = #file, _ function: String = #function, line: Int = #line, context: Any? = nil) {
+        logger.error(message(), file, function, line: line, context: context)
+    }
+    
+    @available(swift, obsoleted: 5.4)
+    @objc public static func logError(_ message: String, file: String, function: String, line: Int) {
+        logger.error(message, file, function, line: line)
+    }
+    
+    // MARK: - Private
+    
+    fileprivate static func configureLogger(_ logger: SwiftyBeaver.Type, withConfiguration configuration: MXLogConfiguration) {
+        if let subLogName = configuration.subLogName {
+            MXLogger.setSubLogName(subLogName)
+        }
+        
+        MXLogger.redirectNSLog(toFiles: configuration.redirectLogsToFiles,
+                               numberOfFiles: configuration.maxLogFilesCount,
+                               sizeLimit: configuration.logFilesSizeLimit)
+        
+        guard configuration.logLevel != .none else {
+            return
+        }
+        
+        let consoleDestination = ConsoleDestination()
+        consoleDestination.useNSLog = true
+        consoleDestination.asynchronously = configuration.asynchronous
+        consoleDestination.format = "$C $M"
+        consoleDestination.levelColor.verbose = " "
+        consoleDestination.levelColor.debug = " "
+        consoleDestination.levelColor.info = " "
+        consoleDestination.levelColor.warning = "⚠️"
+        consoleDestination.levelColor.error = "🚨"
+        
+        switch configuration.logLevel {
+            case .verbose:
+                consoleDestination.minLevel = .verbose
+            case .debug:
+                consoleDestination.minLevel = .debug
+            case .info:
+                consoleDestination.minLevel = .info
+            case .warning:
+                consoleDestination.minLevel = .warning
+            case .error:
+                consoleDestination.minLevel = .error
+            case .none:
+                break
+        }
+        
+        logger.removeAllDestinations()
+        logger.addDestination(consoleDestination)
+    }
+}

--- a/MatrixSDK/Utils/MXLog.swift
+++ b/MatrixSDK/Utils/MXLog.swift
@@ -140,9 +140,9 @@ private var logger: SwiftyBeaver.Type = {
         consoleDestination.useNSLog = true
         consoleDestination.asynchronously = configuration.asynchronous
         consoleDestination.format = "$C $M"
-        consoleDestination.levelColor.verbose = " "
-        consoleDestination.levelColor.debug = " "
-        consoleDestination.levelColor.info = " "
+        consoleDestination.levelColor.verbose = ""
+        consoleDestination.levelColor.debug = ""
+        consoleDestination.levelColor.info = ""
         consoleDestination.levelColor.warning = "⚠️"
         consoleDestination.levelColor.error = "🚨"
         

--- a/MatrixSDK/Utils/MXLog.swift
+++ b/MatrixSDK/Utils/MXLog.swift
@@ -34,9 +34,6 @@ import SwiftyBeaver
     
     /// the subname for log files. Files will be named as 'console-[subLogName].log'. `nil` by default
     @objc public var subLogName: String? = nil
-    
-    /// whether logging runs asyncronously. `true` by default.
-    @objc public var asynchronous: Bool = true
 }
 
 /// MXLog logging levels. Use .none to disable logging entirely.
@@ -138,7 +135,7 @@ private var logger: SwiftyBeaver.Type = {
         
         let consoleDestination = ConsoleDestination()
         consoleDestination.useNSLog = true
-        consoleDestination.asynchronously = configuration.asynchronous
+        consoleDestination.asynchronously = false
         consoleDestination.format = "$C $M"
         consoleDestination.levelColor.verbose = ""
         consoleDestination.levelColor.debug = ""

--- a/MatrixSDK/Utils/MXLogObjcWrapper.h
+++ b/MatrixSDK/Utils/MXLogObjcWrapper.h
@@ -1,0 +1,38 @@
+// 
+// Copyright 2021 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ An `MXLog` Objective-C wrapper used to allow calling Swift methods from the variadic macros defined in `MXLog.h`
+ */
+@interface MXLogObjcWrapper : NSObject
+
++ (void)logVerbose:(NSString *)message file:(NSString *)file function:(NSString *)function line:(NSUInteger)line;
+
++ (void)logDebug:(NSString *)message file:(NSString *)file function:(NSString *)function line:(NSUInteger)line;
+
++ (void)logInfo:(NSString *)message file:(NSString *)file function:(NSString *)function line:(NSUInteger)line;
+
++ (void)logWarning:(NSString *)message file:(NSString *)file function:(NSString *)function line:(NSUInteger)line;
+
++ (void)logError:(NSString *)message file:(NSString *)file function:(NSString *)function line:(NSUInteger)line;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixSDK/Utils/MXLogObjcWrapper.m
+++ b/MatrixSDK/Utils/MXLogObjcWrapper.m
@@ -1,0 +1,47 @@
+// 
+// Copyright 2021 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import "MXLogObjcWrapper.h"
+#import "MatrixSDKSwiftHeader.h"
+
+@implementation MXLogObjcWrapper
+
++ (void)logVerbose:(NSString *)message file:(NSString *)file function:(NSString *)function line:(NSUInteger)line
+{
+    [MXLog logVerbose:message file:file function:function line:line];
+}
+
++ (void)logDebug:(NSString *)message file:(NSString *)file function:(NSString *)function line:(NSUInteger)line
+{
+    [MXLog logDebug:message file:file function:function line:line];
+}
+
++ (void)logInfo:(NSString *)message file:(NSString *)file function:(NSString *)function line:(NSUInteger)line
+{
+    [MXLog logInfo:message file:file function:function line:line];
+}
+
++ (void)logWarning:(NSString *)message file:(NSString *)file function:(NSString *)function line:(NSUInteger)line
+{
+    [MXLog logWarning:message file:file function:function line:line];
+}
+
++ (void)logError:(NSString *)message file:(NSString *)file function:(NSString *)function line:(NSUInteger)line
+{
+    [MXLog logError:message file:file function:function line:line];
+}
+
+@end

--- a/MatrixSDK/Utils/MXLogger.m
+++ b/MatrixSDK/Utils/MXLogger.m
@@ -109,11 +109,11 @@ static NSString *subLogName;
         NSString *nsLogPath = [logsFolderPath stringByAppendingPathComponent:[NSString stringWithFormat:@"console%@.log", subLogName]];
         freopen([nsLogPath fileSystemRepresentation], "w+", stderr);
 
-        NSLog(@"[MXLogger] redirectNSLogToFiles: YES");
+        MXLogDebug(@"[MXLogger] redirectNSLogToFiles: YES");
         if (log.length)
         {
             // We can now log into files
-            NSLog(@"%@", log);
+            MXLogDebug(@"%@", log);
         }
         
         [self removeExtraFilesFromCount:numberOfFiles];
@@ -163,7 +163,7 @@ static NSString *subLogName;
         }
     }
 
-    NSLog(@"[MXLogger] logFiles: %@", logFiles);
+    MXLogDebug(@"[MXLogger] logFiles: %@", logFiles);
 
     return logFiles;
 }
@@ -221,7 +221,7 @@ static void handleUncaughtException(NSException *exception)
                     encoding:NSStringEncodingConversionAllowLossy
                        error:nil];
 
-    NSLog(@"[MXLogger] handleUncaughtException:\n%@", description);
+    MXLogDebug(@"[MXLogger] handleUncaughtException:\n%@", description);
 }
 
 // Signals emitted by the app are handled here
@@ -333,7 +333,7 @@ static NSString* crashLogPath(void)
         if ([fileManager fileExistsAtPath:logFile])
         {
             [fileManager removeItemAtPath:logFile error:nil];
-            NSLog(@"[MXLogger] removeExtraFilesFromCount: %@. removeItemAtPath: %@\n", @(count), logFile);
+            MXLogDebug(@"[MXLogger] removeExtraFilesFromCount: %@. removeItemAtPath: %@\n", @(count), logFile);
         }
         else
         {
@@ -375,7 +375,7 @@ static NSString* crashLogPath(void)
     
     if (removeFiles)
     {
-        NSLog(@"[MXLogger] removeFilesAfterSizeLimit: Remove files from index %@ because logs are too large (%@ for a limit of %@)\n",
+        MXLogDebug(@"[MXLogger] removeFilesAfterSizeLimit: Remove files from index %@ because logs are too large (%@ for a limit of %@)\n",
               @(index),
               [NSByteCountFormatter stringFromByteCount:logSize countStyle:NSByteCountFormatterCountStyleBinary],
               [NSByteCountFormatter stringFromByteCount:sizeLimit countStyle:NSByteCountFormatterCountStyleBinary]);
@@ -383,7 +383,7 @@ static NSString* crashLogPath(void)
     }
     else
     {
-        NSLog(@"[MXLogger] removeFilesAfterSizeLimit: No need: %@ for a limit of %@\n",
+        MXLogDebug(@"[MXLogger] removeFilesAfterSizeLimit: No need: %@ for a limit of %@\n",
               [NSByteCountFormatter stringFromByteCount:logSize countStyle:NSByteCountFormatterCountStyleBinary],
               [NSByteCountFormatter stringFromByteCount:sizeLimit countStyle:NSByteCountFormatterCountStyleBinary]);
     }

--- a/MatrixSDK/Utils/MXLogger.m
+++ b/MatrixSDK/Utils/MXLogger.m
@@ -221,7 +221,7 @@ static void handleUncaughtException(NSException *exception)
                     encoding:NSStringEncodingConversionAllowLossy
                        error:nil];
 
-    MXLogDebug(@"[MXLogger] handleUncaughtException:\n%@", description);
+    MXLogError(@"[MXLogger] handleUncaughtException:\n%@", description);
 }
 
 // Signals emitted by the app are handled here
@@ -390,5 +390,4 @@ static NSString* crashLogPath(void)
     
 }
 @end
-
 

--- a/MatrixSDK/Utils/MXServerNotices.m
+++ b/MatrixSDK/Utils/MXServerNotices.m
@@ -181,7 +181,7 @@ NSUInteger const kMXServerNoticesMaxPinnedNoticesPerRoom = 2;
 
                 } failure:^(NSError *error) {
 
-                    NSLog(@"[MXServerNotices] Failed to get pinned event %@. Continue anyway", pinnedEventId);
+                    MXLogDebug(@"[MXServerNotices] Failed to get pinned event %@. Continue anyway", pinnedEventId);
                     dispatch_group_leave(group);
                 }];
             }

--- a/MatrixSDK/Utils/MXThrottler.m
+++ b/MatrixSDK/Utils/MXThrottler.m
@@ -60,7 +60,7 @@ NSUInteger count = 0;
     // Cancel any existing work item if it has not yet executed
     if (workItem)
     {
-        NSLog(@"[MXThrottler] throttle: Cancel previous block");
+        MXLogDebug(@"[MXThrottler] throttle: Cancel previous block");
         workItem = nil;
     }
     
@@ -98,7 +98,7 @@ NSUInteger count = 0;
     }
     else
     {
-        NSLog(@"[MXThrottler] throttle: Delay block by %@s", @(delay));
+        MXLogDebug(@"[MXThrottler] throttle: Delay block by %@s", @(delay));
         
         isTimerArmed = YES;
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)), _queue, ^{

--- a/MatrixSDK/Utils/MXTools.h
+++ b/MatrixSDK/Utils/MXTools.h
@@ -281,7 +281,7 @@ FOUNDATION_EXPORT NSString *const kMXToolsRegexStringForMatrixGroupIdentifier;
 #define MXStrongifyAndReturnIfNil(var) \
     if (!weak##var) \
     { \
-        NSLog(@"[MXStrongifyAndReturnIfNil] Released reference at %@:%d", @(__FILE__).lastPathComponent, __LINE__); \
+        MXLogWarning(@"[MXStrongifyAndReturnIfNil] Released reference at %@:%d", @(__FILE__).lastPathComponent, __LINE__); \
         return; \
     } \
     typeof(var) var = weak##var
@@ -297,7 +297,7 @@ FOUNDATION_EXPORT NSString *const kMXToolsRegexStringForMatrixGroupIdentifier;
 #define MXStrongifyAndReturnValueIfNil(var, value) \
     if (!weak##var) \
     { \
-        NSLog(@"[MXStrongifyAndReturnIfNil] Released reference at %@:%d", @(__FILE__).lastPathComponent, __LINE__); \
+        MXLogWarning(@"[MXStrongifyAndReturnIfNil] Released reference at %@:%d", @(__FILE__).lastPathComponent, __LINE__); \
         return value; \
     } \
     typeof(var) var = weak##var

--- a/MatrixSDK/Utils/MXTools.m
+++ b/MatrixSDK/Utils/MXTools.m
@@ -839,7 +839,7 @@ static NSMutableDictionary *fileExtensionByContentType = nil;
     }
     else
     {
-        NSLog(@"[MXTools] convertVideoToMP4: Warning: MPEG-4 file format is not supported. Use QuickTime format.");
+        MXLogDebug(@"[MXTools] convertVideoToMP4: Warning: MPEG-4 file format is not supported. Use QuickTime format.");
         
         // Fallback to QuickTime format
         exportSession.outputFileType = AVFileTypeQuickTimeMovie;
@@ -882,7 +882,7 @@ static NSMutableDictionary *fileExtensionByContentType = nil;
                 else
                 {
                     
-                    NSLog(@"[MXTools] convertVideoToMP4: Video export failed. Cannot extract video size.");
+                    MXLogDebug(@"[MXTools] convertVideoToMP4: Video export failed. Cannot extract video size.");
                     
                     // Remove output file (if any)
                     [[NSFileManager defaultManager] removeItemAtPath:[outputVideoLocalURL path] error:nil];
@@ -892,7 +892,7 @@ static NSMutableDictionary *fileExtensionByContentType = nil;
             else
             {
                 
-                NSLog(@"[MXTools] convertVideoToMP4: Video export failed. exportSession.status: %tu", status);
+                MXLogDebug(@"[MXTools] convertVideoToMP4: Video export failed. exportSession.status: %tu", status);
                 
                 // Remove output file (if any)
                 [[NSFileManager defaultManager] removeItemAtPath:[outputVideoLocalURL path] error:nil];

--- a/MatrixSDK/Utils/MXUIKitApplicationStateService.swift
+++ b/MatrixSDK/Utils/MXUIKitApplicationStateService.swift
@@ -92,7 +92,7 @@ public class MXUIKitApplicationStateService: NSObject {
         if newApplicationState != applicationState {
             let applicationStateString = MXUIKitApplicationStateService.readableApplicationState(applicationState: applicationState)
             let newApplicationStateString = MXUIKitApplicationStateService.readableApplicationState(applicationState: newApplicationState)
-            NSLog("[MXUIKitApplicationStateService] applicationStateDidChange: from \(applicationStateString) to \(newApplicationStateString)")
+            MXLog.debug("[MXUIKitApplicationStateService] applicationStateDidChange: from \(applicationStateString) to \(newApplicationStateString)")
             
             applicationState = newApplicationState
         }

--- a/MatrixSDK/Utils/MXUIKitBackgroundModeHandler.m
+++ b/MatrixSDK/Utils/MXUIKitBackgroundModeHandler.m
@@ -61,7 +61,7 @@ static const NSTimeInterval BackgroundTimeRemainingThresholdToStartTasks = 5.0;
     if (applicationStateService.applicationState == UIApplicationStateBackground &&
         applicationStateService.backgroundTimeRemaining < BackgroundTimeRemainingThresholdToStartTasks)
     {
-        NSLog(@"[MXBackgroundTask] Do not start background task - %@, as not enough time exists", name);
+        MXLogDebug(@"[MXBackgroundTask] Do not start background task - %@, as not enough time exists", name);
         
         //  call expiration handler immediately
         if (expirationHandler)
@@ -78,7 +78,7 @@ static const NSTimeInterval BackgroundTimeRemainingThresholdToStartTasks = 5.0;
         NSString *readableAppState = [MXUIKitApplicationStateService readableApplicationStateWithApplicationState:applicationStateService.applicationState];
         NSString *readableBackgroundTimeRemaining = [MXUIKitApplicationStateService readableEstimatedBackgroundTimeRemainingWithBackgroundTimeRemaining:applicationStateService.backgroundTimeRemaining];
         
-        NSLog(@"[MXBackgroundTask] Background task %@ started with app state: %@ and estimated background time remaining: %@", backgroundTask.name, readableAppState, readableBackgroundTimeRemaining);
+        MXLogDebug(@"[MXBackgroundTask] Background task %@ started with app state: %@ and estimated background time remaining: %@", backgroundTask.name, readableAppState, readableBackgroundTimeRemaining);
     }
 
     return backgroundTask;

--- a/MatrixSDK/Utils/MXUIKitBackgroundTask.m
+++ b/MatrixSDK/Utils/MXUIKitBackgroundTask.m
@@ -66,7 +66,7 @@
                 
                 MXStrongifyAndReturnIfNil(self);
                 
-                NSLog(@"[MXBackgroundTask] Background task expired #%lu - %@ after %.0fms", (unsigned long)self.identifier, self.name, self.elapsedTime);
+                MXLogDebug(@"[MXBackgroundTask] Background task expired #%lu - %@ after %.0fms", (unsigned long)self.identifier, self.name, self.elapsedTime);
                 
                 //  call expiration handler immediately
                 if (self.expirationHandler)
@@ -81,7 +81,7 @@
             //  our assumption is wrong, OS declined it
             if (self.identifier == UIBackgroundTaskInvalid)
             {
-                NSLog(@"[MXBackgroundTask] Do not start background task - %@, as OS declined", self.name);
+                MXLogDebug(@"[MXBackgroundTask] Do not start background task - %@, as OS declined", self.name);
                 
                 //  call expiration handler immediately
                 if (self.expirationHandler)
@@ -91,11 +91,11 @@
                 return nil;
             }
             
-            NSLog(@"[MXBackgroundTask] Start background task #%lu - %@", (unsigned long)self.identifier, self.name);
+            MXLogDebug(@"[MXBackgroundTask] Start background task #%lu - %@", (unsigned long)self.identifier, self.name);
         }
         else
         {
-            NSLog(@"[MXBackgroundTask] Background task creation failed. UIApplication.shared is nil");
+            MXLogDebug(@"[MXBackgroundTask] Background task creation failed. UIApplication.shared is nil");
             
             //  we're probably in an app extension here.
             //  Do not call expiration handler as it'll cause some network requests to be cancelled,
@@ -134,7 +134,7 @@
         UIApplication *sharedApplication = [self sharedApplication];
         if (sharedApplication)
         {
-            NSLog(@"[MXBackgroundTask] Stop background task #%lu - %@ after %.0fms", (unsigned long)self.identifier, self.name, self.elapsedTime);
+            MXLogDebug(@"[MXBackgroundTask] Stop background task #%lu - %@ after %.0fms", (unsigned long)self.identifier, self.name, self.elapsedTime);
             
             [sharedApplication endBackgroundTask:self.identifier];
             self.identifier = UIBackgroundTaskInvalid;

--- a/MatrixSDK/Utils/Media/MXMediaLoader.m
+++ b/MatrixSDK/Utils/Media/MXMediaLoader.m
@@ -64,7 +64,7 @@ NSString *const kMXMediaUploadIdPrefix = @"upload-";
     // Cancel potential connection
     if (downloadConnection)
     {
-        NSLog(@"[MXMediaLoader] Media download has been cancelled (%@)", self.downloadMediaURL);
+        MXLogDebug(@"[MXMediaLoader] Media download has been cancelled (%@)", self.downloadMediaURL);
         if (onError){
             onError(nil);
         }
@@ -81,7 +81,7 @@ NSString *const kMXMediaUploadIdPrefix = @"upload-";
         if (operation && operation.operation
             && operation.operation.state != NSURLSessionTaskStateCanceling && operation.operation.state != NSURLSessionTaskStateCompleted)
         {
-            NSLog(@"[MXMediaLoader] Media upload has been cancelled");
+            MXLogDebug(@"[MXMediaLoader] Media upload has been cancelled");
             [operation cancel];
             operation = nil;
         }
@@ -157,7 +157,7 @@ NSString *const kMXMediaUploadIdPrefix = @"upload-";
 
 - (void)connection:(NSURLConnection *)connection didFailWithError:(NSError *)error
 {
-    NSLog(@"[MXMediaLoader] Failed to download media (%@): %@", self.downloadMediaURL, error);
+    MXLogDebug(@"[MXMediaLoader] Failed to download media (%@): %@", self.downloadMediaURL, error);
     // send the latest known download info
     [self progressCheckTimeout:nil];
     statisticsDict = nil;
@@ -244,7 +244,7 @@ NSString *const kMXMediaUploadIdPrefix = @"upload-";
         }
         else
         {
-            NSLog(@"[MXMediaLoader] Failed to write file: %@", self.downloadMediaURL);
+            MXLogDebug(@"[MXMediaLoader] Failed to write file: %@", self.downloadMediaURL);
             if (onError){
                 onError(nil);
             }
@@ -254,7 +254,7 @@ NSString *const kMXMediaUploadIdPrefix = @"upload-";
     }
     else
     {
-        NSLog(@"[MXMediaLoader] Failed to download media: %@", self.downloadMediaURL);
+        MXLogDebug(@"[MXMediaLoader] Failed to download media: %@", self.downloadMediaURL);
         if (onError){
             onError(nil);
         }
@@ -343,7 +343,7 @@ NSString *const kMXMediaUploadIdPrefix = @"upload-";
                     }
                     else
                     {
-                        NSLog(@"[MXMediaLoader] Certificate check failed for %@", protectionSpace);
+                        MXLogDebug(@"[MXMediaLoader] Certificate check failed for %@", protectionSpace);
                         [connection cancel];
 
                         // Generate same kind of error as AFNetworking

--- a/MatrixSDK/Utils/Media/MXMediaManager.m
+++ b/MatrixSDK/Utils/Media/MXMediaManager.m
@@ -203,7 +203,7 @@ static MXLRUCache* imagesCacheLruCache = nil;
             
         } completionHandler:^(BOOL successFlag, NSError *error) {
             
-            NSLog(@"Finished adding asset. %@", (successFlag ? @"Success" : error));
+            MXLogDebug(@"Finished adding asset. %@", (successFlag ? @"Success" : error));
             
             if (successFlag)
             {
@@ -275,7 +275,7 @@ static MXLRUCache* imagesCacheLruCache = nil;
             localId = [[assetRequest placeholderForCreatedAsset] localIdentifier];
             
         } completionHandler:^(BOOL successFlag, NSError *error) {
-            NSLog(@"Finished adding asset. %@", (successFlag ? @"Success" : error));
+            MXLogDebug(@"Finished adding asset. %@", (successFlag ? @"Success" : error));
             
             if (successFlag)
             {
@@ -313,7 +313,7 @@ static MXLRUCache* imagesCacheLruCache = nil;
                                                            }
                                                            else
                                                            {
-                                                               NSLog(@"[MXMediaManager] Failed to retrieve the asset URL of the saved video!");
+                                                               MXLogDebug(@"[MXMediaManager] Failed to retrieve the asset URL of the saved video!");
                                                                dispatch_async(dispatch_get_main_queue(), ^{
                                                                    success (nil);
                                                                });
@@ -321,7 +321,7 @@ static MXLRUCache* imagesCacheLruCache = nil;
                                                        }
                                                        else
                                                        {
-                                                           NSLog(@"[MXMediaManager] Failed to retrieve editing input from asset");
+                                                           MXLogDebug(@"[MXMediaManager] Failed to retrieve editing input from asset");
                                                            
                                                            // Return on main thread
                                                            dispatch_async(dispatch_get_main_queue(), ^{
@@ -474,7 +474,7 @@ static MXLRUCache* imagesCacheLruCache = nil;
     NSString *mediaURL = [self urlOfContent:mxContentURI];
     if (!mediaURL)
     {
-        NSLog(@"[MXMediaManager] downloadMediaFromMatrixContentURI: invalid media content URI");
+        MXLogDebug(@"[MXMediaManager] downloadMediaFromMatrixContentURI: invalid media content URI");
         if (failure) failure(nil);
         return nil;
     }
@@ -514,7 +514,7 @@ static MXLRUCache* imagesCacheLruCache = nil;
     NSString *mediaURL = [self urlOfContentThumbnail:mxContentURI toFitViewSize:viewSize withMethod:thumbnailingMethod];
     if (!mediaURL)
     {
-        NSLog(@"[MXMediaManager] downloadThumbnailFromMatrixContentURI: invalid media content URI");
+        MXLogDebug(@"[MXMediaManager] downloadThumbnailFromMatrixContentURI: invalid media content URI");
         if (failure) failure(nil);
         return nil;
     }
@@ -623,7 +623,7 @@ static MXLRUCache* imagesCacheLruCache = nil;
                 }
                 else
                 {
-                    NSLog(@"[MXMediaManager] download encrypted content failed");
+                    MXLogDebug(@"[MXMediaManager] download encrypted content failed");
                     if (failure) failure(nil);
                     [mediaLoader cancel];
                     [downloadTable removeObjectForKey:downloadId];
@@ -680,7 +680,7 @@ static MXLRUCache* imagesCacheLruCache = nil;
     
     if (!downloadMediaURL)
     {
-        NSLog(@"[MXMediaManager] downloadEncryptedMediaFromMatrixContentFile: invalid media content URI");
+        MXLogDebug(@"[MXMediaManager] downloadEncryptedMediaFromMatrixContentFile: invalid media content URI");
         if (failure) failure(nil);
         return nil;
     }
@@ -905,7 +905,7 @@ static NSMutableDictionary* fileBaseFromMimeType = nil;
     // That is why we allow here to retrieve a cache file path from an upload identifier.
     if (![mxContentURI hasPrefix:kMXContentUriScheme] && ![mxContentURI hasPrefix:kMXMediaUploadIdPrefix])
     {
-        NSLog(@"[MXMediaManager] cachePathForMatrixContentURI: invalid media content URI");
+        MXLogDebug(@"[MXMediaManager] cachePathForMatrixContentURI: invalid media content URI");
         return nil;
     }
     
@@ -943,7 +943,7 @@ static NSMutableDictionary* fileBaseFromMimeType = nil;
     // Check whether the provided uri is valid.
     if (![mxContentURI hasPrefix:kMXContentUriScheme])
     {
-        NSLog(@"[MXMediaManager] thumbnailCachePathForMatrixContentURI: invalid media content URI");
+        MXLogDebug(@"[MXMediaManager] thumbnailCachePathForMatrixContentURI: invalid media content URI");
         return nil;
     }
     
@@ -1133,16 +1133,16 @@ static NSMutableDictionary* fileBaseFromMimeType = nil;
     
     if (mediaCachePath)
     {
-        NSLog(@"[MXMediaManager] Delete media cache directory");
+        MXLogDebug(@"[MXMediaManager] Delete media cache directory");
         
         if (![[NSFileManager defaultManager] removeItemAtPath:mediaCachePath error:&error])
         {
-            NSLog(@"[MXMediaManager] Failed to delete media cache dir: %@", error);
+            MXLogDebug(@"[MXMediaManager] Failed to delete media cache dir: %@", error);
         }
     }
     else
     {
-        NSLog(@"[MXMediaManager] Media cache does not exist");
+        MXLogDebug(@"[MXMediaManager] Media cache does not exist");
     }
     
     mediaCachePath = nil;
@@ -1177,7 +1177,7 @@ static NSMutableDictionary* fileBaseFromMimeType = nil;
             NSString *cacheVersionFile = [mediaCachePath stringByAppendingPathComponent:mediaCacheVersionString];
             if (![[NSFileManager defaultManager] fileExistsAtPath:cacheVersionFile])
             {
-                NSLog(@"[MXMediaManager] New media cache version detected");
+                MXLogDebug(@"[MXMediaManager] New media cache version detected");
                 [MXMediaManager clearCache];
             }
         }

--- a/MatrixSDK/Utils/Profiling/MXBaseProfiler.m
+++ b/MatrixSDK/Utils/Profiling/MXBaseProfiler.m
@@ -18,6 +18,8 @@
 
 #import "MXTaskProfile_Private.h"
 
+#import "MXLog.h"
+
 @interface MXBaseProfiler ()
 {
     NSMutableArray<MXTaskProfile *> *taskProfiles;
@@ -54,7 +56,7 @@
 {
     [taskProfile markAsCompleted];
     
-    NSLog(@"[MXBaseProfiler] Task %@ - %@ for %@ units completed in %.3fms%@",
+    MXLogDebug(@"[MXBaseProfiler] Task %@ - %@ for %@ units completed in %.3fms%@",
           taskProfile.category,
           taskProfile.name,
           @(taskProfile.units),

--- a/MatrixSDK/Utils/Realm/MXRealmHelper.m
+++ b/MatrixSDK/Utils/Realm/MXRealmHelper.m
@@ -18,6 +18,8 @@
 
 #import <Realm/Realm.h>
 
+#import "MXLog.h"
+
 static NSString* const kRealmFileExtension = @"realm";
 
 @implementation MXRealmHelper
@@ -47,7 +49,7 @@ static NSString* const kRealmFileExtension = @"realm";
             
             if (error)
             {
-                NSLog(@"[MXRealmHelper] Fail to delete Realm file with URL %@ with error: %@", url, error);
+                MXLogDebug(@"[MXRealmHelper] Fail to delete Realm file with URL %@ with error: %@", url, error);
             }
         }
     }

--- a/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.m
+++ b/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.m
@@ -267,7 +267,7 @@ NSString * const kMXCallKitAdapterAudioSessionDidActive = @"kMXCallKitAdapterAud
     update.supportsHolding = supportsHolding;
     
     [self.provider reportCallWithUUID:callUUID updated:update];
-    NSLog(@"[MXCallKitAdapter] updateSupportsHoldingForCall, call(%@) updated to: %u", call.callId, supportsHolding);
+    MXLogDebug(@"[MXCallKitAdapter] updateSupportsHoldingForCall, call(%@) updated to: %u", call.callId, supportsHolding);
 }
 
 + (BOOL)callKitAvailable
@@ -286,7 +286,7 @@ NSString * const kMXCallKitAdapterAudioSessionDidActive = @"kMXCallKitAdapterAud
 
 - (void)providerDidReset:(CXProvider *)provider
 {
-    NSLog(@"Provider did reset");
+    MXLogDebug(@"Provider did reset");
 }
 
 - (void)provider:(CXProvider *)provider didActivateAudioSession:(AVAudioSession *)audioSession

--- a/MatrixSDK/VoIP/MXCall.m
+++ b/MatrixSDK/VoIP/MXCall.m
@@ -142,7 +142,7 @@ NSString *const kMXCallSupportsTransferringStatusDidChange = @"kMXCallSupportsTr
         callStackCall = [callManager.callStack createCall];
         if (nil == callStackCall)
         {
-            NSLog(@"[MXCall] Error: Cannot create call. [MXCallStack createCall] returned nil.");
+            MXLogDebug(@"[MXCall] Error: Cannot create call. [MXCallStack createCall] returned nil.");
             [callManager.mxSession releasePreventPause];
             return nil;
         }
@@ -252,7 +252,7 @@ NSString *const kMXCallSupportsTransferringStatusDidChange = @"kMXCallSupportsTr
 #pragma mark - Controls
 - (void)callWithVideo:(BOOL)video
 {
-    NSLog(@"[MXCall] callWithVideo");
+    MXLogDebug(@"[MXCall] callWithVideo");
     
     _isIncoming = NO;
 
@@ -283,7 +283,7 @@ NSString *const kMXCallSupportsTransferringStatusDidChange = @"kMXCallSupportsTr
 
                 [self setState:MXCallStateCreateOffer reason:nil];
 
-                NSLog(@"[MXCall] callWithVideo:%@ - Offer created: %@", (video ? @"YES" : @"NO"), sdp);
+                MXLogDebug(@"[MXCall] callWithVideo:%@ - Offer created: %@", (video ? @"YES" : @"NO"), sdp);
 
                 // The call invite can sent to the HS
                 NSMutableDictionary *content = [@{
@@ -310,16 +310,16 @@ NSString *const kMXCallSupportsTransferringStatusDidChange = @"kMXCallSupportsTr
                     [self setState:MXCallStateInviteSent reason:nil];
 
                 } failure:^(NSError *error) {
-                    NSLog(@"[MXCall] callWithVideo: ERROR: Cannot send m.call.invite event.");
+                    MXLogDebug(@"[MXCall] callWithVideo: ERROR: Cannot send m.call.invite event.");
                     [self didEncounterError:error reason:MXCallHangupReasonUnknownError];
                 }];
 
             } failure:^(NSError *error) {
-                NSLog(@"[MXCall] callWithVideo: ERROR: Cannot create offer. Error: %@", error);
+                MXLogDebug(@"[MXCall] callWithVideo: ERROR: Cannot create offer. Error: %@", error);
                 [self didEncounterError:error reason:MXCallHangupReasonIceFailed];
             }];
         } failure:^(NSError *error) {
-            NSLog(@"[MXCall] callWithVideo: ERROR: Cannot start capturing media. Error: %@", error);
+            MXLogDebug(@"[MXCall] callWithVideo: ERROR: Cannot start capturing media. Error: %@", error);
             [self didEncounterError:error reason:MXCallHangupReasonUserMediaFailed];
         }];
     }];
@@ -327,7 +327,7 @@ NSString *const kMXCallSupportsTransferringStatusDidChange = @"kMXCallSupportsTr
 
 - (void)answer
 {
-    NSLog(@"[MXCall] answer");
+    MXLogDebug(@"[MXCall] answer");
     
     MXWeakify(self);
     [callStackCallOperationQueue addOperationWithBlock:^{
@@ -345,7 +345,7 @@ NSString *const kMXCallSupportsTransferringStatusDidChange = @"kMXCallSupportsTr
             void(^answer)(void) = ^{
                 MXStrongifyAndReturnIfNil(self);
 
-                NSLog(@"[MXCall] answer: answering...");
+                MXLogDebug(@"[MXCall] answer: answering...");
 
                 // The incoming call is accepted
                 if (self->inviteExpirationTimer)
@@ -361,7 +361,7 @@ NSString *const kMXCallSupportsTransferringStatusDidChange = @"kMXCallSupportsTr
                 [self->callStackCall createAnswer:^(NSString *sdpAnswer) {
                     MXStrongifyAndReturnIfNil(self);
 
-                    NSLog(@"[MXCall] answer - Created SDP:\n%@", sdpAnswer);
+                    MXLogDebug(@"[MXCall] answer - Created SDP:\n%@", sdpAnswer);
 
                     // The call invite can sent to the HS
                     NSDictionary *content = @{
@@ -384,12 +384,12 @@ NSString *const kMXCallSupportsTransferringStatusDidChange = @"kMXCallSupportsTr
                             @"content": content
                         }];
                     } failure:^(NSError *error) {
-                        NSLog(@"[MXCall] answer: ERROR: Cannot send m.call.answer event.");
+                        MXLogDebug(@"[MXCall] answer: ERROR: Cannot send m.call.answer event.");
                         [self didEncounterError:error reason:MXCallHangupReasonUnknownError];
                     }];
 
                 } failure:^(NSError *error) {
-                    NSLog(@"[MXCall] answer: ERROR: Cannot create answer. Error: %@", error);
+                    MXLogDebug(@"[MXCall] answer: ERROR: Cannot create answer. Error: %@", error);
                     [self didEncounterError:error reason:MXCallHangupReasonIceFailed];
                 }];
             };
@@ -400,9 +400,9 @@ NSString *const kMXCallSupportsTransferringStatusDidChange = @"kMXCallSupportsTr
             // MXEncryptingErrorUnknownDeviceReason.
             if (self.callSignalingRoom.summary.isEncrypted)
             {
-                NSLog(@"[MXCall] answer: ensuring encryption is ready to use ...");
+                MXLogDebug(@"[MXCall] answer: ensuring encryption is ready to use ...");
                 [self->callManager.mxSession.crypto ensureEncryptionInRoom:self.callSignalingRoom.roomId success:answer failure:^(NSError *error) {
-                    NSLog(@"[MXCall] answer: ERROR: [MXCrypto ensureEncryptionInRoom] failed. Error: %@", error);
+                    MXLogDebug(@"[MXCall] answer: ERROR: [MXCrypto ensureEncryptionInRoom] failed. Error: %@", error);
                     [self didEncounterError:error reason:MXCallHangupReasonUnknownError];
                 }];
             }
@@ -431,7 +431,7 @@ NSString *const kMXCallSupportsTransferringStatusDidChange = @"kMXCallSupportsTr
 
 - (void)hangup
 {
-    NSLog(@"[MXCall] hangup");
+    MXLogDebug(@"[MXCall] hangup");
     
     if (self.state == MXCallStateRinging && [callInviteEventContent.version isEqualToString:kMXCallVersion])
     {
@@ -443,7 +443,7 @@ NSString *const kMXCallSupportsTransferringStatusDidChange = @"kMXCallSupportsTr
                                   };
         
         [_callSignalingRoom sendEventOfType:kMXEventTypeStringCallReject content:content localEcho:nil success:nil failure:^(NSError *error) {
-            NSLog(@"[MXCall] hangup: ERROR: Cannot send m.call.reject event.");
+            MXLogDebug(@"[MXCall] hangup: ERROR: Cannot send m.call.reject event.");
             [self didEncounterError:error reason:MXCallHangupReasonUnknownError];
         }];
         
@@ -463,7 +463,7 @@ NSString *const kMXCallSupportsTransferringStatusDidChange = @"kMXCallSupportsTr
 
 - (void)hangupWithReason:(MXCallHangupReason)reason
 {
-    NSLog(@"[MXCall] hangupWithReason: %ld", (long)reason);
+    MXLogDebug(@"[MXCall] hangupWithReason: %ld", (long)reason);
     
     if (self.state != MXCallStateEnded)
     {
@@ -479,7 +479,7 @@ NSString *const kMXCallSupportsTransferringStatusDidChange = @"kMXCallSupportsTr
                                                                category:kMXAnalyticsVoipCategory
                                                                    name:kMXAnalyticsVoipNameCallHangup];
         } failure:^(NSError *error) {
-            NSLog(@"[MXCall] hangupWithReason: ERROR: Cannot send m.call.hangup event.");
+            MXLogDebug(@"[MXCall] hangupWithReason: ERROR: Cannot send m.call.hangup event.");
             [self didEncounterError:error reason:MXCallHangupReasonUnknownError];
         }];
         
@@ -543,7 +543,7 @@ NSString *const kMXCallSupportsTransferringStatusDidChange = @"kMXCallSupportsTr
         [self->callStackCall hold:hold success:^(NSString * _Nonnull sdp) {
             MXStrongifyAndReturnIfNil(self);
             
-            NSLog(@"[MXCall] hold: %@ offer created: %@", (hold ? @"Hold" : @"Resume"), sdp);
+            MXLogDebug(@"[MXCall] hold: %@ offer created: %@", (hold ? @"Hold" : @"Resume"), sdp);
 
             // The call hold offer can sent to the HS
             NSMutableDictionary *content = [@{
@@ -569,12 +569,12 @@ NSString *const kMXCallSupportsTransferringStatusDidChange = @"kMXCallSupportsTr
                 }
 
             } failure:^(NSError *error) {
-                NSLog(@"[MXCall] hold: ERROR: Cannot send m.call.negotiate event.");
+                MXLogDebug(@"[MXCall] hold: ERROR: Cannot send m.call.negotiate event.");
                 [self didEncounterError:error reason:MXCallHangupReasonUnknownError];
             }];
             
         } failure:^(NSError * _Nonnull error) {
-            NSLog(@"[MXCall] hold: ERROR: Cannot create %@ offer. Error: %@", (hold ? @"Hold" : @"Resume"), error);
+            MXLogDebug(@"[MXCall] hold: ERROR: Cannot create %@ offer. Error: %@", (hold ? @"Hold" : @"Resume"), error);
             [self didEncounterError:error reason:MXCallHangupReasonIceFailed];
         }];
     }];
@@ -643,7 +643,7 @@ NSString *const kMXCallSupportsTransferringStatusDidChange = @"kMXCallSupportsTr
         [self terminateWithReason:nil];
     }
                                     failure:^(NSError *error) {
-        NSLog(@"[MXCall] transferToRoom: ERROR: Cannot send m.call.replaces event.");
+        MXLogDebug(@"[MXCall] transferToRoom: ERROR: Cannot send m.call.replaces event.");
         if (failure)
         {
             failure(error);
@@ -700,7 +700,7 @@ NSString *const kMXCallSupportsTransferringStatusDidChange = @"kMXCallSupportsTr
 
 - (void)setState:(MXCallState)state reason:(MXEvent *)event
 {
-    NSLog(@"[MXCall] setState. old: %@. New: %@", @(_state), @(state));
+    MXLogDebug(@"[MXCall] setState. old: %@. New: %@", @(_state), @(state));
 
     // Manage call duration
     if (MXCallStateConnected == state)
@@ -922,7 +922,7 @@ NSString *const kMXCallSupportsTransferringStatusDidChange = @"kMXCallSupportsTr
 
     if (localICECandidates.count)
     {
-        NSLog(@"MXCall] onICECandidate: Send %tu candidates", localICECandidates.count);
+        MXLogDebug(@"MXCall] onICECandidate: Send %tu candidates", localICECandidates.count);
 
         NSDictionary *content = @{
                                   @"version": kMXCallVersion,
@@ -932,7 +932,7 @@ NSString *const kMXCallSupportsTransferringStatusDidChange = @"kMXCallSupportsTr
                                   };
 
         [_callSignalingRoom sendEventOfType:kMXEventTypeStringCallCandidates content:content localEcho:nil success:nil failure:^(NSError *error) {
-            NSLog(@"[MXCall] onICECandidate: Warning: Cannot send m.call.candidates event.");
+            MXLogDebug(@"[MXCall] onICECandidate: Warning: Cannot send m.call.candidates event.");
             [self didEncounterError:error reason:MXCallHangupReasonUnknownError];
         }];
 
@@ -950,7 +950,7 @@ NSString *const kMXCallSupportsTransferringStatusDidChange = @"kMXCallSupportsTr
 
 - (void)callStackCall:(id<MXCallStackCall>)callStackCall onError:(NSError *)error
 {
-    NSLog(@"[MXCall] callStackCall didEncounterError: %@", error);
+    MXLogDebug(@"[MXCall] callStackCall didEncounterError: %@", error);
     
     if (self.isEstablished)
     {
@@ -1041,13 +1041,13 @@ NSString *const kMXCallSupportsTransferringStatusDidChange = @"kMXCallSupportsTr
                 }
             }
                                      failure:^(NSError * _Nonnull error) {
-                NSLog(@"[MXCall] handleCallInvite: ERROR: Couldn't handle offer. Error: %@", error);
+                MXLogDebug(@"[MXCall] handleCallInvite: ERROR: Couldn't handle offer. Error: %@", error);
                 [self didEncounterError:error reason:MXCallHangupReasonUnknownError];
             }];
             
             
         } failure:^(NSError *error) {
-            NSLog(@"[MXCall] handleCallInvite: startCapturingMediaWithVideo : ERROR: Couldn't start capturing. Error: %@", error);
+            MXLogDebug(@"[MXCall] handleCallInvite: startCapturingMediaWithVideo : ERROR: Couldn't start capturing. Error: %@", error);
             [self didEncounterError:error reason:MXCallHangupReasonUserMediaFailed];
         }];
 
@@ -1097,7 +1097,7 @@ NSString *const kMXCallSupportsTransferringStatusDidChange = @"kMXCallSupportsTr
             [self->callStackCall handleAnswer:content.answer.sdp
                                 success:^{}
                                 failure:^(NSError *error) {
-                NSLog(@"[MXCall] handleCallAnswer: ERROR: Cannot send handle answer. Error: %@\nEvent: %@", error, event);
+                MXLogDebug(@"[MXCall] handleCallAnswer: ERROR: Cannot send handle answer. Error: %@\nEvent: %@", error, event);
                 self.selectedAnswer = nil;
                 [self didEncounterError:error reason:MXCallHangupReasonIceFailed];
             }];
@@ -1121,7 +1121,7 @@ NSString *const kMXCallSupportsTransferringStatusDidChange = @"kMXCallSupportsTr
                 continueBlock();
                 
             } failure:^(NSError *error) {
-                NSLog(@"[MXCall] handleCallAnswer: ERROR: Cannot send m.call.select_answer event. Error: %@\n", error);
+                MXLogDebug(@"[MXCall] handleCallAnswer: ERROR: Cannot send m.call.select_answer event. Error: %@\n", error);
                 self.selectedAnswer = nil;
                 [self didEncounterError:error reason:MXCallHangupReasonUnknownError];
             }];
@@ -1181,7 +1181,7 @@ NSString *const kMXCallSupportsTransferringStatusDidChange = @"kMXCallSupportsTr
         
         MXCallCandidatesEventContent *content = [MXCallCandidatesEventContent modelFromJSON:event.content];
 
-        NSLog(@"[MXCall] handleCallCandidates: %@", content.candidates);
+        MXLogDebug(@"[MXCall] handleCallCandidates: %@", content.candidates);
         for (MXCallCandidate *canditate in content.candidates)
         {
             [self->callStackCall handleRemoteCandidate:canditate.JSONDictionary];
@@ -1232,7 +1232,7 @@ NSString *const kMXCallSupportsTransferringStatusDidChange = @"kMXCallSupportsTr
                 [self terminateWithReason:event];
                 
             } failure:^(NSError *error) {
-                NSLog(@"[MXCall] handleCallReject: ERROR: Cannot send m.call.select_answer event. Error: %@\n", error);
+                MXLogDebug(@"[MXCall] handleCallReject: ERROR: Cannot send m.call.select_answer event. Error: %@\n", error);
                 self.selectedAnswer = nil;
                 [self didEncounterError:error reason:MXCallHangupReasonUnknownError];
             }];
@@ -1280,7 +1280,7 @@ NSString *const kMXCallSupportsTransferringStatusDidChange = @"kMXCallSupportsTr
                 [self->callStackCall createAnswer:^(NSString * _Nonnull sdpAnswer) {
                     MXStrongifyAndReturnIfNil(self);
                     
-                    NSLog(@"[MXCall] handleCallNegotiate: answer negotiation - Created SDP:\n%@", sdpAnswer);
+                    MXLogDebug(@"[MXCall] handleCallNegotiate: answer negotiation - Created SDP:\n%@", sdpAnswer);
                     
                     NSDictionary *content = @{
                         @"call_id": self.callId,
@@ -1292,16 +1292,16 @@ NSString *const kMXCallSupportsTransferringStatusDidChange = @"kMXCallSupportsTr
                         @"party_id": self.partyId
                     };
                     [self.callSignalingRoom sendEventOfType:kMXEventTypeStringCallNegotiate content:content localEcho:nil success:nil failure:^(NSError *error) {
-                        NSLog(@"[MXCall] handleCallNegotiate: negotiate answer: ERROR: Cannot send m.call.negotiate event.");
+                        MXLogDebug(@"[MXCall] handleCallNegotiate: negotiate answer: ERROR: Cannot send m.call.negotiate event.");
                         [self didEncounterError:error reason:MXCallHangupReasonUnknownError];
                     }];
                 } failure:^(NSError * _Nonnull error) {
-                    NSLog(@"[MXCall] handleCallNegotiate: negotiate answer: ERROR: Cannot create negotiate answer. Error: %@", error);
+                    MXLogDebug(@"[MXCall] handleCallNegotiate: negotiate answer: ERROR: Cannot create negotiate answer. Error: %@", error);
                     [self didEncounterError:error reason:MXCallHangupReasonIceFailed];
                 }];
             }
                                      failure:^(NSError * _Nonnull error) {
-                NSLog(@"[MXCall] handleCallNegotiate: ERROR: Couldn't handle negotiate offer. Error: %@", error);
+                MXLogDebug(@"[MXCall] handleCallNegotiate: ERROR: Couldn't handle negotiate offer. Error: %@", error);
                 [self didEncounterError:error reason:MXCallHangupReasonIceFailed];
             }];
         }
@@ -1310,7 +1310,7 @@ NSString *const kMXCallSupportsTransferringStatusDidChange = @"kMXCallSupportsTr
             [self->callStackCall handleAnswer:content.sessionDescription.sdp
                                 success:^{}
                                 failure:^(NSError *error) {
-                NSLog(@"[MXCall] handleCallNegotiate: ERROR: Cannot send handle negotiate answer. Error: %@\nEvent: %@", error, event);
+                MXLogDebug(@"[MXCall] handleCallNegotiate: ERROR: Cannot send handle negotiate answer. Error: %@\nEvent: %@", error, event);
                 [self didEncounterError:error reason:MXCallHangupReasonIceFailed];
             }];
         }
@@ -1350,12 +1350,12 @@ NSString *const kMXCallSupportsTransferringStatusDidChange = @"kMXCallSupportsTr
     }
     else if (callManager.fallbackSTUNServer)
     {
-        NSLog(@"[MXCall] No TURN server: using fallback STUN server: %@", callManager.fallbackSTUNServer);
+        MXLogDebug(@"[MXCall] No TURN server: using fallback STUN server: %@", callManager.fallbackSTUNServer);
         [callStackCall addTURNServerUris:@[callManager.fallbackSTUNServer] withUsername:nil password:nil];
     }
     else if (!callManager.turnServers && !callManager.fallbackSTUNServer)
     {
-        NSLog(@"[MXCall] No TURN server and no fallback STUN server");
+        MXLogDebug(@"[MXCall] No TURN server and no fallback STUN server");
 
         // Setup the call with no STUN server
         [callStackCall addTURNServerUris:nil withUsername:nil password:nil];
@@ -1474,7 +1474,7 @@ NSString *const kMXCallSupportsTransferringStatusDidChange = @"kMXCallSupportsTr
         _endReason = MXCallEndReasonHangup;
     }
     
-    NSLog(@"[MXCall] terminateWithReason: %@, endReason: %ld", event, (long)_endReason);
+    MXLogDebug(@"[MXCall] terminateWithReason: %@, endReason: %ld", event, (long)_endReason);
 
     [self setState:MXCallStateEnded reason:event];
 }

--- a/MatrixSDK/VoIP/MXCallManager.m
+++ b/MatrixSDK/VoIP/MXCallManager.m
@@ -350,7 +350,7 @@ NSTimeInterval const kMXCallDirectRoomJoinTimeout = 30;
     }
     else
     {
-        NSLog(@"[MXCallManager] placeCallInRoom: ERROR: Cannot place call in %@. Members count: %tu", roomId, room.summary.membersCount.joined);
+        MXLogDebug(@"[MXCallManager] placeCallInRoom: ERROR: Cannot place call in %@. Members count: %tu", roomId, room.summary.membersCount.joined);
 
         if (failure)
         {
@@ -415,7 +415,7 @@ NSTimeInterval const kMXCallDirectRoomJoinTimeout = 30;
     [_mxSession.matrixRestClient turnServer:^(MXTurnServerResponse *turnServerResponse) {
         MXStrongifyAndReturnIfNil(self);
 
-        NSLog(@"[MXCallManager] refreshTURNServer: TTL:%tu URIs: %@", turnServerResponse.ttl, turnServerResponse.uris);
+        MXLogDebug(@"[MXCallManager] refreshTURNServer: TTL:%tu URIs: %@", turnServerResponse.ttl, turnServerResponse.uris);
 
         if (turnServerResponse.uris)
         {
@@ -432,15 +432,15 @@ NSTimeInterval const kMXCallDirectRoomJoinTimeout = 30;
         }
         else
         {
-            NSLog(@"No TURN server: using fallback STUN server: %@", self->_fallbackSTUNServer);
+            MXLogDebug(@"No TURN server: using fallback STUN server: %@", self->_fallbackSTUNServer);
             self.turnServers = nil;
         }
 
     } failure:^(NSError *error) {
         MXStrongifyAndReturnIfNil(self);
 
-        NSLog(@"[MXCallManager] refreshTURNServer: Failed to get TURN URIs.\n");
-        NSLog(@"Retry in 60s");
+        MXLogDebug(@"[MXCallManager] refreshTURNServer: Failed to get TURN URIs.\n");
+        MXLogDebug(@"Retry in 60s");
         self->refreshTURNServerTimer = [NSTimer timerWithTimeInterval:60 target:self selector:@selector(refreshTURNServer) userInfo:nil repeats:NO];
         [[NSRunLoop mainRunLoop] addTimer:self->refreshTURNServerTimer forMode:NSDefaultRunLoopMode];
     }];
@@ -710,14 +710,14 @@ NSTimeInterval const kMXCallDirectRoomJoinTimeout = 30;
                 {
                     //  auto-accept this invite from the virtual room, if a direct room with the native user found
                     [room join:^{
-                        NSLog(@"[MXCallManager] handleRoomMember: auto-joined on virtual room successfully.");
+                        MXLogDebug(@"[MXCallManager] handleRoomMember: auto-joined on virtual room successfully.");
                         
                         //  set account data on the room, if required
                         [self.mxSession.roomAccountDataUpdateDelegate updateAccountDataIfRequiredForRoom:room
                                                                                         withNativeRoomId:nativeRoom.roomId
                                                                                               completion:nil];
                     } failure:^(NSError *error) {
-                        NSLog(@"[MXCallManager] handleRoomMember: auto-join on virtual room failed with error: %@", error);
+                        MXLogDebug(@"[MXCallManager] handleRoomMember: auto-join on virtual room failed with error: %@", error);
                     }];
                 }
             } failure:nil];
@@ -956,7 +956,7 @@ NSTimeInterval const kMXCallDirectRoomJoinTimeout = 30;
                         
                         continueBlock(call);
                     } failure:^(NSError * _Nullable error) {
-                        NSLog(@"[MXCallManager] transferCall: couldn't call the target: %@", error);
+                        MXLogDebug(@"[MXCallManager] transferCall: couldn't call the target: %@", error);
                         if (failure)
                         {
                             failure(error);
@@ -1368,7 +1368,7 @@ NSString *const kMXCallManagerConferenceUserDomain  = @"matrix.org";
         self.virtualRoomsSupported = (sipNativeProtocol && sipVirtualProtocol);
         
     } failure:^(NSError *error) {
-        NSLog(@"Failed to check for third party protocols with error: %@", error);
+        MXLogDebug(@"Failed to check for third party protocols with error: %@", error);
         self.pstnProtocol = nil;
     }];
 }
@@ -1385,7 +1385,7 @@ NSString *const kMXCallManagerConferenceUserDomain  = @"matrix.org";
         
         MXThirdPartyUserInstance * user = [thirdpartyUsersResponse.users firstObject];
         
-        NSLog(@"Succeeded to look up the phone number: %@", user.userId);
+        MXLogDebug(@"Succeeded to look up the phone number: %@", user.userId);
         
         if (user)
         {
@@ -1402,7 +1402,7 @@ NSString *const kMXCallManagerConferenceUserDomain  = @"matrix.org";
             }
         }
     } failure:^(NSError *error) {
-        NSLog(@"Failed to look up the phone number with error: %@", error);
+        MXLogDebug(@"Failed to look up the phone number with error: %@", error);
         if (failure)
         {
             failure(error);
@@ -1432,7 +1432,7 @@ NSString *const kMXCallManagerConferenceUserDomain  = @"matrix.org";
             else
             {
                 //  no room found
-                NSLog(@"Failed to find a room for call with error: %@", error);
+                MXLogDebug(@"Failed to find a room for call with error: %@", error);
                 if (failure)
                 {
                     failure(error);
@@ -1468,7 +1468,7 @@ NSString *const kMXCallManagerConferenceUserDomain  = @"matrix.org";
         
         MXThirdPartyUserInstance * user = [thirdpartyUsersResponse.users firstObject];
         
-        NSLog(@"[MXCallManager] getVirtualUserFrom: Succeeded to look up the virtual user: %@", user.userId);
+        MXLogDebug(@"[MXCallManager] getVirtualUserFrom: Succeeded to look up the virtual user: %@", user.userId);
         
         if (user && user.userId.length > 0)
         {
@@ -1485,7 +1485,7 @@ NSString *const kMXCallManagerConferenceUserDomain  = @"matrix.org";
             }
         }
     } failure:^(NSError *error) {
-        NSLog(@"[MXCallManager] getVirtualUserFrom: Failed to look up the virtual user with error: %@", error);
+        MXLogDebug(@"[MXCallManager] getVirtualUserFrom: Failed to look up the virtual user with error: %@", error);
         if (failure)
         {
             failure(error);
@@ -1505,7 +1505,7 @@ NSString *const kMXCallManagerConferenceUserDomain  = @"matrix.org";
         
         MXThirdPartyUserInstance * user = [thirdpartyUsersResponse.users firstObject];
         
-        NSLog(@"[MXCallManager] getNativeUserFrom: Succeeded to look up the native user: %@", user.userId);
+        MXLogDebug(@"[MXCallManager] getNativeUserFrom: Succeeded to look up the native user: %@", user.userId);
         
         if (user && user.userId.length > 0)
         {
@@ -1522,7 +1522,7 @@ NSString *const kMXCallManagerConferenceUserDomain  = @"matrix.org";
             }
         }
     } failure:^(NSError *error) {
-        NSLog(@"[MXCallManager] getNativeUserFrom: Failed to look up the native user with error: %@", error);
+        MXLogDebug(@"[MXCallManager] getNativeUserFrom: Failed to look up the native user with error: %@", error);
         if (failure)
         {
             failure(error);

--- a/MatrixSDKTests/DirectRoomTests.m
+++ b/MatrixSDKTests/DirectRoomTests.m
@@ -303,8 +303,8 @@
 
             if (observer)
             {
-                NSLog(@"[testDirectRoomsRaceConditions] Direct rooms with Alice: %@", @(bobSession.directRooms[aliceUserId].count));
-                NSLog(@"[testDirectRoomsRaceConditions] Direct rooms with Charlie: %@", @(bobSession.directRooms[charlieUserId].count));
+                MXLogDebug(@"[testDirectRoomsRaceConditions] Direct rooms with Alice: %@", @(bobSession.directRooms[aliceUserId].count));
+                MXLogDebug(@"[testDirectRoomsRaceConditions] Direct rooms with Charlie: %@", @(bobSession.directRooms[charlieUserId].count));
 
                 notificationCount++;
             }

--- a/MatrixSDKTests/MXCryptoTests.m
+++ b/MatrixSDKTests/MXCryptoTests.m
@@ -1491,7 +1491,7 @@
                 
                 // Reply to first message
                 [roomFromBobPOV sendReplyToEvent:event withTextMessage:secondMessageReplyToFirst formattedTextMessage:secondMessageFormattedReplyToFirst stringLocalizations:defaultStringLocalizations localEcho:&localEchoEvent success:^(NSString *eventId) {
-                    NSLog(@"Send reply to first message with success");
+                    MXLogDebug(@"Send reply to first message with success");
                 } failure:^(NSError *error) {
                     XCTFail(@"The request should not fail - NSError: %@", error);
                     [expectation fulfill];
@@ -1524,7 +1524,7 @@
                 
                 // Reply to second message, which was also a reply
                 [roomFromBobPOV sendReplyToEvent:event withTextMessage:thirdMessageReplyToSecond formattedTextMessage:thirdMessageFormattedReplyToSecond stringLocalizations:defaultStringLocalizations localEcho:&localEchoEvent success:^(NSString *eventId) {
-                    NSLog(@"Send reply to second message with success");
+                    MXLogDebug(@"Send reply to second message with success");
                 } failure:^(NSError *error) {
                     XCTFail(@"The request should not fail - NSError: %@", error);
                     [expectation fulfill];
@@ -1588,7 +1588,7 @@
         
         // Send first message
         [roomFromBobPOV sendTextMessage:firstMessage formattedText:firstFormattedMessage localEcho:nil success:^(NSString *eventId) {
-            NSLog(@"Send first message with success");
+            MXLogDebug(@"Send first message with success");
         } failure:^(NSError *error) {
             XCTFail(@"The request should not fail - NSError: %@", error);
             [expectation fulfill];

--- a/MatrixSDKTests/MXLazyLoadingTests.m
+++ b/MatrixSDKTests/MXLazyLoadingTests.m
@@ -935,7 +935,7 @@ Common initial conditions:
                         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 2000 * USEC_PER_SEC), dispatch_get_main_queue(), ^{
 
                             // Keep a ref to room2 so that requests on it can complete
-                            NSLog(@"%@", room2);
+                            MXLogDebug(@"%@", room2);
 
                             MXRoom *room2b = [aliceSession2 roomWithRoomId:roomId];
                             MXRoomSummary *summary2b = [aliceSession2 roomSummaryWithRoomId:roomId];

--- a/MatrixSDKTests/MXLoggerUnitTests.m
+++ b/MatrixSDKTests/MXLoggerUnitTests.m
@@ -18,6 +18,10 @@
 
 #import "MXLogger.h"
 
+#import "MXLog.h"
+
+#import "MatrixSDKSwiftHeader.h"
+
 @interface MXLoggerUnitTests : XCTestCase
 
 @end
@@ -26,12 +30,17 @@
 
 - (void)testMXLogger
 {
-    [MXLogger redirectNSLogToFiles:YES];
+    MXLogConfiguration *configuration = [[MXLogConfiguration alloc] init];
+    configuration.asynchronous = NO;
+    configuration.redirectLogsToFiles = YES;
+    
+    [MXLog configure:configuration];
 
-    NSString *log = [NSString stringWithFormat:@"testLogFileContent: %@", [NSDate date]];
-    NSLog(@"%@", log);
-
-    [MXLogger redirectNSLogToFiles:NO];
+    NSString *log = @"Lorem ipsum dolor sit amet";
+    MXLogDebug(@"%@", log);
+    
+    configuration.redirectLogsToFiles = NO;
+    [MXLog configure:configuration];
 
     NSArray *logFiles = [MXLogger logFiles];
     XCTAssertGreaterThanOrEqual(logFiles.count, 1);
@@ -52,7 +61,7 @@
     [MXLogger redirectNSLogToFiles:YES];
 
     NSString *log = [NSString stringWithFormat:@"testLogFileContent: %@", [NSDate date]];
-    NSLog(@"%@", log);
+    MXLogDebug(@"%@", log);
 
     [MXLogger redirectNSLogToFiles:NO];
 

--- a/MatrixSDKTests/MXLoggerUnitTests.m
+++ b/MatrixSDKTests/MXLoggerUnitTests.m
@@ -31,25 +31,24 @@
 - (void)testMXLogger
 {
     MXLogConfiguration *configuration = [[MXLogConfiguration alloc] init];
-    configuration.asynchronous = NO;
     configuration.redirectLogsToFiles = YES;
     
     [MXLog configure:configuration];
-
+    
     NSString *log = @"Lorem ipsum dolor sit amet";
     MXLogDebug(@"%@", log);
     
     configuration.redirectLogsToFiles = NO;
     [MXLog configure:configuration];
-
+    
     NSArray *logFiles = [MXLogger logFiles];
     XCTAssertGreaterThanOrEqual(logFiles.count, 1);
-
+    
     // The last string in logFiles should be "console.log"
     NSString* logContent = [NSString stringWithContentsOfFile:logFiles[logFiles.count - 1]
-                                                  encoding:NSUTF8StringEncoding
-                                                     error:NULL];
-
+                                                     encoding:NSUTF8StringEncoding
+                                                        error:NULL];
+    
     if (0 == [logContent rangeOfString:log].length)
     {
         XCTFail(@"%@ does not contain %@\nIts content: %@", logFiles[logFiles.count - 1], log, logContent);
@@ -59,14 +58,14 @@
 - (void)testDeleteLogFiles
 {
     [MXLogger redirectNSLogToFiles:YES];
-
+    
     NSString *log = [NSString stringWithFormat:@"testLogFileContent: %@", [NSDate date]];
     MXLogDebug(@"%@", log);
-
+    
     [MXLogger redirectNSLogToFiles:NO];
-
+    
     [MXLogger deleteLogFiles];
-
+    
     NSArray *logFiles = [MXLogger logFiles];
     XCTAssertEqual(logFiles.count, 0, @"All log files must have been deleted. deleteLogFiles returned: %@", logFiles);
 }

--- a/MatrixSDKTests/MXMegolmExportEncryptionUnitTests.m
+++ b/MatrixSDKTests/MXMegolmExportEncryptionUnitTests.m
@@ -19,6 +19,8 @@
 
 #import "MXMegolmExportEncryption.h"
 
+#import "MXLog.h"
+
 @interface MXMegolmExportEncryptionUnitTests : XCTestCase
 
 @end
@@ -69,7 +71,7 @@
         NSError *error;
         NSData *decrypted = [MXMegolmExportEncryption decryptMegolmKeyFile:[input dataUsingEncoding:NSUTF8StringEncoding] withPassword:password error:&error];
 
-        NSLog(@"testDecrypt test: %@", plain);
+        MXLogDebug(@"testDecrypt test: %@", plain);
         XCTAssertNil(error);
         XCTAssert(decrypted);
 

--- a/MatrixSDKTests/MXRoomStateDynamicTests.m
+++ b/MatrixSDKTests/MXRoomStateDynamicTests.m
@@ -395,7 +395,7 @@
                 __block NSUInteger eventCount = 0;
                 [room listenToEventsOfTypes:nil onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
 
-                    NSLog(@"eventCount: %tu - %@", eventCount, event);
+                    MXLogDebug(@"eventCount: %tu - %@", eventCount, event);
                     
                     MXRoomMember *beforeEventAliceMember = [roomstate.members memberWithUserId:aliceRestClient.credentials.userId];
                     MXRoomMember *aliceMember = [room.state.members memberWithUserId:aliceRestClient.credentials.userId];

--- a/MatrixSDKTests/MXRoomSummaryTests.m
+++ b/MatrixSDKTests/MXRoomSummaryTests.m
@@ -736,7 +736,7 @@ NSString *uisiString = @"The sender's device has not sent us the keys for this m
         NSString *newRoomTopic = @"An interesting topic";
 
         // Required to make kMXSessionInvitedRoomsDidChangeNotification work
-        NSLog(@"%@", bobSession.invitedRooms);
+        MXLogDebug(@"%@", bobSession.invitedRooms);
 
         [[NSNotificationCenter defaultCenter] addObserverForName:kMXSessionInvitedRoomsDidChangeNotification object:bobSession queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *note) {
 

--- a/MatrixSDKTests/MXRoomTests.m
+++ b/MatrixSDKTests/MXRoomTests.m
@@ -722,7 +722,7 @@
                 
                 // Reply to first message
                 [room sendReplyToEvent:event withTextMessage:secondMessageReplyToFirst formattedTextMessage:secondMessageFormattedReplyToFirst stringLocalizations:defaultStringLocalizations localEcho:&localEchoEvent success:^(NSString *eventId) {
-                    NSLog(@"Send reply to first message with success");
+                    MXLogDebug(@"Send reply to first message with success");
                 } failure:^(NSError *error) {
                     XCTFail(@"The request should not fail - NSError: %@", error);
                     [expectation fulfill];
@@ -754,7 +754,7 @@
                 
                 // Reply to second message, which was also a reply
                 [room sendReplyToEvent:event withTextMessage:thirdMessageReplyToSecond formattedTextMessage:thirdMessageFormattedReplyToSecond stringLocalizations:defaultStringLocalizations localEcho:&localEchoEvent success:^(NSString *eventId) {
-                    NSLog(@"Send reply to second message with success");
+                    MXLogDebug(@"Send reply to second message with success");
                 } failure:^(NSError *error) {
                     XCTFail(@"The request should not fail - NSError: %@", error);
                     [expectation fulfill];
@@ -788,7 +788,7 @@
         
         // Send first message
         [room sendTextMessage:firstMessage formattedText:firstFormattedMessage localEcho:nil success:^(NSString *eventId) {
-            NSLog(@"Send first message with success");
+            MXLogDebug(@"Send first message with success");
         } failure:^(NSError *error) {
             XCTFail(@"The request should not fail - NSError: %@", error);
             [expectation fulfill];

--- a/MatrixSDKTests/MXStoreTests.m
+++ b/MatrixSDKTests/MXStoreTests.m
@@ -438,7 +438,7 @@
                     [room2LiveTimeline paginate:5 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^() {
 
                         // Log room2 to keep a ref on it up to here
-                        NSLog(@"%@", room2);
+                        MXLogDebug(@"%@", room2);
 
                         [room2LiveTimeline paginate:100 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^() {
 
@@ -538,7 +538,7 @@
                         [room2liveTimeline paginate:5 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^() {
 
                             // Log room2 to keep a ref on it up to here
-                            NSLog(@"%@", room2);
+                            MXLogDebug(@"%@", room2);
                             
                             [room2liveTimeline paginate:100 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^() {
 

--- a/MatrixSDKTests/MatrixSDKTestsData.m
+++ b/MatrixSDKTests/MatrixSDKTestsData.m
@@ -158,7 +158,7 @@ NSString * const kMXTestsAliceAvatarURL = @"mxc://matrix.org/kciiXusgZFKuNLIfLqm
         // Create a random room to use
         [bobRestClient createRoom:nil visibility:kMXRoomDirectoryVisibilityPrivate roomAlias:nil topic:nil success:^(MXCreateRoomResponse *response) {
 
-            NSLog(@"Created room %@ for %@", response.roomId, testCase.name);
+            MXLogDebug(@"Created room %@ for %@", response.roomId, testCase.name);
             
             readyToTest(bobRestClient, response.roomId, expectation);
             
@@ -176,7 +176,7 @@ NSString * const kMXTestsAliceAvatarURL = @"mxc://matrix.org/kciiXusgZFKuNLIfLqm
                             // Create a random room to use
                             [bobRestClient createRoom:nil visibility:kMXRoomDirectoryVisibilityPublic roomAlias:nil topic:nil success:^(MXCreateRoomResponse *response) {
 
-                                NSLog(@"Created public room %@ for %@", response.roomId, testCase.name);
+                                MXLogDebug(@"Created public room %@ for %@", response.roomId, testCase.name);
 
                                 readyToTest(bobRestClient, response.roomId, expectation);
                                 
@@ -231,7 +231,7 @@ NSString * const kMXTestsAliceAvatarURL = @"mxc://matrix.org/kciiXusgZFKuNLIfLqm
         // Create a random room to use
         [bobRestClient createRoom:nil visibility:kMXRoomDirectoryVisibilityPrivate roomAlias:nil topic:nil success:^(MXCreateRoomResponse *response) {
 
-            NSLog(@"Created room %@ for %@", response.roomId, testCase.name);
+            MXLogDebug(@"Created room %@ for %@", response.roomId, testCase.name);
 
             // Send the the message text in it
             [bobRestClient sendTextMessageToRoom:response.roomId text:newTextMessage success:^(NSString *eventId) {
@@ -294,7 +294,7 @@ NSString * const kMXTestsAliceAvatarURL = @"mxc://matrix.org/kciiXusgZFKuNLIfLqm
 
 - (void)for:(MXRestClient *)mxRestClient2 andRoom:(NSString*)roomId sendMessages:(NSUInteger)messagesCount testCase:(XCTestCase*)testCase success:(void (^)(void))success
 {
-    NSLog(@"sendMessages :%tu to %@", messagesCount, roomId);
+    MXLogDebug(@"sendMessages :%tu to %@", messagesCount, roomId);
     if (0 == messagesCount)
     {
         success();
@@ -326,7 +326,7 @@ NSString * const kMXTestsAliceAvatarURL = @"mxc://matrix.org/kciiXusgZFKuNLIfLqm
         // Create the room
         [mxRestClient2 createRoom:nil visibility:kMXRoomDirectoryVisibilityPrivate roomAlias:nil topic:nil success:^(MXCreateRoomResponse *response) {
 
-            NSLog(@"Created room %@ in createRooms", response.roomId);
+            MXLogDebug(@"Created room %@ in createRooms", response.roomId);
 
             // Fill it with messages
             [self for:mxRestClient2 andRoom:response.roomId sendMessages:messagesCount testCase:testCase success:^{

--- a/Podfile
+++ b/Podfile
@@ -4,6 +4,8 @@ abstract_target 'MatrixSDK' do
     
     pod 'AFNetworking', '~> 4.0.0'
     pod 'GZIP', '~> 1.3.0'
+
+    pod 'SwiftyBeaver', '1.9.5'
     
     pod 'OLMKit', '~> 3.2.2', :inhibit_warnings => true
     #pod 'OLMKit', :path => '../olm/OLMKit.podspec'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -37,6 +37,7 @@ PODS:
   - Realm (10.7.6):
     - Realm/Headers (= 10.7.6)
   - Realm/Headers (10.7.6)
+  - SwiftyBeaver (1.9.5)
 
 DEPENDENCIES:
   - AFNetworking (~> 4.0.0)
@@ -45,6 +46,7 @@ DEPENDENCIES:
   - OHHTTPStubs (~> 9.1.0)
   - OLMKit (~> 3.2.2)
   - Realm (= 10.7.6)
+  - SwiftyBeaver (= 1.9.5)
 
 SPEC REPOS:
   trunk:
@@ -54,6 +56,7 @@ SPEC REPOS:
     - OHHTTPStubs
     - OLMKit
     - Realm
+    - SwiftyBeaver
 
 SPEC CHECKSUMS:
   AFNetworking: 7864c38297c79aaca1500c33288e429c3451fdce
@@ -62,7 +65,8 @@ SPEC CHECKSUMS:
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   OLMKit: 20d1c564033a1ae7148f8f599378d4c798363905
   Realm: ed860452717c8db8f4bf832b6807f7f2ce708839
+  SwiftyBeaver: 84069991dd5dca07d7069100985badaca7f0ce82
 
-PODFILE CHECKSUM: 2dcb37ef834ab283bce675f4ee6849ece6682f6e
+PODFILE CHECKSUM: 58ac8e9156940bc571fe75a09f7dd646f5d924f5
 
 COCOAPODS: 1.10.1

--- a/README.rst
+++ b/README.rst
@@ -108,7 +108,7 @@ instantiated with initWithHomeServer does the job:
     [mxRestClient publicRooms:^(NSArray *rooms) {
 
         // rooms is an array of MXPublicRoom objects containing information like room id
-        NSLog(@"The public rooms are: %@", rooms);
+        MXLogDebug(@"The public rooms are: %@", rooms);
 
     } failure:^(MXError *error) {
     }];


### PR DESCRIPTION
Replaced NSLog usages with a custom MXLog implementation based on SwiftyBeaver. 
- added ObjC interop through the macros from MXLog.h and an pure ObjC wrapper in order to support variable arguments
- moved logging configuration and MXLogger redirecting to the MXLog configure method
- using MXLogDebug everywhere for now, better grouping will be done later down the line