### PR TITLE
Fix Invite Room State Parsing

### DIFF
--- a/MatrixSDK/JSONModels/Event/MXEventUnsignedData.m
+++ b/MatrixSDK/JSONModels/Event/MXEventUnsignedData.m
@@ -40,7 +40,7 @@
         MXJSONModelSetDictionary(unsignedData->_prevContent, JSONDictionary[@"prev_content"]);
         MXJSONModelSetDictionary(unsignedData->_redactedBecause, JSONDictionary[@"redacted_because"]);
         MXJSONModelSetString(unsignedData->_transactionId, JSONDictionary[@"transaction_id"]);
-        MXJSONModelSetDictionary(unsignedData->_inviteRoomState, JSONDictionary[@"invite_room_state"]);
+        MXJSONModelSetMXJSONModelArray(unsignedData->_inviteRoomState, MXEvent, JSONDictionary[@"invite_room_state"]);
         MXJSONModelSetMXJSONModel(unsignedData->_relations, MXEventRelations, JSONDictionary[@"m.relations"]);
     }
 


### PR DESCRIPTION
### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [ ] Pull request updates [CHANGES.rst](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CHANGES.rst)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)

### Fixes
- fixes JSON parsing of the `_inviteRoomState` property of `MXEventUnsignedData`

I ran into a parsing exception when my client was invited to a room created with
```swift
roomParameters.initialStateEvents = [MXRoomCreationParameters.initialStateEventForEncryption(withAlgorithm: kMXCryptoMegolmAlgorithm)]
```

The server implementation was [Dendrite](https://github.com/matrix-org/dendrite).

I didn't modify `CHANGES.rst` yet since it has no space resevered for a new release and I didn't want to introduce conflicts with other PRs.

Signed-off-by: Christopher Kobusch <ck@peeree.de>