### PR TITLE
Fix self verification with QR code

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changes to be released in next version
  * 
 
 🐛 Bugfix
- * 
+ * Fix QR self verification with QR code (#1147)
 
 ⚠️ API Changes
  * 

--- a/MatrixSDK/Crypto/Verification/MXKeyVerificationManager.m
+++ b/MatrixSDK/Crypto/Verification/MXKeyVerificationManager.m
@@ -1935,7 +1935,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
         if (currentUserTrustLevel.isCrossSigningVerified)
         {
             // This is a self verification and I am the old device (Osborne2)
-            qrCodeData = [self createSelfVerifyingMasterKeyTrustedQRCodeDataWithTransactionId:transactionId otherDeviceId:otherUserId];
+            qrCodeData = [self createSelfVerifyingMasterKeyTrustedQRCodeDataWithTransactionId:transactionId otherDeviceId:otherDeviceId];
         }
         else
         {


### PR DESCRIPTION
This method expects the other device ID as a param, not the other
user ID

Fixes https://github.com/vector-im/element-ios/issues/4463