### PR TITLE
MXSession: Fix app that can fail to resume

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,7 @@ Changes to be released in next version
  * VoIP: Change hold direction to send-only.
 
 🐛 Bugfix
- * 
+ * MXSession: Fix app that can fail to resume (vector-im/element-ios/issues/4417).
 
 ⚠️ API Changes
  * MXRoomSummary: `lastMessageEvent` property removed for performance reasons (vector-im/element-ios/issues/4360).

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -1519,9 +1519,9 @@ typedef void (^MXOnResumeDone)(void);
                 // This happens when the SDK cannot make any more requests because the app is in background
                 // and the background task is expired or going to expire.
                 // The app should have paused the SDK before but it did not. So, pause the SDK ourselves.
-                // Note that we need to come back to MXSessionStateRunning in order to be able to pause.
+                // Note that we need to come back to MXSessionStatePauseRequested in order to be able to pause.
                 MXLogDebug(@"[MXSession] -> Go to pause");
-                [self setState:MXSessionStateRunning];
+                [self setState:MXSessionStatePauseRequested];
                 [self pause];
             }
         }


### PR DESCRIPTION
Fix vector-im/element-ios/issues/4417

The root cause of the issue is a race condition in the MXSession pause management between the sdk state machine and the kit state machine.

The SDK was blocked and dead in MXSessionStateSyncInProgress state. The kit thought it does not need to resume it on app resume.

This fix is very related on how the kit and the sdk work together. But it could make sense in a more general manner.

I was able to reproduce the issue ("[MXSession] The connection has been cancelled.") by adding a delay of 25s in /sync response. Then, if you background the app just after starting it, you will hit this case.