### PR TITLE
MXSession.homeserverWellknown was no more computed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changes to be released in next version
  * MXSDKOptions: Introduce an option to auto-accept room invites.
 
 🐛 Bugfix
- * 
+ * MXSession.homeserverWellknown was no more computed since 0.19.0.
 
 ⚠️ API Changes
  * 

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -882,7 +882,7 @@ typedef void (^MXOnResumeDone)(void);
     // Get wellknown data only at the login time
     if (!self.homeserverWellknown)
     {
-//        [self refreshHomeserverWellknown:nil failure:nil];
+        [self refreshHomeserverWellknown:nil failure:nil];
     }
 }
 


### PR DESCRIPTION
It affects all new logged in users since 0.19.0 and https://github.com/matrix-org/matrix-ios-sdk/commit/38df17fe6a6013b91f493a8c2d9c6db9fcb4a1da.