### PR TITLE
MXRoomState: Fix a crash in `aliases` getter

### DIFF
--- a/MatrixSDK/Data/MXRoomState.m
+++ b/MatrixSDK/Data/MXRoomState.m
@@ -220,7 +220,7 @@
         NSDictionary<NSString *, id> *eventContent = [self contentOfEvent:event];
         NSArray<NSString *> *aliasesBunch = eventContent[@"aliases"];
         
-        if (aliasesBunch.count)
+        if ([aliasesBunch isKindOfClass:[NSArray class]] && aliasesBunch.count)
         {
             [aliases addObjectsFromArray:aliasesBunch];
         }

--- a/changelog.d/4678.bugfix
+++ b/changelog.d/4678.bugfix
@@ -1,0 +1,1 @@
+MXRoomState: Fix a crash on `aliases` getter.


### PR DESCRIPTION
Fix vector-im/element-ios#4678