### PR TITLE
MXCryptoStore: Keep current store version after resetting data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changes to be released in next version
  * 
 
 🐛 Bugfix
- * 
+ * MXCryptoStore: Keep current store version after resetting data to avoid dead state on an initial sync (vector-im/element-ios/issues/4594).
 
 ⚠️ API Changes
  * 

--- a/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
+++ b/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
@@ -416,9 +416,6 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
                 [realm transactionWithBlock:^{
                     [realm deleteAllObjects];
                 }];
-                
-                // We must keep the last version
-                [self setVersion:MXCryptoVersionLast];
             }
             else
             {
@@ -450,7 +447,8 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
             {
                 MXLogDebug(@"[MXRealmCryptoStore] Credentials do not match");
                 [MXRealmCryptoStore deleteStoreWithCredentials:credentials];
-                return [MXRealmCryptoStore createStoreWithCredentials:credentials];
+                self = [MXRealmCryptoStore createStoreWithCredentials:credentials];
+                self.cryptoVersion = MXCryptoVersionLast;
             }
         }
         


### PR DESCRIPTION
Fix vector-im/element-ios/issues/4594

to avoid dead state on an initial sync.

There is a db version update to fix possible wrong value for MXRealmOlmAccount.cryptoVersion.