### PR TITLE
MXSession: Clear initial sync cache on MXSession.close()

### DIFF
--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -1075,6 +1075,9 @@ typedef void (^MXOnResumeDone)(void);
         [user removeAllListeners];
     }
     
+    // Clean any cached initial sync response
+    [self.initialSyncResponseCache deleteData];
+    
     // Flush the store
     if ([_store respondsToSelector:@selector(close)])
     {


### PR DESCRIPTION
It will fix tests that are reopening sessions in loop while new data is coming.
It will not change behavior of MatrixKit nor EI. They call it only on logout.

The issue came during this sprint with the fix of this cache in https://github.com/matrix-org/matrix-ios-sdk/pull/1101.