### PR TITLE
Initial support for MSC 2448 (BlurHash)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changes to be released in next version
  * 
 
 🙌 Improvements
+ * MXRoom: Added support for posting `m.image`s with BlurHash (MSC 2448)
  * MXRoomLastMessage: Use MXKeyProvider methods to encrypt/decrypt last message dictionary.
  * VoIP: Change hold direction to send-only.
  * Encrypted Media: Remove redundant and undocumented mimetype fields from encrypted attachments (vector-im/element-ios/issues/4303).

--- a/MatrixSDK/Contrib/Swift/Data/MXRoom.swift
+++ b/MatrixSDK/Contrib/Swift/Data/MXRoom.swift
@@ -186,6 +186,7 @@ public extension MXRoom {
         - size: the original size of the image.
         - mimeType:  the image mimetype.
         - thumbnail: optional thumbnail image (may be nil).
+        - blurhash: optional BlurHash (may be nil).
         - localEcho: a pointer to a MXEvent object.
      
              This pointer is set to an actual MXEvent object
@@ -204,8 +205,8 @@ public extension MXRoom {
      - returns: a `MXHTTPOperation` instance.
      */
 
-    @nonobjc @discardableResult func sendImage(data imageData: Data, size: CGSize, mimeType: String, thumbnail: MXImage?, localEcho: inout MXEvent?, completion: @escaping (_ response: MXResponse<String?>) -> Void) -> MXHTTPOperation {
-        return __sendImage(imageData, withImageSize: size, mimeType: mimeType, andThumbnail: thumbnail, localEcho: &localEcho, success: currySuccess(completion), failure: curryFailure(completion))
+    @nonobjc @discardableResult func sendImage(data imageData: Data, size: CGSize, mimeType: String, thumbnail: MXImage?, blurhash: String?, localEcho: inout MXEvent?, completion: @escaping (_ response: MXResponse<String?>) -> Void) -> MXHTTPOperation {
+        return __sendImage(imageData, withImageSize: size, mimeType: mimeType, andThumbnail: thumbnail, blurHash: blurhash, localEcho: &localEcho, success: currySuccess(completion), failure: curryFailure(completion))
     }
     
     

--- a/MatrixSDK/Data/MXRoom.h
+++ b/MatrixSDK/Data/MXRoom.h
@@ -400,6 +400,34 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidFlushDataNotification;
 #endif
                     localEcho:(MXEvent**)localEcho
                       success:(void (^)(NSString *eventId))success
+                      failure:(void (^)(NSError *error))failure;
+
+/**
+ Send an image to the room.
+
+ @param imageData the data of the image to send.
+ @param imageSize the original size of the image.
+ @param mimetype  the image mimetype.
+ @param thumbnail optional thumbnail image (may be nil).
+ @param blurhash optional BlurHash (may be nil).
+ @param localEcho a pointer to a MXEvent object (@see sendMessageWithContent: for details).
+ @param success A block object called when the operation succeeds. It returns
+                the event id of the event generated on the home server
+ @param failure A block object called when the operation fails.
+
+ @return a MXHTTPOperation instance.
+ */
+- (MXHTTPOperation*)sendImage:(NSData*)imageData
+                withImageSize:(CGSize)imageSize
+                     mimeType:(NSString*)mimetype
+#if TARGET_OS_IPHONE
+                 andThumbnail:(UIImage*)thumbnail
+#elif TARGET_OS_OSX
+                 andThumbnail:(NSImage*)thumbnail
+#endif
+                     blurHash:(NSString*)blurhash
+                    localEcho:(MXEvent**)localEcho
+                      success:(void (^)(NSString *eventId))success
                       failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -864,6 +864,29 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
                       success:(void (^)(NSString *eventId))success
                       failure:(void (^)(NSError *error))failure
 {
+    return [self sendImage:imageData
+             withImageSize:imageSize
+                  mimeType:mimetype
+              andThumbnail:thumbnail
+                  blurHash:nil
+                 localEcho:localEcho
+                   success:success
+                   failure:failure];
+}
+
+- (MXHTTPOperation*)sendImage:(NSData*)imageData
+                withImageSize:(CGSize)imageSize
+                     mimeType:(NSString*)mimetype
+#if TARGET_OS_IPHONE
+                 andThumbnail:(UIImage*)thumbnail
+#elif TARGET_OS_OSX
+                 andThumbnail:(NSImage*)thumbnail
+#endif
+                     blurHash:(NSString*)blurhash
+                    localEcho:(MXEvent**)localEcho
+                      success:(void (^)(NSString *eventId))success
+                      failure:(void (^)(NSError *error))failure
+{
     __block MXRoomOperation *roomOperation;
 
     double endRange = 1.0;
@@ -903,6 +926,10 @@ NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotificatio
                                                      @"size": @(imageData.length)
                                                      } mutableCopy]
                                          } mutableCopy];
+    if (blurhash)
+    {
+        msgContent[@"info"][@"blurhash"] = blurhash;
+    }
     
     __block MXEvent *event;
     __block id uploaderObserver;


### PR DESCRIPTION
Added support for BlurHash (https://github.com/woltapp/blurhash) to MXRoom.sendImage() for MSC2448

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request updates [CHANGES.rst](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CHANGES.rst)
* [ ] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)
