### PR TITLE
MXCryptoStore: Use UI background task to make sure that write operations complete

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changes to be released in next version
  * 
 
 🐛 Bugfix
- * 
+ * MXCryptoStore: Use UI background task to make sure that write operations complete (vector-im/element-ios/issues/4579).
 
 ⚠️ API Changes
  * 

--- a/MatrixSDK/Utils/MXUIKitBackgroundTask.m
+++ b/MatrixSDK/Utils/MXUIKitBackgroundTask.m
@@ -134,7 +134,7 @@
         UIApplication *sharedApplication = [self sharedApplication];
         if (sharedApplication)
         {
-            MXLogDebug(@"[MXBackgroundTask] Stop background task #%lu - %@ after %.0fms", (unsigned long)self.identifier, self.name, self.elapsedTime);
+            MXLogDebug(@"[MXBackgroundTask] Stop background task #%lu - %@ after %.3fms", (unsigned long)self.identifier, self.name, self.elapsedTime);
             
             [sharedApplication endBackgroundTask:self.identifier];
             self.identifier = UIBackgroundTaskInvalid;


### PR DESCRIPTION
Fixes vector-im/element-ios/issues/4579

to avoid to keep the realm internal lock until the app resumes. Thus, other components (Notification Extension Service, Share Extension, ...) will not be blocked by this lock.

Logging is changed a bit. We now rely on logs made by `MXBackgroundTask`

Now:
```
2021-07-21 10:29:44.019804+0200 Riot[4534:558069]  [MXBackgroundTask] Start background task #3892 - [MXRealmCryptoStore] performSessionOperationWithGroupSessionWithId
2021-07-21 10:29:44.021086+0200 Riot[4534:558069]  [MXBackgroundTask] Background task [MXRealmCryptoStore] performSessionOperationWithGroupSessionWithId started with app state: active and estimated background time remaining: undetermined
2021-07-21 10:29:44.036865+0200 Riot[4534:558069]  [MXBackgroundTask] Stop background task #3892 - [MXRealmCryptoStore] performSessionOperationWithGroupSessionWithId after 17.246ms
```

before:
```
2021-07-16 22:10:26.681 Riot[2419:1190872]  [MXRealmCryptoStore] performSessionOperationWithGroupSessionWithId done in 5.050ms
```