### PR TITLE
Stop unnecessary contact refeshes in Element

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Changes to be released in next version
 🐛 Bugfix
  * MXCryptoStore: Keep current store version after resetting data to avoid dead state on an initial sync (vector-im/element-ios/issues/4594).
  * Prevent session pause until reject/hangup event is sent (vector-im/element-ios/issues/4612).
+ * Only post identity server changed notification if the server actually changed.
 
 ⚠️ API Changes
  * 

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -1725,11 +1725,11 @@ typedef void (^MXOnResumeDone)(void);
 
                     // Use the IS from the account data
                     [self setIdentityServer:identityServer andAccessToken:nil];
+                    
+                    [[NSNotificationCenter defaultCenter] postNotificationName:kMXSessionAccountDataDidChangeIdentityServerNotification
+                                                                        object:self
+                                                                      userInfo:nil];
                 }
-
-                [[NSNotificationCenter defaultCenter] postNotificationName:kMXSessionAccountDataDidChangeIdentityServerNotification
-                                                                    object:self
-                                                                  userInfo:nil];
             }
         }
 


### PR DESCRIPTION
The `kMXSessionAccountDataDidChangeIdentityServerNotification` notification was being posted every time the app launched (provided the identity server ToS had been accepted), which in turn meant `MXKContactManager` would refresh its local contacts on every launch too.

In some circumstances this could be a small contributor to https://github.com/vector-im/element-ios/issues/4484.