### PR TITLE
Add excludingUserIDs parameter to displayname and avatar updater methods.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changes to be released in next version
  * 
 
 🙌 Improvements
- * 
+ * MXRoomSummaryUpdater: Add variants of updateSummaryDisplayname and updateSummaryAvatar methods that can exclude specified user IDs (vector-im/element-ios/issues/4609).
 
 🐛 Bugfix
  * 

--- a/MatrixSDK/Data/MXRoomSummaryUpdater.h
+++ b/MatrixSDK/Data/MXRoomSummaryUpdater.h
@@ -88,4 +88,28 @@
 */
 @property (nonatomic) NSArray<NSString *> *showRoomTypeStrings;
 
+/**
+ Update the room summary's display name on received summary update, with additional support for excluding specified user IDs.
+
+ @param summary the room summary.
+ @param session the session the room belongs to.
+ @param serverRoomSummary the homeserver side room summary, or nil if updating from state events.
+ @param roomState the current state of the room.
+ @param excludedUserIDs an array of user IDs to ignore when computing the room name.
+ @return YES if the room summary has changed.
+ */
+- (BOOL)updateSummaryDisplayname:(MXRoomSummary *)summary session:(MXSession *)session withServerRoomSummary:(MXRoomSyncSummary *)serverRoomSummary roomState:(MXRoomState *)roomState excludingUserIDs:(NSArray<NSString *> *)excludedUserIDs;
+
+/**
+ Update the room summary's avatar on received summary update, with additional support for excluding specified user IDs..
+
+ @param summary the room summary.
+ @param session the session the room belongs to.
+ @param serverRoomSummary the homeserver side room summary, or nil if updating from state events.
+ @param roomState the current state of the room.
+ @param excludedUserIDs an array of user IDs to ignore when updating the avatar.
+ @return YES if the room summary has changed.
+ */
+- (BOOL)updateSummaryAvatar:(MXRoomSummary *)summary session:(MXSession *)session withServerRoomSummary:(MXRoomSyncSummary *)serverRoomSummary roomState:(MXRoomState *)roomState excludingUserIDs:(NSArray<NSString *> *)excludedUserIDs;
+
 @end

--- a/MatrixSDK/Data/MXRoomSummaryUpdater.m
+++ b/MatrixSDK/Data/MXRoomSummaryUpdater.m
@@ -587,6 +587,9 @@
     return NO;
 }
 
+/**
+ Returns the heroes from the serverRoomSummary, excluding any of the specified user IDs.
+ */
 - (NSArray<NSString *> *)filteredHeroesFromServerRoomSummary:(MXRoomSyncSummary *)serverRoomSummary excludingUserIDs:(NSArray<NSString *> *)excludedUserIDs
 {
     NSMutableArray<NSString*> *filteredHeroes = [NSMutableArray arrayWithCapacity:serverRoomSummary.heroes.count];
@@ -601,6 +604,9 @@
     return filteredHeroes;
 }
 
+/**
+ Returns the members array, excluding any members who match one of the specified user IDs.
+ */
 - (NSArray<MXRoomMember *> *)filteredMembersFromMembers:(NSArray<MXRoomMember *> *)members excludingUserIDs:(NSArray<NSString *> *)excludedUserIDs
 {
     NSMutableArray<MXRoomMember*> *filteredMembers = [NSMutableArray arrayWithCapacity:members.count];

--- a/MatrixSDKTests/MXRoomSummaryTests.m
+++ b/MatrixSDKTests/MXRoomSummaryTests.m
@@ -468,50 +468,20 @@ NSString *uisiString = @"The sender's device has not sent us the keys for this m
 
 - (void)testRoomDisplaynameExcludingUsers
 {
-    __block BOOL hasInvitedAlice = NO;
-    __block NSString *aliceUserID = @"";
-    
-    // Set up a room with bob as a starting point.
-    [matrixSDKTestsData doMXSessionTestWithBobAndARoom:self
-                                              andStore:[[MXFileStore alloc] init]
-                                           readyToTest:^(MXSession *mxSession, MXRoom *room, XCTestExpectation *expectation) {
+    [matrixSDKTestsData doMXSessionTestWithBobAndAliceInARoom:self readyToTest:^(MXSession *bobSession, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
+        MXRoom *room = [bobSession roomWithRoomId:roomId];
         MXRoomSummary *summary = room.summary;
-        MXRoomSummaryUpdater *updater = (MXRoomSummaryUpdater*)mxSession.roomSummaryUpdateDelegate;
-
-        observer = [[NSNotificationCenter defaultCenter] addObserverForName:kMXRoomSummaryDidChangeNotification object:summary queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *note) {
+        MXRoomSummaryUpdater *updater = (MXRoomSummaryUpdater*)bobSession.roomSummaryUpdateDelegate;
+        
+        [room state:^(MXRoomState *roomState) {
+            // Given a room with two users.
+            XCTAssertEqualObjects(summary.displayname, @"mxAlice", @"A room with one other user should be given the name of that user.");
             
-            if (!hasInvitedAlice)
-            {
-                // Given a room with only the current user as a member.
-                XCTAssertEqualObjects(summary.displayname, @"Empty room", @"A room with no other users that has no display name should be shown as empty.");
-                
-                // When adding a second user who is excluded from updateSummaryDisplayname in summary updater.
-                [matrixSDKTestsData doMXSessionTestWithAlice:nil readyToTest:^(MXSession *aliceSession, XCTestExpectation *expectation2) {
-                    aliceUserID = aliceSession.myUser.userId;
-                    
-                    [room inviteUser:aliceUserID success:nil failure:^(NSError *error) {
-                        XCTFail(@"Cannot set up initial test conditions - error: %@", error);
-                        [expectation fulfill];
-                    }];
-                }];
-                
-                hasInvitedAlice = YES;
-            }
-            else if (room.summary.membersCount.members == 2)
-            {
-                [room state:^(MXRoomState *roomState) {
-                    [updater updateSummaryDisplayname:summary session:mxSession withServerRoomSummary:nil roomState:roomState excludingUserIDs: @[aliceUserID]];
-                    
-                    // Then the name of the room should not change.
-                    XCTAssertEqualObjects(summary.displayname, @"Empty room", @"The name of the room should not be updated when an unimportant user is added.");
-                    [expectation fulfill];
-                }];
-            }
-         }];
-
-        // Set an empty name to allow the roomSummaryUpdateDelegate to compute the name.
-        [room setName:@"" success:nil failure:^(NSError *error) {
-            XCTFail(@"Cannot set up initial test conditions - error: %@", error);
+            // When excluding the other user during a display name update.
+            [updater updateSummaryDisplayname:summary session:bobSession withServerRoomSummary:nil roomState:roomState excludingUserIDs: @[aliceRestClient.credentials.userId]];
+            
+            // Then the name of the room should no longer include the other user.
+            XCTAssertEqualObjects(summary.displayname, @"Empty room", @"The name of the room should not include the other user when they are excluded.");
             [expectation fulfill];
         }];
     }];
@@ -519,57 +489,26 @@ NSString *uisiString = @"The sender's device has not sent us the keys for this m
 
 - (void)testRoomAvatarExcludingUsers
 {
-    __block BOOL hasInvitedAlice = NO;
-    __block NSString *aliceUserID = @"";
-    
-    // Set up a room with bob as a starting point.
-    [matrixSDKTestsData doMXSessionTestWithBobAndARoom:self
-                                              andStore:[[MXFileStore alloc] init]
-                                           readyToTest:^(MXSession *mxSession, MXRoom *room, XCTestExpectation *expectation) {
+    [matrixSDKTestsData doMXSessionTestWithBobAndAliceInARoom:self readyToTest:^(MXSession *bobSession, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
+        MXRoom *room = [bobSession roomWithRoomId:roomId];
         MXRoomSummary *summary = room.summary;
-        MXRoomSummaryUpdater *updater = (MXRoomSummaryUpdater*)mxSession.roomSummaryUpdateDelegate;
-
-        observer = [[NSNotificationCenter defaultCenter] addObserverForName:kMXRoomSummaryDidChangeNotification object:summary queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *note) {
-            
-            if (!hasInvitedAlice)
-            {
-                // Given a room with only the current user as a member.
-                XCTAssertEqualObjects(summary.avatar, nil, @"A room with no other users should not have an avatar.");
+        MXRoomSummaryUpdater *updater = (MXRoomSummaryUpdater*)bobSession.roomSummaryUpdateDelegate;
+        
+        NSString *avatarURL = @"http://matrix.org/matrix.png";
+        
+        [aliceRestClient setAvatarUrl:avatarURL success:^{
+            [room state:^(MXRoomState *roomState) {
+                // Given a room with two users.
+                XCTAssertNotEqualObjects(summary.avatar, nil, @"A room with one other user who has set an avatar should have that same avatar.");
                 
-                // When adding a second user who has set an avatar and is excluded from updateSummaryAvatar in summary updater.
-                [matrixSDKTestsData doMXSessionTestWithAlice:nil readyToTest:^(MXSession *aliceSession, XCTestExpectation *expectation2) {
-                    aliceUserID = aliceSession.myUser.userId;
-                    
-                    NSString *avatarURL = @"http://matrix.org/matrix.png";
-                    [aliceSession.matrixRestClient setAvatarUrl:avatarURL success:^{
-                        XCTAssertNotEqualObjects(aliceSession.myUser.avatarUrl, nil, @"The user should have an avatar after setting it.");
-                        
-                        [room inviteUser:aliceSession.myUser.userId success:nil failure:^(NSError *error) {
-                            XCTFail(@"Cannot set up initial test conditions - error: %@", error);
-                            [expectation fulfill];
-                        }];
-                    } failure:^(NSError *error) {
-                        XCTFail(@"Cannot set up initial test conditions - error: %@", error);
-                        [expectation fulfill];
-                    }];
-                }];
+                // When excluding the other user during an avatar update.
+                [updater updateSummaryAvatar:summary session:bobSession withServerRoomSummary:nil roomState:roomState excludingUserIDs: @[aliceRestClient.credentials.userId]];
                 
-                hasInvitedAlice = YES;
-            }
-            else if (room.summary.membersCount.members == 2)
-            {
-                [room state:^(MXRoomState *roomState) {
-                    [updater updateSummaryAvatar:summary session:mxSession withServerRoomSummary:nil roomState:roomState excludingUserIDs: @[aliceUserID]];
-                        
-                    // Then the room should not be given an avatar.
-                    XCTAssertEqualObjects(summary.avatar, nil, @"A room where the only other user is unimportant should not have an avatar");
-                    [expectation fulfill];
-                }];
-            }
-         }];
-
-        // Set the room's name to trigger the observer.
-        [room setName:@"" success:nil failure:^(NSError *error) {
+                // Then the room should no longer display that user's avatar.
+                XCTAssertEqualObjects(summary.avatar, nil, @"A room where the only other user is unimportant should not have an avatar");
+                [expectation fulfill];
+            }];
+        } failure:^(NSError *error) {
             XCTFail(@"Cannot set up initial test conditions - error: %@", error);
             [expectation fulfill];
         }];

--- a/changelog.d/4609.change
+++ b/changelog.d/4609.change
@@ -1,0 +1,1 @@
+MXRoomSummaryUpdater: Add variants of updateSummaryDisplayname and updateSummaryAvatar methods that can exclude specified user IDs.


### PR DESCRIPTION
Allows specified users to be excluded when computing the room's name and avatar. The new functions contain the implementation, with the older ones now calling into these.

Includes tests for the functions.