### PR TITLE
MXSDKOptions: Add wellknownDomainUrl to customise the domain for wellknown

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changes to be released in next version
  * 
 
 🙌 Improvements
- * 
+ * MXDehydrationService: Support full rehydration feature (vector-im/element-ios/issues/1117).
+ * MXSDKOptions: Add wellknownDomainUrl to customise the domain for wellknown (vector-im/element-ios/issues/#4489).
 
 🐛 Bugfix
  * 
@@ -114,7 +115,6 @@ Changes in 0.19.0 (2021-06-02)
  * Pod: Update OLMKit to 3.2.4.
  * MXRealmCryptoStore: Use Realm instances as read-only in background store (vector-im/element-ios/issues/4352).
  * MXLog: centralised logging facility, use everywhere instead of NSLog (vector-im/element-ios/issues/4351).
- * MXDehydrationService: Support full rehydration feature (vector-im/element-ios/issues/1117).
 
 🐛 Bugfix
  * MXRoomSummary: Fix decryption of the last message when it is edited (vector-im/element-ios/issues/4322).

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Changes to be released in next version
 🙌 Improvements
  * MXDehydrationService: Support full rehydration feature (vector-im/element-ios/issues/1117).
  * MXSDKOptions: Add wellknownDomainUrl to customise the domain for wellknown (vector-im/element-ios/issues/#4489).
+ * MXSession: Refresh homeserverWellknown on every start.
 
 🐛 Bugfix
  * 

--- a/MatrixSDK/MXSDKOptions.h
+++ b/MatrixSDK/MXSDKOptions.h
@@ -135,6 +135,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, assign) BOOL autoAcceptRoomInvites;
 
+/**
+ Custom domain to use to fetch the matrix client wellknown.
+ 
+ It is nil by default. By default, MXSession uses the domain of the user id.
+ */
+@property (nonatomic, nullable) NSString *wellknownDomainUrl;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -4094,18 +4094,20 @@ typedef void (^MXOnResumeDone)(void);
     MXLogDebug(@"[MXSession] refreshHomeserverWellknown");
     if (!autoDiscovery)
     {
-        NSString *homeServer;
-        
-        // Retrieve the domain from the user id as it can be different from the `MXRestClient.homeserver` that uses the client-server API endpoint domain.
-        NSString *userDomain = [MXTools serverNameInMatrixIdentifier:self.myUserId];
-        
-        if (userDomain)
+        NSString *homeServer = [MXSDKOptions sharedInstance].wellknownDomainUrl;
+        if (!homeServer)
         {
-            homeServer =  [NSString stringWithFormat:@"https://%@", userDomain];
-        }
-        else
-        {
-            homeServer = matrixRestClient.homeserver;
+            // Retrieve the domain from the user id as it can be different from the `MXRestClient.homeserver` that uses the client-server API endpoint domain.
+            NSString *userDomain = [MXTools serverNameInMatrixIdentifier:self.myUserId];
+            
+            if (userDomain)
+            {
+                homeServer =  [NSString stringWithFormat:@"https://%@", userDomain];
+            }
+            else
+            {
+                homeServer = matrixRestClient.homeserver;
+            }
         }
         
         autoDiscovery = [[MXAutoDiscovery alloc] initWithUrl:homeServer];

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -879,11 +879,8 @@ typedef void (^MXOnResumeDone)(void);
         }];
     }
 
-    // Get wellknown data only at the login time
-    if (!self.homeserverWellknown)
-    {
-        [self refreshHomeserverWellknown:nil failure:nil];
-    }
+    // Refresh wellknown data
+    [self refreshHomeserverWellknown:nil failure:nil];
 }
 
 - (NSString *)syncFilterId


### PR DESCRIPTION
fix https://github.com/vector-im/element-ios/issues/#4489.

I also added a commit to refresh the wellknown on every start to get latest services available on the server.

