### PR TITLE
Separate CI jobs into individual actions

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -1,0 +1,42 @@
+name: Lint CI
+
+on:
+  # Triggers the workflow on any pull request and push to develop
+  push:
+    branches: [ develop ]
+  pull_request:
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  lint:
+    name: pod lib lint
+    runs-on: macos-latest
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Common cache
+      # Note: GH actions do not support yaml anchor yet. We need to duplicate this for every job
+      - uses: actions/cache@v2
+        with:
+          path: Pods
+          key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
+      - uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+      # Common setup
+      # Note: GH actions do not support yaml anchor yet. We need to duplicate this for every job
+      - name: Bundle install
+        run: |
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+      # Main step
+      - name: Lint MatrixSDK.podspec
+        run: bundle exec fastlane lint_pods

--- a/.github/workflows/ci-unit-tests.yml
+++ b/.github/workflows/ci-unit-tests.yml
@@ -56,37 +56,3 @@ jobs:
         with:
           name: MatrixSDK-macOS.xcresult
           path: build/test/MatrixSDK-macOS.xcresult/
-
-
-  lint:
-    name: pod lib lint
-    runs-on: macos-latest
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
-
-      # Common cache
-      # Note: GH actions do not support yaml anchor yet. We need to duplicate this for every job
-      - uses: actions/cache@v2
-        with:
-          path: Pods
-          key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pods-
-      - uses: actions/cache@v2
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-
-
-      # Common setup
-      # Note: GH actions do not support yaml anchor yet. We need to duplicate this for every job
-      - name: Bundle install
-        run: |
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
-
-      # Main step
-      - name: Lint MatrixSDK.podspec
-        run: bundle exec fastlane lint_pods

--- a/.github/workflows/ci-unit-tests.yml
+++ b/.github/workflows/ci-unit-tests.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Unit Tests CI
 
 on:
   # Triggers the workflow on any pull request and push to develop

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,7 +20,7 @@ Changes to be released in next version
  * 
 
 Others
- * 
+ * Separated CI jobs into individual actions
 
 Changes in 0.19.5 (2021-07-22)
 =================================================


### PR DESCRIPTION
Matches vector-im/element-ios#4581 to allow us to re-run only failed jobs, instead of having to run them all again.