### PR TITLE
MXRecoveryService: Expose checkPrivateKey to validate a private key

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Changes to be released in next version
  * MXRoomLastMessage: Use MXKeyProvider methods to encrypt/decrypt last message dictionary.
  * VoIP: Change hold direction to send-only.
  * Encrypted Media: Remove redundant and undocumented mimetype fields from encrypted attachments (vector-im/element-ios/issues/4303).
+ * MXRecoveryService: Expose checkPrivateKey to validate a private key (vector-im/element-ios/issues/4430).
 
 🐛 Bugfix
  * MXSession: Fix app that can fail to resume (vector-im/element-ios/issues/4417).

--- a/MatrixSDK/Crypto/Recovery/MXRecoveryService.h
+++ b/MatrixSDK/Crypto/Recovery/MXRecoveryService.h
@@ -86,6 +86,14 @@ typedef NS_ENUM(NSInteger, MXRecoveryServiceErrorCode)
                                         success:(void (^)(void))success
                                         failure:(void (^)(NSError *error))failure;
 
+/**
+ Check whether a private key corresponds to the current recovery.
+ 
+ @param privateKey the private key.
+ @param complete called with a boolean that indicates whether or not the key matches
+ */
+- (void)checkPrivateKey:(NSData*)privateKey complete:(void (^)(BOOL match))complete;
+
 
 #pragma mark - Secrets in the recovery
 

--- a/MatrixSDK/Crypto/Recovery/MXRecoveryService.m
+++ b/MatrixSDK/Crypto/Recovery/MXRecoveryService.m
@@ -185,6 +185,18 @@ NSString *const MXRecoveryServiceErrorDomain = @"org.matrix.sdk.recoveryService"
     } failure:failure];
 }
 
+- (void)checkPrivateKey:(NSData*)privateKey complete:(void (^)(BOOL match))complete
+{
+    MXSecretStorageKeyContent *keyContent = [_secretStorage keyWithKeyId:self.recoveryId];
+    if (!keyContent)
+    {
+        complete(NO);
+        return;
+    }
+    
+    [_secretStorage checkPrivateKey:privateKey withKey:keyContent complete:complete];
+}
+
 
 #pragma mark - Secrets in the recovery
 
@@ -310,6 +322,7 @@ NSString *const MXRecoveryServiceErrorDomain = @"org.matrix.sdk.recoveryService"
         // Set this recovery as the default SSSS key id
         [self.secretStorage setAsDefaultKeyWithKeyId:keyCreationInfo.keyId success:^{
             
+            // ####
             [self updateRecoveryForSecrets:secrets withPrivateKey:keyCreationInfo.privateKey success:^{
                 success(keyCreationInfo);
             } failure:failure];

--- a/MatrixSDK/Crypto/Recovery/MXRecoveryService.m
+++ b/MatrixSDK/Crypto/Recovery/MXRecoveryService.m
@@ -322,7 +322,6 @@ NSString *const MXRecoveryServiceErrorDomain = @"org.matrix.sdk.recoveryService"
         // Set this recovery as the default SSSS key id
         [self.secretStorage setAsDefaultKeyWithKeyId:keyCreationInfo.keyId success:^{
             
-            // ####
             [self updateRecoveryForSecrets:secrets withPrivateKey:keyCreationInfo.privateKey success:^{
                 success(keyCreationInfo);
             } failure:failure];


### PR DESCRIPTION
Useful for vector-im/element-ios/issues/4430.