### PR TITLE
Olm fallback key support

### DIFF
--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -39,7 +39,7 @@ Pod::Spec.new do |s|
       ss.dependency 'SwiftyBeaver', '1.9.5'
 
       # Requirements for e2e encryption
-      ss.dependency 'OLMKit', '~> 3.2.4'
+      ss.dependency 'OLMKit', '~> 3.2.5'
       ss.dependency 'Realm', '10.7.6'
       ss.dependency 'libbase58', '~> 0.1.4'
   end

--- a/MatrixSDK/Contrib/Swift/MXRestClient.swift
+++ b/MatrixSDK/Contrib/Swift/MXRestClient.swift
@@ -1727,13 +1727,14 @@ public extension MXRestClient {
      - parameters:
         - deviceKeys: the device keys to send.
         - oneTimeKeys: the one-time keys to send.
+        - fallbackKeys: the fallback keys to send
         - completion: A block object called when the operation completes.
         - response: Provides information about the keys on success.
      
      - returns: a `MXHTTPOperation` instance.
      */
-    @nonobjc @discardableResult func uploadKeys(_ deviceKeys: [String: Any], oneTimeKeys: [String: Any], forDevice deviceId: String? = nil, completion: @escaping (_ response: MXResponse<MXKeysUploadResponse>) -> Void) -> MXHTTPOperation {
-        return __uploadKeys(deviceKeys, oneTimeKeys: oneTimeKeys, success: currySuccess(completion), failure: curryFailure(completion))
+    @nonobjc @discardableResult func uploadKeys(_ deviceKeys: [String: Any]?, oneTimeKeys: [String: Any]?, fallbackKeys: [String: Any]?, forDevice deviceId: String? = nil, completion: @escaping (_ response: MXResponse<MXKeysUploadResponse>) -> Void) -> MXHTTPOperation {
+        return __uploadKeys(deviceKeys, oneTimeKeys: oneTimeKeys, fallbackKeys: fallbackKeys, success: currySuccess(completion), failure: curryFailure(completion))
     }
     
     /**

--- a/MatrixSDK/Crypto/Dehydration/MXDehydrationService.m
+++ b/MatrixSDK/Crypto/Dehydration/MXDehydrationService.m
@@ -268,7 +268,7 @@ NSString *const MXDehydrationServiceErrorDomain = @"org.matrix.sdk.dehydration.s
     }
 
     MXWeakify(self);
-    [restClient uploadKeys:deviceInfo.JSONDictionary oneTimeKeys:oneTimeJson forDeviceWithId:deviceInfo.deviceId success:^(MXKeysUploadResponse *keysUploadResponse) {
+    [restClient uploadKeys:deviceInfo.JSONDictionary oneTimeKeys:oneTimeJson fallbackKeys:nil forDeviceWithId:deviceInfo.deviceId success:^(MXKeysUploadResponse *keysUploadResponse) {
         [account markOneTimeKeysAsPublished];
         MXLogDebug(@"[MXDehydrationManager] dehydration done succesfully:\n device ID = %@\n ed25519 = %@\n curve25519 = %@", deviceInfo.deviceId, account.identityKeys[@"ed25519"], account.identityKeys[@"curve25519"]);
         MXStrongifyAndReturnIfNil(self);

--- a/MatrixSDK/Crypto/MXCrypto.h
+++ b/MatrixSDK/Crypto/MXCrypto.h
@@ -256,6 +256,13 @@ extern NSString *const MXDeviceListDidUpdateUsersDevicesNotification;
 - (void)handleDeviceOneTimeKeysCount:(NSDictionary<NSString *, NSNumber*>*)deviceOneTimeKeysCount;
 
 /**
+ Handle the unused fallback keys returned in the /sync response.
+
+ @param deviceUnusedFallbackKeys the algorithms for which there are unused fallback keys
+ */
+- (void)handleDeviceUnusedFallbackKeys:(NSArray<NSString *> *)deviceUnusedFallbackKeys;
+
+/**
  Handle a room key event.
  
  @param event the room key event.

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -126,6 +126,10 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     // Migration tool
     MXCryptoMigration *cryptoMigration;
 }
+
+// The current fallback key operation, if any
+@property(nonatomic, strong) MXHTTPOperation *uploadFallbackKeyOperation;
+
 @end
 
 #endif
@@ -279,7 +283,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     // The session must be initialised enough before starting this module
     if (!_mxSession.myUser.userId)
     {
-        MXLogDebug(@"[MXCrypto] start. ERROR: mxSession.myUser.userId cannot be nil");
+        MXLogError(@"[MXCrypto] start. ERROR: mxSession.myUser.userId cannot be nil");
         failure(nil);
         return;
     }
@@ -357,7 +361,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
         } failure:^(NSError *error) {
             MXStrongifyAndReturnIfNil(self);
 
-            MXLogDebug(@"[MXCrypto] start. Error in maybeUploadOneTimeKeys: %@", error);
+            MXLogError(@"[MXCrypto] start. Error in maybeUploadOneTimeKeys: %@", error);
             dispatch_async(dispatch_get_main_queue(), ^{
                 self->startOperation = nil;
                 failure(error);
@@ -367,7 +371,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     } failure:^(NSError *error) {
         MXStrongifyAndReturnIfNil(self);
 
-        MXLogDebug(@"[MXCrypto] start. Error in uploadDeviceKeys: %@", error);
+        MXLogError(@"[MXCrypto] start. Error in uploadDeviceKeys: %@", error);
         dispatch_async(dispatch_get_main_queue(), ^{
             self->startOperation = nil;
             failure(error);
@@ -395,6 +399,9 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
         // Cancel pending one-time keys upload
         [self->uploadOneTimeKeysOperation cancel];
         self->uploadOneTimeKeysOperation = nil;
+        
+        [self.uploadFallbackKeyOperation cancel];
+        self.uploadFallbackKeyOperation = nil;
 
         [self->outgoingRoomKeyRequestManager close];
         self->outgoingRoomKeyRequestManager = nil;
@@ -505,7 +512,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
                         });
 
                     } failure:^(NSError *error) {
-                        MXLogDebug(@"[MXCrypto] encryptEventContent: Error: %@", error);
+                        MXLogError(@"[MXCrypto] encryptEventContent: Error: %@", error);
 
                         dispatch_async(dispatch_get_main_queue(), ^{
                             failure(error);
@@ -610,7 +617,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
         result = [alg decryptEvent:event inTimeline:timeline];
         if (result.error)
         {
-            MXLogDebug(@"[MXCrypto] decryptEvent: Error for %@: %@\nEvent: %@", event.eventId, result.error, event.JSONDictionary);
+            MXLogError(@"[MXCrypto] decryptEvent: Error for %@: %@\nEvent: %@", event.eventId, result.error, event.JSONDictionary);
             
             if ([result.error.domain isEqualToString:MXDecryptingErrorDomain]
                 && result.error.code == MXDecryptingErrorBadEncryptedMessageCode)
@@ -819,14 +826,14 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
         return;
     }
 
-    MXLogDebug(@"[MXCrypto] handleDeviceOneTimeKeysCount: %@ keys on the homeserver", deviceOneTimeKeysCount[@"signed_curve25519"]);
+    MXLogDebug(@"[MXCrypto] handleDeviceOneTimeKeysCount: %@ keys on the homeserver", deviceOneTimeKeysCount[kMXKeySignedCurve25519Type]);
 
     MXWeakify(self);
     dispatch_async(_cryptoQueue, ^{
         MXStrongifyAndReturnIfNil(self);
 
         NSNumber *currentCount;
-        MXJSONModelSetNumber(currentCount, deviceOneTimeKeysCount[@"signed_curve25519"]);
+        MXJSONModelSetNumber(currentCount, deviceOneTimeKeysCount[kMXKeySignedCurve25519Type]);
 
         if (currentCount)
         {
@@ -834,6 +841,28 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
         }
     });
 
+#endif
+}
+
+- (void)handleDeviceUnusedFallbackKeys:(NSArray<NSString *> *)deviceFallbackKeys
+{
+#ifdef MX_CRYPTO
+    if (deviceFallbackKeys == nil) {
+        return;
+    }
+    
+    if ([deviceFallbackKeys containsObject:kMXKeySignedCurve25519Type]) {
+        return;
+    }
+    
+    if (self.uploadFallbackKeyOperation)
+    {
+        MXLogDebug(@"[MXCrypto] handleDeviceUnusedFallbackKeys: Fallback key upload already in progress.");
+        return;
+    }
+    
+    // We will be checking this often enough for it not to warrant automatic retries.
+    self.uploadFallbackKeyOperation = [self generateAndUploadFallbackKey];
 #endif
 }
 
@@ -864,7 +893,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
                 } failure:^(NSError *error) {
 
                     // If that failed, we fall back to invalidating everyone.
-                    MXLogDebug(@"[MXCrypto] onSyncCompleted: Error fetching changed device list. Error: %@", error);
+                    MXLogError(@"[MXCrypto] onSyncCompleted: Error fetching changed device list. Error: %@", error);
                     [self.deviceList invalidateAllDeviceLists];
                 }];
             }
@@ -1571,7 +1600,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 #ifdef MX_CRYPTO
     dispatch_async(cargoQueue, ^{
 
-        MXLogDebug(@"[MXCrypto] importRoomKeys:withPassord:");
+        MXLogDebug(@"[MXCrypto] importRoomKeys:withPassword:");
 
         NSError *error;
         NSDate *startDate = [NSDate date];
@@ -1584,7 +1613,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
             {
                 [self importRoomKeys:keys success:^(NSUInteger total, NSUInteger imported) {
 
-                    MXLogDebug(@"[MXCrypto] importRoomKeys:withPassord: Imported %tu keys from %tu provided keys in %.0fms", imported, total, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
+                    MXLogDebug(@"[MXCrypto] importRoomKeys:withPassword: Imported %tu keys from %tu provided keys in %.0fms", imported, total, [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 
                     if (success)
                     {
@@ -1598,7 +1627,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 
         dispatch_async(dispatch_get_main_queue(), ^{
 
-            MXLogDebug(@"[MXCrypto] importRoomKeys:withPassord: Error: %@", error);
+            MXLogError(@"[MXCrypto] importRoomKeys:withPassword: Error: %@", error);
 
             if (failure)
             {
@@ -1696,7 +1725,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     {
         dispatch_async(dispatch_get_main_queue(), ^{
 
-            MXLogDebug(@"[MXCrypto] acceptPendingKeyRequests: ERROR: unknown alg %@ in room %@", alg, roomId);
+            MXLogError(@"[MXCrypto] acceptPendingKeyRequests: ERROR: unknown alg %@ in room %@", alg, roomId);
             if (failure)
             {
                 failure(nil);
@@ -1905,8 +1934,8 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
             _myDevice = [[MXDeviceInfo alloc] initWithDeviceId:deviceId];
             _myDevice.userId = userId;
             _myDevice.keys = @{
-                               [NSString stringWithFormat:@"ed25519:%@", deviceId]: _olmDevice.deviceEd25519Key,
-                               [NSString stringWithFormat:@"curve25519:%@", deviceId]: _olmDevice.deviceCurve25519Key,
+                               [NSString stringWithFormat:@"%@:%@", kMXKeyEd25519Type, deviceId]: _olmDevice.deviceEd25519Key,
+                               [NSString stringWithFormat:@"%@:%@", kMXKeyCurve25519Type, deviceId]: _olmDevice.deviceCurve25519Key,
                                };
             _myDevice.algorithms = [[MXCryptoAlgorithms sharedAlgorithms] supportedAlgorithms];
             [_myDevice updateTrustLevel:[MXDeviceTrustLevel trustLevelWithLocalVerificationStatus:MXDeviceVerified
@@ -1985,7 +2014,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     // fingerprint of the purported sending device.
     //
     // (see https://github.com/vector-im/vector-web/issues/2215)
-    NSString *claimedKey = event.keysClaimed[@"ed25519"];
+    NSString *claimedKey = event.keysClaimed[kMXKeyEd25519Type];
     if (!claimedKey)
     {
         MXLogDebug(@"[MXCrypto] eventSenderDeviceOfEvent: Event %@ claims no ed25519 key. Cannot verify sending device", event.eventId);
@@ -2276,7 +2305,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 
     } failure:^(NSError *error) {
 
-        MXLogDebug(@"[MXCrypto] ensureOlmSessionsForDevices: claimOneTimeKeysForUsersDevices request failed.");
+        MXLogError(@"[MXCrypto] ensureOlmSessionsForDevices: claimOneTimeKeysForUsersDevices request failed.");
 
         // Broadcast the /claim request is done
         [[NSNotificationCenter defaultCenter] postNotificationName:kMXCryptoOneTimeKeyClaimCompleteNotification
@@ -2293,7 +2322,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     NSString *sessionId;
 
     NSString *deviceId = deviceInfo.deviceId;
-    NSString *signKeyId = [NSString stringWithFormat:@"ed25519:%@", deviceId];
+    NSString *signKeyId = [NSString stringWithFormat:@"%@:%@", kMXKeyEd25519Type, deviceId];
     NSString *signature = [oneTimeKey.signatures objectForDevice:signKeyId forUser:userId];
 
     // Check one-time key signature
@@ -2310,12 +2339,12 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
         else
         {
             // Possibly a bad key
-            MXLogDebug(@"[MXCrypto] verifyKeyAndStartSession: Error starting olm session with device %@:%@", userId, deviceId);
+            MXLogError(@"[MXCrypto] verifyKeyAndStartSession: Error starting olm session with device %@:%@", userId, deviceId);
         }
     }
     else
     {
-        MXLogDebug(@"[MXCrypto] verifyKeyAndStartSession: Unable to verify signature on one-time key for device %@:%@. Error: %@", userId, deviceId, error.localizedFailureReason);
+        MXLogError(@"[MXCrypto] verifyKeyAndStartSession: Unable to verify signature on one-time key for device %@:%@. Error: %@", userId, deviceId, error.localizedFailureReason);
     }
 
     return sessionId;
@@ -2342,7 +2371,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
             // the curve25519 key and the ed25519 key are owned by
             // the same device.
             payloadJson[@"keys"] = @{
-                                     @"ed25519": _olmDevice.deviceEd25519Key
+                                     kMXKeyEd25519Type: _olmDevice.deviceEd25519Key
                                      };
 
             // Include the recipient device details in the payload,
@@ -2350,7 +2379,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
             // https://github.com/vector-im/vector-web/issues/2483
             payloadJson[@"recipient"] = recipientDevice.userId;
             payloadJson[@"recipient_keys"] = @{
-                                               @"ed25519": recipientDevice.fingerprint
+                                               kMXKeyEd25519Type: recipientDevice.fingerprint
                                                };
 
             NSData *payloadData = [NSJSONSerialization  dataWithJSONObject:payloadJson options:0 error:nil];
@@ -2413,7 +2442,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 {
     return @{
              _myDevice.userId: @{
-                     [NSString stringWithFormat:@"ed25519:%@", _myDevice.deviceId]: [_olmDevice signJSON:object]
+                     [NSString stringWithFormat:@"%@:%@", kMXKeyEd25519Type, _myDevice.deviceId]: [_olmDevice signJSON:object]
                      }
              };
 }
@@ -2592,14 +2621,14 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 {
     if (!event.content[@"room_id"] || !event.content[@"algorithm"])
     {
-        MXLogDebug(@"[MXCrypto] onRoomKeyEvent: ERROR: Key event is missing fields");
+        MXLogError(@"[MXCrypto] onRoomKeyEvent: ERROR: Key event is missing fields");
         return;
     }
 
     id<MXDecrypting> alg = [self getRoomDecryptor:event.content[@"room_id"] algorithm:event.content[@"algorithm"]];
     if (!alg)
     {
-        MXLogDebug(@"[MXCrypto] onRoomKeyEvent: ERROR: Unable to handle keys for %@", event.content[@"algorithm"]);
+        MXLogError(@"[MXCrypto] onRoomKeyEvent: ERROR: Unable to handle keys for %@", event.content[@"algorithm"]);
         return;
     }
 
@@ -2698,7 +2727,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     // Sanity check
     if (!_matrixRestClient.credentials.userId)
     {
-        MXLogDebug(@"[MXCrypto] uploadDeviceKeys. ERROR: _matrixRestClient.credentials.userId cannot be nil");
+        MXLogError(@"[MXCrypto] uploadDeviceKeys. ERROR: _matrixRestClient.credentials.userId cannot be nil");
         failure(nil);
         return nil;
     }
@@ -2708,13 +2737,13 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     NSString *signature = [_olmDevice signJSON:_myDevice.signalableJSONDictionary];
     _myDevice.signatures = @{
                             _matrixRestClient.credentials.userId: @{
-                                    [NSString stringWithFormat:@"ed25519:%@", _myDevice.deviceId]: signature
+                                    [NSString stringWithFormat:@"%@:%@", kMXKeyEd25519Type, _myDevice.deviceId]: signature
                                     }
                             };
 
     // For now, we set the device id explicitly, as we may not be using the
     // same one as used in login.
-    return [_matrixRestClient uploadKeys:_myDevice.JSONDictionary oneTimeKeys:nil success:success failure:failure];
+    return [_matrixRestClient uploadKeys:_myDevice.JSONDictionary oneTimeKeys:nil fallbackKeys:nil success:success failure:failure];
 }
 
 /**
@@ -2764,7 +2793,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
         } failure:^(NSError *error) {
             MXStrongifyAndReturnIfNil(self);
             
-            MXLogDebug(@"[MXCrypto] maybeUploadOneTimeKeys: Failed to publish one-time keys. Error: %@", error);
+            MXLogError(@"[MXCrypto] maybeUploadOneTimeKeys: Failed to publish one-time keys. Error: %@", error);
             self->uploadOneTimeKeysOperation = nil;
             
             if (failure)
@@ -2810,7 +2839,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
             } failure:^(NSError *error) {
                 MXStrongifyAndReturnIfNil(self);
                 
-                MXLogDebug(@"[MXCrypto] maybeUploadOneTimeKeys: Failed to publish one-time keys. Error: %@", error);
+                MXLogError(@"[MXCrypto] maybeUploadOneTimeKeys: Failed to publish one-time keys. Error: %@", error);
                 self->uploadOneTimeKeysOperation = nil;
                 
                 if (failure)
@@ -2835,7 +2864,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
         } failure:^(NSError *error) {
             MXStrongifyAndReturnIfNil(self);
 
-            MXLogDebug(@"[MXCrypto] maybeUploadOneTimeKeys: Get published one-time keys count failed. Error: %@", error);
+            MXLogError(@"[MXCrypto] maybeUploadOneTimeKeys: Get published one-time keys count failed. Error: %@", error);
             self->uploadOneTimeKeysOperation = nil;
 
             if (failure)
@@ -2857,7 +2886,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
         operation = [self uploadOneTimeKeys:^(MXKeysUploadResponse *keysUploadResponse) {
             success();
         } failure:^(NSError *error) {
-            MXLogDebug(@"[MXCrypto] generateAndUploadOneTimeKeys: Failed to publish one-time keys. Error: %@", error);
+            MXLogError(@"[MXCrypto] generateAndUploadOneTimeKeys: Failed to publish one-time keys. Error: %@", error);
             
             if ([MXError isMXError:error] && retry)
             {
@@ -2865,7 +2894,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
                 // Reset local OTKs we tried to push and retry
                 // There is no matrix specific error but we really want to detect the error described at
                 // https://github.com/vector-im/element-ios/issues/3721
-                MXLogDebug(@"[MXCrypto] uploadOneTimeKeys: Reset local OTKs because the server does not like them");
+                MXLogError(@"[MXCrypto] uploadOneTimeKeys: Reset local OTKs because the server does not like them");
                 [self.olmDevice markOneTimeKeysAsPublished];
                 
                 [self generateAndUploadOneTimeKeys:keyCount retry:NO success:success failure:failure];
@@ -2878,6 +2907,35 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     }
     
     return operation;
+}
+
+- (MXHTTPOperation *)generateAndUploadFallbackKey
+{
+    [_olmDevice generateFallbackKey];
+    
+    NSDictionary *fallbackKey = _olmDevice.fallbackKey;
+    NSMutableDictionary *fallbackKeyJson = [NSMutableDictionary dictionary];
+    
+    for (NSString *keyId in fallbackKey[kMXKeyCurve25519Type])
+    {
+        // Sign the fallback key
+        NSMutableDictionary *signedKey = [NSMutableDictionary dictionary];
+        signedKey[@"key"] = fallbackKey[kMXKeyCurve25519Type][keyId];
+        signedKey[@"signatures"] = [self signObject:signedKey];
+        
+        fallbackKeyJson[[NSString stringWithFormat:@"%@:%@", kMXKeySignedCurve25519Type, keyId]] = signedKey;
+    }
+    
+    MXLogDebug(@"[MXCrypto] generateAndUploadFallbackKey: Started uploading fallback key.");
+    
+    MXWeakify(self);
+    return [_matrixRestClient uploadKeys:nil oneTimeKeys:nil fallbackKeys:fallbackKeyJson success:^(MXKeysUploadResponse *keysUploadResponse) {
+        weakself.uploadFallbackKeyOperation = nil;
+        MXLogDebug(@"[MXCrypto] generateAndUploadFallbackKey: Finished uploading fallback key.");
+    } failure:^(NSError *error) {
+        weakself.uploadFallbackKeyOperation = nil;
+        MXLogError(@"[MXCrypto] generateAndUploadFallbackKey: Failed uploading fallback key.");
+    }];
 }
 
 /**
@@ -2944,29 +3002,29 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     NSDictionary *oneTimeKeys = _olmDevice.oneTimeKeys;
     NSMutableDictionary *oneTimeJson = [NSMutableDictionary dictionary];
 
-    for (NSString *keyId in oneTimeKeys[@"curve25519"])
+    for (NSString *keyId in oneTimeKeys[kMXKeyCurve25519Type])
     {
         // Sign each one-time key
         NSMutableDictionary *k = [NSMutableDictionary dictionary];
-        k[@"key"] = oneTimeKeys[@"curve25519"][keyId];
+        k[@"key"] = oneTimeKeys[kMXKeyCurve25519Type][keyId];
         k[@"signatures"] = [self signObject:k];
 
-        oneTimeJson[[NSString stringWithFormat:@"signed_curve25519:%@", keyId]] = k;
+        oneTimeJson[[NSString stringWithFormat:@"%@:%@", kMXKeySignedCurve25519Type, keyId]] = k;
     }
 
-    MXLogDebug(@"[MXCrypto] uploadOneTimeKeys: Upload %tu keys", ((NSDictionary*)oneTimeKeys[@"curve25519"]).count);
+    MXLogDebug(@"[MXCrypto] uploadOneTimeKeys: Upload %tu keys", ((NSDictionary*)oneTimeKeys[kMXKeyCurve25519Type]).count);
 
     // For now, we set the device id explicitly, as we may not be using the
     // same one as used in login.
     MXWeakify(self);
-    return [_matrixRestClient uploadKeys:nil oneTimeKeys:oneTimeJson success:^(MXKeysUploadResponse *keysUploadResponse) {
+    return [_matrixRestClient uploadKeys:nil oneTimeKeys:oneTimeJson fallbackKeys:nil success:^(MXKeysUploadResponse *keysUploadResponse) {
         MXStrongifyAndReturnIfNil(self);
 
         [self.olmDevice markOneTimeKeysAsPublished];
         success(keysUploadResponse);
 
     } failure:^(NSError *error) {
-        MXLogDebug(@"[MXCrypto] uploadOneTimeKeys fails.");
+        MXLogError(@"[MXCrypto] uploadOneTimeKeys fails.");
         failure(error);
     }];
 }
@@ -2974,16 +3032,16 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 // Ask the server how many keys we have
 - (MXHTTPOperation *)publishedOneTimeKeysCount:(void (^)(NSUInteger publishedKeyCount))success failure:(void (^)(NSError *))failure
 {
-    return [_matrixRestClient uploadKeys:_myDevice.JSONDictionary oneTimeKeys:nil success:^(MXKeysUploadResponse *keysUploadResponse) {
+    return [_matrixRestClient uploadKeys:_myDevice.JSONDictionary oneTimeKeys:nil fallbackKeys:nil success:^(MXKeysUploadResponse *keysUploadResponse) {
         
-        NSUInteger publishedkeyCount = [keysUploadResponse oneTimeKeyCountsForAlgorithm:@"signed_curve25519"];
+        NSUInteger publishedkeyCount = [keysUploadResponse oneTimeKeyCountsForAlgorithm:kMXKeySignedCurve25519Type];
         
         MXLogDebug(@"[MXCrypto] publishedOneTimeKeysCount: %@ OTKs on the homeserver", @(publishedkeyCount));
         
         success(publishedkeyCount);
         
     } failure:^(NSError *error) {
-        MXLogDebug(@"[MXCrypto] publishedOneTimeKeysCount failed. Error: %@", error);
+        MXLogError(@"[MXCrypto] publishedOneTimeKeysCount failed. Error: %@", error);
         failure(error);
     }];
 }
@@ -3059,7 +3117,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
         }];
         
     } failure:^(NSError *error) {
-        MXLogDebug(@"[MXCrypto] markOlmSessionForUnwedgingInEvent: ERROR for ensureOlmSessionsForDevices: %@", error);
+        MXLogError(@"[MXCrypto] markOlmSessionForUnwedgingInEvent: ERROR for ensureOlmSessionsForDevices: %@", error);
     }];
 }
 

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -2930,10 +2930,14 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     
     MXWeakify(self);
     return [_matrixRestClient uploadKeys:nil oneTimeKeys:nil fallbackKeys:fallbackKeyJson success:^(MXKeysUploadResponse *keysUploadResponse) {
-        weakself.uploadFallbackKeyOperation = nil;
+        MXStrongifyAndReturnIfNil(self);
+        
+        self.uploadFallbackKeyOperation = nil;
         MXLogDebug(@"[MXCrypto] generateAndUploadFallbackKey: Finished uploading fallback key.");
     } failure:^(NSError *error) {
-        weakself.uploadFallbackKeyOperation = nil;
+        MXStrongifyAndReturnIfNil(self);
+        
+        self.uploadFallbackKeyOperation = nil;
         MXLogError(@"[MXCrypto] generateAndUploadFallbackKey: Failed uploading fallback key.");
     }];
 }

--- a/MatrixSDK/Crypto/MXOlmDevice.h
+++ b/MatrixSDK/Crypto/MXOlmDevice.h
@@ -99,6 +99,20 @@
 - (void)generateOneTimeKeys:(NSUInteger)numKeys;
 
 /**
+ The current fallback key for this account.
+
+ @return a dictionary with one key which is "curve25519".
+         Its value is a dictionary where keys are keys ids
+         and values, the Curve25519 keys.
+ */
+@property (nonatomic, readonly) NSDictionary *fallbackKey;
+
+/**
+ Generate a new fallback key
+ */
+- (void)generateFallbackKey;
+
+/**
  Generate a new outbound session.
  
  The new session will be stored in the MXStore.

--- a/MatrixSDK/Crypto/MXOlmDevice.m
+++ b/MatrixSDK/Crypto/MXOlmDevice.m
@@ -141,6 +141,18 @@
     }];
 }
 
+- (NSDictionary *)fallbackKey
+{
+    return store.account.fallbackKey;
+}
+
+- (void)generateFallbackKey
+{
+    [store performAccountOperationWithBlock:^(OLMAccount *olmAccount) {
+        [olmAccount generateFallbackKey];
+    }];
+}
+
 - (NSString *)createOutboundSession:(NSString *)theirIdentityKey theirOneTimeKey:(NSString *)theirOneTimeKey
 {
     NSError *error;

--- a/MatrixSDK/JSONModels/Sync/MXSyncResponse.h
+++ b/MatrixSDK/JSONModels/Sync/MXSyncResponse.h
@@ -61,6 +61,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, nullable) NSDictionary<NSString *, NSNumber*> *deviceOneTimeKeysCount;
 
 /**
+ List of algorithms for which the server has unused fallback keys
+ */
+@property (nonatomic, nullable) NSArray<NSString*> *unusedFallbackKeys;
+
+/**
  List of rooms.
  */
 @property (nonatomic, nullable) MXRoomsSyncResponse *rooms;

--- a/MatrixSDK/JSONModels/Sync/MXSyncResponse.m
+++ b/MatrixSDK/JSONModels/Sync/MXSyncResponse.m
@@ -22,6 +22,8 @@
 #import "MXRoomsSyncResponse.h"
 #import "MXGroupsSyncResponse.h"
 
+static NSString * const kMXDeviceUnusedFallbackKeyTypesKey = @"org.matrix.msc2732.device_unused_fallback_key_types";
+
 @implementation MXSyncResponse
 
 + (id)modelFromJSON:(NSDictionary *)JSONDictionary
@@ -35,6 +37,7 @@
         MXJSONModelSetMXJSONModel(syncResponse.toDevice, MXToDeviceSyncResponse, JSONDictionary[@"to_device"]);
         MXJSONModelSetMXJSONModel(syncResponse.deviceLists, MXDeviceListResponse, JSONDictionary[@"device_lists"]);
         MXJSONModelSetDictionary(syncResponse.deviceOneTimeKeysCount, JSONDictionary[@"device_one_time_keys_count"])
+        MXJSONModelSetArray(syncResponse.unusedFallbackKeys, JSONDictionary[kMXDeviceUnusedFallbackKeyTypesKey])
         MXJSONModelSetMXJSONModel(syncResponse.rooms, MXRoomsSyncResponse, JSONDictionary[@"rooms"]);
         MXJSONModelSetMXJSONModel(syncResponse.groups, MXGroupsSyncResponse, JSONDictionary[@"groups"]);
     }
@@ -66,6 +69,10 @@
     if (self.deviceOneTimeKeysCount)
     {
         JSONDictionary[@"device_one_time_keys_count"] = self.deviceOneTimeKeysCount;
+    }
+    if (self.unusedFallbackKeys)
+    {
+        JSONDictionary[kMXDeviceUnusedFallbackKeyTypesKey] = self.unusedFallbackKeys;
     }
     if (self.rooms)
     {

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -2137,13 +2137,16 @@ Get the maximum size a media upload can be in bytes.
 
  @param deviceKeys the device keys to send.
  @param oneTimeKeys the one-time keys to send.
+ @param fallbackKeys the fallback keys to send.
 
  @param success A block object called when the operation succeeds.
  @param failure A block object called when the operation fails.
 
  @return a MXHTTPOperation instance.
  */
-- (MXHTTPOperation*)uploadKeys:(NSDictionary*)deviceKeys oneTimeKeys:(NSDictionary*)oneTimeKeys
+- (MXHTTPOperation*)uploadKeys:(NSDictionary*)deviceKeys
+                   oneTimeKeys:(NSDictionary*)oneTimeKeys
+                  fallbackKeys:(NSDictionary *)fallbackKeys
                        success:(void (^)(MXKeysUploadResponse *keysUploadResponse))success
                        failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -2155,6 +2155,7 @@ Get the maximum size a media upload can be in bytes.
 
  @param deviceKeys the device keys to send.
  @param oneTimeKeys the one-time keys to send.
+ @param fallbackKeys the fallback keys to send.
  @param deviceId ID of the device the keys belong to. Nil to upload keys to the device of the current session.
 
  @param success A block object called when the operation succeeds.
@@ -2162,7 +2163,9 @@ Get the maximum size a media upload can be in bytes.
 
  @return a MXHTTPOperation instance.
  */
-- (MXHTTPOperation*)uploadKeys:(NSDictionary*)deviceKeys oneTimeKeys:(NSDictionary*)oneTimeKeys
+- (MXHTTPOperation*)uploadKeys:(NSDictionary*)deviceKeys
+                   oneTimeKeys:(NSDictionary*)oneTimeKeys
+                  fallbackKeys:(NSDictionary *)fallbackKeys
                forDeviceWithId:(NSString*)deviceId
                        success:(void (^)(MXKeysUploadResponse *keysUploadResponse))success
                        failure:(void (^)(NSError *error))failure;

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -4046,14 +4046,18 @@ MXAuthAction;
 
 
 #pragma mark - Crypto
-- (MXHTTPOperation*)uploadKeys:(NSDictionary*)deviceKeys oneTimeKeys:(NSDictionary*)oneTimeKeys
+- (MXHTTPOperation*)uploadKeys:(NSDictionary*)deviceKeys
+                   oneTimeKeys:(NSDictionary*)oneTimeKeys
+                  fallbackKeys:(NSDictionary *)fallbackKeys
                        success:(void (^)(MXKeysUploadResponse *keysUploadResponse))success
                        failure:(void (^)(NSError *error))failure
 {
-    return [self uploadKeys:deviceKeys oneTimeKeys:oneTimeKeys forDeviceWithId:nil success:success failure:failure];
+    return [self uploadKeys:deviceKeys oneTimeKeys:oneTimeKeys fallbackKeys:fallbackKeys forDeviceWithId:nil success:success failure:failure];
 }
 
-- (MXHTTPOperation*)uploadKeys:(NSDictionary*)deviceKeys oneTimeKeys:(NSDictionary*)oneTimeKeys
+- (MXHTTPOperation*)uploadKeys:(NSDictionary*)deviceKeys
+                   oneTimeKeys:(NSDictionary*)oneTimeKeys
+                  fallbackKeys:(NSDictionary *)fallbackKeys
                forDeviceWithId:(NSString*)deviceId
                        success:(void (^)(MXKeysUploadResponse *keysUploadResponse))success
                        failure:(void (^)(NSError *error))failure
@@ -4068,6 +4072,10 @@ MXAuthAction;
     if (oneTimeKeys)
     {
         parameters[@"one_time_keys"] = oneTimeKeys;
+    }
+    if (fallbackKeys)
+    {
+        parameters[@"org.matrix.msc2732.fallback_keys"] = fallbackKeys;
     }
 
     MXWeakify(self);

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -649,6 +649,8 @@ typedef void (^MXOnResumeDone)(void);
                     [self.crypto handleDeviceOneTimeKeysCount:syncResponse.deviceOneTimeKeysCount];
                 }
                 
+                [self.crypto handleDeviceUnusedFallbackKeys:syncResponse.unusedFallbackKeys];
+                
                 // Tell the crypto module to do its processing
                 [self.crypto onSyncCompleted:self.store.eventStreamToken
                                nextSyncToken:syncResponse.nextBatch

--- a/MatrixSDKTests/MXRestClientTests.m
+++ b/MatrixSDKTests/MXRestClientTests.m
@@ -1581,21 +1581,10 @@
         // Upload the device keys
         [bobRestClient uploadKeys:nil oneTimeKeys:otks fallbackKeys:nil success:^(MXKeysUploadResponse *keysUploadResponse) {
             XCTAssert(keysUploadResponse.oneTimeKeyCounts);
-            
             XCTAssertEqual(keysUploadResponse.oneTimeKeyCounts[@"curve25519"].unsignedIntValue, 2, @"Key count must be 2 for 'curve25519'");
             XCTAssertEqual([keysUploadResponse oneTimeKeyCountsForAlgorithm:@"curve25519"], 2, @"Key count must be 2 for 'curve25519'");
-            
-            [keysUploadResponse.oneTimeKeyCounts enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSNumber *obj, BOOL *stop) {
-                if ([key isEqualToString:@"curve25519"]) {
-                    return;
-                }
-                
-                XCTAssertEqual(obj.unsignedIntValue, 0, @"Key count must be 0 for any other algorithm.");
-                XCTAssertEqual([keysUploadResponse oneTimeKeyCountsForAlgorithm:key], 0, @"Key count must be 0 for any other algorithm.");
-            }];
-
+            XCTAssertEqual([keysUploadResponse oneTimeKeyCountsForAlgorithm:@"deded"], 0, @"It must response 0 for any other algo");
             [expectation fulfill];
-
         } failure:^(NSError *error) {
             XCTFail(@"The request should not fail - NSError: %@", error);
             [expectation fulfill];

--- a/MatrixSDKTests/MXRestClientTests.m
+++ b/MatrixSDKTests/MXRestClientTests.m
@@ -29,9 +29,9 @@
 #pragma clang diagnostic ignored "-Warc-retain-cycles"
 
 @interface MXRestClientTests : XCTestCase
-{
-    MatrixSDKTestsData *matrixSDKTestsData;
-}
+
+@property (nonatomic, strong, readonly) MatrixSDKTestsData *matrixSDKTestsData;
+
 
 @end
 
@@ -41,23 +41,23 @@
 {
     [super setUp];
 
-    matrixSDKTestsData = [[MatrixSDKTestsData alloc] init];
+    _matrixSDKTestsData = [[MatrixSDKTestsData alloc] init];
 }
 
 - (void)tearDown
 {
     [super tearDown];
 
-    matrixSDKTestsData = nil;
+    _matrixSDKTestsData = nil;
 }
 
 - (void)testInit
 {
-    [matrixSDKTestsData doMXRestClientTestWithBob:self readyToTest:^(MXRestClient *bobRestClient, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXRestClientTestWithBob:self readyToTest:^(MXRestClient *bobRestClient, XCTestExpectation *expectation) {
 
         XCTAssertTrue([bobRestClient.homeserver isEqualToString:kMXTestsHomeServerURL], "bobRestClient.homeserver(%@) is wrong", bobRestClient.homeserver);
-        XCTAssertTrue([bobRestClient.credentials.userId isEqualToString:matrixSDKTestsData.bobCredentials.userId], "bobRestClient.userId(%@) is wrong", bobRestClient.credentials.userId);
-        XCTAssertTrue([bobRestClient.credentials.accessToken isEqualToString:matrixSDKTestsData.bobCredentials.accessToken], "bobRestClient.accessToken(%@) is wrong", bobRestClient.credentials.accessToken);
+        XCTAssertTrue([bobRestClient.credentials.userId isEqualToString:self.matrixSDKTestsData.bobCredentials.userId], "bobRestClient.userId(%@) is wrong", bobRestClient.credentials.userId);
+        XCTAssertTrue([bobRestClient.credentials.accessToken isEqualToString:self.matrixSDKTestsData.bobCredentials.accessToken], "bobRestClient.accessToken(%@) is wrong", bobRestClient.credentials.accessToken);
         
         [expectation fulfill];
     }];
@@ -66,7 +66,7 @@
 - (void)testClose
 {
     // This test on sendTextMessage validates sendMessage and sendEvent too
-    [matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
         [bobRestClient sendTextMessageToRoom:roomId text:@"This is text message" success:^(NSString *eventId) {
 
@@ -101,7 +101,7 @@
 - (void)testSendTextMessage
 {
     // This test on sendTextMessage validates sendMessage and sendEvent too
-    [matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
         
         [bobRestClient sendTextMessageToRoom:roomId text:@"This is text message" success:^(NSString *eventId) {
             
@@ -118,7 +118,7 @@
 
 - (void)testRoomTopic
 {
-    [matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
         [bobRestClient setRoomTopic:roomId topic:@"Topic setter and getter functions are tested here" success:^{
             
@@ -143,7 +143,7 @@
 
 - (void)testRoomAvatar
 {
-    [matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
         __block MXRestClient *bobRestClient2 = bobRestClient;
         [bobRestClient setRoomAvatar:roomId avatar:@"http://matrix.org/matrix.png" success:^{
@@ -169,7 +169,7 @@
 
 - (void)testRoomName
 {
-    [matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
         
         __block MXRestClient *bobRestClient2 = bobRestClient;
         [bobRestClient setRoomName:roomId name:@"My room name" success:^{
@@ -195,7 +195,7 @@
 
 - (void)testRoomHistoryVisibility
 {
-    [matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
         __block MXRestClient *bobRestClient2 = bobRestClient;
         [bobRestClient setRoomHistoryVisibility:roomId historyVisibility:kMXRoomHistoryVisibilityInvited success:^{
@@ -221,7 +221,7 @@
 
 - (void)testRoomJoinRule
 {
-    [matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
         __block MXRestClient *bobRestClient2 = bobRestClient;
         [bobRestClient setRoomJoinRule:roomId joinRule:kMXRoomJoinRulePublic success:^{
@@ -247,7 +247,7 @@
 
 - (void)testRoomGuestAccess
 {
-    [matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
         __block MXRestClient *bobRestClient2 = bobRestClient;
         [bobRestClient setRoomGuestAccess:roomId guestAccess:kMXRoomGuestAccessCanJoin success:^{
@@ -273,7 +273,7 @@
 
 - (void)testRoomDirectoryVisibility
 {
-    [matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
         __block MXRestClient *bobRestClient2 = bobRestClient;
         [bobRestClient setRoomDirectoryVisibility:roomId directoryVisibility:kMXRoomDirectoryVisibilityPublic success:^{
@@ -299,7 +299,7 @@
 
 - (void)testRoomAddAlias
 {
-    [matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
         
         NSString *globallyUniqueString = [[NSProcessInfo processInfo] globallyUniqueString];
         NSString *wrongAlias = [NSString stringWithFormat:@"#%@", globallyUniqueString];
@@ -357,7 +357,7 @@
 
 - (void)testRoomRemoveAlias
 {
-    [matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
         
         NSString *globallyUniqueString = [[NSProcessInfo processInfo] globallyUniqueString];
         NSString *roomAlias = [NSString stringWithFormat:@"#%@%@", globallyUniqueString, bobRestClient.homeserverSuffix];
@@ -397,7 +397,7 @@
 
 - (void)testRoomCanonicalAlias
 {
-    [matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
         
         NSString *globallyUniqueString = [[NSProcessInfo processInfo] globallyUniqueString];
         NSString *roomAlias = [NSString stringWithFormat:@"#%@%@", globallyUniqueString, bobRestClient.homeserverSuffix];
@@ -451,7 +451,7 @@
 
 - (void)testJoinRoomWithRoomId
 {
-    [matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
         
         [bobRestClient joinRoom:roomId viaServers:nil withThirdPartySigned:nil success:^(NSString *theRoomId) {
             
@@ -467,9 +467,9 @@
 
 - (void)testJoinRoomWithRoomAlias
 {
-    [matrixSDKTestsData doMXRestClientTestWithBobAndThePublicRoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXRestClientTestWithBobAndThePublicRoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
-        [bobRestClient joinRoom:matrixSDKTestsData.thePublicRoomAlias viaServers:nil withThirdPartySigned:nil success:^(NSString *theRoomId) {
+        [bobRestClient joinRoom:self.matrixSDKTestsData.thePublicRoomAlias viaServers:nil withThirdPartySigned:nil success:^(NSString *theRoomId) {
 
             XCTAssertEqualObjects(roomId, theRoomId);
             [expectation fulfill];
@@ -484,7 +484,7 @@
 
 - (void)testLeaveRoom
 {
-    [matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
         
         [bobRestClient leaveRoom:roomId success:^{
             
@@ -500,12 +500,12 @@
 
 - (void)testInviteUserToRoom
 {
-    [matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
         
-        [matrixSDKTestsData doMXRestClientTestWithAlice:nil readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation2) {
+        [self.matrixSDKTestsData doMXRestClientTestWithAlice:nil readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation2) {
             
             // Do the test
-            [bobRestClient inviteUser:matrixSDKTestsData.aliceCredentials.userId toRoom:roomId success:^{
+            [bobRestClient inviteUser:self.matrixSDKTestsData.aliceCredentials.userId toRoom:roomId success:^{
                 
                 // Check room actual members
                 [bobRestClient membersOfRoom:roomId success:^(NSArray *roomMemberEvents) {
@@ -516,14 +516,14 @@
                     {
                         MXRoomMember *member = [[MXRoomMember alloc] initWithMXEvent:roomMemberEvent];
                         
-                        if ([member.userId isEqualToString:matrixSDKTestsData.aliceCredentials.userId])
+                        if ([member.userId isEqualToString:self.matrixSDKTestsData.aliceCredentials.userId])
                         {
                             XCTAssertEqual(member.membership, MXMembershipInvite, @"A invited user membership is invite, not %tu", member.membership);
                         }
                         else
                         {
                             // The other user is Bob
-                            XCTAssert([member.userId isEqualToString:matrixSDKTestsData.bobCredentials.userId], @"Unexpected member: %@", member);
+                            XCTAssert([member.userId isEqualToString:self.matrixSDKTestsData.bobCredentials.userId], @"Unexpected member: %@", member);
                         }
                     }
                     
@@ -545,9 +545,9 @@
 
 - (void)testKickUserFromRoom
 {
-    [matrixSDKTestsData doMXRestClientTestWithBobAndAliceInARoom:self readyToTest:^(MXRestClient *bobRestClient, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXRestClientTestWithBobAndAliceInARoom:self readyToTest:^(MXRestClient *bobRestClient, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
         
-        [bobRestClient kickUser:matrixSDKTestsData.aliceCredentials.userId fromRoom:roomId reason:@"No particular reason" success:^{
+        [bobRestClient kickUser:self.matrixSDKTestsData.aliceCredentials.userId fromRoom:roomId reason:@"No particular reason" success:^{
             
             // Check room actual members
             [bobRestClient membersOfRoom:roomId success:^(NSArray *roomMemberEvents) {
@@ -558,14 +558,14 @@
                 {
                     MXRoomMember *member = [[MXRoomMember alloc] initWithMXEvent:roomMemberEvent];
                     
-                    if ([member.userId isEqualToString:matrixSDKTestsData.aliceCredentials.userId])
+                    if ([member.userId isEqualToString:self.matrixSDKTestsData.aliceCredentials.userId])
                     {
                         XCTAssertEqual(member.membership, MXMembershipLeave, @"A kicked user membership is leave, not %tu", member.membership);
                     }
                     else
                     {
                         // The other user is Bob
-                        XCTAssert([member.userId isEqualToString:matrixSDKTestsData.bobCredentials.userId], @"Unexpected member: %@", member);
+                        XCTAssert([member.userId isEqualToString:self.matrixSDKTestsData.bobCredentials.userId], @"Unexpected member: %@", member);
                     }
                 }
                 
@@ -585,9 +585,9 @@
 
 - (void)testBanUserInRoom
 {
-    [matrixSDKTestsData doMXRestClientTestWithBobAndAliceInARoom:self readyToTest:^(MXRestClient *bobRestClient, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXRestClientTestWithBobAndAliceInARoom:self readyToTest:^(MXRestClient *bobRestClient, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
         
-        [bobRestClient banUser:matrixSDKTestsData.aliceCredentials.userId inRoom:roomId reason:@"No particular reason" success:^{
+        [bobRestClient banUser:self.matrixSDKTestsData.aliceCredentials.userId inRoom:roomId reason:@"No particular reason" success:^{
             
             // Check room actual members
             [bobRestClient membersOfRoom:roomId success:^(NSArray *roomMemberEvents) {
@@ -598,14 +598,14 @@
                 {
                     MXRoomMember *member = [[MXRoomMember alloc] initWithMXEvent:roomMemberEvent];
                     
-                    if ([member.userId isEqualToString:matrixSDKTestsData.aliceCredentials.userId])
+                    if ([member.userId isEqualToString:self.matrixSDKTestsData.aliceCredentials.userId])
                     {
                         XCTAssertEqual(member.membership, MXMembershipBan, @"A banned user membership is ban, not %tu", member.membership);
                     }
                     else
                     {
                         // The other user is Bob
-                        XCTAssert([member.userId isEqualToString:matrixSDKTestsData.bobCredentials.userId], @"Unexpected member: %@", member);
+                        XCTAssert([member.userId isEqualToString:self.matrixSDKTestsData.bobCredentials.userId], @"Unexpected member: %@", member);
                     }
                 }
                 
@@ -625,7 +625,7 @@
 
 - (void)testCreateRoom
 {
-    [matrixSDKTestsData doMXRestClientTestWithBob:self readyToTest:^(MXRestClient *bobRestClient, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXRestClientTestWithBob:self readyToTest:^(MXRestClient *bobRestClient, XCTestExpectation *expectation) {
         
         // Create a random room with no params
         [bobRestClient createRoom:nil visibility:nil roomAlias:nil topic:nil success:^(MXCreateRoomResponse *response) {
@@ -646,13 +646,13 @@
 
 - (void)testCreateRoomWithInvite
 {
-    [matrixSDKTestsData doMXRestClientTestWithBob:self readyToTest:^(MXRestClient *bobRestClient, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXRestClientTestWithBob:self readyToTest:^(MXRestClient *bobRestClient, XCTestExpectation *expectation) {
         
-        [matrixSDKTestsData doMXRestClientTestWithAlice:nil readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation2) {
+        [self.matrixSDKTestsData doMXRestClientTestWithAlice:nil readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation2) {
             
             // Create a random room by inviting alice
             MXRoomCreationParameters *parameters = [MXRoomCreationParameters new];
-            parameters.inviteArray = @[matrixSDKTestsData.aliceCredentials.userId];
+            parameters.inviteArray = @[self.matrixSDKTestsData.aliceCredentials.userId];
             [bobRestClient createRoomWithParameters:parameters success:^(MXCreateRoomResponse *response) {
                 
                 XCTAssertNotNil(response);
@@ -668,9 +668,9 @@
                     BOOL succeed;
                     if ([roomMemberEvent1.stateKey isEqualToString:bobRestClient.credentials.userId])
                     {
-                        succeed = [roomMemberEvent2.stateKey isEqualToString:matrixSDKTestsData.aliceCredentials.userId];
+                        succeed = [roomMemberEvent2.stateKey isEqualToString:self.matrixSDKTestsData.aliceCredentials.userId];
                     }
-                    else if ([roomMemberEvent1.stateKey isEqualToString:matrixSDKTestsData.aliceCredentials.userId])
+                    else if ([roomMemberEvent1.stateKey isEqualToString:self.matrixSDKTestsData.aliceCredentials.userId])
                     {
                         succeed = [roomMemberEvent2.stateKey isEqualToString:bobRestClient.credentials.userId];
                     }
@@ -696,7 +696,7 @@
 
 - (void)testMessagesWithNoParams
 {
-    [matrixSDKTestsData  doMXRestClientTestWithBobAndARoomWithMessages:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData  doMXRestClientTestWithBobAndARoomWithMessages:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
         
         [bobRestClient messagesForRoom:roomId from:nil direction:MXTimelineDirectionBackwards limit:-1 filter:nil success:^(MXPaginationResponse *paginatedResponse) {
             
@@ -718,7 +718,7 @@
 
 - (void)testMessagesWithOneParam
 {
-    [matrixSDKTestsData  doMXRestClientTestWithBobAndARoomWithMessages:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData  doMXRestClientTestWithBobAndARoomWithMessages:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
         [bobRestClient messagesForRoom:roomId from:nil direction:MXTimelineDirectionBackwards limit:100 filter:nil success:^(MXPaginationResponse *paginatedResponse) {
 
@@ -740,7 +740,7 @@
 
 - (void)testMembers
 {
-    [matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
         
         [bobRestClient membersOfRoom:roomId success:^(NSArray *roomMemberEvents) {
             
@@ -761,7 +761,7 @@
 
 - (void)testStateOfRoom
 {
-    [matrixSDKTestsData doMXRestClientTestWithBobAndARoomWithMessages:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXRestClientTestWithBobAndARoomWithMessages:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
         
         [bobRestClient stateOfRoom:roomId success:^(NSDictionary *JSONData) {
             
@@ -791,7 +791,7 @@
 
 - (void)testSendTypingNotification
 {
-    [matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
         [bobRestClient sendTypingNotificationInRoom:roomId typing:YES timeout:30000 success:^{
 
@@ -813,7 +813,7 @@
 
 - (void)testRedactEvent
 {
-    [matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
         [bobRestClient sendTextMessageToRoom:roomId text:@"This is text message" success:^(NSString *eventId) {
 
@@ -835,7 +835,7 @@
 
 - (void)testInitialSyncOfRoom
 {
-    [matrixSDKTestsData doMXRestClientTestWithBobAndARoomWithMessages:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXRestClientTestWithBobAndARoomWithMessages:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
         
         [bobRestClient initialSyncOfRoom:roomId withLimit:3 success:^(MXRoomInitialSync *roomInitialSync) {
             
@@ -871,7 +871,7 @@
 
 - (void)testEventWithEventId
 {
-    [matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
         NSString *message = @"This is text message";
 
@@ -903,7 +903,7 @@
 
 - (void)testEventWithEventIdInRoomId
 {
-    [matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
         NSString *message = @"This is text message";
 
@@ -935,7 +935,7 @@
 
 - (void)testContextOfEvent
 {
-    [matrixSDKTestsData doMXRestClientTestWithBobAndARoomWithMessages:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXRestClientTestWithBobAndARoomWithMessages:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
         [bobRestClient initialSyncOfRoom:roomId withLimit:10 success:^(MXRoomInitialSync *roomInitialSync) {
 
@@ -986,7 +986,7 @@
 
 - (void)testMXRoomMemberEventContent
 {
-    [matrixSDKTestsData doMXRestClientTestWithBobAndAliceInARoom:self readyToTest:^(MXRestClient *bobRestClient, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXRestClientTestWithBobAndAliceInARoom:self readyToTest:^(MXRestClient *bobRestClient, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
         
         [bobRestClient membersOfRoom:roomId success:^(NSArray *roomMemberEvents) {
             for (MXEvent *roomMemberEvent in roomMemberEvents)
@@ -1012,7 +1012,7 @@
 #pragma mark - Room tags operations
 - (void)testAddAndRemoveTag
 {
-    [matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
         // Add a new tag
         [bobRestClient addTag:@"aTag" withOrder:nil toRoom:roomId success:^{
 
@@ -1055,7 +1055,7 @@
 #pragma mark - Filter operations
 - (void)testFilter
 {
-    [matrixSDKTestsData doMXRestClientTestWithAlice:self readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXRestClientTestWithAlice:self readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation) {
 
         MXFilterJSONModel *filter = [[MXFilterJSONModel alloc] init];
 
@@ -1116,7 +1116,7 @@
 #pragma mark - Profile operations
 - (void)testUserDisplayName
 {
-    [matrixSDKTestsData doMXRestClientTestWithAlice:self readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXRestClientTestWithAlice:self readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation) {
         
         __block MXRestClient *aliceRestClient2 = aliceRestClient;
         
@@ -1144,16 +1144,16 @@
 
 - (void)testOtherUserDisplayName
 {
-    [matrixSDKTestsData doMXRestClientTestWithAlice:self readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXRestClientTestWithAlice:self readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation) {
         
         // Set the name
         __block NSString *newDisplayName = @"mxAlice2";
         [aliceRestClient setDisplayName:newDisplayName success:^{
             
-            [matrixSDKTestsData doMXRestClientTestWithBob:nil readyToTest:^(MXRestClient *bobRestClient, XCTestExpectation *expectation2) {
+            [self.matrixSDKTestsData doMXRestClientTestWithBob:nil readyToTest:^(MXRestClient *bobRestClient, XCTestExpectation *expectation2) {
                 
                 // Then retrieve it from a Bob restClient
-                [bobRestClient displayNameForUser:matrixSDKTestsData.aliceCredentials.userId success:^(NSString *displayname) {
+                [bobRestClient displayNameForUser:self.matrixSDKTestsData.aliceCredentials.userId success:^(NSString *displayname) {
                     
                     XCTAssertTrue([displayname isEqualToString:newDisplayName], @"Must retrieved the set string: %@ - %@", displayname, newDisplayName);
                     [expectation fulfill];
@@ -1175,7 +1175,7 @@
 // local part of the user id as the default displayname
 //- (void)testUserNilDisplayName
 //{
-//    [matrixSDKTestsData doMXRestClientTestWithBob:self readyToTest:^(MXRestClient *bobRestClient, XCTestExpectation *expectation) {
+//    [self.matrixSDKTestsData doMXRestClientTestWithBob:self readyToTest:^(MXRestClient *bobRestClient, XCTestExpectation *expectation) {
 //
 //        [bobRestClient displayNameForUser:nil success:^(NSString *displayname) {
 //
@@ -1192,7 +1192,7 @@
 
 - (void)testUserAvatarUrl
 {
-    [matrixSDKTestsData doMXRestClientTestWithAlice:self readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXRestClientTestWithAlice:self readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation) {
 
         // Set the avatar url
         __block NSString *newAvatarUrl = @"http://matrix.org/matrix2.png";
@@ -1218,16 +1218,16 @@
 
 - (void)testOtherUserAvatarUrl
 {
-    [matrixSDKTestsData doMXRestClientTestWithAlice:self readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXRestClientTestWithAlice:self readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation) {
 
         // Set the avatar url
         __block NSString *newAvatarUrl = @"http://matrix.org/matrix2.png";
         [aliceRestClient setAvatarUrl:newAvatarUrl success:^{
 
-            [matrixSDKTestsData doMXRestClientTestWithBob:nil readyToTest:^(MXRestClient *bobRestClient, XCTestExpectation *expectation2) {
+            [self.matrixSDKTestsData doMXRestClientTestWithBob:nil readyToTest:^(MXRestClient *bobRestClient, XCTestExpectation *expectation2) {
 
                 // Then retrieve it from a Bob restClient
-                [bobRestClient avatarUrlForUser:matrixSDKTestsData.aliceCredentials.userId success:^(NSString *avatarUrl) {
+                [bobRestClient avatarUrlForUser:self.matrixSDKTestsData.aliceCredentials.userId success:^(NSString *avatarUrl) {
 
                     XCTAssertEqualObjects(avatarUrl, newAvatarUrl);
                     [expectation fulfill];
@@ -1250,7 +1250,7 @@
 - (void)testUserPresence
 {
     // Make sure the test is valid once the bug is fixed server side
-    [matrixSDKTestsData doMXRestClientTestWithAlice:self readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXRestClientTestWithAlice:self readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation) {
         
         __block MXRestClient *aliceRestClient2 = aliceRestClient;
         
@@ -1286,7 +1286,7 @@
 // The test must be updated if those HS default rules change.
 - (void)testPushRules
 {
-    [matrixSDKTestsData doMXRestClientTestWithBob:self readyToTest:^(MXRestClient *bobRestClient, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXRestClientTestWithBob:self readyToTest:^(MXRestClient *bobRestClient, XCTestExpectation *expectation) {
 
         [bobRestClient pushRules:^(MXPushRulesResponse *pushRules) {
 
@@ -1345,7 +1345,7 @@
 #pragma mark - Search
 - (void)testSearchText
 {
-    [matrixSDKTestsData doMXRestClientTestWithBobAndARoomWithMessages:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXRestClientTestWithBobAndARoomWithMessages:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
         
         MXRoomEventFilter *roomEventFilter = [[MXRoomEventFilter alloc] init];
         roomEventFilter.rooms = @[roomId];
@@ -1380,7 +1380,7 @@
 
 - (void)testSearchUniqueTextAcrossRooms
 {
-    [matrixSDKTestsData doMXSessionTestWithBobAndARoomWithMessages:self readyToTest:^(MXSession *mxSession, MXRoom *room, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXSessionTestWithBobAndARoomWithMessages:self readyToTest:^(MXSession *mxSession, MXRoom *room, XCTestExpectation *expectation) {
 
         NSString *message = [[NSProcessInfo processInfo] globallyUniqueString];
         __block NSString *messageEventId;
@@ -1423,10 +1423,10 @@
 
 - (void)testSearchPaginate
 {
-    [matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
         
         // Add 50 messages to the room
-        [matrixSDKTestsData for:bobRestClient andRoom:roomId sendMessages:20 testCase:self success:^{
+        [self.matrixSDKTestsData for:bobRestClient andRoom:roomId sendMessages:20 testCase:self success:^{
             
             MXRoomEventFilter *roomEventFilter = [[MXRoomEventFilter alloc] init];
             roomEventFilter.rooms = @[roomId];
@@ -1497,7 +1497,7 @@
 #pragma mark - Users search
 - (void)testUsersSearch
 {
-    [matrixSDKTestsData doMXRestClientTestWithBobAndAliceInARoom:self readyToTest:^(MXRestClient *bobRestClient, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXRestClientTestWithBobAndAliceInARoom:self readyToTest:^(MXRestClient *bobRestClient, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
         // Do a search with no expected results
         [bobRestClient searchUsers:@"random" limit:1 success:^(MXUserSearchResponse *userSearchResponse) {
@@ -1519,7 +1519,7 @@
 #ifdef MX_CRYPTO
 - (void)testDeviceKeys
 {
-    [matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
         NSString *ed25519key = @"wV5E3EUSHpHuoZLljNzojlabjGdXT3Mz7rugG9zgbkI";
 
@@ -1535,9 +1535,11 @@
         [bobRestClient uploadKeys:bobDevice.JSONDictionary oneTimeKeys:nil success:^(MXKeysUploadResponse *keysUploadResponse) {
 
             XCTAssert(keysUploadResponse.oneTimeKeyCounts);
-            XCTAssertEqual(keysUploadResponse.oneTimeKeyCounts.count, 0, @"There is no yet one-time keys");
-
-            XCTAssertEqual([keysUploadResponse oneTimeKeyCountsForAlgorithm:@"deded"], 0, @"It must response 0 for any algo");
+            
+            [keysUploadResponse.oneTimeKeyCounts enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSNumber *obj, BOOL *stop) {
+                XCTAssertEqual(obj.unsignedIntValue, 0, @"There shouldn't be any one time keys at this point");
+                XCTAssertEqual([keysUploadResponse oneTimeKeyCountsForAlgorithm:key], 0, @"There shouldn't be any one time keys at this point");
+            }];
 
             // And download back it
             [bobRestClient downloadKeysForUsers:@[bobRestClient.credentials.userId] token:nil success:^(MXKeysQueryResponse *keysQueryResponse) {
@@ -1569,21 +1571,28 @@
 
 - (void)testOneTimeKeys
 {
-    [matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
-
+    [self.matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
+        
         NSDictionary *otks = @{
-                              @"curve25519:AAAABQ": @"ueuHES/Q0P1MZ4J3IUpC8iQTkgQNX66ZpxVLUaTDuB8",
-                              @"curve25519:AAAABA": @"PmyaaB68Any+za9CuZXzFsQZW31s/TW6XbAB9akEpQs"
-                              };
-
+            @"curve25519:AAAABQ": @"ueuHES/Q0P1MZ4J3IUpC8iQTkgQNX66ZpxVLUaTDuB8",
+            @"curve25519:AAAABA": @"PmyaaB68Any+za9CuZXzFsQZW31s/TW6XbAB9akEpQs"
+        };
+        
         // Upload the device keys
         [bobRestClient uploadKeys:nil oneTimeKeys:otks success:^(MXKeysUploadResponse *keysUploadResponse) {
-
             XCTAssert(keysUploadResponse.oneTimeKeyCounts);
-            XCTAssertEqual(keysUploadResponse.oneTimeKeyCounts.count, 1, @"There is no yet one-time keys");
-
-            XCTAssertEqual([keysUploadResponse oneTimeKeyCountsForAlgorithm:@"curve25519"], 2, @"It must response 2 for 'curve25519'");
-            XCTAssertEqual([keysUploadResponse oneTimeKeyCountsForAlgorithm:@"deded"], 0, @"It must response 0 for any other algo");
+            
+            XCTAssertEqual(keysUploadResponse.oneTimeKeyCounts[@"curve25519"].unsignedIntValue, 2, @"Key count must be 2 for 'curve25519'");
+            XCTAssertEqual([keysUploadResponse oneTimeKeyCountsForAlgorithm:@"curve25519"], 2, @"Key count must be 2 for 'curve25519'");
+            
+            [keysUploadResponse.oneTimeKeyCounts enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSNumber *obj, BOOL *stop) {
+                if ([key isEqualToString:@"curve25519"]) {
+                    return;
+                }
+                
+                XCTAssertEqual(obj.unsignedIntValue, 0, @"Key count must be 0 for any other algorithm.");
+                XCTAssertEqual([keysUploadResponse oneTimeKeyCountsForAlgorithm:key], 0, @"Key count must be 0 for any other algorithm.");
+            }];
 
             [expectation fulfill];
 
@@ -1596,31 +1605,31 @@
 
 - (void)testClaimOneTimeKeysForUsersDevices
 {
-    [matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
-
+    [self.matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
+        
         NSDictionary *otks = @{
-                               @"curve25519:AAAABQ": @{
-                                       @"key": @"ueuHES/Q0P1MZ4J3IUpC8iQTkgQNX66ZpxVLUaTDuB8",
-                                       @"signatures": @{
-                                               @"@mxAlice:localhost:8480": @{
-                                                       @"ed25519:OSXDWZOVKR": @"fw0H0YWu9HJ2vNFB3pEzVLc9NpQAKXlUZR/2mJUEUzl+ptYtnroG7JSONITtvSZFJIol7b7iSs5pVM0NFr+sBg"
-                                                       }
-                                               }
-                                       },
-                               @"curve25519:AAAABA": @{
-                                       @"key": @"PmyaaB68Any+za9CuZXzFsQZW31s/TW6XbAB9akEpQs",
-                                       @"signatures": @{
-                                               @"@mxAlice:localhost:8480": @{
-                                                       @"ed25519:OSXDWZOVKR": @"fw0H0YWu9HJ2vNFB3pEzVLc9NpQAKXlUZR/2mJUEUzl+ptYtnroG7JSONITtvSZFJIol7b7iSs5pVM0NFr+sBg"
-                                                       }
-                                               }
-                                       }
-                               };
+            @"curve25519:AAAABQ": @{
+                    @"key": @"ueuHES/Q0P1MZ4J3IUpC8iQTkgQNX66ZpxVLUaTDuB8",
+                    @"signatures": @{
+                            @"@mxAlice:localhost:8480": @{
+                                    @"ed25519:OSXDWZOVKR": @"fw0H0YWu9HJ2vNFB3pEzVLc9NpQAKXlUZR/2mJUEUzl+ptYtnroG7JSONITtvSZFJIol7b7iSs5pVM0NFr+sBg"
+                            }
+                    }
+            },
+            @"curve25519:AAAABA": @{
+                    @"key": @"PmyaaB68Any+za9CuZXzFsQZW31s/TW6XbAB9akEpQs",
+                    @"signatures": @{
+                            @"@mxAlice:localhost:8480": @{
+                                    @"ed25519:OSXDWZOVKR": @"fw0H0YWu9HJ2vNFB3pEzVLc9NpQAKXlUZR/2mJUEUzl+ptYtnroG7JSONITtvSZFJIol7b7iSs5pVM0NFr+sBg"
+                            }
+                    }
+            }
+        };
 
         // Upload the device keys
         [bobRestClient uploadKeys:nil oneTimeKeys:otks success:^(MXKeysUploadResponse *keysUploadResponse) {
 
-            [matrixSDKTestsData doMXRestClientTestWithAlice:nil readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation2) {
+            [self.matrixSDKTestsData doMXRestClientTestWithAlice:nil readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation2) {
 
                 MXUsersDevicesMap<NSString *> *usersDevicesKeyTypesMap = [[MXUsersDevicesMap alloc] init];
                 [usersDevicesKeyTypesMap setObject:@"curve25519" forUser:bobRestClient.credentials.userId andDevice:bobRestClient.credentials.deviceId];
@@ -1662,7 +1671,7 @@
 
 - (void)testDevices
 {
-    [matrixSDKTestsData doMXRestClientTestWithAlice:self readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXRestClientTestWithAlice:self readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation) {
         
         // Get the devices
         [aliceRestClient devices:^(NSArray<MXDevice *> *devices){
@@ -1680,7 +1689,7 @@
 
 - (void)testDeviceByDeviceId
 {
-    [matrixSDKTestsData doMXRestClientTestWithAlice:self readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXRestClientTestWithAlice:self readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation) {
         
         // Get the devices
         [aliceRestClient devices:^(NSArray<MXDevice *> *devices){
@@ -1713,7 +1722,7 @@
 
 - (void)testSetDeviceName
 {
-    [matrixSDKTestsData doMXRestClientTestWithAlice:self readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXRestClientTestWithAlice:self readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation) {
         
         // Get the devices
         [aliceRestClient devices:^(NSArray<MXDevice *> *devices){
@@ -1753,7 +1762,7 @@
 
 - (void)testThirdpartyProtocols
 {
-    [matrixSDKTestsData doMXRestClientTestWithBob:self readyToTest:^(MXRestClient *bobRestClient, XCTestExpectation *expectation) {
+    [self.matrixSDKTestsData doMXRestClientTestWithBob:self readyToTest:^(MXRestClient *bobRestClient, XCTestExpectation *expectation) {
 
         [bobRestClient thirdpartyProtocols:^(MXThirdpartyProtocolsResponse *thirdpartyProtocolsResponse) {
 

--- a/MatrixSDKTests/MXSessionTests.m
+++ b/MatrixSDKTests/MXSessionTests.m
@@ -770,9 +770,12 @@
             XCTAssertNil(syncResponse.presence, @"Presence should be nil");
             XCTAssertNil(syncResponse.toDevice, @"To device events should be nil");
             XCTAssertNil(syncResponse.deviceLists, @"Device lists should be nil");
-            XCTAssertNil(syncResponse.deviceOneTimeKeysCount, @"Device one time keys count should be nil");
             XCTAssertNil(syncResponse.rooms, @"Rooms should be nil");
             XCTAssertNil(syncResponse.groups, @"Groups should be nil");
+            XCTAssertEqual(syncResponse.unusedFallbackKeys.count, 0, @"Device shouldn't have any fallback keys");
+            for (NSNumber *numberOfKeys in syncResponse.deviceOneTimeKeysCount.allKeys) {
+                XCTAssertEqual(numberOfKeys.unsignedIntValue, 0, @"Device shouldn't have any one time keys");
+            }
 
             [expectation fulfill];
         }];

--- a/MatrixSDKTests/MatrixSDKTestsData.h
+++ b/MatrixSDKTests/MatrixSDKTestsData.h
@@ -41,7 +41,7 @@ FOUNDATION_EXPORT NSString * const kMXTestsAliceAvatarURL;
 
 #pragma mark - mxBob
 // Credentials for the user mxBob on the home server located at kMXTestsHomeServerURL
-@property (nonatomic, readonly) MXCredentials *bobCredentials;
+@property (nonatomic, strong, readonly) MXCredentials *bobCredentials;
 
 // Get credentials asynchronously
 // The user will be created if needed
@@ -91,7 +91,7 @@ FOUNDATION_EXPORT NSString * const kMXTestsAliceAvatarURL;
 
 
 #pragma mark - mxAlice
-@property (nonatomic, readonly) MXCredentials *aliceCredentials;
+@property (nonatomic, strong, readonly) MXCredentials *aliceCredentials;
 
 - (void)doMXRestClientTestWithAlice:(XCTestCase*)testCase
                         readyToTest:(void (^)(MXRestClient *aliceRestClient, XCTestExpectation *expectation))readyToTest;
@@ -104,8 +104,8 @@ FOUNDATION_EXPORT NSString * const kMXTestsAliceAvatarURL;
 
 #pragma mark - both
 // The id and alias used for the public room created with *ThePublicRoom* methods
-@property (nonatomic,readonly) NSString *thePublicRoomId;
-@property (nonatomic,readonly) NSString *thePublicRoomAlias;
+@property (nonatomic, strong, readonly) NSString *thePublicRoomId;
+@property (nonatomic, strong, readonly) NSString *thePublicRoomAlias;
 
 - (void)doMXRestClientTestWithBobAndAliceInARoom:(XCTestCase*)testCase
                                      readyToTest:(void (^)(MXRestClient *bobRestClient, MXRestClient *aliceRestClient, NSString* roomId, XCTestExpectation *expectation))readyToTest;

--- a/MatrixSDKTests/MatrixSDKTestsData.m
+++ b/MatrixSDKTests/MatrixSDKTestsData.m
@@ -42,29 +42,35 @@ NSString * const kMXTestsAliceAvatarURL = @"mxc://matrix.org/kciiXusgZFKuNLIfLqm
 
 
 @interface MatrixSDKTestsData ()
-{
-    NSDate *startDate;
 
-    NSMutableArray <NSObject*> *retainedObjects;
-}
+@property (nonatomic, strong, readonly)NSDate *startDate;
+
+@property (nonatomic, strong, readonly) NSMutableArray <NSObject*> *retainedObjects;
+
+@property (nonatomic, strong) MXCredentials *aliceCredentials;
+@property (nonatomic, strong) MXCredentials *bobCredentials;
+
+@property (nonatomic, strong) NSString *thePublicRoomId;
+@property (nonatomic, strong) NSString *thePublicRoomAlias;
+
 @end
 
 @implementation MatrixSDKTestsData
 
 - (id)init
 {
-    self = [super init];
-    if (self)
+    if (self = [super init])
     {
-        startDate = [NSDate date];
-        retainedObjects = [NSMutableArray array];
+        _startDate = [NSDate date];
+        _retainedObjects = [NSMutableArray array];
     }
+    
     return self;
 }
 
 - (void)dealloc
 {
-    retainedObjects = [NSMutableArray array];
+    _retainedObjects = [NSMutableArray array];
 }
 
 - (void)getBobCredentials:(XCTestCase*)testCase
@@ -87,7 +93,7 @@ NSString * const kMXTestsAliceAvatarURL = @"mxc://matrix.org/kciiXusgZFKuNLIfLqm
         // First, try register the user
         MXHTTPOperation *operation = [mxRestClient registerWithLoginType:kMXLoginFlowTypeDummy username:bobUniqueUser password:MXTESTS_BOB_PWD success:^(MXCredentials *credentials) {
 
-            _bobCredentials = credentials;
+            self.bobCredentials = credentials;
             readyToTest();
             
         } failure:^(NSError *error) {
@@ -98,7 +104,7 @@ NSString * const kMXTestsAliceAvatarURL = @"mxc://matrix.org/kciiXusgZFKuNLIfLqm
                 // Log Bob in to get his keys
                 [mxRestClient loginWithLoginType:kMXLoginFlowTypeDummy username:bobUniqueUser password:MXTESTS_BOB_PWD success:^(MXCredentials *credentials) {
                     
-                    _bobCredentials = credentials;
+                    self.bobCredentials = credentials;
                     readyToTest();
                     
                 } failure:^(NSError *error) {
@@ -193,22 +199,22 @@ NSString * const kMXTestsAliceAvatarURL = @"mxc://matrix.org/kciiXusgZFKuNLIfLqm
 {
     [self doMXRestClientTestWithBob:testCase readyToTest:^(MXRestClient *bobRestClient, XCTestExpectation *expectation) {
 
-        if (_thePublicRoomId)
+        if (self.thePublicRoomId)
         {
-            readyToTest(bobRestClient, _thePublicRoomId, expectation);
+            readyToTest(bobRestClient, self.thePublicRoomId, expectation);
         }
         else
         {
             // Create a public room starting with #mxPublic
-            _thePublicRoomAlias = [NSString stringWithFormat:@"mxPublic-%@", [[NSUUID UUID] UUIDString]];
+            self.thePublicRoomAlias = [NSString stringWithFormat:@"mxPublic-%@", [[NSUUID UUID] UUIDString]];
 
             [bobRestClient createRoom:@"MX Public Room test"
                            visibility:kMXRoomDirectoryVisibilityPublic
-                            roomAlias:_thePublicRoomAlias
+                            roomAlias:self.thePublicRoomAlias
                                 topic:@"The public room used by SDK tests"
                               success:^(MXCreateRoomResponse *response) {
 
-                                  _thePublicRoomId = response.roomId;
+                                  self.thePublicRoomId = response.roomId;
                                   readyToTest(bobRestClient, response.roomId, expectation);
 
                               } failure:^(NSError *error) {
@@ -303,7 +309,7 @@ NSString * const kMXTestsAliceAvatarURL = @"mxc://matrix.org/kciiXusgZFKuNLIfLqm
     }
     else
     {
-        [mxRestClient2 sendTextMessageToRoom:roomId text:[NSString stringWithFormat:@"Fake message sent at %.0f ms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000]
+        [mxRestClient2 sendTextMessageToRoom:roomId text:[NSString stringWithFormat:@"Fake message sent at %.0f ms", [[NSDate date] timeIntervalSinceDate:self.startDate] * 1000]
                            success:^(NSString *eventId) {
 
             // Send the next message
@@ -471,7 +477,7 @@ NSString * const kMXTestsAliceAvatarURL = @"mxc://matrix.org/kciiXusgZFKuNLIfLqm
         // First, try register the user
         MXHTTPOperation *operation = [mxRestClient registerWithLoginType:kMXLoginFlowTypeDummy username:aliceUniqueUser password:MXTESTS_ALICE_PWD success:^(MXCredentials *credentials) {
             
-            _aliceCredentials = credentials;
+            self.aliceCredentials = credentials;
             readyToTest();
             
         } failure:^(NSError *error) {
@@ -482,7 +488,7 @@ NSString * const kMXTestsAliceAvatarURL = @"mxc://matrix.org/kciiXusgZFKuNLIfLqm
                 // Log Alice in to get his keys
                 [mxRestClient loginWithLoginType:kMXLoginFlowTypeDummy username:aliceUniqueUser password:MXTESTS_ALICE_PWD success:^(MXCredentials *credentials) {
 
-                    _aliceCredentials = credentials;
+                    self.aliceCredentials = credentials;
                     readyToTest();
                     
                 } failure:^(NSError *error) {
@@ -757,7 +763,7 @@ onUnrecognizedCertificateBlock:(MXHTTPClientOnUnrecognizedCertificate)onUnrecogn
         // First, try register the user
         MXHTTPOperation *operation = [mxRestClient registerWithLoginType:kMXLoginFlowTypeDummy username:bobUniqueUser password:MXTESTS_BOB_PWD success:^(MXCredentials *credentials) {
 
-            _bobCredentials = credentials;
+            self.bobCredentials = credentials;
             readyToTest();
 
         } failure:^(NSError *error) {
@@ -768,7 +774,7 @@ onUnrecognizedCertificateBlock:(MXHTTPClientOnUnrecognizedCertificate)onUnrecogn
                 // Log Bob in to get his keys
                 [mxRestClient loginWithLoginType:kMXLoginFlowTypeDummy username:bobUniqueUser password:MXTESTS_BOB_PWD success:^(MXCredentials *credentials) {
 
-                    _bobCredentials = credentials;
+                    self.bobCredentials = credentials;
                     readyToTest();
 
                 } failure:^(NSError *error) {
@@ -1009,7 +1015,7 @@ onUnrecognizedCertificateBlock:(MXHTTPClientOnUnrecognizedCertificate)onUnrecogn
 #pragma mark Reference keeping
 - (void)retain:(NSObject*)object
 {
-    [retainedObjects addObject:object];
+    [self.retainedObjects addObject:object];
 }
 
 @end

--- a/Podfile
+++ b/Podfile
@@ -7,7 +7,7 @@ abstract_target 'MatrixSDK' do
 
     pod 'SwiftyBeaver', '1.9.5'
     
-    pod 'OLMKit', '~> 3.2.4', :inhibit_warnings => true
+    pod 'OLMKit', '~> 3.2.5', :inhibit_warnings => true
     #pod 'OLMKit', :path => '../olm/OLMKit.podspec'
     
     pod 'Realm', '10.7.6'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -29,11 +29,11 @@ PODS:
   - OHHTTPStubs/NSURLSession (9.1.0):
     - OHHTTPStubs/Core
   - OHHTTPStubs/OHPathHelpers (9.1.0)
-  - OLMKit (3.2.4):
-    - OLMKit/olmc (= 3.2.4)
-    - OLMKit/olmcpp (= 3.2.4)
-  - OLMKit/olmc (3.2.4)
-  - OLMKit/olmcpp (3.2.4)
+  - OLMKit (3.2.5):
+    - OLMKit/olmc (= 3.2.5)
+    - OLMKit/olmcpp (= 3.2.5)
+  - OLMKit/olmc (3.2.5)
+  - OLMKit/olmcpp (3.2.5)
   - Realm (10.7.6):
     - Realm/Headers (= 10.7.6)
   - Realm/Headers (10.7.6)
@@ -44,7 +44,7 @@ DEPENDENCIES:
   - GZIP (~> 1.3.0)
   - libbase58 (~> 0.1.4)
   - OHHTTPStubs (~> 9.1.0)
-  - OLMKit (~> 3.2.4)
+  - OLMKit (~> 3.2.5)
   - Realm (= 10.7.6)
   - SwiftyBeaver (= 1.9.5)
 
@@ -63,10 +63,10 @@ SPEC CHECKSUMS:
   GZIP: 416858efbe66b41b206895ac6dfd5493200d95b3
   libbase58: 7c040313537b8c44b6e2d15586af8e21f7354efd
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
-  OLMKit: 2d73cd67d149b5c3e3a8eb8ecae93d0b429d8a02
+  OLMKit: 9fb4799c4a044dd2c06bda31ec31a12191ad30b5
   Realm: ed860452717c8db8f4bf832b6807f7f2ce708839
   SwiftyBeaver: 84069991dd5dca07d7069100985badaca7f0ce82
 
-PODFILE CHECKSUM: b0507b1015a54cf1383ca163c439a86ace34824e
+PODFILE CHECKSUM: ca61b137d30e689c0afb8cb0ffe424c3e276bab6
 
 COCOAPODS: 1.10.2

--- a/changelog.d/4406.feature
+++ b/changelog.d/4406.feature
@@ -1,0 +1,1 @@
+Implemented Olm fallback key support.


### PR DESCRIPTION
Implements vector-im/element-ios/issues/4406 - Olm fallback key support. NB this PR requires the current development version of Olm (future 3.2.5 release presumably) 