### PR TITLE
Improve video transcoding quality

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,13 +5,13 @@ Changes to be released in next version
  * 
 
 🙌 Improvements
- * 
+ * MXTools: Default to 1080p when converting a video (vector-im/element-ios/issues/4478).
 
 🐛 Bugfix
  * 
 
 ⚠️ API Changes
- * 
+ * MXSDKOptions: Add videoConversionPresetName to customise video conversion quality.
 
 🗣 Translations
  * 

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -1214,7 +1214,9 @@ NSInteger const kMXRoomAlreadyJoinedErrorCode = 9001;
     roomOperation = [self preserveOperationOrder:event block:^{
 
         // Before sending data to the server, convert the video to MP4
-        [MXTools convertVideoToMP4:videoLocalURL success:^(NSURL *convertedLocalURL, NSString *mimetype, CGSize size, double durationInMs) {
+        [MXTools convertVideoToMP4:videoLocalURL
+                 withMaxUploadSize:[self mxSession].maxUploadSize
+                           success:^(NSURL *convertedLocalURL, NSString *mimetype, CGSize size, double durationInMs) {
 
             if (![[NSFileManager defaultManager] fileExistsAtPath:convertedLocalURL.path])
             {

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -1215,7 +1215,7 @@ NSInteger const kMXRoomAlreadyJoinedErrorCode = 9001;
 
         // Before sending data to the server, convert the video to MP4
         [MXTools convertVideoToMP4:videoLocalURL
-                 withMaxUploadSize:[self mxSession].maxUploadSize
+                withTargetFileSize:[self mxSession].maxUploadSize
                            success:^(NSURL *convertedLocalURL, NSString *mimetype, CGSize size, double durationInMs) {
 
             if (![[NSFileManager defaultManager] fileExistsAtPath:convertedLocalURL.path])

--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
@@ -447,6 +447,20 @@ static NSUInteger preloadOptions;
     }
 }
 
+- (NSInteger)maxUploadSize
+{
+    return metaData.maxUploadSize;
+}
+
+- (void)storeMaxUploadSize:(NSInteger)maxUploadSize
+{
+    if (metaData)
+    {
+        metaData.maxUploadSize = maxUploadSize;
+        metaDataHasChanged = YES;
+    }
+}
+
 - (BOOL)isPermanent
 {
     return YES;

--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStoreMetaData.h
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStoreMetaData.h
@@ -56,4 +56,9 @@
  */
 @property (nonatomic) MXWellKnown *homeserverWellknown;
 
+/**
+ The maximum size an upload can be in bytes.
+ */
+@property (nonatomic) NSInteger maxUploadSize;
+
 @end

--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStoreMetaData.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStoreMetaData.m
@@ -34,6 +34,9 @@
         _version = [version unsignedIntegerValue];
 
         _homeserverWellknown = dict[@"wellknown"];
+        
+        NSNumber *maxUploadSize = dict[@"maxUploadSize"];
+        _maxUploadSize = [maxUploadSize integerValue] ?: -1;
     }
     return self;
 }
@@ -46,6 +49,7 @@
                                   @"homeServer": _homeServer,
                                   @"userId": _userId,
                                   @"version": @(_version),
+                                  @"maxUploadSize": @(_maxUploadSize),
                                   }];
 
     // Nullable properties
@@ -78,6 +82,7 @@
     metaData->_version = _version;
     metaData->_eventStreamToken = [_eventStreamToken copyWithZone:zone];
     metaData->_userAccountData = [_userAccountData copyWithZone:zone];
+    metaData->_maxUploadSize = _maxUploadSize;
  
     return metaData;
 }

--- a/MatrixSDK/Data/Store/MXStore.h
+++ b/MatrixSDK/Data/Store/MXStore.h
@@ -324,6 +324,21 @@
 - (void)close;
 
 
+#pragma mark - Media repository
+
+/**
+ The maximum size an upload can be in bytes.
+ */
+@property (nonatomic, readonly) NSInteger maxUploadSize;
+
+/**
+ Store the maximum upload size.
+
+ @param maxUploadSize The maximum upload size to store.
+ */
+- (void)storeMaxUploadSize:(NSInteger)maxUploadSize;
+
+
 #pragma mark - Permanent storage -
 
 /**

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -1925,6 +1925,17 @@ typedef MXHTTPOperation* (^MXRestClientIdentityServerAccessTokenHandler)(void (^
                           failure:(void (^)(NSError *error))failure
                    uploadProgress:(void (^)(NSProgress *uploadProgress))uploadProgress NS_REFINED_FOR_SWIFT;
 
+/**
+Get the maximum size a media upload can be in bytes.
+ 
+@param success A block object called when the operation succeeds. It provides the maximum size an upload can be in bytes.
+@param failure A block object called when the operation fails.
+
+@return a MXHTTPOperation instance.
+*/
+- (MXHTTPOperation*) maxUploadSize:(void (^)(NSInteger maxUploadSize))success
+                           failure:(void (^)(NSError *error))failure;
+
 
 #pragma mark - Antivirus server API
 

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -3687,7 +3687,7 @@ MXAuthAction;
                                      {
                                          __block NSInteger maxUploadSize;
                                          [self dispatchProcessing:^{
-                                             MXJSONModelSetInteger(maxUploadSize, JSONResponse[@"m.upload.size"]);
+                                             MXJSONModelSetInteger(maxUploadSize, JSONResponse[@"m.upload.size"] ?: [NSNumber numberWithInteger:-1]);
                                          } andCompletion:^{
                                              success(maxUploadSize);
                                          }];

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -3685,7 +3685,7 @@ MXAuthAction;
 
                                      if (success)
                                      {
-                                         __block NSInteger maxUploadSize;
+                                         __block NSInteger maxUploadSize = 0;
                                          [self dispatchProcessing:^{
                                              MXJSONModelSetInteger(maxUploadSize, JSONResponse[@"m.upload.size"] ?: [NSNumber numberWithInteger:-1]);
                                          } andCompletion:^{

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -3673,6 +3673,32 @@ MXAuthAction;
                                  }];
 }
 
+- (MXHTTPOperation*) maxUploadSize:(void (^)(NSInteger maxUploadSize))success
+                           failure:(void (^)(NSError *error))failure
+{
+    MXWeakify(self);
+    return [httpClient requestWithMethod:@"GET"
+                                    path:[NSString stringWithFormat:@"%@/config", contentPathPrefix]
+                              parameters:nil
+                                 success:^(NSDictionary *JSONResponse) {
+                                     MXStrongifyAndReturnIfNil(self);
+
+                                     if (success)
+                                     {
+                                         __block NSInteger maxUploadSize;
+                                         [self dispatchProcessing:^{
+                                             MXJSONModelSetInteger(maxUploadSize, JSONResponse[@"m.upload.size"]);
+                                         } andCompletion:^{
+                                             success(maxUploadSize);
+                                         }];
+                                     }
+                                 }
+                                 failure:^(NSError *error) {
+                                     MXStrongifyAndReturnIfNil(self);
+                                     [self dispatchFailure:error inBlock:failure];
+                                 }];
+}
+
 #pragma mark - Antivirus server API
 - (void)setAntivirusServer:(NSString *)antivirusServer
 {

--- a/MatrixSDK/MXSDKOptions.h
+++ b/MatrixSDK/MXSDKOptions.h
@@ -17,6 +17,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import <AVFoundation/AVFoundation.h>
 
 #import "MXAnalyticsDelegate.h"
 #import "MXProfiler.h"
@@ -111,6 +112,13 @@ NS_ASSUME_NONNULL_BEGIN
  The default version value is 0.
  */
 @property (nonatomic) NSUInteger mediaCacheAppVersion;
+
+/**
+ The preset name given to AVAssetExportSession when converting a video.
+ 
+ The default value is AVAssetExportPreset1920x1080.
+ */
+@property (nonatomic) NSString *videoConversionPresetName;
 
 /**
  Object that handle enabling background mode

--- a/MatrixSDK/MXSDKOptions.m
+++ b/MatrixSDK/MXSDKOptions.m
@@ -43,6 +43,7 @@ static MXSDKOptions *sharedOnceInstance = nil;
         _enableCryptoWhenStartingMXSession = NO;
         _enableKeyBackupWhenStartingMXCrypto = YES;
         _mediaCacheAppVersion = 0;
+        _videoConversionPresetName = AVAssetExportPreset1920x1080;
         _applicationGroupIdentifier = nil;
         _HTTPAdditionalHeaders = @{};
         _autoAcceptRoomInvites = NO;

--- a/MatrixSDK/MXSession.h
+++ b/MatrixSDK/MXSession.h
@@ -399,7 +399,7 @@ FOUNDATION_EXPORT NSString *const kMXSessionNoRoomTag;
 @property (nonatomic, readonly) MXMediaManager *mediaManager;
 
 /**
- The the maximum size an upload can be in bytes.
+ The maximum size an upload can be in bytes.
  */
 @property (nonatomic, readonly) NSInteger maxUploadSize;
 

--- a/MatrixSDK/MXSession.h
+++ b/MatrixSDK/MXSession.h
@@ -399,6 +399,11 @@ FOUNDATION_EXPORT NSString *const kMXSessionNoRoomTag;
 @property (nonatomic, readonly) MXMediaManager *mediaManager;
 
 /**
+ The the maximum size an upload can be in bytes.
+ */
+@property (nonatomic, readonly) NSInteger maxUploadSize;
+
+/**
  The current state of the session.
  */
 @property (nonatomic, readonly) MXSessionState state;

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -886,7 +886,7 @@ typedef void (^MXOnResumeDone)(void);
     [self.matrixRestClient maxUploadSize:^(NSInteger maxUploadSize) {
         [self.store storeMaxUploadSize:maxUploadSize];
     } failure:^(NSError *error) {
-        MXLogDebug(@"[MXSession] Failed to get maximum upload size.");
+        MXLogError(@"[MXSession] Failed to get maximum upload size.");
     }];
 }
 

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -946,6 +946,12 @@ typedef void (^MXOnResumeDone)(void);
     [self handleBackgroundSyncCacheIfRequiredWithCompletion:^{
         [self _resume:resumeDone];
     }];
+    
+    [self.matrixRestClient maxUploadSize:^(NSInteger maxUploadSize) {
+        self->_maxUploadSize = maxUploadSize;
+    } failure:^(NSError *error) {
+        MXLogDebug(@"Failed to get maximum upload size.");
+    }];
 }
 
 - (void)_resume:(void (^)(void))resumeDone

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -881,6 +881,13 @@ typedef void (^MXOnResumeDone)(void);
 
     // Refresh wellknown data
     [self refreshHomeserverWellknown:nil failure:nil];
+    
+    // Get the maxmium file size allowed for uploading media
+    [self.matrixRestClient maxUploadSize:^(NSInteger maxUploadSize) {
+        [self.store storeMaxUploadSize:maxUploadSize];
+    } failure:^(NSError *error) {
+        MXLogDebug(@"[MXSession] Failed to get maximum upload size.");
+    }];
 }
 
 - (NSString *)syncFilterId
@@ -945,12 +952,6 @@ typedef void (^MXOnResumeDone)(void);
 {
     [self handleBackgroundSyncCacheIfRequiredWithCompletion:^{
         [self _resume:resumeDone];
-    }];
-    
-    [self.matrixRestClient maxUploadSize:^(NSInteger maxUploadSize) {
-        self->_maxUploadSize = maxUploadSize;
-    } failure:^(NSError *error) {
-        MXLogDebug(@"Failed to get maximum upload size.");
     }];
 }
 
@@ -4129,6 +4130,12 @@ typedef void (^MXOnResumeDone)(void);
     } failure:failure];
 }
 
+#pragma mark - Media repository
+
+- (NSInteger)maxUploadSize
+{
+    return self.store.maxUploadSize;
+}
 
 #pragma mark - Matrix filters
 - (MXHTTPOperation*)setFilter:(MXFilterJSONModel*)filter

--- a/MatrixSDK/Utils/MXTools.h
+++ b/MatrixSDK/Utils/MXTools.h
@@ -235,13 +235,13 @@ FOUNDATION_EXPORT NSString *const kMXToolsRegexStringForMatrixGroupIdentifier;
  If the device does not support MP4 file format, the function will use the QuickTime format.
  
  @param videoLocalURL the local path of the video to convert.
- @param maxUploadSize a file size limit to aim for.
+ @param targetFileSize a file size limit to aim for.
  @param success A block object called when the operation succeeded. It returns
  the path of the output video with some metadata.
  @param failure A block object called when the operation failed.
  */
 + (void)convertVideoToMP4:(NSURL*)videoLocalURL
-        withMaxUploadSize:(NSInteger)maxUploadSize
+       withTargetFileSize:(NSInteger)targetFileSize
                   success:(void(^)(NSURL *videoLocalURL, NSString *mimetype, CGSize size, double durationInMs))success
                   failure:(void(^)(void))failure;
 

--- a/MatrixSDK/Utils/MXTools.h
+++ b/MatrixSDK/Utils/MXTools.h
@@ -25,6 +25,7 @@
 
 #import "MXEvent.h"
 #import "MXJSONModels.h"
+#import "MXSDKOptions.h"
 #import "MXEnumConstants.h"
 #import "MXCallHangupEventContent.h"
 #import "MXCallSessionDescription.h"

--- a/MatrixSDK/Utils/MXTools.h
+++ b/MatrixSDK/Utils/MXTools.h
@@ -235,11 +235,13 @@ FOUNDATION_EXPORT NSString *const kMXToolsRegexStringForMatrixGroupIdentifier;
  If the device does not support MP4 file format, the function will use the QuickTime format.
  
  @param videoLocalURL the local path of the video to convert.
+ @param maxUploadSize a file size limit to aim for.
  @param success A block object called when the operation succeeded. It returns
  the path of the output video with some metadata.
  @param failure A block object called when the operation failed.
  */
 + (void)convertVideoToMP4:(NSURL*)videoLocalURL
+        withMaxUploadSize:(NSInteger)maxUploadSize
                   success:(void(^)(NSURL *videoLocalURL, NSString *mimetype, CGSize size, double durationInMs))success
                   failure:(void(^)(void))failure;
 

--- a/MatrixSDK/Utils/MXTools.m
+++ b/MatrixSDK/Utils/MXTools.m
@@ -825,12 +825,13 @@ static NSMutableDictionary *fileExtensionByContentType = nil;
     NSString *cacheRoot = [paths objectAtIndex:0];
     outputVideoLocalURL = [NSURL fileURLWithPath:[cacheRoot stringByAppendingPathComponent:outputFileName]];
     
-    // Convert video container to mp4
-    // Use medium quality to save bandwidth
+    // Convert video container to mp4 using preset from MXSDKOptions.
+    // Reduce the target file size by 10% as fileLengthLimit isn't a hard limit
     AVURLAsset* videoAsset = [AVURLAsset URLAssetWithURL:videoLocalURL options:nil];
-    AVAssetExportSession *exportSession = [AVAssetExportSession exportSessionWithAsset:videoAsset presetName:AVAssetExportPreset3840x2160];
+    NSString *presetName = [MXSDKOptions sharedInstance].videoConversionPresetName;
+    AVAssetExportSession *exportSession = [AVAssetExportSession exportSessionWithAsset:videoAsset presetName:presetName];
+    exportSession.fileLengthLimit = targetFileSize * 0.9;
     exportSession.outputURL = outputVideoLocalURL;
-    exportSession.fileLengthLimit = targetFileSize;
     
     // Check output file types supported by the device
     NSArray *supportedFileTypes = exportSession.supportedFileTypes;

--- a/MatrixSDK/Utils/MXTools.m
+++ b/MatrixSDK/Utils/MXTools.m
@@ -826,12 +826,16 @@ static NSMutableDictionary *fileExtensionByContentType = nil;
     outputVideoLocalURL = [NSURL fileURLWithPath:[cacheRoot stringByAppendingPathComponent:outputFileName]];
     
     // Convert video container to mp4 using preset from MXSDKOptions.
-    // Reduce the target file size by 10% as fileLengthLimit isn't a hard limit
     AVURLAsset* videoAsset = [AVURLAsset URLAssetWithURL:videoLocalURL options:nil];
     NSString *presetName = [MXSDKOptions sharedInstance].videoConversionPresetName;
     AVAssetExportSession *exportSession = [AVAssetExportSession exportSessionWithAsset:videoAsset presetName:presetName];
-    exportSession.fileLengthLimit = targetFileSize * 0.9;
     exportSession.outputURL = outputVideoLocalURL;
+    
+    if (targetFileSize > 0)
+    {
+        // Reduce the target file size by 10% as fileLengthLimit isn't a hard limit
+        exportSession.fileLengthLimit = targetFileSize * 0.9;
+    }
     
     // Check output file types supported by the device
     NSArray *supportedFileTypes = exportSession.supportedFileTypes;

--- a/MatrixSDK/Utils/MXTools.m
+++ b/MatrixSDK/Utils/MXTools.m
@@ -809,6 +809,7 @@ static NSMutableDictionary *fileExtensionByContentType = nil;
 #pragma mark - Video processing
 
 + (void)convertVideoToMP4:(NSURL*)videoLocalURL
+            withMaxUploadSize:(NSInteger)maxUploadSize
                   success:(void(^)(NSURL *videoLocalURL, NSString *mimetype, CGSize size, double durationInMs))success
                   failure:(void(^)(void))failure
 {
@@ -827,8 +828,9 @@ static NSMutableDictionary *fileExtensionByContentType = nil;
     // Convert video container to mp4
     // Use medium quality to save bandwidth
     AVURLAsset* videoAsset = [AVURLAsset URLAssetWithURL:videoLocalURL options:nil];
-    AVAssetExportSession *exportSession = [AVAssetExportSession exportSessionWithAsset:videoAsset presetName:AVAssetExportPresetMediumQuality];
+    AVAssetExportSession *exportSession = [AVAssetExportSession exportSessionWithAsset:videoAsset presetName:AVAssetExportPreset3840x2160];
     exportSession.outputURL = outputVideoLocalURL;
+    exportSession.fileLengthLimit = maxUploadSize;
     
     // Check output file types supported by the device
     NSArray *supportedFileTypes = exportSession.supportedFileTypes;

--- a/MatrixSDK/Utils/MXTools.m
+++ b/MatrixSDK/Utils/MXTools.m
@@ -809,7 +809,7 @@ static NSMutableDictionary *fileExtensionByContentType = nil;
 #pragma mark - Video processing
 
 + (void)convertVideoToMP4:(NSURL*)videoLocalURL
-            withMaxUploadSize:(NSInteger)maxUploadSize
+       withTargetFileSize:(NSInteger)targetFileSize
                   success:(void(^)(NSURL *videoLocalURL, NSString *mimetype, CGSize size, double durationInMs))success
                   failure:(void(^)(void))failure
 {
@@ -830,7 +830,7 @@ static NSMutableDictionary *fileExtensionByContentType = nil;
     AVURLAsset* videoAsset = [AVURLAsset URLAssetWithURL:videoLocalURL options:nil];
     AVAssetExportSession *exportSession = [AVAssetExportSession exportSessionWithAsset:videoAsset presetName:AVAssetExportPreset3840x2160];
     exportSession.outputURL = outputVideoLocalURL;
-    exportSession.fileLengthLimit = maxUploadSize;
+    exportSession.fileLengthLimit = targetFileSize;
     
     // Check output file types supported by the device
     NSArray *supportedFileTypes = exportSession.supportedFileTypes;


### PR DESCRIPTION
Draft for now as I have a couple of questions.

Add `maxUploadSize:failure:` to `MXRestClient` and stores the size in `MXSession`.
Pass a target file size to `MXTools` and use `AVAssetExportPreset3840x2160` when transcoding.