### PR TITLE
Lazy load room messages

### DIFF
--- a/MatrixSDK/Aggregations/MXAggregatedEditsUpdater.m
+++ b/MatrixSDK/Aggregations/MXAggregatedEditsUpdater.m
@@ -215,31 +215,31 @@
 - (void)handleReplace:(MXEvent *)replaceEvent
 {
     NSString *roomId = replaceEvent.roomId;
-    MXEvent *event = [self.matrixStore eventWithEventId:replaceEvent.relatesTo.eventId inRoom:roomId];
-
-    if (event)
-    {
-        if (![event.sender isEqualToString:replaceEvent.sender])
+    [self.matrixStore eventWithEventId:replaceEvent.relatesTo.eventId inRoom:roomId completion:^(MXEvent * _Nullable event) {
+        if (event)
         {
-            //  not coming from the original sender, ignore
-            MXLogDebug(@"[MXAggregations] handleReplace: Edit event not coming from the original sender, ignoring.");
-            return;
-        }
-        if (![event.unsignedData.relations.replace.eventId isEqualToString:replaceEvent.eventId])
-        {
-            MXEvent *editedEvent = [event editedEventFromReplacementEvent:replaceEvent];
-
-            if (editedEvent)
+            if (![event.sender isEqualToString:replaceEvent.sender])
             {
-                [self.matrixStore replaceEvent:editedEvent inRoom:roomId];
-                [self notifyEventEditsListenersOfRoom:roomId replaceEvent:replaceEvent];
+                //  not coming from the original sender, ignore
+                MXLogDebug(@"[MXAggregations] handleReplace: Edit event not coming from the original sender, ignoring.");
+                return;
+            }
+            if (![event.unsignedData.relations.replace.eventId isEqualToString:replaceEvent.eventId])
+            {
+                MXEvent *editedEvent = [event editedEventFromReplacementEvent:replaceEvent];
+
+                if (editedEvent)
+                {
+                    [self.matrixStore replaceEvent:editedEvent inRoom:roomId];
+                    [self notifyEventEditsListenersOfRoom:roomId replaceEvent:replaceEvent];
+                }
             }
         }
-    }
-    else
-    {
-        MXLogDebug(@"[MXAggregations] handleReplace: Unknown event id: %@", replaceEvent.relatesTo.eventId);
-    }
+        else
+        {
+            MXLogDebug(@"[MXAggregations] handleReplace: Unknown event id: %@", replaceEvent.relatesTo.eventId);
+        }
+    }];
 }
 
 //- (void)handleRedaction:(MXEvent *)event

--- a/MatrixSDK/Aggregations/MXAggregatedReactionsUpdater.h
+++ b/MatrixSDK/Aggregations/MXAggregatedReactionsUpdater.h
@@ -42,7 +42,9 @@ NS_ASSUME_NONNULL_BEGIN
                failure:(void (^)(NSError *error))failure;
 
 #pragma mark - Data access
-- (nullable MXAggregatedReactions *)aggregatedReactionsOnEvent:(NSString*)eventId inRoom:(NSString*)roomId;
+- (void)aggregatedReactionsOnEvent:(NSString*)eventId
+                            inRoom:(NSString*)roomId
+                        completion:(nonnull void(^)(MXAggregatedReactions * _Nullable))completion;
 - (nullable MXReactionCount*)reactionCountForReaction:(NSString*)reaction onEvent:(NSString*)eventId;
 
 #pragma mark - Data update listener

--- a/MatrixSDK/Aggregations/MXAggregatedReferencesUpdater.m
+++ b/MatrixSDK/Aggregations/MXAggregatedReferencesUpdater.m
@@ -48,24 +48,24 @@
     MXEventContentRelatesTo *relation = referenceEvent.relatesTo;
 
     NSString *roomId = referenceEvent.roomId;
-    MXEvent *event = [self.matrixStore eventWithEventId:relation.eventId inRoom:roomId];
-
-    if (event)
-    {
-        MXEvent *newEvent = [event eventWithNewReferenceRelation:referenceEvent];
-
-        if (newEvent)
+    [self.matrixStore eventWithEventId:relation.eventId inRoom:roomId completion:^(MXEvent * _Nullable event) {
+        if (event)
         {
-            [self.matrixStore replaceEvent:newEvent inRoom:roomId];
+            MXEvent *newEvent = [event eventWithNewReferenceRelation:referenceEvent];
 
-            // TODO or not?
-            //[self notifyEventEditsListenersOfRoom:roomId replaceEvent:replaceEvent];
+            if (newEvent)
+            {
+                [self.matrixStore replaceEvent:newEvent inRoom:roomId];
+
+                // TODO or not?
+                //[self notifyEventEditsListenersOfRoom:roomId replaceEvent:replaceEvent];
+            }
         }
-    }
-    else
-    {
-        MXLogDebug(@"[MXAggregations] handleReference: Unknown event id: %@", relation.eventId);
-    }
+        else
+        {
+            MXLogDebug(@"[MXAggregations] handleReference: Unknown event id: %@", relation.eventId);
+        }
+    }];
 }
 
 @end

--- a/MatrixSDK/Aggregations/MXAggregations.h
+++ b/MatrixSDK/Aggregations/MXAggregations.h
@@ -72,9 +72,11 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param eventId the id of the event.
  @param roomId the id of the room.
- @return the top most reactions counts.
+ @param completion Completion block containing the top most reactions counts.
  */
-- (nullable MXAggregatedReactions *)aggregatedReactionsOnEvent:(NSString*)eventId inRoom:(NSString*)roomId;
+- (void)aggregatedReactionsOnEvent:(NSString*)eventId
+                            inRoom:(NSString*)roomId
+                        completion:(nonnull void(^)(MXAggregatedReactions * _Nullable))completion;
 
 
 /**

--- a/MatrixSDK/Aggregations/MXAggregations.m
+++ b/MatrixSDK/Aggregations/MXAggregations.m
@@ -65,9 +65,11 @@
     [self.aggregatedReactionsUpdater removeReaction:reaction forEvent:eventId inRoom:roomId success:success failure:failure];
 }
 
-- (nullable MXAggregatedReactions *)aggregatedReactionsOnEvent:(NSString*)eventId inRoom:(NSString*)roomId
+- (void)aggregatedReactionsOnEvent:(NSString*)eventId
+                            inRoom:(NSString*)roomId
+                        completion:(nonnull void(^)(MXAggregatedReactions * _Nullable))completion
 {
-    return [self.aggregatedReactionsUpdater aggregatedReactionsOnEvent:eventId inRoom:roomId];
+    [self.aggregatedReactionsUpdater aggregatedReactionsOnEvent:eventId inRoom:roomId completion:completion];
 }
 
 - (id)listenToReactionCountUpdateInRoom:(NSString *)roomId block:(void (^)(NSDictionary<NSString *,MXReactionCountChange *> * _Nonnull))block

--- a/MatrixSDK/Aggregations/MXAggregations.m
+++ b/MatrixSDK/Aggregations/MXAggregations.m
@@ -189,12 +189,12 @@
     }
     else
     {
-        NSArray<MXEvent *> *referenceEvents = [self.mxSession.store relationsForEvent:eventId inRoom:roomId relationType:MXEventRelationTypeReference];
-
-        MXAggregationPaginatedResponse *paginatedResponse = [[MXAggregationPaginatedResponse alloc] initWithOriginalEvent:event
-                                                                                                                    chunk:referenceEvents
-                                                                                                                nextBatch:nil];
-        processPaginatedResponse(paginatedResponse);
+        [self.mxSession.store relationsForEvent:eventId inRoom:roomId relationType:MXEventRelationTypeReference completion:^(NSArray<MXEvent *> * _Nonnull referenceEvents) {
+            MXAggregationPaginatedResponse *paginatedResponse = [[MXAggregationPaginatedResponse alloc] initWithOriginalEvent:event
+                                                                                                                        chunk:referenceEvents
+                                                                                                                    nextBatch:nil];
+            processPaginatedResponse(paginatedResponse);
+        }];
     }
 
     return operation;

--- a/MatrixSDK/Background/MXBackgroundStore.swift
+++ b/MatrixSDK/Background/MXBackgroundStore.swift
@@ -147,8 +147,10 @@ class MXBackgroundStore: NSObject, MXStore {
     func storePaginationToken(ofRoom roomId: String, andToken token: String) {
     }
     
-    func paginationToken(ofRoom roomId: String) -> String? {
-        return nil
+    func paginationToken(ofRoom roomId: String, completion: @escaping ((String?) -> Void)) {
+        DispatchQueue.main.async {
+            completion(nil)
+        }
     }
     
     func storeHasReachedHomeServerPaginationEnd(forRoom roomId: String, andValue value: Bool) {

--- a/MatrixSDK/Background/MXBackgroundStore.swift
+++ b/MatrixSDK/Background/MXBackgroundStore.swift
@@ -89,15 +89,20 @@ class MXBackgroundStore: NSObject, MXStore {
         }
     }
     
-    func event(withEventId eventId: String, inRoom roomId: String) -> MXEvent? {
+    func event(withEventId eventId: String, inRoom roomId: String, completion: @escaping (MXEvent?) -> Void) {
         guard let roomStore = roomStore(forRoom: roomId) else {
-            return nil
+            DispatchQueue.main.async {
+                completion(nil)
+            }
+            return
         }
         
         let event = roomStore.event(withEventId: eventId)
         
         MXLog.debug("[MXBackgroundStore] eventWithEventId: \(eventId) \(event == nil ? "not " : "" )found")
-        return event
+        DispatchQueue.main.async {
+            completion(event)
+        }
     }
     
     

--- a/MatrixSDK/Background/MXBackgroundStore.swift
+++ b/MatrixSDK/Background/MXBackgroundStore.swift
@@ -183,8 +183,10 @@ class MXBackgroundStore: NSObject, MXStore {
         }
     }
     
-    func relations(forEvent eventId: String, inRoom roomId: String, relationType: String) -> [MXEvent] {
-        return []
+    func relations(forEvent eventId: String, inRoom roomId: String, relationType: String, completion: @escaping ([MXEvent]) -> Void) {
+        DispatchQueue.main.async {
+            completion([])
+        }
     }
     
     func store(_ user: MXUser) {

--- a/MatrixSDK/Background/MXBackgroundStore.swift
+++ b/MatrixSDK/Background/MXBackgroundStore.swift
@@ -156,8 +156,10 @@ class MXBackgroundStore: NSObject, MXStore {
     func storeHasReachedHomeServerPaginationEnd(forRoom roomId: String, andValue value: Bool) {
     }
     
-    func hasReachedHomeServerPaginationEnd(forRoom roomId: String) -> Bool {
-        return true
+    func hasReachedHomeServerPaginationEnd(forRoom roomId: String, completion: @escaping (Bool) -> Void) {
+        DispatchQueue.main.async {
+            completion(true)
+        }
     }
     
     func storeHasLoadedAllRoomMembers(forRoom roomId: String, andValue value: Bool) {

--- a/MatrixSDK/Background/MXBackgroundStore.swift
+++ b/MatrixSDK/Background/MXBackgroundStore.swift
@@ -131,8 +131,10 @@ class MXBackgroundStore: NSObject, MXStore {
     func replace(_ event: MXEvent, inRoom roomId: String) {
     }
     
-    func eventExists(withEventId eventId: String, inRoom roomId: String) -> Bool {
-        return false
+    func eventExists(withEventId eventId: String, inRoom roomId: String, completion: @escaping (Bool) -> Void) {
+        DispatchQueue.main.async {
+            completion(false)
+        }
     }
     
     func deleteAllMessages(inRoom roomId: String) {

--- a/MatrixSDK/Background/MXBackgroundStore.swift
+++ b/MatrixSDK/Background/MXBackgroundStore.swift
@@ -165,8 +165,10 @@ class MXBackgroundStore: NSObject, MXStore {
     func storeHasLoadedAllRoomMembers(forRoom roomId: String, andValue value: Bool) {
     }
     
-    func hasLoadedAllRoomMembers(forRoom roomId: String) -> Bool {
-        return false
+    func hasLoadedAllRoomMembers(forRoom roomId: String, completion: @escaping (Bool) -> Void) {
+        DispatchQueue.main.async {
+            completion(false)
+        }
     }
     
     func messagesEnumerator(forRoom roomId: String, success: @escaping (MXEventsEnumerator) -> Void, failure: ((Error) -> Void)? = nil) {

--- a/MatrixSDK/Background/MXBackgroundStore.swift
+++ b/MatrixSDK/Background/MXBackgroundStore.swift
@@ -215,8 +215,10 @@ class MXBackgroundStore: NSObject, MXStore {
     func storePartialTextMessage(forRoom roomId: String, partialTextMessage: String) {
     }
     
-    func partialTextMessage(ofRoom roomId: String) -> String? {
-        return nil
+    func partialTextMessage(ofRoom roomId: String, completion: @escaping (String?) -> Void) {
+        DispatchQueue.main.async {
+            completion(nil)
+        }
     }
     
     func getEventReceipts(_ roomId: String, eventId: String, sorted sort: Bool) -> [MXReceiptData]? {

--- a/MatrixSDK/Background/MXBackgroundStore.swift
+++ b/MatrixSDK/Background/MXBackgroundStore.swift
@@ -165,12 +165,16 @@ class MXBackgroundStore: NSObject, MXStore {
         return false
     }
     
-    func messagesEnumerator(forRoom roomId: String) -> MXEventsEnumerator {
-        return MXEventsEnumeratorOnArray(messages: [])
+    func messagesEnumerator(forRoom roomId: String, success: @escaping (MXEventsEnumerator) -> Void, failure: ((Error) -> Void)? = nil) {
+        DispatchQueue.main.async {
+            success(MXEventsEnumeratorOnArray(messages: []))
+        }
     }
     
-    func messagesEnumerator(forRoom roomId: String, withTypeIn types: [Any]?) -> MXEventsEnumerator {
-        return MXEventsEnumeratorOnArray(messages: [])
+    func messagesEnumerator(forRoom roomId: String, withTypeIn types: [String]?, success: @escaping (MXEventsEnumerator) -> Void, failure: ((Error) -> Void)? = nil) {
+        DispatchQueue.main.async {
+            success(MXEventsEnumeratorOnArray(messages: []))
+        }
     }
     
     func relations(forEvent eventId: String, inRoom roomId: String, relationType: String) -> [MXEvent] {

--- a/MatrixSDK/Contrib/Swift/Data/MXEventTimeline.swift
+++ b/MatrixSDK/Contrib/Swift/Data/MXEventTimeline.swift
@@ -42,8 +42,8 @@ public extension MXEventTimeline {
      
      - returns: `true` if we can paginate in the given direction.
      */
-    @nonobjc func canPaginate(_ direction: MXTimelineDirection) -> Bool {
-        return __canPaginate(direction.identifier)
+    @nonobjc func canPaginate(_ direction: MXTimelineDirection, completion: @escaping (Bool) -> Void) {
+        __canPaginate(direction.identifier, completion: completion)
     }
     
     

--- a/MatrixSDK/Data/MXEventTimeline.h
+++ b/MatrixSDK/Data/MXEventTimeline.h
@@ -196,9 +196,9 @@ typedef void (^MXOnRoomEvent)(MXEvent *event, MXTimelineDirection direction, MXR
  Get the number of messages we can still back paginate from the store.
  It provides the count of events available without making a request to the home server.
 
- @return the count of remaining messages in store.
+ @param completion Completion block returning the count of remaining messages in store.
  */
-- (NSUInteger)remainingMessagesForBackPaginationInStore;
+- (void)remainingMessagesForBackPaginationInStoreWithCompletion:(void (^)(NSUInteger))completion;
 
 
 #pragma mark - Server sync

--- a/MatrixSDK/Data/MXEventTimeline.h
+++ b/MatrixSDK/Data/MXEventTimeline.h
@@ -144,9 +144,10 @@ typedef void (^MXOnRoomEvent)(MXEvent *event, MXTimelineDirection direction, MXR
 
  @param direction MXTimelineDirectionBackwards to check if we can paginate backwards.
                   MXTimelineDirectionForwards to check if we can go forwards.
- @return true if we can paginate in the given direction.
+ @param completion Completion block returning true if we can paginate in the given direction.
  */
-- (BOOL)canPaginate:(MXTimelineDirection)direction NS_REFINED_FOR_SWIFT;
+- (void)canPaginate:(MXTimelineDirection)direction
+         completion:(void (^)(BOOL))completion NS_REFINED_FOR_SWIFT;
 
 /**
  Reset the pagination so that future calls to paginate start from the most recent

--- a/MatrixSDK/Data/MXEventTimeline.m
+++ b/MatrixSDK/Data/MXEventTimeline.m
@@ -310,6 +310,9 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
         
         NSUInteger remainingNumItems = numItems;
         NSUInteger eventsFromStoreCount = eventsFromStore.count;
+        __block BOOL shouldReturn = NO;
+        
+        dispatch_group_t dispatchGroupPaginationEnd = dispatch_group_create();
 
         if (direction == MXTimelineDirectionBackwards)
         {
@@ -332,7 +335,7 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
                 return;
             }
 
-            if (0 == remainingNumItems || YES == [self->store hasReachedHomeServerPaginationEndForRoom:self.state.roomId])
+            if (0 == remainingNumItems)
             {
                 dispatch_async(dispatch_get_main_queue(), ^{
                     // Nothing more to do
@@ -342,110 +345,127 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
                 
                 return;
             }
-        }
-
-        // Do not try to paginate forward if end has been reached
-        if (direction == MXTimelineDirectionForwards && YES == self->hasReachedHomeServerForwardsPaginationEnd)
-        {
-            dispatch_async(dispatch_get_main_queue(), ^{
-                // Nothing more to do
-                MXLogDebug(@"[MXEventTimeline] paginate: is done");
-                complete();
-            });
-
-            return;
-        }
-
-        // Not enough messages: make a pagination request to the home server
-        // from last known token
-        NSString *paginationToken;
-        
-        dispatch_group_t dispatchGroup = dispatch_group_create();
-
-        if (direction == MXTimelineDirectionBackwards)
-        {
-            dispatch_group_enter(dispatchGroup);
-            [self->store paginationTokenOfRoom:self.state.roomId
-                                    completion:^(NSString * _Nullable paginationToken2) {
-                paginationToken = paginationToken2;
-                if (nil == paginationToken)
+            
+            dispatch_group_enter(dispatchGroupPaginationEnd);
+            [self->store hasReachedHomeServerPaginationEndForRoom:self.state.roomId
+                                                       completion:^(BOOL hasReachedHomeServerPaginationEndForRoom) {
+                if (hasReachedHomeServerPaginationEndForRoom)
                 {
-                    paginationToken = @"END";
+                    shouldReturn = YES;
+                    dispatch_async(dispatch_get_main_queue(), ^{
+                        // Nothing more to do
+                        MXLogDebug(@"[MXEventTimeline] paginate: is done");
+                        complete();
+                    });
                 }
-                dispatch_group_leave(dispatchGroup);
+                dispatch_group_leave(dispatchGroupPaginationEnd);
             }];
         }
-        else
-        {
-            paginationToken = self->forwardsPaginationToken;
-        }
         
-        dispatch_group_notify(dispatchGroup, dispatch_get_main_queue(), ^{
-            MXLogDebug(@"[MXEventTimeline] paginate : request %tu messages from the server", remainingNumItems);
-
-            MXWeakify(self);
-            MXHTTPOperation *operation2 = [self->room.mxSession.matrixRestClient messagesForRoom:self.state.roomId from:paginationToken direction:direction limit:remainingNumItems filter:self.roomEventFilter success:^(MXPaginationResponse *paginatedResponse) {
-                MXStrongifyAndReturnIfNil(self);
-
-                MXLogDebug(@"[MXEventTimeline] paginate : got %tu messages from the server", paginatedResponse.chunk.count);
-
-                // Check if the room has not been left while waiting for the response
-                if ([self->room.mxSession hasRoomWithRoomId:self->room.roomId]
-                    || [self->room.mxSession isPeekingInRoomWithRoomId:self->room.roomId])
-                {
-                    [self handlePaginationResponse:paginatedResponse direction:direction onComplete:^{
-                        MXLogDebug(@"[MXEventTimeline] paginate: is done");
-                        
-                        // Inform the method caller
-                        complete();
-                    }];
-                }
-                else
-                {
+        dispatch_group_notify(dispatchGroupPaginationEnd, dispatch_get_main_queue(), ^{
+            // Do not try to paginate forward if end has been reached
+            if (direction == MXTimelineDirectionForwards && YES == self->hasReachedHomeServerForwardsPaginationEnd)
+            {
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    // Nothing more to do
                     MXLogDebug(@"[MXEventTimeline] paginate: is done");
-                    // Inform the method caller
                     complete();
-                }
+                });
 
-            } failure:^(NSError *error) {
-                MXStrongifyAndReturnIfNil(self);
+                return;
+            }
+            
+            dispatch_group_t dispatchGroupToken = dispatch_group_create();
 
-                // Check whether the pagination end is reached
-                MXError *mxError = [[MXError alloc] initWithNSError:error];
-                if (mxError && [mxError.error isEqualToString:kMXErrorStringInvalidToken])
-                {
-                    // Store the fact we run out of items
-                    if (direction == MXTimelineDirectionBackwards)
+            // Not enough messages: make a pagination request to the home server
+            // from last known token
+            __block NSString *paginationToken;
+            
+            if (direction == MXTimelineDirectionBackwards)
+            {
+                dispatch_group_enter(dispatchGroupToken);
+                [self->store paginationTokenOfRoom:self.state.roomId
+                                        completion:^(NSString * _Nullable paginationToken2) {
+                    paginationToken = paginationToken2;
+                    if (nil == paginationToken)
                     {
-                        [self->store storeHasReachedHomeServerPaginationEndForRoom:self->_state.roomId andValue:YES];
+                        paginationToken = @"END";
+                    }
+                    dispatch_group_leave(dispatchGroupToken);
+                }];
+            }
+            else
+            {
+                paginationToken = self->forwardsPaginationToken;
+            }
+            
+            dispatch_group_notify(dispatchGroupToken, dispatch_get_main_queue(), ^{
+                MXLogDebug(@"[MXEventTimeline] paginate : request %tu messages from the server", remainingNumItems);
+
+                MXWeakify(self);
+                MXHTTPOperation *operation2 = [self->room.mxSession.matrixRestClient messagesForRoom:self.state.roomId from:paginationToken direction:direction limit:remainingNumItems filter:self.roomEventFilter success:^(MXPaginationResponse *paginatedResponse) {
+                    MXStrongifyAndReturnIfNil(self);
+
+                    MXLogDebug(@"[MXEventTimeline] paginate : got %tu messages from the server", paginatedResponse.chunk.count);
+
+                    // Check if the room has not been left while waiting for the response
+                    if ([self->room.mxSession hasRoomWithRoomId:self->room.roomId]
+                        || [self->room.mxSession isPeekingInRoomWithRoomId:self->room.roomId])
+                    {
+                        [self handlePaginationResponse:paginatedResponse direction:direction onComplete:^{
+                            MXLogDebug(@"[MXEventTimeline] paginate: is done");
+                            
+                            // Inform the method caller
+                            complete();
+                        }];
                     }
                     else
                     {
-                        self->hasReachedHomeServerForwardsPaginationEnd = YES;
+                        MXLogDebug(@"[MXEventTimeline] paginate: is done");
+                        // Inform the method caller
+                        complete();
                     }
 
-                    MXLogDebug(@"[MXEventTimeline] paginate: pagination end has been reached");
+                } failure:^(NSError *error) {
+                    MXStrongifyAndReturnIfNil(self);
 
-                    // Ignore the error
-                    complete();
-                    return;
-                }
+                    // Check whether the pagination end is reached
+                    MXError *mxError = [[MXError alloc] initWithNSError:error];
+                    if (mxError && [mxError.error isEqualToString:kMXErrorStringInvalidToken])
+                    {
+                        // Store the fact we run out of items
+                        if (direction == MXTimelineDirectionBackwards)
+                        {
+                            [self->store storeHasReachedHomeServerPaginationEndForRoom:self->_state.roomId andValue:YES];
+                        }
+                        else
+                        {
+                            self->hasReachedHomeServerForwardsPaginationEnd = YES;
+                        }
 
-                MXLogDebug(@"[MXEventTimeline] paginate failed");
-                if (failure)
+                        MXLogDebug(@"[MXEventTimeline] paginate: pagination end has been reached");
+
+                        // Ignore the error
+                        complete();
+                        return;
+                    }
+
+                    MXLogDebug(@"[MXEventTimeline] paginate failed");
+                    if (failure)
+                    {
+                        failure(error);
+                    }
+                }];
+
+                if (eventsFromStoreCount)
                 {
-                    failure(error);
+                    // Disable retry to let the caller handle messages from store without delay.
+                    // The caller will trigger a new pagination if need.
+                    operation2.maxNumberOfTries = 1;
                 }
-            }];
-
-            if (eventsFromStoreCount)
-            {
-                // Disable retry to let the caller handle messages from store without delay.
-                // The caller will trigger a new pagination if need.
-                operation2.maxNumberOfTries = 1;
-            }
-            
-            [operation mutateTo:operation2];
+                
+                [operation mutateTo:operation2];
+            });
         });
     }];
         

--- a/MatrixSDK/Data/MXEventTimeline.m
+++ b/MatrixSDK/Data/MXEventTimeline.m
@@ -216,7 +216,6 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
 
     // Reset store pagination
     cachedStoreMessagesEnumerator = nil;
-    [self storeMessagesEnumerator:nil];
 }
 
 - (MXHTTPOperation *)resetPaginationAroundInitialEventWithLimit:(NSUInteger)limit success:(void (^)(void))success failure:(void (^)(NSError *))failure

--- a/MatrixSDK/Data/MXEventTimeline.m
+++ b/MatrixSDK/Data/MXEventTimeline.m
@@ -186,14 +186,21 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
         // canPaginate depends on two things:
         //  - did we end to paginate from the MXStore?
         //  - did we reach the top of the pagination in our requests to the home server?
-        [store hasReachedHomeServerPaginationEndForRoom:_state.roomId completion:^(BOOL hasReachedHomeServerPaginationEnd) {
-            BOOL canPaginate = !self->cachedStoreMessagesEnumerator
-                || (0 < self->cachedStoreMessagesEnumerator.remaining)
-                || !hasReachedHomeServerPaginationEnd;
-            
+        if (!self->cachedStoreMessagesEnumerator
+            || (0 < self->cachedStoreMessagesEnumerator.remaining))
+        {
             if (completion)
             {
-                completion(canPaginate);
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    completion(YES);
+                });
+            }
+            return;
+        }
+        [store hasReachedHomeServerPaginationEndForRoom:_state.roomId completion:^(BOOL hasReachedHomeServerPaginationEnd) {
+            if (completion)
+            {
+                completion(!hasReachedHomeServerPaginationEnd);
             }
         }];
     }

--- a/MatrixSDK/Data/MXEventTimeline.m
+++ b/MatrixSDK/Data/MXEventTimeline.m
@@ -746,12 +746,20 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
                   it again in the store.
  @param isRoomInitialSync YES we are managing the first sync of this room.
  */
-- (void)addEvent:(MXEvent*)event direction:(MXTimelineDirection)direction fromStore:(BOOL)fromStore isRoomInitialSync:(BOOL)isRoomInitialSync
+- (void)addEvent:(MXEvent*)event
+       direction:(MXTimelineDirection)direction
+       fromStore:(BOOL)fromStore
+isRoomInitialSync:(BOOL)isRoomInitialSync
+      completion:(void(^)(void))completion
 {
     // Make sure we have not processed this event yet
     [store eventExistsWithEventId:event.eventId inRoom:room.roomId completion:^(BOOL eventExists) {
         if (fromStore == NO && eventExists)
         {
+            if (completion)
+            {
+                completion();
+            }
             return;
         }
         
@@ -792,6 +800,11 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
 
         // Notify listeners
         [self notifyListeners:event direction:direction];
+        
+        if (completion)
+        {
+            completion();
+        }
     }];
 }
 

--- a/MatrixSDK/Data/MXEventTimeline.m
+++ b/MatrixSDK/Data/MXEventTimeline.m
@@ -909,16 +909,21 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
         [room.mxSession.roomAccountDataUpdateDelegate updateAccountDataForRoom:room
                                                                withStateEvents:stateEvents];
 
-        if (!room.mxSession.syncWithLazyLoadOfRoomMembers && ![store hasLoadedAllRoomMembersForRoom:room.roomId])
+        if (!room.mxSession.syncWithLazyLoadOfRoomMembers)
         {
-            // If there is no lazy loading of room members, consider we have fetched
-            // all of them
-            MXLogDebug(@"[MXEventTimeline] handleStateEvents: syncWithLazyLoadOfRoomMembers disabled. Mark all room members loaded for room %@",  room.roomId);
-            
-            // XXX: Optimisation removed because of https://github.com/vector-im/element-ios/issues/3807
-            // There can be a race on mxSession.syncWithLazyLoadOfRoomMembers. Its value may be not set yet.
-            // LL should be always enabled now. So, we should never come here.
-            //[store storeHasLoadedAllRoomMembersForRoom:room.roomId andValue:YES];
+            [store hasLoadedAllRoomMembersForRoom:room.roomId completion:^(BOOL hasLoadedAllRoomMembers) {
+                if (!hasLoadedAllRoomMembers)
+                {
+                    // If there is no lazy loading of room members, consider we have fetched
+                    // all of them
+                    MXLogDebug(@"[MXEventTimeline] handleStateEvents: syncWithLazyLoadOfRoomMembers disabled. Mark all room members loaded for room %@",  room.roomId);
+                    
+                    // XXX: Optimisation removed because of https://github.com/vector-im/element-ios/issues/3807
+                    // There can be a race on mxSession.syncWithLazyLoadOfRoomMembers. Its value may be not set yet.
+                    // LL should be always enabled now. So, we should never come here.
+                    //[store storeHasLoadedAllRoomMembersForRoom:room.roomId andValue:YES];
+                }
+            }];
         }
     }
 }

--- a/MatrixSDK/Data/MXEventTimeline.m
+++ b/MatrixSDK/Data/MXEventTimeline.m
@@ -161,7 +161,10 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
     if (cachedStoreMessagesEnumerator)
     {
         dispatch_async(dispatch_get_main_queue(), ^{
-            completion(self->cachedStoreMessagesEnumerator);
+            if (completion)
+            {
+                completion(self->cachedStoreMessagesEnumerator);
+            }
         });
         return;
     }

--- a/MatrixSDK/Data/MXRoom.h
+++ b/MatrixSDK/Data/MXRoom.h
@@ -246,8 +246,12 @@ FOUNDATION_EXPORT NSInteger const kMXRoomAlreadyJoinedErrorCode;
 #pragma mark - Stored messages enumerator
 /**
  Get an enumerator on all messages of the room downloaded so far.
+ 
+ @param success Success block
+ @param failure Failure block
  */
-@property (nonatomic, readonly) id<MXEventsEnumerator> enumeratorForStoredMessages;
+- (void)enumeratorForStoredMessagesWithSuccess:(void (^)(id<MXEventsEnumerator>))success
+                                       failure:(void (^)(NSError * error))failure;
 
 /**
  Get an events enumerator on messages of the room with a filter on the events types.
@@ -255,15 +259,21 @@ FOUNDATION_EXPORT NSInteger const kMXRoomAlreadyJoinedErrorCode;
  An optional array of event types may be provided to filter room events. When this array is not nil,
  the type of the returned last event should match with one of the provided types.
 
- @param types an array of event types strings (MXEventTypeString).
- @return the events enumerator.
+ @param types an array of event types strings.
+ @param success Success block
+ @param failure Failure block
  */
-- (id<MXEventsEnumerator>)enumeratorForStoredMessagesWithTypeIn:(NSArray<MXEventTypeString> *)types;
+- (void)enumeratorForStoredMessagesWithTypeIn:(NSArray<MXEventTypeString> *)types
+                            success:(void (^)(id<MXEventsEnumerator>))success
+                            failure:(void (^)(NSError * error))failure;
 
 /**
  The count of stored messages for this room.
+ @param success Success block
+ @param failure Failure block
  */
-@property (nonatomic, readonly) NSUInteger storedMessagesCount;
+- (void)storedMessagesCountWithSuccess:(void (^)(NSUInteger))success
+                               failure:(void (^)(NSError * error))failure;
 
 
 #pragma mark - Room operations
@@ -568,9 +578,10 @@ FOUNDATION_EXPORT NSInteger const kMXRoomAlreadyJoinedErrorCode;
  Determine if an event has a local echo.
  
  @param event the concerned event.
- @return a local echo event corresponding to the event. Nil if there is no match.
+ @param completion Completion block.
  */
-- (MXEvent*)pendingLocalEchoRelatedToEvent:(MXEvent*)event;
+- (void)pendingLocalEchoRelatedToEvent:(MXEvent*)event
+                            completion:(void (^)(MXEvent*))completion;
 
 /**
  Remove a local echo event from the pending queue.
@@ -1027,7 +1038,7 @@ FOUNDATION_EXPORT NSInteger const kMXRoomAlreadyJoinedErrorCode;
 /**
  All outgoing messages pending in the room.
  */
-- (NSArray<MXEvent*>*)outgoingMessages;
+- (void)outgoingMessagesWithCompletion:(void (^)(NSArray<MXEvent*>*))completion;
 
 
 #pragma mark - Room tags operations

--- a/MatrixSDK/Data/MXRoom.h
+++ b/MatrixSDK/Data/MXRoom.h
@@ -157,7 +157,9 @@ FOUNDATION_EXPORT NSInteger const kMXRoomAlreadyJoinedErrorCode;
  when the application restarts.
  */
 // @TODO(summary): Move to MXRoomSummary
-@property (nonatomic) NSString *partialTextMessage;
+- (void)partialTextMessageWithCompletion:(void(^)(NSString*))completion;
+
+- (void)setPartialTextMessage:(NSString *)partialTextMessage;
 
 /**
  The list of ids of users currently typing in this room.

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -368,9 +368,9 @@ NSInteger const kMXRoomAlreadyJoinedErrorCode = 9001;
     }
 }
 
-- (NSString *)partialTextMessage
+- (void)partialTextMessageWithCompletion:(void(^)(NSString*))completion
 {
-    return [mxSession.store partialTextMessageOfRoom:self.roomId];
+    [mxSession.store partialTextMessageOfRoom:self.roomId completion:completion];
 }
 
 

--- a/MatrixSDK/Data/MXRoomSummary.m
+++ b/MatrixSDK/Data/MXRoomSummary.m
@@ -246,7 +246,8 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
                                                        onComplete:(void (^)(void))onComplete
                                                           failure:(void (^)(NSError *))failure
                                                          timeline:(MXEventTimeline *)timeline
-                                                        operation:(MXHTTPOperation *)operation commit:(BOOL)commit
+                                                        operation:(MXHTTPOperation *)operation
+                                                           commit:(BOOL)commit
 {
     // Sanity checks
     MXRoom *room = self.room;
@@ -294,63 +295,64 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
         }
     }];
     
-   
-    if (timeline.remainingMessagesForBackPaginationInStore)
-    {
-        // First, for performance reason, read messages only from the store
-        // Do it one by one to decrypt the minimal number of events.
-        MXHTTPOperation *newOperation = [timeline paginate:1 direction:MXTimelineDirectionBackwards onlyFromStore:YES complete:^{
-            if (lastMessageUpdated)
-            {
-                // We are done
-                [self save:commit];
-                onComplete();
-            }
-            else
-            {
-                // Need more messages
-                [self fetchLastMessageWithMaxServerPaginationCount:maxServerPaginationCount onComplete:onComplete failure:failure timeline:timeline operation:operation commit:commit];
-            }
+    [timeline remainingMessagesForBackPaginationInStoreWithCompletion:^(NSUInteger remainingMessagesForBackPaginationInStore) {
+        if (remainingMessagesForBackPaginationInStore)
+        {
+            // First, for performance reason, read messages only from the store
+            // Do it one by one to decrypt the minimal number of events.
+            MXHTTPOperation *newOperation = [timeline paginate:1 direction:MXTimelineDirectionBackwards onlyFromStore:YES complete:^{
+                if (lastMessageUpdated)
+                {
+                    // We are done
+                    [self save:commit];
+                    onComplete();
+                }
+                else
+                {
+                    // Need more messages
+                    [self fetchLastMessageWithMaxServerPaginationCount:maxServerPaginationCount onComplete:onComplete failure:failure timeline:timeline operation:operation commit:commit];
+                }
+                
+            } failure:failure];
             
-        } failure:failure];
-        
-        [operation mutateTo:newOperation];
-    }
-    else if (maxServerPaginationCount)
-    {
-        // If requested, get messages from the homeserver
-        // Fetch them by batch of 50 messages
-        NSUInteger paginationCount = MIN(maxServerPaginationCount, MXRoomSummaryPaginationChunkSize);
-        MXLogDebug(@"[MXRoomSummary] fetchLastMessage: paginate %@ (%@) messages from the server in %@", @(paginationCount), @(maxServerPaginationCount), _roomId);
-        
-        MXHTTPOperation *newOperation = [timeline paginate:paginationCount direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^{
-            if (lastMessageUpdated)
-            {
-                // We are done
-                [self save:commit];
-                onComplete();
-            }
-            else if (maxServerPaginationCount > MXRoomSummaryPaginationChunkSize)
-            {
-                MXLogDebug(@"[MXRoomSummary] fetchLastMessage: Failed to find last message in %@. Paginate more...", self.roomId);
-                NSUInteger newMaxServerPaginationCount = maxServerPaginationCount - MXRoomSummaryPaginationChunkSize;
-                [self fetchLastMessageWithMaxServerPaginationCount:newMaxServerPaginationCount onComplete:onComplete failure:failure timeline:timeline operation:operation commit:commit];
-            }
-            else
-            {
-                MXLogDebug(@"[MXRoomSummary] fetchLastMessage: Failed to find last message in %@. Stop paginating.", self.roomId);
-                onComplete();
-            }
+            [operation mutateTo:newOperation];
+        }
+        else if (maxServerPaginationCount)
+        {
+            // If requested, get messages from the homeserver
+            // Fetch them by batch of 50 messages
+            NSUInteger paginationCount = MIN(maxServerPaginationCount, MXRoomSummaryPaginationChunkSize);
+            MXLogDebug(@"[MXRoomSummary] fetchLastMessage: paginate %@ (%@) messages from the server in %@", @(paginationCount), @(maxServerPaginationCount), self.roomId);
             
-        } failure:failure];
-        
-        [operation mutateTo:newOperation];
-    }
-    else
-    {
-        MXLogDebug(@"[MXRoomSummary] fetchLastMessage: Failed to find last message in %@.", self.roomId);
-        onComplete();
-    }
+            MXHTTPOperation *newOperation = [timeline paginate:paginationCount direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^{
+                if (lastMessageUpdated)
+                {
+                    // We are done
+                    [self save:commit];
+                    onComplete();
+                }
+                else if (maxServerPaginationCount > MXRoomSummaryPaginationChunkSize)
+                {
+                    MXLogDebug(@"[MXRoomSummary] fetchLastMessage: Failed to find last message in %@. Paginate more...", self.roomId);
+                    NSUInteger newMaxServerPaginationCount = maxServerPaginationCount - MXRoomSummaryPaginationChunkSize;
+                    [self fetchLastMessageWithMaxServerPaginationCount:newMaxServerPaginationCount onComplete:onComplete failure:failure timeline:timeline operation:operation commit:commit];
+                }
+                else
+                {
+                    MXLogDebug(@"[MXRoomSummary] fetchLastMessage: Failed to find last message in %@. Stop paginating.", self.roomId);
+                    onComplete();
+                }
+                
+            } failure:failure];
+            
+            [operation mutateTo:newOperation];
+        }
+        else
+        {
+            MXLogDebug(@"[MXRoomSummary] fetchLastMessage: Failed to find last message in %@.", self.roomId);
+            onComplete();
+        }
+    }];
     
     return operation;
 }
@@ -887,7 +889,6 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
 
     result = prime * result + [_lastMessage.eventId hash];
     result = prime * result + [_lastMessage.text hash];
-    result = prime * result + self.room.storedMessagesCount;
 
     return result;
 }

--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.h
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.h
@@ -35,7 +35,10 @@ typedef NS_OPTIONS(NSInteger, MXFileStorePreloadOptions)
     MXFileStorePreloadOptionRoomState = 0x2,
 
     // Preload rooms account data
-    MXFileStorePreloadOptionRoomAccountData = 0x4
+    MXFileStorePreloadOptionRoomAccountData = 0x4,
+    
+    // Preload rooms messages
+    MXFileStorePreloadOptionRoomMessage = 0x8
 };
 
 /**

--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
@@ -481,7 +481,8 @@ static NSUInteger preloadOptions;
 
 - (NSArray *)rooms
 {
-    NSArray<NSString *> *roomIDs = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:storeRoomsPath error:nil];
+    NSMutableArray<NSString *> *roomIDs = [NSMutableArray arrayWithArray:[[NSFileManager defaultManager] contentsOfDirectoryAtPath:storeRoomsPath error:nil]];
+    [roomIDs removeObjectsInArray:roomsToCommitForDeletion];
     return roomIDs;
 }
 

--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
@@ -842,7 +842,7 @@ static NSUInteger preloadOptions;
                 {
                     NSDate *startDate = [NSDate date];
                     MXFileRoomStore *roomStore = [NSKeyedUnarchiver unarchiveObjectWithFile:roomFile];
-                    roomStores[roomId] = roomStore;
+                    self->roomStores[roomId] = roomStore;
                     MXLogDebug(@"[MXFileStore] Loaded room messages of room: %@ in %.0fms", roomId, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
                     
                     dispatch_async(dispatch_get_main_queue(), ^{

--- a/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryStore.h
+++ b/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryStore.h
@@ -51,8 +51,9 @@
  Interface to create or retrieve a MXMemoryRoomStore type object.
  
  @param roomId the id for the MXMemoryRoomStore object.
- @return the MXMemoryRoomStore instance.
+ @param completion Completion block containing the MXMemoryRoomStore instance.
  */
-- (MXMemoryRoomStore*)getOrCreateRoomStore:(NSString*)roomId;
+- (void)getOrCreateRoomStore:(NSString * _Nonnull)roomId
+                  completion:(void(^_Nonnull)(MXMemoryRoomStore *_Nullable))completion;
 
 @end

--- a/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryStore.m
+++ b/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryStore.m
@@ -190,10 +190,12 @@
     }];
 }
 
-- (NSString *)partialTextMessageOfRoom:(NSString *)roomId
+- (void)partialTextMessageOfRoom:(NSString *)roomId completion:(void (^)(NSString * _Nullable))completion
 {
-    MXMemoryRoomStore *roomStore = [self getOrCreateRoomStore:roomId];
-    return roomStore.partialTextMessage;
+    [self getOrCreateRoomStore:roomId
+                    completion:^(MXMemoryRoomStore * _Nullable roomStore) {
+        completion(roomStore.partialTextMessage);
+    }];
 }
 
 - (NSArray<MXReceiptData*> *)getEventReceipts:(NSString*)roomId eventId:(NSString*)eventId sorted:(BOOL)sort
@@ -388,7 +390,7 @@
     [self getOrCreateRoomStore:roomId
                     completion:^(MXMemoryRoomStore * _Nullable roomStore) {
         [roomStore storeOutgoingMessage:outgoingMessage];
-    }]
+    }];
 }
 
 - (void)removeAllOutgoingMessagesFromRoom:(NSString*)roomId
@@ -396,7 +398,7 @@
     [self getOrCreateRoomStore:roomId
                     completion:^(MXMemoryRoomStore * _Nullable roomStore) {
         [roomStore removeAllOutgoingMessages];
-    }]
+    }];
 }
 
 - (void)removeOutgoingMessageFromRoom:(NSString*)roomId outgoingMessage:(NSString*)outgoingMessageEventId
@@ -404,7 +406,7 @@
     [self getOrCreateRoomStore:roomId
                     completion:^(MXMemoryRoomStore * _Nullable roomStore) {
         [roomStore removeOutgoingMessage:outgoingMessageEventId];
-    }]
+    }];
 }
 
 - (void)outgoingMessagesInRoom:(NSString *)roomId completion:(void (^)(NSArray<MXEvent *> * _Nullable))completion
@@ -412,7 +414,7 @@
     [self getOrCreateRoomStore:roomId
                     completion:^(MXMemoryRoomStore * _Nullable roomStore) {
         completion(roomStore.outgoingMessages);
-    }]
+    }];
 }
 
 

--- a/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryStore.m
+++ b/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryStore.m
@@ -320,10 +320,14 @@
     self->maxUploadSize = maxUploadSize;
 }
 
-- (NSArray<MXEvent*>* _Nonnull)relationsForEvent:(nonnull NSString*)eventId inRoom:(nonnull  NSString*)roomId relationType:(NSString*)relationType
+- (void)relationsForEvent:(NSString *)eventId
+                   inRoom:(NSString *)roomId
+             relationType:(NSString *)relationType
+               completion:(void (^)(NSArray<MXEvent *> * _Nonnull))completion
 {
-    MXMemoryRoomStore *roomStore = [self getOrCreateRoomStore:roomId];
-    return [roomStore relationsForEvent:eventId relationType:relationType];
+    [self getOrCreateRoomStore:roomId completion:^(MXMemoryRoomStore * _Nullable roomStore) {
+        completion([roomStore relationsForEvent:eventId relationType:relationType]);
+    }];
 }
 
 - (BOOL)isPermanent

--- a/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryStore.m
+++ b/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryStore.m
@@ -153,10 +153,12 @@
     }];
 }
 
-- (BOOL)hasLoadedAllRoomMembersForRoom:(NSString *)roomId
+- (void)hasLoadedAllRoomMembersForRoom:(NSString *)roomId completion:(void (^)(BOOL))completion
 {
-    MXMemoryRoomStore *roomStore = [self getOrCreateRoomStore:roomId];
-    return roomStore.hasLoadedAllRoomMembersForRoom;
+    [self getOrCreateRoomStore:roomId
+                    completion:^(MXMemoryRoomStore * _Nullable roomStore) {
+        completion(roomStore.hasLoadedAllRoomMembersForRoom);
+    }];
 }
 
 - (void)messagesEnumeratorForRoom:(nonnull NSString *)roomId

--- a/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryStore.m
+++ b/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryStore.m
@@ -121,10 +121,12 @@
     }];
 }
 
-- (NSString*)paginationTokenOfRoom:(NSString*)roomId
+- (void)paginationTokenOfRoom:(NSString *)roomId completion:(void (^)(NSString * _Nullable))completion
 {
-    MXMemoryRoomStore *roomStore = [self getOrCreateRoomStore:roomId];
-    return roomStore.paginationToken;
+    [self getOrCreateRoomStore:roomId
+                    completion:^(MXMemoryRoomStore * _Nullable roomStore) {
+        completion(roomStore.paginationToken);
+    }]
 }
 
 - (void)storeHasReachedHomeServerPaginationEndForRoom:(NSString*)roomId andValue:(BOOL)value

--- a/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryStore.m
+++ b/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryStore.m
@@ -143,17 +143,25 @@
     return roomStore.hasLoadedAllRoomMembersForRoom;
 }
 
-
-- (id<MXEventsEnumerator>)messagesEnumeratorForRoom:(NSString *)roomId
+- (void)messagesEnumeratorForRoom:(nonnull NSString *)roomId
+                          success:(nonnull void (^)(id<MXEventsEnumerator> _Nonnull))success
+                          failure:(nullable void (^)(NSError * _Nonnull error))failure
 {
     MXMemoryRoomStore *roomStore = [self getOrCreateRoomStore:roomId];
-    return roomStore.messagesEnumerator;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        success(roomStore.messagesEnumerator);
+    });
 }
 
-- (id<MXEventsEnumerator>)messagesEnumeratorForRoom:(NSString *)roomId withTypeIn:(NSArray *)types
+- (void)messagesEnumeratorForRoom:(nonnull NSString *)roomId
+                      withTypeIn:(nullable NSArray<MXEventTypeString> *)types
+                         success:(nonnull void (^)(id<MXEventsEnumerator> _Nonnull))success
+                         failure:(nullable void (^)(NSError * _Nonnull error))failure
 {
     MXMemoryRoomStore *roomStore = [self getOrCreateRoomStore:roomId];
-    return [roomStore enumeratorForMessagesWithTypeIn:types];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        success([roomStore enumeratorForMessagesWithTypeIn:types]);
+    });
 }
 
 - (void)storePartialTextMessageForRoom:(NSString *)roomId partialTextMessage:(NSString *)partialTextMessage
@@ -373,10 +381,12 @@
     [roomStore removeOutgoingMessage:outgoingMessageEventId];
 }
 
-- (NSArray<MXEvent*>*)outgoingMessagesInRoom:(NSString*)roomId
+- (void)outgoingMessagesInRoom:(NSString *)roomId completion:(void (^)(NSArray<MXEvent *> * _Nullable))completion
 {
     MXMemoryRoomStore *roomStore = [self getOrCreateRoomStore:roomId];
-    return roomStore.outgoingMessages;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        completion(roomStore.outgoingMessages);
+    });
 }
 
 

--- a/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryStore.m
+++ b/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryStore.m
@@ -60,14 +60,18 @@
 
 - (void)storeEventForRoom:(NSString*)roomId event:(MXEvent*)event direction:(MXTimelineDirection)direction
 {
-    MXMemoryRoomStore *roomStore = [self getOrCreateRoomStore:roomId];
-    [roomStore storeEvent:event direction:direction];
+    [self getOrCreateRoomStore:roomId
+                    completion:^(MXMemoryRoomStore * _Nullable roomStore) {
+        [roomStore storeEvent:event direction:direction];
+    }];
 }
 
 - (void)replaceEvent:(MXEvent *)event inRoom:(NSString *)roomId
 {
-    MXMemoryRoomStore *roomStore = [self getOrCreateRoomStore:roomId];
-    [roomStore replaceEvent:event];
+    [self getOrCreateRoomStore:roomId
+                    completion:^(MXMemoryRoomStore * _Nullable roomStore) {
+        [roomStore replaceEvent:event];
+    }];
 }
 
 - (BOOL)eventExistsWithEventId:(NSString *)eventId inRoom:(NSString *)roomId
@@ -83,10 +87,12 @@
 
 - (void)deleteAllMessagesInRoom:(NSString *)roomId
 {
-    MXMemoryRoomStore *roomStore = [self getOrCreateRoomStore:roomId];
-    [roomStore removeAllMessages];
-    roomStore.paginationToken = nil;
-    roomStore.hasReachedHomeServerPaginationEnd = NO;
+    [self getOrCreateRoomStore:roomId
+                    completion:^(MXMemoryRoomStore * _Nullable roomStore) {
+        [roomStore removeAllMessages];
+        roomStore.paginationToken = nil;
+        roomStore.hasReachedHomeServerPaginationEnd = NO;
+    }];
 }
 
 - (void)deleteRoom:(NSString *)roomId
@@ -109,8 +115,10 @@
 
 - (void)storePaginationTokenOfRoom:(NSString*)roomId andToken:(NSString*)token
 {
-    MXMemoryRoomStore *roomStore = [self getOrCreateRoomStore:roomId];
-    roomStore.paginationToken = token;
+    [self getOrCreateRoomStore:roomId
+                    completion:^(MXMemoryRoomStore * _Nullable roomStore) {
+        roomStore.paginationToken = token;
+    }];
 }
 
 - (NSString*)paginationTokenOfRoom:(NSString*)roomId
@@ -121,8 +129,10 @@
 
 - (void)storeHasReachedHomeServerPaginationEndForRoom:(NSString*)roomId andValue:(BOOL)value
 {
-    MXMemoryRoomStore *roomStore = [self getOrCreateRoomStore:roomId];
-    roomStore.hasReachedHomeServerPaginationEnd = value;
+    [self getOrCreateRoomStore:roomId
+                    completion:^(MXMemoryRoomStore * _Nullable roomStore) {
+        roomStore.hasReachedHomeServerPaginationEnd = value;
+    }];
 }
 
 - (BOOL)hasReachedHomeServerPaginationEndForRoom:(NSString*)roomId
@@ -133,8 +143,10 @@
 
 - (void)storeHasLoadedAllRoomMembersForRoom:(NSString *)roomId andValue:(BOOL)value
 {
-    MXMemoryRoomStore *roomStore = [self getOrCreateRoomStore:roomId];
-    roomStore.hasLoadedAllRoomMembersForRoom = value;
+    [self getOrCreateRoomStore:roomId
+                    completion:^(MXMemoryRoomStore * _Nullable roomStore) {
+        roomStore.hasLoadedAllRoomMembersForRoom = value;
+    }];
 }
 
 - (BOOL)hasLoadedAllRoomMembersForRoom:(NSString *)roomId
@@ -147,10 +159,10 @@
                           success:(nonnull void (^)(id<MXEventsEnumerator> _Nonnull))success
                           failure:(nullable void (^)(NSError * _Nonnull error))failure
 {
-    MXMemoryRoomStore *roomStore = [self getOrCreateRoomStore:roomId];
-    dispatch_async(dispatch_get_main_queue(), ^{
+    [self getOrCreateRoomStore:roomId
+                    completion:^(MXMemoryRoomStore * _Nullable roomStore) {
         success(roomStore.messagesEnumerator);
-    });
+    }];
 }
 
 - (void)messagesEnumeratorForRoom:(nonnull NSString *)roomId
@@ -158,16 +170,18 @@
                          success:(nonnull void (^)(id<MXEventsEnumerator> _Nonnull))success
                          failure:(nullable void (^)(NSError * _Nonnull error))failure
 {
-    MXMemoryRoomStore *roomStore = [self getOrCreateRoomStore:roomId];
-    dispatch_async(dispatch_get_main_queue(), ^{
+    [self getOrCreateRoomStore:roomId
+                    completion:^(MXMemoryRoomStore * _Nullable roomStore) {
         success([roomStore enumeratorForMessagesWithTypeIn:types]);
-    });
+    }];
 }
 
 - (void)storePartialTextMessageForRoom:(NSString *)roomId partialTextMessage:(NSString *)partialTextMessage
 {
-    MXMemoryRoomStore *roomStore = [self getOrCreateRoomStore:roomId];
-    roomStore.partialTextMessage = partialTextMessage;
+    [self getOrCreateRoomStore:roomId
+                    completion:^(MXMemoryRoomStore * _Nullable roomStore) {
+        roomStore.partialTextMessage = partialTextMessage;
+    }];
 }
 
 - (NSString *)partialTextMessageOfRoom:(NSString *)roomId
@@ -365,28 +379,34 @@
 #pragma mark - Outgoing events
 - (void)storeOutgoingMessageForRoom:(NSString*)roomId outgoingMessage:(MXEvent*)outgoingMessage
 {
-    MXMemoryRoomStore *roomStore = [self getOrCreateRoomStore:roomId];
-    [roomStore storeOutgoingMessage:outgoingMessage];
+    [self getOrCreateRoomStore:roomId
+                    completion:^(MXMemoryRoomStore * _Nullable roomStore) {
+        [roomStore storeOutgoingMessage:outgoingMessage];
+    }]
 }
 
 - (void)removeAllOutgoingMessagesFromRoom:(NSString*)roomId
 {
-    MXMemoryRoomStore *roomStore = [self getOrCreateRoomStore:roomId];
-    [roomStore removeAllOutgoingMessages];
+    [self getOrCreateRoomStore:roomId
+                    completion:^(MXMemoryRoomStore * _Nullable roomStore) {
+        [roomStore removeAllOutgoingMessages];
+    }]
 }
 
 - (void)removeOutgoingMessageFromRoom:(NSString*)roomId outgoingMessage:(NSString*)outgoingMessageEventId
 {
-    MXMemoryRoomStore *roomStore = [self getOrCreateRoomStore:roomId];
-    [roomStore removeOutgoingMessage:outgoingMessageEventId];
+    [self getOrCreateRoomStore:roomId
+                    completion:^(MXMemoryRoomStore * _Nullable roomStore) {
+        [roomStore removeOutgoingMessage:outgoingMessageEventId];
+    }]
 }
 
 - (void)outgoingMessagesInRoom:(NSString *)roomId completion:(void (^)(NSArray<MXEvent *> * _Nullable))completion
 {
-    MXMemoryRoomStore *roomStore = [self getOrCreateRoomStore:roomId];
-    dispatch_async(dispatch_get_main_queue(), ^{
+    [self getOrCreateRoomStore:roomId
+                    completion:^(MXMemoryRoomStore * _Nullable roomStore) {
         completion(roomStore.outgoingMessages);
-    });
+    }]
 }
 
 
@@ -440,7 +460,7 @@
 
 
 #pragma mark - Protected operations
-- (MXMemoryRoomStore*)getOrCreateRoomStore:(NSString*)roomId
+- (void)getOrCreateRoomStore:(NSString *)roomId completion:(void (^)(MXMemoryRoomStore * _Nullable))completion
 {
     MXMemoryRoomStore *roomStore = roomStores[roomId];
     if (nil == roomStore)
@@ -448,7 +468,9 @@
         roomStore = [[MXMemoryRoomStore alloc] init];
         roomStores[roomId] = roomStore;
     }
-    return roomStore;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        completion(roomStore);
+    });
 }
 
 @end

--- a/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryStore.m
+++ b/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryStore.m
@@ -74,9 +74,9 @@
     }];
 }
 
-- (BOOL)eventExistsWithEventId:(NSString *)eventId inRoom:(NSString *)roomId
+- (void)eventExistsWithEventId:(NSString *)eventId inRoom:(NSString *)roomId completion:(void (^)(BOOL))completion
 {
-    return (nil != [self eventWithEventId:eventId inRoom:roomId]);
+    completion(nil != [self eventWithEventId:eventId inRoom:roomId]);
 }
 
 - (MXEvent *)eventWithEventId:(NSString *)eventId inRoom:(NSString *)roomId

--- a/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryStore.m
+++ b/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryStore.m
@@ -126,7 +126,7 @@
     [self getOrCreateRoomStore:roomId
                     completion:^(MXMemoryRoomStore * _Nullable roomStore) {
         completion(roomStore.paginationToken);
-    }]
+    }];
 }
 
 - (void)storeHasReachedHomeServerPaginationEndForRoom:(NSString*)roomId andValue:(BOOL)value
@@ -137,10 +137,12 @@
     }];
 }
 
-- (BOOL)hasReachedHomeServerPaginationEndForRoom:(NSString*)roomId
+- (void)hasReachedHomeServerPaginationEndForRoom:(NSString *)roomId completion:(void (^)(BOOL))completion
 {
-    MXMemoryRoomStore *roomStore = [self getOrCreateRoomStore:roomId];
-    return roomStore.hasReachedHomeServerPaginationEnd;
+    [self getOrCreateRoomStore:roomId
+                    completion:^(MXMemoryRoomStore * _Nullable roomStore) {
+        completion(roomStore.hasReachedHomeServerPaginationEnd);
+    }];
 }
 
 - (void)storeHasLoadedAllRoomMembersForRoom:(NSString *)roomId andValue:(BOOL)value

--- a/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryStore.m
+++ b/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryStore.m
@@ -76,13 +76,17 @@
 
 - (void)eventExistsWithEventId:(NSString *)eventId inRoom:(NSString *)roomId completion:(void (^)(BOOL))completion
 {
-    completion(nil != [self eventWithEventId:eventId inRoom:roomId]);
+    [self eventWithEventId:eventId inRoom:roomId completion:^(MXEvent * _Nullable event) {
+        completion(nil != event);
+    }];
 }
 
-- (MXEvent *)eventWithEventId:(NSString *)eventId inRoom:(NSString *)roomId
+- (void)eventWithEventId:(NSString *)eventId inRoom:(NSString *)roomId completion:(void (^)(MXEvent * _Nullable))completion
 {
-    MXMemoryRoomStore *roomStore = [self getOrCreateRoomStore:roomId];
-    return [roomStore eventWithEventId:eventId];
+    [self getOrCreateRoomStore:roomId
+                    completion:^(MXMemoryRoomStore * _Nullable roomStore) {
+        completion([roomStore eventWithEventId:eventId]);
+    }];
 }
 
 - (void)deleteAllMessagesInRoom:(NSString *)roomId

--- a/MatrixSDK/Data/Store/MXNoStore/MXNoStore.m
+++ b/MatrixSDK/Data/Store/MXNoStore/MXNoStore.m
@@ -172,9 +172,11 @@
 {
     paginationTokens[roomId] = token;
 }
-- (NSString*)paginationTokenOfRoom:(NSString*)roomId
+- (void)paginationTokenOfRoom:(NSString *)roomId completion:(void (^)(NSString * _Nullable))completion
 {
-    return paginationTokens[roomId];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        completion(paginationTokens[roomId]);
+    });
 }
 
 - (void)storeHasReachedHomeServerPaginationEndForRoom:(NSString*)roomId andValue:(BOOL)value

--- a/MatrixSDK/Data/Store/MXNoStore/MXNoStore.m
+++ b/MatrixSDK/Data/Store/MXNoStore/MXNoStore.m
@@ -184,7 +184,7 @@
     hasReachedHomeServerPaginations[roomId] = [NSNumber numberWithBool:value];
 }
 
-- (BOOL)hasReachedHomeServerPaginationEndForRoom:(NSString*)roomId
+- (void)hasReachedHomeServerPaginationEndForRoom:(NSString *)roomId completion:(void (^)(BOOL))completion
 {
     BOOL hasReachedHomeServerPaginationEnd = NO;
 
@@ -194,7 +194,9 @@
         hasReachedHomeServerPaginationEnd = [hasReachedHomeServerPaginationEndNumber boolValue];
     }
 
-    return hasReachedHomeServerPaginationEnd;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        completion(hasReachedHomeServerPaginationEnd);
+    });
 }
 
 - (void)storeHasLoadedAllRoomMembersForRoom:(NSString *)roomId andValue:(BOOL)value

--- a/MatrixSDK/Data/Store/MXNoStore/MXNoStore.m
+++ b/MatrixSDK/Data/Store/MXNoStore/MXNoStore.m
@@ -115,12 +115,14 @@
     });
 }
 
-- (MXEvent *)eventWithEventId:(NSString *)eventId inRoom:(NSString *)roomId
+- (void)eventWithEventId:(NSString *)eventId inRoom:(NSString *)roomId completion:(void (^)(MXEvent * _Nullable))completion
 {
     // Events are not stored. So, we cannot find it.
     // The drawback is the app using such MXStore will possibly get duplicated event and
     // it will not be able to do redaction of an event.
-    return nil;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        completion(nil);
+    });
 }
 
 - (void)deleteAllMessagesInRoom:(NSString *)roomId

--- a/MatrixSDK/Data/Store/MXNoStore/MXNoStore.m
+++ b/MatrixSDK/Data/Store/MXNoStore/MXNoStore.m
@@ -250,9 +250,14 @@
     });
 }
 
-- (NSArray<MXEvent *> *)relationsForEvent:(NSString *)eventId inRoom:(NSString *)roomId relationType:(NSString *)relationType
+- (void)relationsForEvent:(NSString *)eventId
+                   inRoom:(NSString *)roomId
+             relationType:(NSString *)relationType
+               completion:(void (^)(NSArray<MXEvent *> * _Nonnull))completion
 {
-    return @[];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        completion(@[]);
+    });
 }
 
 #pragma mark - Matrix users

--- a/MatrixSDK/Data/Store/MXNoStore/MXNoStore.m
+++ b/MatrixSDK/Data/Store/MXNoStore/MXNoStore.m
@@ -105,10 +105,14 @@
     }
 }
 
-- (BOOL)eventExistsWithEventId:(NSString *)eventId inRoom:(NSString *)roomId
+- (void)eventExistsWithEventId:(NSString *)eventId
+                        inRoom:(NSString *)roomId
+                    completion:(void (^)(BOOL))completion
 {
     // Events are not stored. So, we cannot find it.
-    return NO;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        completion(NO);
+    });
 }
 
 - (MXEvent *)eventWithEventId:(NSString *)eventId inRoom:(NSString *)roomId

--- a/MatrixSDK/Data/Store/MXNoStore/MXNoStore.m
+++ b/MatrixSDK/Data/Store/MXNoStore/MXNoStore.m
@@ -214,7 +214,9 @@
 }
 
 
-- (id<MXEventsEnumerator>)messagesEnumeratorForRoom:(NSString *)roomId
+- (void)messagesEnumeratorForRoom:(nonnull NSString *)roomId
+                          success:(nonnull void (^)(id<MXEventsEnumerator> _Nonnull))success
+                          failure:(nullable void (^)(NSError * _Nonnull error))failure
 {
     // As the back pagination is based on the HS back pagination API, reset data about it
     [self storePaginationTokenOfRoom:roomId andToken:@"END"];
@@ -224,15 +226,22 @@
     // of MXNoStore is to not store messages so that all paginations are made
     // via requests to the homeserver.
     // So, return an empty enumerator.
-    return [[MXEventsEnumeratorOnArray alloc] initWithMessages:@[]];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        success([[MXEventsEnumeratorOnArray alloc] initWithMessages:@[]]);
+    });
 }
 
-- (id<MXEventsEnumerator>)messagesEnumeratorForRoom:(NSString *)roomId withTypeIn:(NSArray *)types
+- (void)messagesEnumeratorForRoom:(nonnull NSString *)roomId
+                       withTypeIn:(nullable NSArray<MXEventTypeString> *)types
+                          success:(nonnull void (^)(id<MXEventsEnumerator> _Nonnull))success
+                          failure:(nullable void (^)(NSError * _Nonnull error))failure
 {
     // [MXStore messagesEnumeratorForRoom: withTypeIn: ignoreMemberProfileChanges:] is used
     // to get the last message of the room which must not be nil.
     // So return an enumerator with the last message we have without caring of its type.
-    return [[MXEventsEnumeratorOnArray alloc] initWithMessages:@[lastMessages[roomId]]];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        success([[MXEventsEnumeratorOnArray alloc] initWithMessages:@[self->lastMessages[roomId]]]);
+    });
 }
 
 - (NSArray<MXEvent *> *)relationsForEvent:(NSString *)eventId inRoom:(NSString *)roomId relationType:(NSString *)relationType
@@ -300,9 +309,11 @@
 {
 }
 
-- (NSArray<MXEvent*>*)outgoingMessagesInRoom:(NSString*)roomId
+- (void)outgoingMessagesInRoom:(NSString *)roomId completion:(void (^)(NSArray<MXEvent *> * _Nullable))completion
 {
-    return @[];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        completion(@[]);
+    });
 }
 
 #pragma mark - Matrix filters

--- a/MatrixSDK/Data/Store/MXNoStore/MXNoStore.m
+++ b/MatrixSDK/Data/Store/MXNoStore/MXNoStore.m
@@ -204,7 +204,7 @@
     hasLoadedAllRoomMembersForRooms[roomId] = @(value);
 }
 
-- (BOOL)hasLoadedAllRoomMembersForRoom:(NSString *)roomId
+- (void)hasLoadedAllRoomMembersForRoom:(NSString *)roomId completion:(void (^)(BOOL))completion
 {
     BOOL hasLoadedAllRoomMembers = NO;
 
@@ -214,7 +214,9 @@
         hasLoadedAllRoomMembers = [hasLoadedAllRoomMembersNumber boolValue];
     }
 
-    return hasLoadedAllRoomMembers;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        completion(hasLoadedAllRoomMembers);
+    });
 }
 
 

--- a/MatrixSDK/Data/Store/MXNoStore/MXNoStore.m
+++ b/MatrixSDK/Data/Store/MXNoStore/MXNoStore.m
@@ -175,7 +175,7 @@
 - (void)paginationTokenOfRoom:(NSString *)roomId completion:(void (^)(NSString * _Nullable))completion
 {
     dispatch_async(dispatch_get_main_queue(), ^{
-        completion(paginationTokens[roomId]);
+        completion(self->paginationTokens[roomId]);
     });
 }
 
@@ -353,9 +353,11 @@
     }
 }
 
-- (NSString *)partialTextMessageOfRoom:(NSString *)roomId
+- (void)partialTextMessageOfRoom:(NSString *)roomId completion:(void (^)(NSString * _Nullable))completion
 {
-    return partialTextMessages[roomId];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        completion(self->partialTextMessages[roomId]);
+    });
 }
 
 - (BOOL)isPermanent

--- a/MatrixSDK/Data/Store/MXStore.h
+++ b/MatrixSDK/Data/Store/MXStore.h
@@ -230,9 +230,9 @@
  The text message typed by the user but not yet sent.
 
  @param roomId the id of the room.
- @return the text message. Can be nil.
+ @param completion Completion block containing the text message. The partial text message can be nil.
  */
-- (NSString* _Nullable)partialTextMessageOfRoom:(nonnull NSString*)roomId;
+- (void)partialTextMessageOfRoom:(nonnull NSString*)roomId completion:(nonnull void(^)(NSString * _Nullable))completion;
 
 
 /**

--- a/MatrixSDK/Data/Store/MXStore.h
+++ b/MatrixSDK/Data/Store/MXStore.h
@@ -86,10 +86,11 @@
 
  @param eventId the id of the event to retrieve.
  @param roomId the id of the room.
-
- @return the MXEvent object or nil if not found.
+ @param completion Completion block containing the MXEvent object or nil if not found.
  */
-- (MXEvent* _Nullable)eventWithEventId:(nonnull NSString*)eventId inRoom:(nonnull NSString*)roomId;
+- (void)eventWithEventId:(nonnull NSString*)eventId
+                  inRoom:(nonnull NSString*)roomId
+              completion:(nonnull void (^)(MXEvent * _Nullable))completion;
 
 /**
  Remove all existing messages in a room.

--- a/MatrixSDK/Data/Store/MXStore.h
+++ b/MatrixSDK/Data/Store/MXStore.h
@@ -134,20 +134,27 @@
 
 /**
  Get an events enumerator on all messages of a room.
- 
+
  @param roomId the id of the room.
- @return the events enumerator.
+ @param success A block object called when the operation succeeds. Contains the events enumerator.
+ @param failure A block object called when the operation fails.
  */
-- (id<MXEventsEnumerator> _Nonnull)messagesEnumeratorForRoom:(nonnull NSString*)roomId;
+- (void)messagesEnumeratorForRoom:(nonnull NSString *)roomId
+                          success:(nonnull void (^)(id<MXEventsEnumerator> _Nonnull))success
+                          failure:(nullable void (^)(NSError * _Nonnull error))failure;
 
 /**
  Get an events enumerator on messages of a room with a filter on the events types.
 
  @param roomId the id of the room.
  @param types an array of event types strings (MXEventTypeString).
- @return the events enumerator.
+ @param success A block object called when the operation succeeds. Contains the events enumerator.
+ @param failure A block object called when the operation fails.
  */
-- (id<MXEventsEnumerator> _Nonnull)messagesEnumeratorForRoom:(nonnull NSString*)roomId withTypeIn:(nullable NSArray*)types;
+- (void)messagesEnumeratorForRoom:(nonnull NSString *)roomId
+                       withTypeIn:(nullable NSArray<MXEventTypeString> *)types
+                          success:(nonnull void (^)(id<MXEventsEnumerator> _Nonnull))success
+                          failure:(nullable void (^)(NSError * _Nonnull error))failure;
 
 /**
  Get events related to a specific event.
@@ -450,9 +457,10 @@
  Get all outgoing messages pending in a room.
 
  @param roomId the id of the room.
- @return the list of messages that have not been sent yet
+ @param completion Completion block.
  */
-- (NSArray<MXEvent*>* _Nullable)outgoingMessagesInRoom:(nonnull NSString*)roomId;
+- (void)outgoingMessagesInRoom:(nonnull NSString*)roomId
+                    completion:(nonnull void (^)(NSArray<MXEvent*>* _Nullable))completion;
 
 
 #pragma mark - User Account data

--- a/MatrixSDK/Data/Store/MXStore.h
+++ b/MatrixSDK/Data/Store/MXStore.h
@@ -75,10 +75,11 @@
  
  @param eventId the id of the event to retrieve.
  @param roomId the id of the room.
-
- @return YES if the event exists in the store.
+ @param completion Completion block returning YES if the event exists in the store.
  */
-- (BOOL)eventExistsWithEventId:(nonnull NSString*)eventId inRoom:(nonnull NSString*)roomId;
+- (void)eventExistsWithEventId:(nonnull NSString*)eventId
+                        inRoom:(nonnull NSString*)roomId
+                    completion:(nonnull void (^)(BOOL))completion;
 
 /**
  Get an event in a room from the store.

--- a/MatrixSDK/Data/Store/MXStore.h
+++ b/MatrixSDK/Data/Store/MXStore.h
@@ -162,9 +162,12 @@
  @param eventId The event id of the event to find.
  @param roomId The room id.
  @param relationType The related events relation type desired.
- @return An array of events related to the given event id.
+ @param completion Completion block containing an array of events related to the given event id.
  */
-- (NSArray<MXEvent*>* _Nonnull)relationsForEvent:(nonnull NSString*)eventId inRoom:(nonnull NSString*)roomId relationType:(nonnull NSString*)relationType;
+- (void)relationsForEvent:(nonnull NSString*)eventId
+                   inRoom:(nonnull NSString*)roomId
+             relationType:(nonnull NSString*)relationType
+               completion:(nonnull void (^)(NSArray<MXEvent*>* _Nonnull))completion;
 
 
 #pragma mark - Matrix users

--- a/MatrixSDK/Data/Store/MXStore.h
+++ b/MatrixSDK/Data/Store/MXStore.h
@@ -130,7 +130,7 @@
  of a room.
  */
 - (void)storeHasLoadedAllRoomMembersForRoom:(nonnull NSString*)roomId andValue:(BOOL)value;
-- (BOOL)hasLoadedAllRoomMembersForRoom:(nonnull NSString*)roomId;
+- (void)hasLoadedAllRoomMembersForRoom:(nonnull NSString*)roomId completion:(nonnull void (^)(BOOL))completion;
 
 /**
  Get an events enumerator on all messages of a room.

--- a/MatrixSDK/Data/Store/MXStore.h
+++ b/MatrixSDK/Data/Store/MXStore.h
@@ -123,7 +123,7 @@
  */
 // @TODO(summary): Move to MXRoomSummary
 - (void)storeHasReachedHomeServerPaginationEndForRoom:(nonnull NSString*)roomId andValue:(BOOL)value;
-- (BOOL)hasReachedHomeServerPaginationEndForRoom:(nonnull NSString*)roomId;
+- (void)hasReachedHomeServerPaginationEndForRoom:(nonnull NSString*)roomId completion:(nonnull void (^)(BOOL))completion;
 
 /**
  Store/retrieve the flag indicating that the SDK has retrieved all room members

--- a/MatrixSDK/Data/Store/MXStore.h
+++ b/MatrixSDK/Data/Store/MXStore.h
@@ -115,7 +115,7 @@
  */
 // @TODO(summary): Move to MXRoomSummary
 - (void)storePaginationTokenOfRoom:(nonnull NSString*)roomId andToken:(nonnull NSString*)token;
-- (NSString * _Nullable)paginationTokenOfRoom:(nonnull NSString*)roomId;
+- (void)paginationTokenOfRoom:(nonnull NSString*)roomId completion:(nonnull void(^)(NSString * _Nullable))completion;
 
 /**
  Store/retrieve the flag indicating that the SDK has reached the end of pagination

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -2915,11 +2915,13 @@ typedef void (^MXOnResumeDone)(void);
 - (void)fixRoomsSummariesLastMessage
 {
     [self fixRoomsSummariesLastMessageWithMaxServerPaginationCount:MXRoomSummaryPaginationChunkSize
-                                                             force:NO];
+                                                             force:NO
+                                                        completion:nil];
 }
 
 - (void)fixRoomsSummariesLastMessageWithMaxServerPaginationCount:(NSUInteger)maxServerPaginationCount
                                                            force:(BOOL)force
+                                                      completion:(void (^)(void))completion
 {
     if (fixingRoomsLastMessages)
     {
@@ -3003,6 +3005,11 @@ typedef void (^MXOnResumeDone)(void);
         if ([self.store respondsToSelector:@selector(commit)])
         {
             [self.store commit];
+        }
+        
+        if (completion)
+        {
+            completion();
         }
     });
 }

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -203,6 +203,8 @@ typedef void (^MXOnResumeDone)(void);
 
 @property (nonatomic, strong) id<MXSyncResponseStore> initialSyncResponseCache;
 
+@property (nonatomic, readwrite) BOOL syncWithLazyLoadOfRoomMembers;
+
 @end
 
 @implementation MXSession
@@ -783,7 +785,7 @@ typedef void (^MXOnResumeDone)(void);
             if (filter.room.state.lazyLoadMembers)
             {
                 MXLogDebug(@"[MXSession] Set syncWithLazyLoadOfRoomMembers to YES");
-                self->_syncWithLazyLoadOfRoomMembers = YES;
+                self.syncWithLazyLoadOfRoomMembers = YES;
             }
         } failure:nil];
     }

--- a/MatrixSDK/VoIP/MXCallManager.h
+++ b/MatrixSDK/VoIP/MXCallManager.h
@@ -290,14 +290,15 @@ extern NSString *const kMXProtocolVectorSipVirtual;
 
 /**
  Get recent contacts with whom a call was present, either incoming or outgoing.
- Result will be descending order according to the call time.
- So most recent call's contact will be at the beginning of the result.
  
  @param maxNumberOfUsers Maximum number of desired users. Please note that return value could be less than this.
  @param ignoredUserIds Ignored user ids for desired users.
+ @param completion Completion block. Result will be descending ordered according to the call time.
+ So most recent call's contact will be at the beginning of the result.
  */
-- (NSArray<MXUser *> * _Nonnull)getRecentCalledUsers:(NSUInteger)maxNumberOfUsers
-                                      ignoredUserIds:(NSArray<NSString*> * _Nullable)ignoredUserIds;
+- (void)getRecentCalledUsers:(NSUInteger)maxNumberOfUsers
+              ignoredUserIds:(NSArray<NSString*> * _Nullable)ignoredUserIds
+                  completion:(nonnull void (^)(NSArray<MXUser *> * _Nonnull))completion;
 
 @end
 

--- a/MatrixSDKTests/MXAggregatedEditsTests.m
+++ b/MatrixSDKTests/MXAggregatedEditsTests.m
@@ -137,7 +137,7 @@ static NSString* const kEditedMarkdownMessageFormattedText = @"<strong>I meant H
                      [expectation fulfill];
                  }];
 
-                [room listenToEventsOfTypes:@[kMXEventTypeStringRoomMessage] onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
+                __block id listener = [room listenToEventsOfTypes:@[kMXEventTypeStringRoomMessage] onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
 
                     // -> an edit m.room.message must appear in the timeline
                     XCTAssertEqual(event.eventType, MXEventTypeRoomMessage);
@@ -150,6 +150,7 @@ static NSString* const kEditedMarkdownMessageFormattedText = @"<strong>I meant H
                     XCTAssertEqualObjects(event.content[@"m.new_content"][@"body"], kEditedMessageText);
 
                     [expectation fulfill];
+                    [room removeListener:listener];
                 }];
 
             } failure:^(NSError *error) {
@@ -183,7 +184,7 @@ static NSString* const kEditedMarkdownMessageFormattedText = @"<strong>I meant H
                     [expectation fulfill];
                 }];
                 
-                [room listenToEventsOfTypes:@[kMXEventTypeStringRoomMessage] onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
+                __block id listener = [room listenToEventsOfTypes:@[kMXEventTypeStringRoomMessage] onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
                     
                     // -> an edit m.room.message must appear in the timeline
                     XCTAssertEqual(event.eventType, MXEventTypeRoomMessage);
@@ -203,6 +204,8 @@ static NSString* const kEditedMarkdownMessageFormattedText = @"<strong>I meant H
                     XCTAssertEqualObjects(event.content[@"m.new_content"][@"formatted_body"], kEditedMarkdownMessageFormattedText);
                     
                     [expectation fulfill];
+                    
+                    [room removeListener:listener];
                 }];
                 
             } failure:^(NSError *error) {
@@ -613,7 +616,7 @@ static NSString* const kEditedMarkdownMessageFormattedText = @"<strong>I meant H
                     [expectation fulfill];
                 }];
 
-                [room listenToEventsOfTypes:@[kMXEventTypeStringRoomMessage] onEvent:^(MXEvent *editEvent, MXTimelineDirection direction, MXRoomState *roomState) {
+                __block id listener = [room listenToEventsOfTypes:@[kMXEventTypeStringRoomMessage] onEvent:^(MXEvent *editEvent, MXTimelineDirection direction, MXRoomState *roomState) {
 
                     // -> an edit m.room.message must appear in the timeline
                     XCTAssertEqual(editEvent.eventType, MXEventTypeRoomMessage);
@@ -626,6 +629,8 @@ static NSString* const kEditedMarkdownMessageFormattedText = @"<strong>I meant H
 
                     XCTAssertEqualObjects(editEvent.content[@"m.new_content"][@"msgtype"], kMXMessageTypeText);
                     XCTAssertEqualObjects(editEvent.content[@"m.new_content"][@"body"], kEditedMessageText);
+                    
+                    [room removeListener:listener];
 
                     // -> Check the edited message in the store
                     [aliceSession eventWithEventId:eventId inRoom:room.roomId success:^(MXEvent *localEditedEvent) {

--- a/MatrixSDKTests/MXAggregatedReactionTests.m
+++ b/MatrixSDKTests/MXAggregatedReactionTests.m
@@ -232,17 +232,17 @@
             [mxSession start:^{
 
                 // -> Data from aggregations must be right
-                MXAggregatedReactions *reactions = [mxSession.aggregations aggregatedReactionsOnEvent:eventId inRoom:room.roomId];
+                [mxSession.aggregations aggregatedReactionsOnEvent:eventId inRoom:room.roomId completion:^(MXAggregatedReactions * _Nullable reactions) {
+                    XCTAssertNotNil(reactions);
+                    XCTAssertEqual(reactions.reactions.count, 1);
 
-                XCTAssertNotNil(reactions);
-                XCTAssertEqual(reactions.reactions.count, 1);
+                    MXReactionCount *reactionCount = reactions.reactions.firstObject;
+                    XCTAssertEqualObjects(reactionCount.reaction, @"👍");
+                    XCTAssertEqual(reactionCount.count, 1);
+                    XCTAssertTrue(reactionCount.myUserHasReacted);
 
-                MXReactionCount *reactionCount = reactions.reactions.firstObject;
-                XCTAssertEqualObjects(reactionCount.reaction, @"👍");
-                XCTAssertEqual(reactionCount.count, 1);
-                XCTAssertTrue(reactionCount.myUserHasReacted);
-
-                [expectation fulfill];
+                    [expectation fulfill];
+                }];
 
             } failure:^(NSError *error) {
                 XCTFail(@"Cannot set up intial test conditions - error: %@", error);
@@ -264,17 +264,17 @@
     [self createScenario:^(MXSession *mxSession, MXRoom *room, MXSession *otherSession, XCTestExpectation *expectation, NSString *eventId) {
 
         // -> Data from aggregations must be right
-        MXAggregatedReactions *reactions = [mxSession.aggregations aggregatedReactionsOnEvent:eventId inRoom:room.roomId];
+        [mxSession.aggregations aggregatedReactionsOnEvent:eventId inRoom:room.roomId completion:^(MXAggregatedReactions * _Nullable reactions) {
+            XCTAssertNotNil(reactions.reactions);
+            XCTAssertEqual(reactions.reactions.count, 1);
 
-        XCTAssertNotNil(reactions.reactions);
-        XCTAssertEqual(reactions.reactions.count, 1);
+            MXReactionCount *reactionCount = reactions.reactions.firstObject;
+            XCTAssertEqualObjects(reactionCount.reaction, @"👍");
+            XCTAssertEqual(reactionCount.count, 1);
+            XCTAssertTrue(reactionCount.myUserHasReacted);
 
-        MXReactionCount *reactionCount = reactions.reactions.firstObject;
-        XCTAssertEqualObjects(reactionCount.reaction, @"👍");
-        XCTAssertEqual(reactionCount.count, 1);
-        XCTAssertTrue(reactionCount.myUserHasReacted);
-
-        [expectation fulfill];
+            [expectation fulfill];
+        }];
     }];
 }
 
@@ -343,10 +343,11 @@
             // -> Data from aggregations must be right
             if (!change.changeDueToLocalEcho)
             {
-                MXAggregatedReactions *reactions = [mxSession.aggregations aggregatedReactionsOnEvent:eventId inRoom:room.roomId];
-                XCTAssertNil(reactions);
+                [mxSession.aggregations aggregatedReactionsOnEvent:eventId inRoom:room.roomId completion:^(MXAggregatedReactions * _Nullable reactions) {
+                    XCTAssertNil(reactions);
 
-                [expectation fulfill];
+                    [expectation fulfill];
+                }];
             }
         }];
 
@@ -391,9 +392,10 @@
                     // -> Data from aggregations must be right
                     if (!changes.allValues.firstObject.changeDueToLocalEcho)
                     {
-                        MXAggregatedReactions *reactions = [mxSession.aggregations aggregatedReactionsOnEvent:eventId inRoom:room.roomId];
-                        XCTAssertNil(reactions);
-                        [expectation fulfill];
+                        [mxSession.aggregations aggregatedReactionsOnEvent:eventId inRoom:room.roomId completion:^(MXAggregatedReactions * _Nullable reactions) {
+                            XCTAssertNil(reactions);
+                            [expectation fulfill];
+                        }];
                     }
                 }];
 
@@ -489,17 +491,18 @@
             }];
 
             // -> We must have reaction count before the request complete
-            MXAggregatedReactions *reactions = [mxSession.aggregations aggregatedReactionsOnEvent:eventId inRoom:room.roomId];
-            XCTAssertNotNil(reactions);
-            XCTAssertEqual(reactions.reactions.count, 1);
+            [mxSession.aggregations aggregatedReactionsOnEvent:eventId inRoom:room.roomId completion:^(MXAggregatedReactions * _Nullable reactions) {
+                XCTAssertNotNil(reactions);
+                XCTAssertEqual(reactions.reactions.count, 1);
 
-            MXReactionCount *reactionCount = reactions.reactions.firstObject;
-            XCTAssertEqualObjects(reactionCount.reaction, @"👍");
-            XCTAssertEqual(reactionCount.count, 1);
-            XCTAssertTrue(reactionCount.myUserHasReacted);
-            XCTAssertTrue(reactionCount.containsLocalEcho);
+                MXReactionCount *reactionCount = reactions.reactions.firstObject;
+                XCTAssertEqualObjects(reactionCount.reaction, @"👍");
+                XCTAssertEqual(reactionCount.count, 1);
+                XCTAssertTrue(reactionCount.myUserHasReacted);
+                XCTAssertTrue(reactionCount.containsLocalEcho);
 
-            [expectation fulfill];
+                [expectation fulfill];
+            }];
 
         } failure:^(NSError *error) {
             XCTFail(@"Cannot set up intial test conditions - error: %@", error);
@@ -524,18 +527,19 @@
         }];
 
         // -> We must have reaction count before the request complete
-        MXAggregatedReactions *reactions = [mxSession.aggregations aggregatedReactionsOnEvent:eventId inRoom:room.roomId];
+        [mxSession.aggregations aggregatedReactionsOnEvent:eventId inRoom:room.roomId completion:^(MXAggregatedReactions * _Nullable reactions) {
+            XCTAssertNotNil(reactions);
+            XCTAssertEqual(reactions.reactions.count, 1);
 
-        XCTAssertNotNil(reactions);
-        XCTAssertEqual(reactions.reactions.count, 1);
+            MXReactionCount *reactionCount = reactions.reactions.firstObject;
+            XCTAssertEqualObjects(reactionCount.reaction, @"👍");
+            XCTAssertEqual(reactionCount.count, 0);
+            XCTAssertFalse(reactionCount.myUserHasReacted);
+            XCTAssertTrue(reactionCount.containsLocalEcho);
 
-        MXReactionCount *reactionCount = reactions.reactions.firstObject;
-        XCTAssertEqualObjects(reactionCount.reaction, @"👍");
-        XCTAssertEqual(reactionCount.count, 0);
-        XCTAssertFalse(reactionCount.myUserHasReacted);
-        XCTAssertTrue(reactionCount.containsLocalEcho);
+            [expectation fulfill];
+        }];
 
-        [expectation fulfill];
     }];
 }
 
@@ -605,31 +609,33 @@
         }];
 
         // -> We must have right reaction count before the requests complete
-        MXAggregatedReactions *reactions = [mxSession.aggregations aggregatedReactionsOnEvent:eventId inRoom:room.roomId];
+        [mxSession.aggregations aggregatedReactionsOnEvent:eventId inRoom:room.roomId completion:^(MXAggregatedReactions * _Nullable reactions) {
+            XCTAssertNotNil(reactions);
+            XCTAssertEqual(reactions.reactions.count, 1);
 
-        XCTAssertNotNil(reactions);
-        XCTAssertEqual(reactions.reactions.count, 1);
+            MXReactionCount *reactionCount = reactions.reactions.firstObject;
+            XCTAssertEqualObjects(reactionCount.reaction, @"👍");
+            XCTAssertEqual(reactionCount.count, 0);
+            XCTAssertFalse(reactionCount.myUserHasReacted);
+            XCTAssertTrue(reactionCount.containsLocalEcho);
 
-        MXReactionCount *reactionCount = reactions.reactions.firstObject;
-        XCTAssertEqualObjects(reactionCount.reaction, @"👍");
-        XCTAssertEqual(reactionCount.count, 0);
-        XCTAssertFalse(reactionCount.myUserHasReacted);
-        XCTAssertTrue(reactionCount.containsLocalEcho);
+            XCTAssertEqual(reactionCount.localEchoesOperations.count, 1);
 
-        XCTAssertEqual(reactionCount.localEchoesOperations.count, 1);
+            // -> We must have right reaction count at the end (ie, no reactions including no local reaction echoes)
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
 
-        // -> We must have right reaction count at the end (ie, no reactions including no local reaction echoes)
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+                [mxSession.aggregations aggregatedReactionsOnEvent:eventId inRoom:room.roomId completion:^(MXAggregatedReactions * _Nullable reactions2) {
+                    XCTAssertNil(reactions2);
 
-            MXAggregatedReactions *reactions = [mxSession.aggregations aggregatedReactionsOnEvent:eventId inRoom:room.roomId];
-            XCTAssertNil(reactions);
+                    // -> Only one event (redaction) should have been sent
+                    XCTAssertEqual(unreactionEventCount, 1);
+                    XCTAssertEqual(reactionEventCount, 0);
 
-            // -> Only one event (redaction) should have been sent
-            XCTAssertEqual(unreactionEventCount, 1);
-            XCTAssertEqual(reactionEventCount, 0);
+                    [expectation fulfill];
+                }];
+            });
+        }];
 
-            [expectation fulfill];
-        });
     }];
 }
 
@@ -670,11 +676,12 @@
         [liveTimeline paginate:100 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^{
 
             // -> Data from aggregations must be right
-            MXAggregatedReactions *reactions = [mxSession.aggregations aggregatedReactionsOnEvent:eventId inRoom:room.roomId];
-            [self checkGappySyncScenarionReactions:reactions];
+            [mxSession.aggregations aggregatedReactionsOnEvent:eventId inRoom:room.roomId completion:^(MXAggregatedReactions * _Nullable reactions) {
+                [self checkGappySyncScenarionReactions:reactions];
 
-            [expectation fulfill];
-
+                [expectation fulfill];
+            }];
+            
         } failure:^(NSError *error) {
             XCTFail(@"The operation should not fail - NSError: %@", error);
             [expectation fulfill];
@@ -687,12 +694,13 @@
     [self createScenarioWithAGappySync:^(MXSession *mxSession, MXRoom *room, MXSession *otherSession, XCTestExpectation *expectation, NSString *eventId) {
 
         // While we have not yet paginated back, we should see an outdated reaction count
-        MXAggregatedReactions *reactions = [mxSession.aggregations aggregatedReactionsOnEvent:eventId inRoom:room.roomId];
-        XCTAssertNotNil(reactions);
-        XCTAssertEqual(reactions.reactions.count, 1);
-        XCTAssertEqualObjects(reactions.reactions.firstObject.reaction, @"👍");
+        [mxSession.aggregations aggregatedReactionsOnEvent:eventId inRoom:room.roomId completion:^(MXAggregatedReactions * _Nullable reactions) {
+            XCTAssertNotNil(reactions);
+            XCTAssertEqual(reactions.reactions.count, 1);
+            XCTAssertEqualObjects(reactions.reactions.firstObject.reaction, @"👍");
 
-        [self checkReactionsWhenPaginating:mxSession room:room event:eventId expectation:expectation];
+            [self checkReactionsWhenPaginating:mxSession room:room event:eventId expectation:expectation];
+        }];
     }];
 }
 
@@ -716,11 +724,12 @@
         // Random usage to keep a strong reference on timeline
         [timeline resetPagination];
 
-        MXAggregatedReactions *reactions = [mxSession.aggregations aggregatedReactionsOnEvent:eventId inRoom:room.roomId];
-        [self checkGappySyncScenarionReactions:reactions];
+        [mxSession.aggregations aggregatedReactionsOnEvent:eventId inRoom:room.roomId completion:^(MXAggregatedReactions * _Nullable reactions) {
+            [self checkGappySyncScenarionReactions:reactions];
 
-        [expectation fulfill];
-
+            [expectation fulfill];
+        }];
+        
     } failure:^(NSError *error) {
         XCTFail(@"The operation should not fail - NSError: %@", error);
         [expectation fulfill];
@@ -732,12 +741,13 @@
     [self createScenarioWithAGappySync:^(MXSession *mxSession, MXRoom *room, MXSession *otherSession, XCTestExpectation *expectation, NSString *eventId) {
 
         // While we have not yet paginated back, we should see an outdated reaction count
-        MXAggregatedReactions *reactions = [mxSession.aggregations aggregatedReactionsOnEvent:eventId inRoom:room.roomId];
-        XCTAssertNotNil(reactions);
-        XCTAssertEqual(reactions.reactions.count, 1);
-        XCTAssertEqualObjects(reactions.reactions.firstObject.reaction, @"👍");
+        [mxSession.aggregations aggregatedReactionsOnEvent:eventId inRoom:room.roomId completion:^(MXAggregatedReactions * _Nullable reactions) {
+            XCTAssertNotNil(reactions);
+            XCTAssertEqual(reactions.reactions.count, 1);
+            XCTAssertEqualObjects(reactions.reactions.firstObject.reaction, @"👍");
 
-        [self checkReactionsOnPermalink:mxSession room:room event:eventId expectation:expectation];
+            [self checkReactionsOnPermalink:mxSession room:room event:eventId expectation:expectation];
+        }];
     }];
 }
 

--- a/MatrixSDKTests/MXAggregatedReferenceTests.m
+++ b/MatrixSDKTests/MXAggregatedReferenceTests.m
@@ -138,20 +138,20 @@ static NSString* const kThreadedMessage1Text = @"Morning!";
 
             [mxSession start:^{
 
-                MXEvent *event = [mxSession.store eventWithEventId:eventId inRoom:room.roomId];
+                [mxSession.store eventWithEventId:eventId inRoom:room.roomId completion:^(MXEvent * _Nullable event) {
+                    // -> Data from aggregations must be right
+                    XCTAssertNotNil(event);
 
-                // -> Data from aggregations must be right
-                XCTAssertNotNil(event);
+                    MXEventReferenceChunk *references = event.unsignedData.relations.reference;
+                    XCTAssertNotNil(references);
+                    XCTAssertEqualObjects(references.chunk.firstObject.eventId, referenceEventId);
 
-                MXEventReferenceChunk *references = event.unsignedData.relations.reference;
-                XCTAssertNotNil(references);
-                XCTAssertEqualObjects(references.chunk.firstObject.eventId, referenceEventId);
+                    XCTAssertEqual(references.count, 1);
+                    XCTAssertFalse(references.limited);
+                    XCTAssertEqualObjects(references.chunk.firstObject.type, kMXEventTypeStringRoomMessage);
 
-                XCTAssertEqual(references.count, 1);
-                XCTAssertFalse(references.limited);
-                XCTAssertEqualObjects(references.chunk.firstObject.type, kMXEventTypeStringRoomMessage);
-
-                [expectation fulfill];
+                    [expectation fulfill];
+                }];
 
             } failure:^(NSError *error) {
                 XCTFail(@"Cannot set up intial test conditions - error: %@", error);
@@ -174,19 +174,19 @@ static NSString* const kThreadedMessage1Text = @"Morning!";
     [self createScenario:^(MXSession *mxSession, MXRoom *room, XCTestExpectation *expectation, NSString *eventId, NSString *referenceEventId) {
 
         // -> Data from aggregations must be right
-        MXEvent *event = [mxSession.store eventWithEventId:eventId inRoom:room.roomId];
+        [mxSession.store eventWithEventId:eventId inRoom:room.roomId completion:^(MXEvent * _Nullable event) {
+            XCTAssertNotNil(event);
 
-        XCTAssertNotNil(event);
+            MXEventReferenceChunk *references = event.unsignedData.relations.reference;
+            XCTAssertNotNil(references);
+            XCTAssertEqualObjects(references.chunk.firstObject.eventId, referenceEventId);
 
-        MXEventReferenceChunk *references = event.unsignedData.relations.reference;
-        XCTAssertNotNil(references);
-        XCTAssertEqualObjects(references.chunk.firstObject.eventId, referenceEventId);
+            XCTAssertEqual(references.count, 1);
+            XCTAssertFalse(references.limited);
+            XCTAssertEqualObjects(references.chunk.firstObject.type, kMXEventTypeStringRoomMessage);
 
-        XCTAssertEqual(references.count, 1);
-        XCTAssertFalse(references.limited);
-        XCTAssertEqualObjects(references.chunk.firstObject.type, kMXEventTypeStringRoomMessage);
-
-        [expectation fulfill];
+            [expectation fulfill];
+        }];
     }];
 }
 

--- a/MatrixSDKTests/MXBackgroundSyncServiceTests.swift
+++ b/MatrixSDKTests/MXBackgroundSyncServiceTests.swift
@@ -101,23 +101,27 @@ class MXBackgroundSyncServiceTests: XCTestCase {
                             let text = event.content["body"] as? String
                             XCTAssertEqual(text, Constants.messageText, "Event content should match")
 
-                            XCTAssertNil(bobStore.event(withEventId: eventId, inRoom: roomId), "Event should not be in store yet")
+                            bobStore.eventExists(withEventId: eventId, inRoom: roomId) { exists in
+                                XCTAssertFalse(exists, "Event should not be in store yet")
+                                
+                                let syncResponseStore = MXSyncResponseFileStore(withCredentials: bobCredentials)
+                                let syncResponseStoreManager = MXSyncResponseStoreManager(syncResponseStore: syncResponseStore)
+                                XCTAssertNotNil(syncResponseStoreManager.event(withEventId: eventId, inRoom: roomId), "Event should be stored in sync response store")
 
-                            let syncResponseStore = MXSyncResponseFileStore(withCredentials: bobCredentials)
-                            let syncResponseStoreManager = MXSyncResponseStoreManager(syncResponseStore: syncResponseStore)
-                            XCTAssertNotNil(syncResponseStoreManager.event(withEventId: eventId, inRoom: roomId), "Event should be stored in sync response store")
-
-                            // - Bob restarts their MXSession
-                            let newBobSession = MXSession(matrixRestClient: MXRestClient(credentials: bobCredentials, unrecognizedCertificateHandler: nil))
-                            newBobSession?.setStore(bobStore, completion: { (_) in
-                                newBobSession?.start(withSyncFilterId: bobStore.syncFilterId, completion: { (_) in
-                                    
-                                    // -> The message is available from MXSession and no more from MXBackgroundSyncService
-                                    XCTAssertNil(syncResponseStoreManager.event(withEventId: eventId, inRoom: roomId), "Event should not be stored in sync response store anymore")
-                                    XCTAssertNotNil(bobStore.event(withEventId: eventId, inRoom: roomId), "Event should be in session store now")
-                                    expectation?.fulfill()
+                                // - Bob restarts their MXSession
+                                let newBobSession = MXSession(matrixRestClient: MXRestClient(credentials: bobCredentials, unrecognizedCertificateHandler: nil))
+                                newBobSession?.setStore(bobStore, completion: { (_) in
+                                    newBobSession?.start(withSyncFilterId: bobStore.syncFilterId, completion: { (_) in
+                                        
+                                        // -> The message is available from MXSession and no more from MXBackgroundSyncService
+                                        XCTAssertNil(syncResponseStoreManager.event(withEventId: eventId, inRoom: roomId), "Event should not be stored in sync response store anymore")
+                                        bobStore.eventExists(withEventId: eventId, inRoom: roomId) { exists in
+                                            XCTAssertTrue(exists, "Event should be in session store now")
+                                            expectation?.fulfill()
+                                        }
+                                    })
                                 })
-                            })
+                            }
                         case .failure(let error):
                             XCTFail("Cannot fetch the event from background sync service - error: \(error)")
                             expectation?.fulfill()
@@ -190,23 +194,27 @@ class MXBackgroundSyncServiceTests: XCTestCase {
                             let text = event.content["body"] as? String
                             XCTAssertEqual(text, Constants.messageText, "Event content should match")
                             
-                            XCTAssertNil(bobStore.event(withEventId: eventId, inRoom: roomId), "Event should not be in session store yet")
-                            
-                            let syncResponseStore = MXSyncResponseFileStore(withCredentials: bobCredentials)
-                            let syncResponseStoreManager = MXSyncResponseStoreManager(syncResponseStore: syncResponseStore)
-                            XCTAssertNotNil(syncResponseStoreManager.event(withEventId: eventId, inRoom: roomId), "Event should be stored in sync response store")
-                            
-                            // - Bob restarts their MXSession
-                            let newBobSession = MXSession(matrixRestClient: MXRestClient(credentials: bobCredentials, unrecognizedCertificateHandler: nil))
-                            newBobSession?.setStore(bobStore, completion: { (_) in
-                                newBobSession?.start(withSyncFilterId: bobStore.syncFilterId, completion: { (_) in
-                                    
-                                    // -> The message is available from MXSession and no more from MXBackgroundSyncService
-                                    XCTAssertNil(syncResponseStoreManager.event(withEventId: eventId, inRoom: roomId), "Event should not be stored in sync response store anymore")
-                                    XCTAssertNotNil(bobStore.event(withEventId: eventId, inRoom: roomId), "Event should be in session store now")
-                                    expectation?.fulfill()
+                            bobStore.eventExists(withEventId: eventId, inRoom: roomId) { exists in
+                                XCTAssertFalse(exists, "Event should not be in store yet")
+                                
+                                let syncResponseStore = MXSyncResponseFileStore(withCredentials: bobCredentials)
+                                let syncResponseStoreManager = MXSyncResponseStoreManager(syncResponseStore: syncResponseStore)
+                                XCTAssertNotNil(syncResponseStoreManager.event(withEventId: eventId, inRoom: roomId), "Event should be stored in sync response store")
+                                
+                                // - Bob restarts their MXSession
+                                let newBobSession = MXSession(matrixRestClient: MXRestClient(credentials: bobCredentials, unrecognizedCertificateHandler: nil))
+                                newBobSession?.setStore(bobStore, completion: { (_) in
+                                    newBobSession?.start(withSyncFilterId: bobStore.syncFilterId, completion: { (_) in
+                                        
+                                        // -> The message is available from MXSession and no more from MXBackgroundSyncService
+                                        XCTAssertNil(syncResponseStoreManager.event(withEventId: eventId, inRoom: roomId), "Event should not be stored in sync response store anymore")
+                                        bobStore.eventExists(withEventId: eventId, inRoom: roomId) { exists in
+                                            XCTAssertTrue(exists, "Event should be in session store now")
+                                            expectation?.fulfill()
+                                        }
+                                    })
                                 })
-                            })
+                            }
                         case .failure(let error):
                             XCTFail("Cannot fetch the event from background sync service - error: \(error)")
                             expectation?.fulfill()
@@ -290,40 +298,44 @@ class MXBackgroundSyncServiceTests: XCTestCase {
                                         let text = event.content["body"] as? String
                                         XCTAssertEqual(text, Constants.messageText, "Event content should match")
                                         
-                                        XCTAssertNil(bobStore.event(withEventId: eventId, inRoom: roomId), "Event should not be in session store yet")
-                                        
-                                        let syncResponseStore = MXSyncResponseFileStore(withCredentials: bobCredentials)
-                                        let syncResponseStoreManager = MXSyncResponseStoreManager(syncResponseStore: syncResponseStore)
-                                        XCTAssertNotNil(syncResponseStoreManager.event(withEventId: eventId, inRoom: roomId), "Event should be stored in sync response store")
-                                        
-                                        // -> Keys are stored in the intermediate MXBackgroundSyncService crypto store, not in the main crypto store
-                                        let cryptoStore = MXRealmCryptoStore(credentials: bobCredentials)
-                                        let bgSyncServiceCryptoStore = MXRealmCryptoStore(credentials: self.credentialForBgCryptoStore(withCredentials: bobCredentials))
-                                        let sessionId = event.wireContent["session_id"] as! String
-                                        let senderKey = event.wireContent["sender_key"] as! String
-                                        XCTAssertNil(cryptoStore?.inboundGroupSession(withId: sessionId, andSenderKey: senderKey), "Key must not be yet stored in the main MXRealmCryptoStore")
-                                        XCTAssertNotNil(bgSyncServiceCryptoStore?.inboundGroupSession(withId: sessionId, andSenderKey: senderKey), "Key must be stored in the intermediate MXBackgroundService MXRealmCryptoStore")
-                                        
-                                        // - Bob restarts their MXSession
-                                        let newBobSession = MXSession(matrixRestClient: MXRestClient(credentials: bobCredentials, unrecognizedCertificateHandler: nil))
-                                        newBobSession?.setStore(bobStore, completion: { (_) in
-                                            newBobSession?.start(withSyncFilterId: bobStore.syncFilterId, completion: { (_) in
-                                                // -> The message is available from MXSession and no more from MXBackgroundSyncService
-                                                XCTAssertNil(syncResponseStoreManager.event(withEventId: eventId, inRoom: roomId), "Event should not be stored in sync response store anymore")
-                                                XCTAssertNotNil(bobStore.event(withEventId: eventId, inRoom: roomId), "Event should be in session store anymore")
-                                                
-                                                // -> Keys are stored in the main crypto store but no more in the intermediate MXBackgroundSyncService crypto store
-                                                let cryptoStore = MXRealmCryptoStore(credentials: bobCredentials)
-                                                XCTAssertNotNil(cryptoStore?.inboundGroupSession(withId: sessionId, andSenderKey: senderKey), "Key must be now stored in the main MXRealmCryptoStore")
-                                                
-                                                self.bgSyncService?.event(withEventId: eventId, inRoom: roomId) { _ in
-                                                    let bgSyncServiceCryptoStore = MXRealmCryptoStore(credentials: self.credentialForBgCryptoStore(withCredentials: bobCredentials))
-                                                    XCTAssertNil(bgSyncServiceCryptoStore?.inboundGroupSession(withId: sessionId, andSenderKey: senderKey), "Key must be no more stored in the intermediate MXBackgroundService MXRealmCryptoStore")
-                                                    
-                                                    expectation?.fulfill()
-                                                }
+                                        bobStore.eventExists(withEventId: eventId, inRoom: roomId) { exists in
+                                            XCTAssertFalse(exists, "Event should not be in session store yet")
+                                            
+                                            let syncResponseStore = MXSyncResponseFileStore(withCredentials: bobCredentials)
+                                            let syncResponseStoreManager = MXSyncResponseStoreManager(syncResponseStore: syncResponseStore)
+                                            XCTAssertNotNil(syncResponseStoreManager.event(withEventId: eventId, inRoom: roomId), "Event should be stored in sync response store")
+                                            
+                                            // -> Keys are stored in the intermediate MXBackgroundSyncService crypto store, not in the main crypto store
+                                            let cryptoStore = MXRealmCryptoStore(credentials: bobCredentials)
+                                            let bgSyncServiceCryptoStore = MXRealmCryptoStore(credentials: self.credentialForBgCryptoStore(withCredentials: bobCredentials))
+                                            let sessionId = event.wireContent["session_id"] as! String
+                                            let senderKey = event.wireContent["sender_key"] as! String
+                                            XCTAssertNil(cryptoStore?.inboundGroupSession(withId: sessionId, andSenderKey: senderKey), "Key must not be yet stored in the main MXRealmCryptoStore")
+                                            XCTAssertNotNil(bgSyncServiceCryptoStore?.inboundGroupSession(withId: sessionId, andSenderKey: senderKey), "Key must be stored in the intermediate MXBackgroundService MXRealmCryptoStore")
+                                            
+                                            // - Bob restarts their MXSession
+                                            let newBobSession = MXSession(matrixRestClient: MXRestClient(credentials: bobCredentials, unrecognizedCertificateHandler: nil))
+                                            newBobSession?.setStore(bobStore, completion: { (_) in
+                                                newBobSession?.start(withSyncFilterId: bobStore.syncFilterId, completion: { (_) in
+                                                    // -> The message is available from MXSession and no more from MXBackgroundSyncService
+                                                    XCTAssertNil(syncResponseStoreManager.event(withEventId: eventId, inRoom: roomId), "Event should not be stored in sync response store anymore")
+                                                    bobStore.eventExists(withEventId: eventId, inRoom: roomId) { exists in
+                                                        XCTAssertTrue(exists, "Event should be in session store anymore")
+                                                        
+                                                        // -> Keys are stored in the main crypto store but no more in the intermediate MXBackgroundSyncService crypto store
+                                                        let cryptoStore = MXRealmCryptoStore(credentials: bobCredentials)
+                                                        XCTAssertNotNil(cryptoStore?.inboundGroupSession(withId: sessionId, andSenderKey: senderKey), "Key must be now stored in the main MXRealmCryptoStore")
+                                                        
+                                                        self.bgSyncService?.event(withEventId: eventId, inRoom: roomId) { _ in
+                                                            let bgSyncServiceCryptoStore = MXRealmCryptoStore(credentials: self.credentialForBgCryptoStore(withCredentials: bobCredentials))
+                                                            XCTAssertNil(bgSyncServiceCryptoStore?.inboundGroupSession(withId: sessionId, andSenderKey: senderKey), "Key must be no more stored in the intermediate MXBackgroundService MXRealmCryptoStore")
+                                                            
+                                                            expectation?.fulfill()
+                                                        }
+                                                    }
+                                                })
                                             })
-                                        })
+                                        }
                                     case .failure(let error):
                                         XCTFail("Cannot fetch the event from background sync service - error: \(error)")
                                         expectation?.fulfill()
@@ -861,19 +873,24 @@ class MXBackgroundSyncServiceTests: XCTestCase {
             bobSession.resume({
                 // -> Both events should be in the session store
                 // Note: In case of bug, the server will send a gappy sync in this room. The first event will not be available
-                XCTAssertNotNil(bobSession.store.event(withEventId: firstEventId, inRoom: roomId))
-                XCTAssertNotNil(bobSession.store.event(withEventId: lastEventId, inRoom: roomId))
-                
-                // -> Bob session must have the key to decrypt the first message
-                bobSession.event(withEventId: firstEventId, inRoom: roomId) { (event) in
-                    XCTAssertNotNil(event?.clear)
+                bobSession.store.eventExists(withEventId: firstEventId, inRoom: roomId) { firstEventExists in
+                    XCTAssertTrue(firstEventExists)
                     
-                    // -> The background service cache must be reset after session resume
-                    XCTAssertEqual(syncResponseStore.syncResponseIds.count, 0)
-                    expectation.fulfill()
-                } failure: { (error) in
-                    XCTFail("The request should not fail - Error: \(String(describing: error))");
-                    expectation.fulfill()
+                    bobSession.store.eventExists(withEventId: lastEventId, inRoom: roomId) { lastEventExists in
+                        XCTAssertTrue(lastEventExists)
+                        
+                        // -> Bob session must have the key to decrypt the first message
+                        bobSession.event(withEventId: firstEventId, inRoom: roomId) { (event) in
+                            XCTAssertNotNil(event?.clear)
+                            
+                            // -> The background service cache must be reset after session resume
+                            XCTAssertEqual(syncResponseStore.syncResponseIds.count, 0)
+                            expectation.fulfill()
+                        } failure: { (error) in
+                            XCTFail("The request should not fail - Error: \(String(describing: error))");
+                            expectation.fulfill()
+                        }
+                    }
                 }
             })
         }
@@ -932,19 +949,24 @@ class MXBackgroundSyncServiceTests: XCTestCase {
             bobSession.resume({
                 // -> Both events should be in the session store
                 // Note: In case of bug, the server will send a gappy sync in this room. The first event will not be available
-                XCTAssertNotNil(bobSession.store.event(withEventId: firstEventId, inRoom: roomId))
-                XCTAssertNotNil(bobSession.store.event(withEventId: lastEventId, inRoom: roomId))
-                
-                // -> Bob session must have the key to decrypt the first message
-                bobSession.event(withEventId: firstEventId, inRoom: roomId) { (event) in
-                    XCTAssertNotNil(event?.clear)
+                bobSession.store.eventExists(withEventId: firstEventId, inRoom: roomId) { firstEventExists in
+                    XCTAssertTrue(firstEventExists)
                     
-                    // -> The background service cache must be reset after session resume
-                    XCTAssertEqual(syncResponseStore.syncResponseIds.count, 0)
-                    expectation.fulfill()
-                } failure: { (error) in
-                    XCTFail("The request should not fail - Error: \(String(describing: error))");
-                    expectation.fulfill()
+                    bobSession.store.eventExists(withEventId: lastEventId, inRoom: roomId) { lastEventExists in
+                        XCTAssertTrue(lastEventExists)
+                        
+                        // -> Bob session must have the key to decrypt the first message
+                        bobSession.event(withEventId: firstEventId, inRoom: roomId) { (event) in
+                            XCTAssertNotNil(event?.clear)
+                            
+                            // -> The background service cache must be reset after session resume
+                            XCTAssertEqual(syncResponseStore.syncResponseIds.count, 0)
+                            expectation.fulfill()
+                        } failure: { (error) in
+                            XCTFail("The request should not fail - Error: \(String(describing: error))");
+                            expectation.fulfill()
+                        }
+                    }
                 }
             })
         }
@@ -997,19 +1019,24 @@ class MXBackgroundSyncServiceTests: XCTestCase {
             // - Resume Bob session
             bobSession.resume({
                 // -> Only the last event should be in the session store
-                XCTAssertNil(bobSession.store.event(withEventId: firstEventId, inRoom: roomId))
-                XCTAssertNotNil(bobSession.store.event(withEventId: lastEventId, inRoom: roomId))
-                
-                // -> Bob session must have the key to decrypt the first message
-                bobSession.event(withEventId: firstEventId, inRoom: roomId) { (event) in
-                    XCTAssertNotNil(event?.clear)
+                bobSession.store.eventExists(withEventId: firstEventId, inRoom: roomId) { firstEventExists in
+                    XCTAssertFalse(firstEventExists)
                     
-                    // -> The background service cache must be reset after session resume
-                    XCTAssertEqual(syncResponseStore.syncResponseIds.count, 0)
-                    expectation.fulfill()
-                } failure: { (error) in
-                    XCTFail("The request should not fail - Error: \(String(describing: error))");
-                    expectation.fulfill()
+                    bobSession.store.eventExists(withEventId: lastEventId, inRoom: roomId) { lastEventExists in
+                        XCTAssertTrue(lastEventExists)
+                        
+                        // -> Bob session must have the key to decrypt the first message
+                        bobSession.event(withEventId: firstEventId, inRoom: roomId) { (event) in
+                            XCTAssertNotNil(event?.clear)
+                            
+                            // -> The background service cache must be reset after session resume
+                            XCTAssertEqual(syncResponseStore.syncResponseIds.count, 0)
+                            expectation.fulfill()
+                        } failure: { (error) in
+                            XCTFail("The request should not fail - Error: \(String(describing: error))");
+                            expectation.fulfill()
+                        }
+                    }
                 }
             })
         }
@@ -1068,19 +1095,24 @@ class MXBackgroundSyncServiceTests: XCTestCase {
             // - Resume Bob session
             bobSession.resume({
                 // -> Only the last event should be in the session store
-                XCTAssertNil(bobSession.store.event(withEventId: firstEventId, inRoom: roomId))
-                XCTAssertNotNil(bobSession.store.event(withEventId: lastEventId, inRoom: roomId))
-                
-                // -> Bob session must have the key to decrypt the first message
-                bobSession.event(withEventId: firstEventId, inRoom: roomId) { (event) in
-                    XCTAssertNotNil(event?.clear)
+                bobSession.store.eventExists(withEventId: firstEventId, inRoom: roomId) { firstEventExists in
+                    XCTAssertFalse(firstEventExists)
                     
-                    // -> The background service cache must be reset after session resume
-                    XCTAssertEqual(syncResponseStore.syncResponseIds.count, 0)
-                    expectation.fulfill()
-                } failure: { (error) in
-                    XCTFail("The request should not fail - Error: \(String(describing: error))");
-                    expectation.fulfill()
+                    bobSession.store.eventExists(withEventId: lastEventId, inRoom: roomId) { lastEventExists in
+                        XCTAssertTrue(lastEventExists)
+                        
+                        // -> Bob session must have the key to decrypt the first message
+                        bobSession.event(withEventId: firstEventId, inRoom: roomId) { (event) in
+                            XCTAssertNotNil(event?.clear)
+                            
+                            // -> The background service cache must be reset after session resume
+                            XCTAssertEqual(syncResponseStore.syncResponseIds.count, 0)
+                            expectation.fulfill()
+                        } failure: { (error) in
+                            XCTFail("The request should not fail - Error: \(String(describing: error))");
+                            expectation.fulfill()
+                        }
+                    }
                 }
             })
         }

--- a/MatrixSDKTests/MXCrossSigningVerificationTests.m
+++ b/MatrixSDKTests/MXCrossSigningVerificationTests.m
@@ -569,15 +569,16 @@
                     if (doneDone.count == 4)
                     {
                         // Then, test MXKeyVerification
-                        MXEvent *event = [aliceSession.store eventWithEventId:requestId inRoom:roomId];
-                        [aliceSession.crypto.keyVerificationManager keyVerificationFromKeyVerificationEvent:event success:^(MXKeyVerification * _Nonnull verificationFromAlicePOV) {
-                            
-                            XCTAssertEqual(verificationFromAlicePOV.state, MXKeyVerificationStateVerified);
-                            
-                            [expectation fulfill];
-                        } failure:^(NSError * _Nonnull error) {
-                            XCTFail(@"The request should not fail - NSError: %@", error);
-                            [expectation fulfill];
+                        [aliceSession.store eventWithEventId:requestId inRoom:roomId completion:^(MXEvent * _Nullable event) {
+                            [aliceSession.crypto.keyVerificationManager keyVerificationFromKeyVerificationEvent:event success:^(MXKeyVerification * _Nonnull verificationFromAlicePOV) {
+                                
+                                XCTAssertEqual(verificationFromAlicePOV.state, MXKeyVerificationStateVerified);
+                                
+                                [expectation fulfill];
+                            } failure:^(NSError * _Nonnull error) {
+                                XCTFail(@"The request should not fail - NSError: %@", error);
+                                [expectation fulfill];
+                            }];
                         }];
                     }
                 };
@@ -789,15 +790,16 @@
                     if (doneDone.count == 4)
                     {
                         // Then, to test MXKeyVerification
-                        MXEvent *event = [aliceSession.store eventWithEventId:requestId inRoom:roomId];
-                        [aliceSession.crypto.keyVerificationManager keyVerificationFromKeyVerificationEvent:event success:^(MXKeyVerification * _Nonnull verificationFromAlicePOV) {
+                        [aliceSession.store eventWithEventId:requestId inRoom:roomId completion:^(MXEvent * _Nullable event) {
+                            [aliceSession.crypto.keyVerificationManager keyVerificationFromKeyVerificationEvent:event success:^(MXKeyVerification * _Nonnull verificationFromAlicePOV) {
 
-                            XCTAssertEqual(verificationFromAlicePOV.state, MXKeyVerificationStateVerified);
+                                XCTAssertEqual(verificationFromAlicePOV.state, MXKeyVerificationStateVerified);
 
-                            [expectation fulfill];
-                        } failure:^(NSError * _Nonnull error) {
-                            XCTFail(@"The request should not fail - NSError: %@", error);
-                            [expectation fulfill];
+                                [expectation fulfill];
+                            } failure:^(NSError * _Nonnull error) {
+                                XCTFail(@"The request should not fail - NSError: %@", error);
+                                [expectation fulfill];
+                            }];
                         }];
                     }
                 };

--- a/MatrixSDKTests/MXCryptoKeyVerificationTests.m
+++ b/MatrixSDKTests/MXCryptoKeyVerificationTests.m
@@ -1164,15 +1164,16 @@
         if (doneDone.count == 4)
         {
             // Then, test MXKeyVerification
-            MXEvent *event = [aliceSession.store eventWithEventId:requestId inRoom:roomId];
-            [aliceSession.crypto.keyVerificationManager keyVerificationFromKeyVerificationEvent:event success:^(MXKeyVerification * _Nonnull verificationFromAlicePOV) {
-                
-                XCTAssertEqual(verificationFromAlicePOV.state, MXKeyVerificationStateVerified);
-                
-                [expectation fulfill];
-            } failure:^(NSError * _Nonnull error) {
-                XCTFail(@"The request should not fail - NSError: %@", error);
-                [expectation fulfill];
+            [aliceSession.store eventWithEventId:requestId inRoom:roomId completion:^(MXEvent * _Nullable event) {
+                [aliceSession.crypto.keyVerificationManager keyVerificationFromKeyVerificationEvent:event success:^(MXKeyVerification * _Nonnull verificationFromAlicePOV) {
+                    
+                    XCTAssertEqual(verificationFromAlicePOV.state, MXKeyVerificationStateVerified);
+                    
+                    [expectation fulfill];
+                } failure:^(NSError * _Nonnull error) {
+                    XCTFail(@"The request should not fail - NSError: %@", error);
+                    [expectation fulfill];
+                }];
             }];
         }
     };

--- a/MatrixSDKTests/MXCryptoTests.m
+++ b/MatrixSDKTests/MXCryptoTests.m
@@ -695,19 +695,21 @@
 
                     }];
 
-                    XCTAssert([liveTimeline canPaginate:MXTimelineDirectionBackwards]);
+                    [liveTimeline canPaginate:MXTimelineDirectionBackwards completion:^(BOOL canPaginate) {
+                        XCTAssert(canPaginate);
 
-                    [liveTimeline paginate:10 direction:MXTimelineDirectionBackwards onlyFromStore:YES complete:^{
+                        [liveTimeline paginate:10 direction:MXTimelineDirectionBackwards onlyFromStore:YES complete:^{
 
-                        XCTAssertEqual(paginatedMessagesCount, 5);
+                            XCTAssertEqual(paginatedMessagesCount, 5);
 
-                        [expectation fulfill];
+                            [expectation fulfill];
 
-                    } failure:^(NSError *error) {
-                        XCTFail(@"Cannot set up intial test conditions - error: %@", error);
-                        [expectation fulfill];
+                        } failure:^(NSError *error) {
+                            XCTFail(@"Cannot set up intial test conditions - error: %@", error);
+                            [expectation fulfill];
+                        }];
                     }];
-
+                    
                 }];
 
             } failure:^(NSError *error) {
@@ -767,18 +769,21 @@
 
             }];
 
-            XCTAssert([liveTimeline canPaginate:MXTimelineDirectionBackwards]);
+            [liveTimeline canPaginate:MXTimelineDirectionBackwards completion:^(BOOL canPaginate) {
+                XCTAssert(canPaginate);
+                
+                [liveTimeline paginate:10 direction:MXTimelineDirectionBackwards onlyFromStore:YES complete:^{
 
-            [liveTimeline paginate:10 direction:MXTimelineDirectionBackwards onlyFromStore:YES complete:^{
+                    XCTAssertEqual(paginatedMessagesCount, 5);
 
-                XCTAssertEqual(paginatedMessagesCount, 5);
+                    [expectation fulfill];
 
-                [expectation fulfill];
-
-            } failure:^(NSError *error) {
-                XCTFail(@"Cannot set up intial test conditions - error: %@", error);
-                [expectation fulfill];
+                } failure:^(NSError *error) {
+                    XCTFail(@"Cannot set up intial test conditions - error: %@", error);
+                    [expectation fulfill];
+                }];
             }];
+
         }];
 
     }];
@@ -834,19 +839,21 @@
 
         }];
 
-        XCTAssert([timeline canPaginate:MXTimelineDirectionBackwards]);
-
-        [timeline paginate:10 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^{
-
-            XCTAssertEqual(paginatedMessagesCount, 5);
-
-            [expectation fulfill];
+        [timeline canPaginate:MXTimelineDirectionBackwards completion:^(BOOL canPaginate) {
+            XCTAssert(canPaginate);
             
-        } failure:^(NSError *error) {
-            XCTFail(@"Cannot set up intial test conditions - error: %@", error);
-            [expectation fulfill];
+            [timeline paginate:10 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^{
+
+                XCTAssertEqual(paginatedMessagesCount, 5);
+
+                [expectation fulfill];
+                
+            } failure:^(NSError *error) {
+                XCTFail(@"Cannot set up intial test conditions - error: %@", error);
+                [expectation fulfill];
+            }];
         }];
-        
+
     }];
 }
 

--- a/MatrixSDKTests/MXEventTimelineTests.m
+++ b/MatrixSDKTests/MXEventTimelineTests.m
@@ -117,11 +117,16 @@ NSString *theInitialEventMessage = @"The initial timelime event";
                 prev_ts = event.originServerTs;
             }
 
-            XCTAssert([eventTimeline canPaginate:MXTimelineDirectionBackwards]);
-            XCTAssert([eventTimeline canPaginate:MXTimelineDirectionForwards]);
+            [eventTimeline canPaginate:MXTimelineDirectionBackwards completion:^(BOOL canPaginateBackwards) {
+                XCTAssert(canPaginateBackwards);
+                
+                [eventTimeline canPaginate:MXTimelineDirectionForwards completion:^(BOOL canPaginateForwards) {
+                    XCTAssert(canPaginateForwards);
 
-            [expectation fulfill];
-
+                    [expectation fulfill];
+                }];
+            }];
+            
         } failure:^(NSError *error) {
             XCTFail(@"The operation should not fail - NSError: %@", error);
             [expectation fulfill];
@@ -174,10 +179,15 @@ NSString *theInitialEventMessage = @"The initial timelime event";
                     prev_ts = event.originServerTs;
                 }
 
-                XCTAssert([eventTimeline canPaginate:MXTimelineDirectionBackwards]);
-                XCTAssert([eventTimeline canPaginate:MXTimelineDirectionForwards]);
+                [eventTimeline canPaginate:MXTimelineDirectionBackwards completion:^(BOOL canPaginateBackwards) {
+                    XCTAssert(canPaginateBackwards);
+                    
+                    [eventTimeline canPaginate:MXTimelineDirectionForwards completion:^(BOOL canPaginateForwards) {
+                        XCTAssert(canPaginateForwards);
 
-                [expectation fulfill];
+                        [expectation fulfill];
+                    }];
+                }];
 
             } failure:^(NSError *error) {
                 XCTFail(@"The operation should not fail - NSError: %@", error);
@@ -235,41 +245,51 @@ NSString *theInitialEventMessage = @"The initial timelime event";
                     prev_ts = event.originServerTs;
                 }
 
-                XCTAssert([eventTimeline canPaginate:MXTimelineDirectionBackwards]);
-                XCTAssert([eventTimeline canPaginate:MXTimelineDirectionForwards]);
+                [eventTimeline canPaginate:MXTimelineDirectionBackwards completion:^(BOOL canPaginateBackwards) {
+                    XCTAssert(canPaginateBackwards);
+                    
+                    [eventTimeline canPaginate:MXTimelineDirectionForwards completion:^(BOOL canPaginateForwards) {
+                        XCTAssert(canPaginateForwards);
 
-                // Get all past messages
-                [eventTimeline paginate:100 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^{
+                        // Get all past messages
+                        [eventTimeline paginate:100 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^{
 
-                    // @TODO: The result should be 26 but it fails because of https://matrix.org/jira/browse/SYN-641
-                    // @TODO: Come back to 26 once Synapse is fixed
-                    //XCTAssertEqual(events.count, 26, @"20 + 1 + 5 = 26");
-                    XCTAssertEqual(events.count, 31, @"If the result 26, this means that https://matrix.org/jira/browse/SYN-641 is fixed ");
+                            // @TODO: The result should be 26 but it fails because of https://matrix.org/jira/browse/SYN-641
+                            // @TODO: Come back to 26 once Synapse is fixed
+                            //XCTAssertEqual(events.count, 26, @"20 + 1 + 5 = 26");
+                            XCTAssertEqual(events.count, 31, @"If the result 26, this means that https://matrix.org/jira/browse/SYN-641 is fixed ");
 
-                    // Do one more request to test end
-                    [eventTimeline paginate:1 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^{
+                            // Do one more request to test end
+                            [eventTimeline paginate:1 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^{
 
-                        // Check events order
-                        uint64_t prev_ts = 0;
-                        for (MXEvent *event in events)
-                        {
-                            XCTAssertGreaterThanOrEqual(event.originServerTs, prev_ts, @"The events order is wrong");
-                            prev_ts = event.originServerTs;
-                        }
+                                // Check events order
+                                uint64_t prev_ts = 0;
+                                for (MXEvent *event in events)
+                                {
+                                    XCTAssertGreaterThanOrEqual(event.originServerTs, prev_ts, @"The events order is wrong");
+                                    prev_ts = event.originServerTs;
+                                }
 
-                        XCTAssertFalse([eventTimeline canPaginate:MXTimelineDirectionBackwards]);
-                        XCTAssert([eventTimeline canPaginate:MXTimelineDirectionForwards]);
+                                [eventTimeline canPaginate:MXTimelineDirectionBackwards completion:^(BOOL canPaginateBackwards) {
+                                    XCTAssertFalse(canPaginateBackwards);
+                                    
+                                    [eventTimeline canPaginate:MXTimelineDirectionForwards completion:^(BOOL canPaginateForwards) {
+                                        XCTAssert(canPaginateForwards);
+                                        
+                                        [expectation fulfill];
+                                    }];
+                                }];
 
-                        [expectation fulfill];
+                            } failure:^(NSError *error) {
+                                XCTFail(@"The operation should not fail - NSError: %@", error);
+                                [expectation fulfill];
+                            }];
 
-                    } failure:^(NSError *error) {
-                        XCTFail(@"The operation should not fail - NSError: %@", error);
-                        [expectation fulfill];
+                        } failure:^(NSError *error) {
+                            XCTFail(@"The operation should not fail - NSError: %@", error);
+                            [expectation fulfill];
+                        }];
                     }];
-
-                } failure:^(NSError *error) {
-                    XCTFail(@"The operation should not fail - NSError: %@", error);
-                    [expectation fulfill];
                 }];
 
             } failure:^(NSError *error) {
@@ -329,38 +349,48 @@ NSString *theInitialEventMessage = @"The initial timelime event";
                     prev_ts = event.originServerTs;
                 }
 
-                XCTAssert([eventTimeline canPaginate:MXTimelineDirectionBackwards]);
-                XCTAssert([eventTimeline canPaginate:MXTimelineDirectionForwards]);
+                [eventTimeline canPaginate:MXTimelineDirectionBackwards completion:^(BOOL canPaginateBackwards) {
+                    XCTAssert(canPaginateBackwards);
+                    
+                    [eventTimeline canPaginate:MXTimelineDirectionForwards completion:^(BOOL canPaginateForwards) {
+                        XCTAssert(canPaginateForwards);
+                        
+                        // Get all past messages
+                        [eventTimeline paginate:100 direction:MXTimelineDirectionForwards onlyFromStore:NO complete:^{
 
-                // Get all past messages
-                [eventTimeline paginate:100 direction:MXTimelineDirectionForwards onlyFromStore:NO complete:^{
+                            XCTAssertEqual(events.count, 26, @"5 + 1 + 20 = 26");
 
-                    XCTAssertEqual(events.count, 26, @"5 + 1 + 20 = 26");
+                            // Do one more request to test end
+                            [eventTimeline paginate:1 direction:MXTimelineDirectionForwards onlyFromStore:NO complete:^{
 
-                    // Do one more request to test end
-                    [eventTimeline paginate:1 direction:MXTimelineDirectionForwards onlyFromStore:NO complete:^{
+                                // Check events order
+                                uint64_t prev_ts = 0;
+                                for (MXEvent *event in events)
+                                {
+                                    XCTAssertGreaterThanOrEqual(event.originServerTs, prev_ts, @"The events order is wrong");
+                                    prev_ts = event.originServerTs;
+                                }
 
-                        // Check events order
-                        uint64_t prev_ts = 0;
-                        for (MXEvent *event in events)
-                        {
-                            XCTAssertGreaterThanOrEqual(event.originServerTs, prev_ts, @"The events order is wrong");
-                            prev_ts = event.originServerTs;
-                        }
+                                [eventTimeline canPaginate:MXTimelineDirectionBackwards completion:^(BOOL canPaginateBackwards) {
+                                    XCTAssert(canPaginateBackwards);
+                                    
+                                    [eventTimeline canPaginate:MXTimelineDirectionForwards completion:^(BOOL canPaginateForwards) {
+                                        XCTAssertFalse(canPaginateForwards);
+                                        
+                                        [expectation fulfill];
+                                    }];
+                                }];
+                                
+                            } failure:^(NSError *error) {
+                                XCTFail(@"The operation should not fail - NSError: %@", error);
+                                [expectation fulfill];
+                            }];
 
-                        XCTAssert([eventTimeline canPaginate:MXTimelineDirectionBackwards]);
-                        XCTAssertFalse([eventTimeline canPaginate:MXTimelineDirectionForwards]);
-
-                        [expectation fulfill];
-
-                    } failure:^(NSError *error) {
-                        XCTFail(@"The operation should not fail - NSError: %@", error);
-                        [expectation fulfill];
+                        } failure:^(NSError *error) {
+                            XCTFail(@"The operation should not fail - NSError: %@", error);
+                            [expectation fulfill];
+                        }];
                     }];
-
-                } failure:^(NSError *error) {
-                    XCTFail(@"The operation should not fail - NSError: %@", error);
-                    [expectation fulfill];
                 }];
 
             } failure:^(NSError *error) {

--- a/MatrixSDKTests/MXStoreTests.m
+++ b/MatrixSDKTests/MXStoreTests.m
@@ -33,6 +33,8 @@
     MatrixSDKTestsData *matrixSDKTestsData;
 
     id observer;
+    
+    MXRoom *room;
 }
 
 @end
@@ -61,6 +63,8 @@
     }
 
     matrixSDKTestsData = nil;
+    
+    room = nil;
 
     [super tearDown];
 }
@@ -410,6 +414,7 @@
 
             // Use another MXRoom instance to do pagination in several times
             MXRoom *room2 = [[MXRoom alloc] initWithRoomId:room.roomId andMatrixSession:mxSession];
+            self->room = room2;
 
             __block NSMutableArray *room2Events = [NSMutableArray array];
 
@@ -440,9 +445,6 @@
                     }
 
                     [room2LiveTimeline paginate:5 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^() {
-
-                        // Log room2 to keep a ref on it up to here
-                        MXLogDebug(@"%@", room2);
 
                         [room2LiveTimeline paginate:100 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^() {
 

--- a/MatrixSDKTests/MXStoreTests.m
+++ b/MatrixSDKTests/MXStoreTests.m
@@ -425,14 +425,18 @@
 
                 if (mxSession.store.isPermanent)
                 {
-                    XCTAssertGreaterThanOrEqual(room2LiveTimeline.remainingMessagesForBackPaginationInStore, 7);
+                    [room2LiveTimeline remainingMessagesForBackPaginationInStoreWithCompletion:^(NSUInteger remaining) {
+                        XCTAssertGreaterThanOrEqual(remaining, 7);
+                    }];
                 }
 
                 [room2LiveTimeline paginate:2 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^() {
 
                     if (mxSession.store.isPermanent)
                     {
-                        XCTAssertGreaterThanOrEqual(room2LiveTimeline.remainingMessagesForBackPaginationInStore, 5);
+                        [room2LiveTimeline remainingMessagesForBackPaginationInStoreWithCompletion:^(NSUInteger remaining) {
+                            XCTAssertGreaterThanOrEqual(remaining, 5);
+                        }];
                     }
 
                     [room2LiveTimeline paginate:5 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^() {
@@ -514,14 +518,18 @@
                     {
                         if (mxSession.store.isPermanent)
                         {
-                            XCTAssertGreaterThanOrEqual(room2liveTimeline.remainingMessagesForBackPaginationInStore, 7);
+                            [room2liveTimeline remainingMessagesForBackPaginationInStoreWithCompletion:^(NSUInteger remaining) {
+                                XCTAssertGreaterThanOrEqual(remaining, 7);
+                            }];
                         }
 
                         [room2liveTimeline paginate:2 direction:MXTimelineDirectionBackwards onlyFromStore:NO complete:^() {
 
                             if (mxSession.store.isPermanent)
                             {
-                                XCTAssertGreaterThanOrEqual(room2liveTimeline.remainingMessagesForBackPaginationInStore, 5);
+                                [room2liveTimeline remainingMessagesForBackPaginationInStoreWithCompletion:^(NSUInteger remaining) {
+                                    XCTAssertGreaterThanOrEqual(remaining, 5);
+                                }];
                             }
 
                             // Try with 2 more live events

--- a/changelog.d/4382.change
+++ b/changelog.d/4382.change
@@ -1,0 +1,1 @@
+MXStore: Lazy load rooms messages.


### PR DESCRIPTION
Part of vector-im/element-ios#4382

There are some methods causing a room's messages to be loaded. They are:
- [ ] `MXRoom.refreshOutgoingMessages`
- [ ] `MXRoom.sentStatus (sentStatusWithCompletion newly)`