### PR TITLE
MXOlmDevice: Fix a crash in `sessionIdsForDevice` method

### DIFF
--- a/MatrixSDK/Crypto/MXOlmDevice.m
+++ b/MatrixSDK/Crypto/MXOlmDevice.m
@@ -221,7 +221,10 @@
     NSMutableArray *sessionIds = [NSMutableArray arrayWithCapacity:sessions.count];
     for (MXOlmSession *session in sessions)
     {
-        [sessionIds addObject:session.session.sessionIdentifier];
+        if (session.session.sessionIdentifier)
+        {
+            [sessionIds addObject:session.session.sessionIdentifier];
+        }
     }
 
     return sessionIds;

--- a/changelog.d/4679.bugfix
+++ b/changelog.d/4679.bugfix
@@ -1,0 +1,1 @@
+MXOlmDevice: Fix a crash on `sessionIdsForDevice` method.


### PR DESCRIPTION
Fix vector-im/element-ios#4679