### PR TITLE
Release 0.19.5

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Changes to be released in next version
  * MXTools: Default to 1080p when converting a video (vector-im/element-ios/issues/4478).
  * MXEvent: add support for voice messages
  * MXRoom: Add support for sending slow motion videos using AVAsset (vector-im/element-ios/issues/4483).
+ * MXSendReplyEventStringsLocalizable: Added senderSentAVoiceMessage property
 
 🐛 Bugfix
  * Fix QR self verification with QR code (#1147)
@@ -16,6 +17,7 @@ Changes to be released in next version
 
 ⚠️ API Changes
  * MXSDKOptions: Add videoConversionPresetName to customise video conversion quality.
+ * MXRoom: Added duration and sample parameters on the sendVoiceMessage method (vector-im/element-ios/issues/4090)
 
 🗣 Translations
  * 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,27 @@
+Changes to be released in next version
+=================================================
+
+✨ Features
+ * 
+
+🙌 Improvements
+ * 
+
+🐛 Bugfix
+ * 
+
+⚠️ API Changes
+ * 
+
+🗣 Translations
+ * 
+    
+🧱 Build
+ * 
+
+Others
+ * 
+
 Changes in 0.19.4 (2021-07-15)
 =================================================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-Changes to be released in next version
+Changes in 0.19.5 (2021-07-22)
 =================================================
 
 ✨ Features
@@ -21,6 +21,9 @@ Changes to be released in next version
 
 Others
  * 
+
+Improvements:
+
 
 Changes in 0.19.4 (2021-07-15)
 =================================================

--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "MatrixSDK"
-  s.version      = "0.19.4"
+  s.version      = "0.19.5"
   s.summary      = "The iOS SDK to build apps compatible with Matrix (https://www.matrix.org)"
 
   s.description  = <<-DESC

--- a/MatrixSDK/Contrib/Swift/Data/MXRoom.swift
+++ b/MatrixSDK/Contrib/Swift/Data/MXRoom.swift
@@ -350,7 +350,7 @@ public extension MXRoom {
      - returns: a `MXHTTPOperation` instance.
      */
     
-    @nonobjc @discardableResult func sendVoiceMessage(localURL: URL, mimeType: String?, duration: TimeInterval, samples: [Float]?, localEcho: inout MXEvent?, completion: @escaping (_ response: MXResponse<String?>) -> Void) -> MXHTTPOperation {
+    @nonobjc @discardableResult func sendVoiceMessage(localURL: URL, mimeType: String?, duration: UInt, samples: [Float]?, localEcho: inout MXEvent?, completion: @escaping (_ response: MXResponse<String?>) -> Void) -> MXHTTPOperation {
         let boxedSamples = samples?.compactMap { NSNumber(value: $0) }
         return __sendVoiceMessage(localURL, mimeType: mimeType, duration: duration, samples: boxedSamples, localEcho: &localEcho, success: currySuccess(completion), failure: curryFailure(completion), keepActualFilename: false)
     }

--- a/MatrixSDK/Contrib/Swift/Data/MXRoom.swift
+++ b/MatrixSDK/Contrib/Swift/Data/MXRoom.swift
@@ -330,6 +330,8 @@ public extension MXRoom {
      - parameters:
      - localURL: the local filesystem path of the file to send.
      - mimeType: (optional) the mime type of the file. Defaults to `audio/ogg`.
+     - duration: the length of the voice message in milliseconds
+     - samples: an array of floating point values normalized to [0, 1]
      - localEcho: a pointer to a MXEvent object.
      
      This pointer is set to an actual MXEvent object
@@ -348,8 +350,9 @@ public extension MXRoom {
      - returns: a `MXHTTPOperation` instance.
      */
     
-    @nonobjc @discardableResult func sendVoiceMessage(localURL: URL, mimeType: String?, localEcho: inout MXEvent?, completion: @escaping (_ response: MXResponse<String?>) -> Void) -> MXHTTPOperation {
-        return __sendVoiceMessage(localURL, mimeType: mimeType, localEcho: &localEcho, success: currySuccess(completion), failure: curryFailure(completion), keepActualFilename: false)
+    @nonobjc @discardableResult func sendVoiceMessage(localURL: URL, mimeType: String?, duration: TimeInterval, samples: [Float]?, localEcho: inout MXEvent?, completion: @escaping (_ response: MXResponse<String?>) -> Void) -> MXHTTPOperation {
+        let boxedSamples = samples?.compactMap { NSNumber(value: $0) }
+        return __sendVoiceMessage(localURL, mimeType: mimeType, duration: duration, samples: boxedSamples, localEcho: &localEcho, success: currySuccess(completion), failure: curryFailure(completion), keepActualFilename: false)
     }
     
     /**

--- a/MatrixSDK/Contrib/Swift/JSONModels/MXEvent.swift
+++ b/MatrixSDK/Contrib/Swift/JSONModels/MXEvent.swift
@@ -141,7 +141,7 @@ public enum MXEventType: Equatable, Hashable {
 
 /// Types of messages
 public enum MXMessageType: Equatable, Hashable {
-    case text, emote, notice, image, audio, voiceMessage, video, location, file
+    case text, emote, notice, image, audio, video, location, file
     case custom(String)
     
     public var identifier: String {
@@ -151,7 +151,6 @@ public enum MXMessageType: Equatable, Hashable {
         case .notice: return kMXMessageTypeNotice
         case .image: return kMXMessageTypeImage
         case .audio: return kMXMessageTypeAudio
-        case .voiceMessage: return kMXMessageTypeVoiceMessage
         case .video: return kMXMessageTypeVideo
         case .location: return kMXMessageTypeLocation
         case .file: return kMXMessageTypeFile
@@ -160,7 +159,7 @@ public enum MXMessageType: Equatable, Hashable {
     }
 
     public init(identifier: String) {
-        let messages: [MXMessageType] = [.text, .emote, .notice, .image, .audio, .voiceMessage, .video, .location, .file]
+        let messages: [MXMessageType] = [.text, .emote, .notice, .image, .audio, .video, .location, .file]
         self = messages.first(where: { $0.identifier == identifier }) ?? .custom(identifier)
     }
 }

--- a/MatrixSDK/Data/MXRoom.h
+++ b/MatrixSDK/Data/MXRoom.h
@@ -546,7 +546,7 @@ FOUNDATION_EXPORT NSInteger const kMXRoomAlreadyJoinedErrorCode;
  */
 - (MXHTTPOperation*)sendVoiceMessage:(NSURL*)fileLocalURL
                             mimeType:(NSString*)mimeType
-                            duration:(NSTimeInterval)duration
+                            duration:(NSUInteger)duration
                              samples:(NSArray<NSNumber *> *)samples
                            localEcho:(MXEvent**)localEcho
                              success:(void (^)(NSString *eventId))success

--- a/MatrixSDK/Data/MXRoom.h
+++ b/MatrixSDK/Data/MXRoom.h
@@ -534,6 +534,8 @@ FOUNDATION_EXPORT NSInteger const kMXRoomAlreadyJoinedErrorCode;
  
  @param fileLocalURL the local filesystem path of the file to send.
  @param mimeType (optional) the mime type of the file. Defaults to `audio/ogg`
+ @param duration the length of the voice message in milliseconds
+ @param samples an array of floating point values normalized to [0, 1], boxed within NSNumbers
  @param localEcho a pointer to a MXEvent object (@see sendMessageWithContent: for details).
  @param success A block object called when the operation succeeds. It returns
  the event id of the event generated on the home server
@@ -544,6 +546,8 @@ FOUNDATION_EXPORT NSInteger const kMXRoomAlreadyJoinedErrorCode;
  */
 - (MXHTTPOperation*)sendVoiceMessage:(NSURL*)fileLocalURL
                             mimeType:(NSString*)mimeType
+                            duration:(NSTimeInterval)duration
+                             samples:(NSArray<NSNumber *> *)samples
                            localEcho:(MXEvent**)localEcho
                              success:(void (^)(NSString *eventId))success
                              failure:(void (^)(NSError *error))failure

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -1427,7 +1427,7 @@ NSInteger const kMXRoomAlreadyJoinedErrorCode = 9001;
 
 - (MXHTTPOperation*)sendVoiceMessage:(NSURL*)fileLocalURL
                             mimeType:(NSString*)mimeType
-                            duration:(NSTimeInterval)duration
+                            duration:(NSUInteger)duration
                              samples:(NSArray<NSNumber *> *)samples
                            localEcho:(MXEvent**)localEcho
                              success:(void (^)(NSString *eventId))success

--- a/MatrixSDK/Data/MXSendReplyEventDefaultStringLocalizations.h
+++ b/MatrixSDK/Data/MXSendReplyEventDefaultStringLocalizations.h
@@ -25,6 +25,7 @@
 @property (copy, readonly, nonnull) NSString *senderSentAnImage;
 @property (copy, readonly, nonnull) NSString *senderSentAVideo;
 @property (copy, readonly, nonnull) NSString *senderSentAnAudioFile;
+@property (copy, readonly, nonnull) NSString *senderSentAVoiceMessage;
 @property (copy, readonly, nonnull) NSString *senderSentAFile;
 @property (copy, readonly, nonnull) NSString *messageToReplyToPrefix;
 

--- a/MatrixSDK/Data/MXSendReplyEventDefaultStringLocalizations.m
+++ b/MatrixSDK/Data/MXSendReplyEventDefaultStringLocalizations.m
@@ -25,6 +25,7 @@
         _senderSentAnImage = @"sent an image.";
         _senderSentAVideo = @"sent a video.";
         _senderSentAnAudioFile = @"sent an audio file.";
+        _senderSentAVoiceMessage = @"sent a voice message.";
         _senderSentAFile = @"sent a file.";
         _messageToReplyToPrefix = @"In reply to";
     }

--- a/MatrixSDK/Data/MXSendReplyEventStringsLocalizable.h
+++ b/MatrixSDK/Data/MXSendReplyEventStringsLocalizable.h
@@ -27,6 +27,7 @@
 @property (copy, readonly, nonnull) NSString *senderSentAnImage;
 @property (copy, readonly, nonnull) NSString *senderSentAVideo;
 @property (copy, readonly, nonnull) NSString *senderSentAnAudioFile;
+@property (copy, readonly, nonnull) NSString *senderSentAVoiceMessage;
 @property (copy, readonly, nonnull) NSString *senderSentAFile;
 @property (copy, readonly, nonnull) NSString *messageToReplyToPrefix;
 

--- a/MatrixSDK/JSONModels/MXEvent.h
+++ b/MatrixSDK/JSONModels/MXEvent.h
@@ -181,10 +181,6 @@ FOUNDATION_EXPORT NSString *const kMXMessageTypeFile;
 FOUNDATION_EXPORT NSString *const kMXMessageTypeServerNotice;
 FOUNDATION_EXPORT NSString *const kMXMessageTypeKeyVerificationRequest;
 
-FOUNDATION_EXPORT NSString *const kMXMessageTypeVoiceMessage;
-FOUNDATION_EXPORT NSString *const kMXMessageTypeVoiceMessageMSC2516;
-FOUNDATION_EXPORT NSString *const kMXMessageTypeVoiceMessageMSC3245;
-
 /**
  Event relations
  */
@@ -196,6 +192,14 @@ FOUNDATION_EXPORT NSString *const MXEventRelationTypeReplace;       // Edition
  Prefix used for id of temporary local event.
  */
 FOUNDATION_EXPORT NSString *const kMXEventLocalEventIdPrefix;
+
+
+FOUNDATION_EXPORT NSString *const kMXMessageContentKeyVoiceMessage;
+FOUNDATION_EXPORT NSString *const kMXMessageContentKeyVoiceMessageMSC2516;
+FOUNDATION_EXPORT NSString *const kMXMessageContentKeyVoiceMessageMSC3245;
+FOUNDATION_EXPORT NSString *const kMXMessageContentKeyExtensibleAudio;
+FOUNDATION_EXPORT NSString *const kMXMessageContentKeyExtensibleAudioDuration;
+FOUNDATION_EXPORT NSString *const kMXMessageContentKeyExtensibleAudioWaveform;
 
 /**
  The internal event state used to handle the different steps of the event sending.
@@ -449,6 +453,11 @@ extern NSString *const kMXEventIdentifierKey;
  Return YES if the event is a reply event.
  */
 - (BOOL)isReplyEvent;
+
+/**
+ Return YES if the event contains a voice message
+ */
+- (BOOL)isVoiceMessage;
 
 /**
  Return YES if the event content has been edited.

--- a/MatrixSDK/JSONModels/MXEvent.m
+++ b/MatrixSDK/JSONModels/MXEvent.m
@@ -85,34 +85,37 @@ NSString *const kMXEventTypeStringTaggedEvents          = @"m.tagged_events";
 // Use temporary event type until the MSC approval
 NSString *const kMXEventTypeStringSpaceChild            = @"org.matrix.msc1772.space.child";
 
-NSString *const kMXMessageTypeText          = @"m.text";
-NSString *const kMXMessageTypeEmote         = @"m.emote";
-NSString *const kMXMessageTypeNotice        = @"m.notice";
-NSString *const kMXMessageTypeImage         = @"m.image";
-NSString *const kMXMessageTypeAudio         = @"m.audio";
-NSString *const kMXMessageTypeVideo         = @"m.video";
-NSString *const kMXMessageTypeLocation      = @"m.location";
-NSString *const kMXMessageTypeFile          = @"m.file";
-NSString *const kMXMessageTypeServerNotice  = @"m.server_notice";
+NSString *const kMXMessageTypeText                   = @"m.text";
+NSString *const kMXMessageTypeEmote                  = @"m.emote";
+NSString *const kMXMessageTypeNotice                 = @"m.notice";
+NSString *const kMXMessageTypeImage                  = @"m.image";
+NSString *const kMXMessageTypeAudio                  = @"m.audio";
+NSString *const kMXMessageTypeVideo                  = @"m.video";
+NSString *const kMXMessageTypeLocation               = @"m.location";
+NSString *const kMXMessageTypeFile                   = @"m.file";
+NSString *const kMXMessageTypeServerNotice           = @"m.server_notice";
 NSString *const kMXMessageTypeKeyVerificationRequest = @"m.key.verification.request";
 
-NSString *const kMXMessageTypeVoiceMessageMSC2516  = @"org.matrix.msc2516.voice";
-NSString *const kMXMessageTypeVoiceMessageMSC3245  = @"org.matrix.msc3245.voice";
-NSString *const kMXMessageTypeVoiceMessage         = @"m.voice";
+NSString *const MXEventRelationTypeAnnotation        = @"m.annotation";
+NSString *const MXEventRelationTypeReference         = @"m.reference";
+NSString *const MXEventRelationTypeReplace           = @"m.replace";
 
-NSString *const MXEventRelationTypeAnnotation = @"m.annotation";
-NSString *const MXEventRelationTypeReference = @"m.reference";
-NSString *const MXEventRelationTypeReplace = @"m.replace";
-
-NSString *const kMXEventLocalEventIdPrefix = @"kMXEventLocalId_";
+NSString *const kMXEventLocalEventIdPrefix           = @"kMXEventLocalId_";
 
 uint64_t const kMXUndefinedTimestamp = (uint64_t)-1;
 
-NSString *const kMXEventDidChangeSentStateNotification = @"kMXEventDidChangeSentStateNotification";
+NSString *const kMXEventDidChangeSentStateNotification  = @"kMXEventDidChangeSentStateNotification";
 NSString *const kMXEventDidChangeIdentifierNotification = @"kMXEventDidChangeIdentifierNotification";
-NSString *const kMXEventDidDecryptNotification = @"kMXEventDidDecryptNotification";
+NSString *const kMXEventDidDecryptNotification          = @"kMXEventDidDecryptNotification";
 
-NSString *const kMXEventIdentifierKey = @"kMXEventIdentifierKey";
+NSString *const kMXEventIdentifierKey                   = @"kMXEventIdentifierKey";
+
+NSString *const kMXMessageContentKeyVoiceMessageMSC2516     = @"org.matrix.msc2516.voice";
+NSString *const kMXMessageContentKeyVoiceMessageMSC3245     = @"org.matrix.msc3245.voice";
+NSString *const kMXMessageContentKeyVoiceMessage            = @"m.voice";
+NSString *const kMXMessageContentKeyExtensibleAudio         = @"org.matrix.msc1767.audio";
+NSString *const kMXMessageContentKeyExtensibleAudioDuration = @"duration";
+NSString *const kMXMessageContentKeyExtensibleAudioWaveform = @"waveform";
 
 #pragma mark - MXEvent
 @interface MXEvent ()
@@ -431,6 +434,14 @@ NSString *const kMXEventIdentifierKey = @"kMXEventIdentifierKey";
 - (BOOL)isReplyEvent
 {
     return self.eventType == MXEventTypeRoomMessage && self.content[@"m.relates_to"][@"m.in_reply_to"][@"event_id"] != nil;
+}
+
+- (BOOL)isVoiceMessage
+{
+    NSString *msgtype = self.content[@"msgtype"];
+    return [msgtype isEqualToString:kMXMessageTypeAudio] && (self.content[kMXMessageContentKeyVoiceMessage] ||
+                                                             self.content[kMXMessageContentKeyVoiceMessageMSC2516] ||
+                                                             self.content[kMXMessageContentKeyVoiceMessageMSC3245]);
 }
 
 - (BOOL)contentHasBeenEdited

--- a/MatrixSDK/MatrixSDKVersion.m
+++ b/MatrixSDK/MatrixSDKVersion.m
@@ -16,4 +16,4 @@
 
 #import <Foundation/Foundation.h>
 
-NSString *const MatrixSDKVersion = @"0.19.4";
+NSString *const MatrixSDKVersion = @"0.19.5";


### PR DESCRIPTION
This PR prepares the release of MatrixSDK v0.19.5.

Notes:
- This PR targets `release/0.19.5/master`, which has been cut from `master`.
- It includes changes to the `Podfile`, but _not_ the corresponding changes to `Podfile.lock`, as `pod install` hasn't yet been run.
  This is because the `Podfile` targets future versions of dependencies yet to be released, so `pod install` wouldn't be able to find them yet.
- When the CI runs its checks, it will temporarily point to the pending release branches of those dependencies beforehand
- It is only during `release:finish` that `pod update` will be run -- updating the `Podfile.lock`
to use the now officially released dependencies -- before ultimately merging `release/0.19.5/master` into `master` to tag the release.

---

➡️  Once this PR is merged, you will need to first ensure that the products this one depends on are fully released,
   then run `bundle exec rake release:finish` to close this release.

💡 If you want to review _only_ the changes made since the release branch was cut from `develop`,
   you can [check those here](https://github.com/matrix-org/matrix-ios-sdk/compare/develop...release/0.19.5/release)
