### PR TITLE
Include debug symbols in XCFramework output

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,7 +21,7 @@ Changes to be released in next version
  * 
     
 🧱 Build
- * 
+ * build.sh: Include debug symbols when building XCFramework 
 
 Others
  * 

--- a/build.sh
+++ b/build.sh
@@ -20,7 +20,15 @@ then
 	if [ -f 'MatrixSDK.xcframework.zip' ]; then rm -rf MatrixSDK.xcframework.zip; fi
 
 	# build and zip the xcframework
-	xcodebuild -create-xcframework -framework MatrixSDK-iOS.xcarchive/Products/Library/Frameworks/MatrixSDK.framework -framework MatrixSDK-iOSSimulator.xcarchive/Products/Library/Frameworks/MatrixSDK.framework -framework MatrixSDK-macOS.xcarchive/Products/Library/Frameworks/MatrixSDK.framework -framework MatrixSDK-MacCatalyst.xcarchive/Products/Library/Frameworks/MatrixSDK.framework -output MatrixSDK.xcframework
+	xcodebuild -create-xcframework \
+		-framework MatrixSDK-iOS.xcarchive/Products/Library/Frameworks/MatrixSDK.framework \
+		-debug-symbols ${PWD}/MatrixSDK-iOS.xcarchive/dSYMs/MatrixSDK.framework.dSYM \
+		-debug-symbols ${PWD}/MatrixSDK-iOS.xcarchive/BCSymbolMaps/*.bcsymbolmap \
+		-framework MatrixSDK-iOSSimulator.xcarchive/Products/Library/Frameworks/MatrixSDK.framework \
+		-debug-symbols ${PWD}/MatrixSDK-iOSSimulator.xcarchive/dSYMs/MatrixSDK.framework.dSYM \
+		-framework MatrixSDK-macOS.xcarchive/Products/Library/Frameworks/MatrixSDK.framework \
+		-framework MatrixSDK-MacCatalyst.xcarchive/Products/Library/Frameworks/MatrixSDK.framework \
+		-output MatrixSDK.xcframework
 	zip -ry MatrixSDK.xcframework.zip MatrixSDK.xcframework
 else
 	xcodebuild -workspace MatrixSDK.xcworkspace/ -scheme MatrixSDK -sdk iphonesimulator  -destination 'name=iPhone 5s'


### PR DESCRIPTION
Note: The `-debug-symbols` arg requires an absolute path. BCSymbolMap files have a UUID filename, hence the wildcard. There should only ever be one per XCArchive.

Fixes #1122.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request updates [CHANGES.rst](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CHANGES.rst)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)
