### PR TITLE
Fix dehydration

### DIFF
--- a/MatrixSDKTests/MatrixSDKTestsData.h
+++ b/MatrixSDKTests/MatrixSDKTestsData.h
@@ -159,6 +159,16 @@ onUnrecognizedCertificateBlock:(MXHTTPClientOnUnrecognizedCertificate)onUnrecogn
                          withPassword:(NSString*)password
                            onComplete:(void (^)(MXSession *newSession))onComplete;
 
+// Log the user on a new device
+- (void)loginUserOnANewDevice:(XCTestCase*)testCase
+                  credentials:(MXCredentials*)credentials
+                 withPassword:(NSString*)password
+              sessionToLogout:(MXSession*)sessionToLogout
+              newSessionStore:(id<MXStore>)newSessionStore
+              startNewSession:(BOOL)startNewSession
+                          e2e:(BOOL)e2e
+                   onComplete:(void (^)(MXSession *newSession))onComplete;
+
 - (void)for:(MXRestClient *)mxRestClient2 andRoom:(NSString*)roomId sendMessages:(NSUInteger)messagesCount testCase:(XCTestCase*)testCase success:(void (^)(void))success;
 
 


### PR DESCRIPTION
More smaller tests showed that the dehydration was not working as expected. There were 2 issues: the signature computation reported [here](https://github.com/matrix-org/matrix-ios-sdk/pull/1117#discussion_r649641475) and the signature format sent with OTK.

Some tests did not work because the session was started before the rehydration. I added a new helper `loginUserOnANewDevice` with several parameters to match the needs here.

![image](https://user-images.githubusercontent.com/8418515/122364953-8cbaf100-cf5a-11eb-9783-db25759be948.png)
 