### PR TITLE
Add support for sending slow motion videos

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,6 @@ Changes to be released in next version
 
 ⚠️ API Changes
  * MXSDKOptions: Add videoConversionPresetName to customise video conversion quality.
- * MXTools: `convertToMP4` now takes an `AVAsset` instead of an `NSURL`.
 
 🗣 Translations
  * 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Changes to be released in next version
 
 ⚠️ API Changes
  * MXSDKOptions: Add videoConversionPresetName to customise video conversion quality.
+ * MXTools: `convertToMP4` now takes an `AVAsset` instead of an `NSURL`.
 
 🗣 Translations
  * 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Changes to be released in next version
 🙌 Improvements
  * MXTools: Default to 1080p when converting a video (vector-im/element-ios/issues/4478).
  * MXEvent: add support for voice messages
+ * MXRoom: Add support for sending slow motion videos using AVAsset (vector-im/element-ios/issues/4483).
 
 🐛 Bugfix
  * Fix QR self verification with QR code (#1147)

--- a/MatrixSDK/Contrib/Swift/Data/MXRoom.swift
+++ b/MatrixSDK/Contrib/Swift/Data/MXRoom.swift
@@ -235,8 +235,8 @@ public extension MXRoom {
      
      - returns: a `MXHTTPOperation` instance.
      */
-    @nonobjc @discardableResult func sendVideo(localURL: URL, thumbnail: MXImage?, localEcho: inout MXEvent?, completion: @escaping (_ response: MXResponse<String?>) -> Void) -> MXHTTPOperation {
-        return __sendVideo(localURL, withThumbnail: thumbnail, localEcho: &localEcho, success: currySuccess(completion), failure: curryFailure(completion))
+    @nonobjc @discardableResult func sendVideo(videoAsset: AVAsset, thumbnail: MXImage?, localEcho: inout MXEvent?, completion: @escaping (_ response: MXResponse<String?>) -> Void) -> MXHTTPOperation {
+        return __sendVideo(videoAsset, withThumbnail: thumbnail, localEcho: &localEcho, success: currySuccess(completion), failure: curryFailure(completion))
     }
     
     

--- a/MatrixSDK/Contrib/Swift/Data/MXRoom.swift
+++ b/MatrixSDK/Contrib/Swift/Data/MXRoom.swift
@@ -235,8 +235,36 @@ public extension MXRoom {
      
      - returns: a `MXHTTPOperation` instance.
      */
-    @nonobjc @discardableResult func sendVideo(videoAsset: AVAsset, thumbnail: MXImage?, localEcho: inout MXEvent?, completion: @escaping (_ response: MXResponse<String?>) -> Void) -> MXHTTPOperation {
-        return __sendVideo(videoAsset, withThumbnail: thumbnail, localEcho: &localEcho, success: currySuccess(completion), failure: curryFailure(completion))
+    @nonobjc @discardableResult func sendVideo(localURL: URL, thumbnail: MXImage?, localEcho: inout MXEvent?, completion: @escaping (_ response: MXResponse<String?>) -> Void) -> MXHTTPOperation {
+        return __sendVideo(localURL, withThumbnail: thumbnail, localEcho: &localEcho, success: currySuccess(completion), failure: curryFailure(completion))
+    }
+    
+    
+    /**
+     Send a video to the room.
+     
+     - parameters:
+        - videoAsset: an AVAsset that represents the video to send.
+        - thumbnail: the UIImage hosting a video thumbnail.
+        - localEcho: a pointer to a MXEvent object.
+     
+             This pointer is set to an actual MXEvent object
+             containing the local created event which should be used to echo the message in
+             the messages list until the resulting event come through the server sync.
+             For information, the identifier of the created local event has the prefix
+             `kMXEventLocalEventIdPrefix`.
+             
+             You may specify nil for this parameter if you do not want this information.
+             
+             You may provide your own MXEvent object, in this case only its send state is updated.
+     
+        - completion: A block object called when the operation completes.
+        - response: Provides the event id of the event generated on the home server on success.
+     
+     - returns: a `MXHTTPOperation` instance.
+     */
+    @nonobjc @discardableResult func sendVideo(asset: AVAsset, thumbnail: MXImage?, localEcho: inout MXEvent?, completion: @escaping (_ response: MXResponse<String?>) -> Void) -> MXHTTPOperation {
+        return __sendVideoAsset(asset, withThumbnail: thumbnail, localEcho: &localEcho, success: currySuccess(completion), failure: curryFailure(completion))
     }
     
     

--- a/MatrixSDK/Data/MXRoom.h
+++ b/MatrixSDK/Data/MXRoom.h
@@ -437,9 +437,9 @@ FOUNDATION_EXPORT NSInteger const kMXRoomAlreadyJoinedErrorCode;
                       failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
- Send an video to the room.
+ Send a video to the room.
  
- @param videoAsset the video to send as an AVAsset object.
+ @param videoLocalURL the local filesystem path of the video to send.
  @param videoThumbnail the UIImage hosting a video thumbnail.
  @param localEcho a pointer to a MXEvent object (@see sendMessageWithContent: for details).
  @param success A block object called when the operation succeeds. It returns
@@ -448,7 +448,7 @@ FOUNDATION_EXPORT NSInteger const kMXRoomAlreadyJoinedErrorCode;
  
  @return a MXHTTPOperation instance.
  */
-- (MXHTTPOperation*)sendVideo:(AVAsset*)videoAsset
+- (MXHTTPOperation*)sendVideo:(NSURL*)videoLocalURL
 #if TARGET_OS_IPHONE
                 withThumbnail:(UIImage*)videoThumbnail
 #elif TARGET_OS_OSX
@@ -457,6 +457,28 @@ FOUNDATION_EXPORT NSInteger const kMXRoomAlreadyJoinedErrorCode;
                     localEcho:(MXEvent**)localEcho
                       success:(void (^)(NSString *eventId))success
                       failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
+
+/**
+ Send a video to the room.
+ 
+ @param videoAsset an AVAsset that represents the video to send.
+ @param videoThumbnail the UIImage hosting a video thumbnail.
+ @param localEcho a pointer to a MXEvent object (@see sendMessageWithContent: for details).
+ @param success A block object called when the operation succeeds. It returns
+                the event id of the event generated on the home server
+ @param failure A block object called when the operation fails.
+ 
+ @return a MXHTTPOperation instance.
+ */
+- (MXHTTPOperation*)sendVideoAsset:(AVAsset*)videoAsset
+#if TARGET_OS_IPHONE
+                     withThumbnail:(UIImage*)videoThumbnail
+#elif TARGET_OS_OSX
+                     withThumbnail:(NSImage*)videoThumbnail
+#endif
+                         localEcho:(MXEvent**)localEcho
+                           success:(void (^)(NSString *eventId))success
+                           failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
  Send a file to the room.

--- a/MatrixSDK/Data/MXRoom.h
+++ b/MatrixSDK/Data/MXRoom.h
@@ -18,6 +18,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import <AVFoundation/AVFoundation.h>
 
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
@@ -438,7 +439,7 @@ FOUNDATION_EXPORT NSInteger const kMXRoomAlreadyJoinedErrorCode;
 /**
  Send an video to the room.
  
- @param videoLocalURL the local filesystem path of the video to send.
+ @param videoAsset the video to send as an AVAsset object.
  @param videoThumbnail the UIImage hosting a video thumbnail.
  @param localEcho a pointer to a MXEvent object (@see sendMessageWithContent: for details).
  @param success A block object called when the operation succeeds. It returns
@@ -447,7 +448,7 @@ FOUNDATION_EXPORT NSInteger const kMXRoomAlreadyJoinedErrorCode;
  
  @return a MXHTTPOperation instance.
  */
-- (MXHTTPOperation*)sendVideo:(NSURL*)videoLocalURL
+- (MXHTTPOperation*)sendVideo:(AVAsset*)videoAsset
 #if TARGET_OS_IPHONE
                 withThumbnail:(UIImage*)videoThumbnail
 #elif TARGET_OS_OSX

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -1111,15 +1111,29 @@ NSInteger const kMXRoomAlreadyJoinedErrorCode = 9001;
     return roomOperation.operation;
 }
 
-- (MXHTTPOperation*)sendVideo:(AVAsset*)videoAsset
+- (MXHTTPOperation *)sendVideo:(NSURL *)videoLocalURL
 #if TARGET_OS_IPHONE
-                withThumbnail:(UIImage*)videoThumbnail
+                 withThumbnail:(UIImage*)videoThumbnail
 #elif TARGET_OS_OSX
-                withThumbnail:(NSImage*)videoThumbnail
+                 withThumbnail:(NSImage*)videoThumbnail
 #endif
-                    localEcho:(MXEvent**)localEcho
-                      success:(void (^)(NSString *eventId))success
-                      failure:(void (^)(NSError *error))failure
+                     localEcho:(MXEvent**)localEcho
+                       success:(void (^)(NSString *eventId))success
+                       failure:(void (^)(NSError *error))failure
+{
+    AVURLAsset *videoAsset = [AVURLAsset assetWithURL:videoLocalURL];
+    return [self sendVideoAsset:videoAsset withThumbnail:videoThumbnail localEcho:localEcho success:success failure:failure];
+}
+
+- (MXHTTPOperation*)sendVideoAsset:(AVAsset*)videoAsset
+#if TARGET_OS_IPHONE
+                     withThumbnail:(UIImage*)videoThumbnail
+#elif TARGET_OS_OSX
+                     withThumbnail:(NSImage*)videoThumbnail
+#endif
+                         localEcho:(MXEvent**)localEcho
+                           success:(void (^)(NSString *eventId))success
+                           failure:(void (^)(NSError *error))failure
 {
     __block MXRoomOperation *roomOperation;
 

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -1111,7 +1111,7 @@ NSInteger const kMXRoomAlreadyJoinedErrorCode = 9001;
     return roomOperation.operation;
 }
 
-- (MXHTTPOperation*)sendVideo:(NSURL*)videoLocalURL
+- (MXHTTPOperation*)sendVideo:(AVAsset*)videoAsset
 #if TARGET_OS_IPHONE
                 withThumbnail:(UIImage*)videoThumbnail
 #elif TARGET_OS_OSX
@@ -1214,7 +1214,7 @@ NSInteger const kMXRoomAlreadyJoinedErrorCode = 9001;
     roomOperation = [self preserveOperationOrder:event block:^{
 
         // Before sending data to the server, convert the video to MP4
-        [MXTools convertVideoToMP4:videoLocalURL
+        [MXTools convertVideoToMP4:videoAsset
                 withTargetFileSize:[self mxSession].maxUploadSize
                            success:^(NSURL *convertedLocalURL, NSString *mimetype, CGSize size, double durationInMs) {
 

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -1111,15 +1111,15 @@ NSInteger const kMXRoomAlreadyJoinedErrorCode = 9001;
     return roomOperation.operation;
 }
 
-- (MXHTTPOperation *)sendVideo:(NSURL *)videoLocalURL
+- (MXHTTPOperation*)sendVideo:(NSURL*)videoLocalURL
 #if TARGET_OS_IPHONE
-                 withThumbnail:(UIImage*)videoThumbnail
+                withThumbnail:(UIImage*)videoThumbnail
 #elif TARGET_OS_OSX
-                 withThumbnail:(NSImage*)videoThumbnail
+                withThumbnail:(NSImage*)videoThumbnail
 #endif
-                     localEcho:(MXEvent**)localEcho
-                       success:(void (^)(NSString *eventId))success
-                       failure:(void (^)(NSError *error))failure
+                    localEcho:(MXEvent**)localEcho
+                      success:(void (^)(NSString *eventId))success
+                      failure:(void (^)(NSError *error))failure
 {
     AVURLAsset *videoAsset = [AVURLAsset assetWithURL:videoLocalURL];
     return [self sendVideoAsset:videoAsset withThumbnail:videoThumbnail localEcho:localEcho success:success failure:failure];

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -1228,9 +1228,9 @@ NSInteger const kMXRoomAlreadyJoinedErrorCode = 9001;
     roomOperation = [self preserveOperationOrder:event block:^{
 
         // Before sending data to the server, convert the video to MP4
-        [MXTools convertVideoToMP4:videoAsset
-                withTargetFileSize:[self mxSession].maxUploadSize
-                           success:^(NSURL *convertedLocalURL, NSString *mimetype, CGSize size, double durationInMs) {
+        [MXTools convertVideoAssetToMP4:videoAsset
+                     withTargetFileSize:[self mxSession].maxUploadSize
+                                success:^(NSURL *convertedLocalURL, NSString *mimetype, CGSize size, double durationInMs) {
 
             if (![[NSFileManager defaultManager] fileExistsAtPath:convertedLocalURL.path])
             {

--- a/MatrixSDK/Utils/MXTools.h
+++ b/MatrixSDK/Utils/MXTools.h
@@ -235,13 +235,13 @@ FOUNDATION_EXPORT NSString *const kMXToolsRegexStringForMatrixGroupIdentifier;
  @discussion
  If the device does not support MP4 file format, the function will use the QuickTime format.
  
- @param videoLocalURL the local path of the video to convert.
+ @param videoAsset an AVAsset for the video to convert.
  @param targetFileSize a file size limit to aim for.
  @param success A block object called when the operation succeeded. It returns
  the path of the output video with some metadata.
  @param failure A block object called when the operation failed.
  */
-+ (void)convertVideoToMP4:(NSURL*)videoLocalURL
++ (void)convertVideoToMP4:(AVAsset*)videoAsset
        withTargetFileSize:(NSInteger)targetFileSize
                   success:(void(^)(NSURL *videoLocalURL, NSString *mimetype, CGSize size, double durationInMs))success
                   failure:(void(^)(void))failure;

--- a/MatrixSDK/Utils/MXTools.h
+++ b/MatrixSDK/Utils/MXTools.h
@@ -235,16 +235,33 @@ FOUNDATION_EXPORT NSString *const kMXToolsRegexStringForMatrixGroupIdentifier;
  @discussion
  If the device does not support MP4 file format, the function will use the QuickTime format.
  
+ @param videoLocalURL the local path of the video to convert.
+ @param targetFileSize a file size limit to aim for.
+ @param success A block object called when the operation succeeded. It returns
+ the path of the output video with some metadata.
+ @param failure A block object called when the operation failed.
+ */
++ (void)convertVideoToMP4:(NSURL*)videoLocalURL
+       withTargetFileSize:(NSInteger)targetFileSize
+                  success:(void(^)(NSURL *videoLocalURL, NSString *mimetype, CGSize size, double durationInMs))success
+                  failure:(void(^)(void))failure;
+
+/**
+ Convert from a video to a MP4 video container.
+ 
+ @discussion
+ If the device does not support MP4 file format, the function will use the QuickTime format.
+ 
  @param videoAsset an AVAsset for the video to convert.
  @param targetFileSize a file size limit to aim for.
  @param success A block object called when the operation succeeded. It returns
  the path of the output video with some metadata.
  @param failure A block object called when the operation failed.
  */
-+ (void)convertVideoToMP4:(AVAsset*)videoAsset
-       withTargetFileSize:(NSInteger)targetFileSize
-                  success:(void(^)(NSURL *videoLocalURL, NSString *mimetype, CGSize size, double durationInMs))success
-                  failure:(void(^)(void))failure;
++ (void)convertVideoAssetToMP4:(AVAsset*)videoAsset
+            withTargetFileSize:(NSInteger)targetFileSize
+                       success:(void(^)(NSURL *videoLocalURL, NSString *mimetype, CGSize size, double durationInMs))success
+                       failure:(void(^)(void))failure;
 
 #pragma mark - JSON Serialisation
 

--- a/MatrixSDK/Utils/MXTools.m
+++ b/MatrixSDK/Utils/MXTools.m
@@ -808,7 +808,7 @@ static NSMutableDictionary *fileExtensionByContentType = nil;
 
 #pragma mark - Video processing
 
-+ (void)convertVideoToMP4:(NSURL*)videoLocalURL
++ (void)convertVideoToMP4:(AVAsset*)videoAsset
        withTargetFileSize:(NSInteger)targetFileSize
                   success:(void(^)(NSURL *videoLocalURL, NSString *mimetype, CGSize size, double durationInMs))success
                   failure:(void(^)(void))failure
@@ -826,7 +826,6 @@ static NSMutableDictionary *fileExtensionByContentType = nil;
     outputVideoLocalURL = [NSURL fileURLWithPath:[cacheRoot stringByAppendingPathComponent:outputFileName]];
     
     // Convert video container to mp4 using preset from MXSDKOptions.
-    AVURLAsset* videoAsset = [AVURLAsset URLAssetWithURL:videoLocalURL options:nil];
     NSString *presetName = [MXSDKOptions sharedInstance].videoConversionPresetName;
     AVAssetExportSession *exportSession = [AVAssetExportSession exportSessionWithAsset:videoAsset presetName:presetName];
     exportSession.outputURL = outputVideoLocalURL;

--- a/MatrixSDK/Utils/MXTools.m
+++ b/MatrixSDK/Utils/MXTools.m
@@ -808,10 +808,19 @@ static NSMutableDictionary *fileExtensionByContentType = nil;
 
 #pragma mark - Video processing
 
-+ (void)convertVideoToMP4:(AVAsset*)videoAsset
++ (void)convertVideoToMP4:(NSURL*)videoLocalURL
        withTargetFileSize:(NSInteger)targetFileSize
                   success:(void(^)(NSURL *videoLocalURL, NSString *mimetype, CGSize size, double durationInMs))success
                   failure:(void(^)(void))failure
+{
+    AVURLAsset *videoAsset = [AVURLAsset assetWithURL:videoLocalURL];
+    [self convertVideoAssetToMP4:videoAsset withTargetFileSize:targetFileSize success:success failure:failure];
+}
+
++ (void)convertVideoAssetToMP4:(AVAsset*)videoAsset
+            withTargetFileSize:(NSInteger)targetFileSize
+                       success:(void(^)(NSURL *videoLocalURL, NSString *mimetype, CGSize size, double durationInMs))success
+                       failure:(void(^)(void))failure
 {
     NSParameterAssert(success);
     NSParameterAssert(failure);
@@ -845,7 +854,7 @@ static NSMutableDictionary *fileExtensionByContentType = nil;
     }
     else
     {
-        MXLogDebug(@"[MXTools] convertVideoToMP4: Warning: MPEG-4 file format is not supported. Use QuickTime format.");
+        MXLogDebug(@"[MXTools] convertVideoAssetToMP4: Warning: MPEG-4 file format is not supported. Use QuickTime format.");
         
         // Fallback to QuickTime format
         exportSession.outputFileType = AVFileTypeQuickTimeMovie;
@@ -888,7 +897,7 @@ static NSMutableDictionary *fileExtensionByContentType = nil;
                 else
                 {
                     
-                    MXLogDebug(@"[MXTools] convertVideoToMP4: Video export failed. Cannot extract video size.");
+                    MXLogDebug(@"[MXTools] convertVideoAssetToMP4: Video export failed. Cannot extract video size.");
                     
                     // Remove output file (if any)
                     [[NSFileManager defaultManager] removeItemAtPath:[outputVideoLocalURL path] error:nil];
@@ -898,7 +907,7 @@ static NSMutableDictionary *fileExtensionByContentType = nil;
             else
             {
                 
-                MXLogDebug(@"[MXTools] convertVideoToMP4: Video export failed. exportSession.status: %tu", status);
+                MXLogDebug(@"[MXTools] convertVideoAssetToMP4: Video export failed. exportSession.status: %tu", status);
                 
                 // Remove output file (if any)
                 [[NSFileManager defaultManager] removeItemAtPath:[outputVideoLocalURL path] error:nil];


### PR DESCRIPTION
Slow motion videos are returned from the photos picker as `AVComposition` objects.
- Add `sendVideoAsset:withThumbnail:localEcho:success:failure:` to support `AVComposition`.
- Call this new method from `sendVideo:withThumbnail:localEcho:success:failure:`.
- Use the `AVAsset` when transcoding in `MXTools`.

Part of https://github.com/vector-im/element-ios/pull/4541 along with https://github.com/matrix-org/matrix-ios-kit/pull/848