### PR TITLE
Account Notification Settings and Keywords.

### DIFF
--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -737,7 +737,22 @@ typedef MXHTTPOperation* (^MXRestClientIdentityServerAccessTokenHandler)(void (^
                          success:(void (^)(void))success
                          failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
+/**
+ Update push rule actions.
 
+ @param ruleId The identifier for the rule (it depends on rule kind: user id for sender rule, room id for room rule...).
+ @param scope Either 'global' or 'device/<profile_tag>' to specify global rules or device rules for the given profile_tag.
+ @param kind The kind of rule, ie. 'sender', 'room' or 'content' (see MXPushRuleKind).
+ @param actions The rule actions: notify, don't notify, set tweak...
+ @param success A block object called when the operation succeeds.
+ @param failure A block object called when the operation fails.
+ */
+- (MXHTTPOperation *)updateActionsForPushRule:(NSString*)ruleId
+                                        scope:(NSString*)scope
+                                         kind:(MXPushRuleKind)kind
+                                      actions:(NSArray*)actions
+                                      success:(void (^)(void))success
+                                      failure:(void (^)(NSError *error))failure;
 #pragma mark - Room operations
 /**
  Send a generic non state event to a room.

--- a/MatrixSDK/NotificationCenter/MXNotificationCenter.h
+++ b/MatrixSDK/NotificationCenter/MXNotificationCenter.h
@@ -237,7 +237,7 @@ extern NSString *const kMXNotificationCenterAllOtherRoomMessagesRuleID;
  @param sound enable/disable sound during notification.
  @param highlight enable/disable highlight option.
  */
-- (void)addContentRuleWithMatchingRuleIdAndPattern:(NSString *)pattern
+- (void)addContentRuleWithRuleIdMatchingPattern:(NSString *)pattern
                                             notify:(BOOL)notify
                                              sound:(NSString *)sound
                                          highlight:(BOOL)highlight;

--- a/MatrixSDK/NotificationCenter/MXNotificationCenter.h
+++ b/MatrixSDK/NotificationCenter/MXNotificationCenter.h
@@ -201,8 +201,24 @@ extern NSString *const kMXNotificationCenterAllOtherRoomMessagesRuleID;
 - (void)enableRule:(MXPushRule*)pushRule isEnabled:(BOOL)enable;
 
 /**
- Create a content push rule, see MXNotificationCenter notifications for operation result.
+ Update the actions for an existing push rule.
  
+ @param ruleId the rule identifier.
+ @param kind The kind of rule, ie. 'sender', 'room' or 'content' (see MXPushRuleKind).
+ @param notify enable/disable notification.
+ @param soundName the name of the sound to apply (`ring`, `default`, etc).
+ @param highlight enable/disable highlight option.
+ */
+- (void)updatePushRuleActions:(NSString*)ruleId
+                         kind:(MXPushRuleKind)kind
+                       notify:(BOOL)notify
+                    soundName:(NSString*)soundName
+                    highlight:(BOOL)highlight;
+
+/**
+ Create a content push rule, see MXNotificationCenter notifications for operation result.
+ Generates a ruleID from pattern by restricting characaters to [a-zA-Z123456789_]
+ and adding an integer on the end if there is a clash.
  @param pattern the pattern on which the content rule is based.
  @param notify enable/disable notification on events that match with the pattern.
  @param sound enable/disable sound during notification.
@@ -212,6 +228,19 @@ extern NSString *const kMXNotificationCenterAllOtherRoomMessagesRuleID;
                 notify:(BOOL)notify
                  sound:(BOOL)sound
              highlight:(BOOL)highlight;
+
+/**
+ Create a content push rule, see MXNotificationCenter notifications for operation result.
+ Uses pattern as ruleId.
+ @param pattern enable/disable notification.
+ @param notify enable/disable notification on events that match with the pattern.
+ @param sound enable/disable sound during notification.
+ @param highlight enable/disable highlight option.
+ */
+- (void)addContentRuleWithMatchingRuleIdAndPattern:(NSString *)pattern
+                                            notify:(BOOL)notify
+                                             sound:(NSString *)sound
+                                         highlight:(BOOL)highlight;
 
 /**
  Create a room push rule, see MXNotificationCenter notifications for operation result.
@@ -253,7 +282,4 @@ extern NSString *const kMXNotificationCenterAllOtherRoomMessagesRuleID;
                        notify:(BOOL)notify
                         sound:(BOOL)sound
                     highlight:(BOOL)highlight;
-
 @end
-
-

--- a/MatrixSDK/NotificationCenter/MXNotificationCenter.h
+++ b/MatrixSDK/NotificationCenter/MXNotificationCenter.h
@@ -238,9 +238,9 @@ extern NSString *const kMXNotificationCenterAllOtherRoomMessagesRuleID;
  @param highlight enable/disable highlight option.
  */
 - (void)addContentRuleWithRuleIdMatchingPattern:(NSString *)pattern
-                                            notify:(BOOL)notify
-                                             sound:(NSString *)sound
-                                         highlight:(BOOL)highlight;
+                                         notify:(BOOL)notify
+                                          sound:(NSString *)sound
+                                      highlight:(BOOL)highlight;
 
 /**
  Create a room push rule, see MXNotificationCenter notifications for operation result.

--- a/MatrixSDK/NotificationCenter/MXNotificationCenter.m
+++ b/MatrixSDK/NotificationCenter/MXNotificationCenter.m
@@ -486,10 +486,10 @@ NSString *const kMXNotificationCenterAllOtherRoomMessagesRuleID = @".m.rule.mess
     [self addRuleWithId:ruleId kind:MXPushRuleKindContent pattern:pattern conditions:nil notify:notify sound:sound highlight:highlight];
 }
 
-- (void)addContentRuleWithMatchingRuleIdAndPattern:(NSString *)pattern
-                notify:(BOOL)notify
-                 sound:(NSString *)sound
-             highlight:(BOOL)highlight
+- (void)addContentRuleWithRuleIdMatchingPattern:(NSString *)pattern
+                                         notify:(BOOL)notify
+                                          sound:(NSString *)sound
+                                      highlight:(BOOL)highlight
 {
     NSString *ruleId = [MXTools encodeURIComponent:pattern];
     [self addRuleWithId:ruleId kind:MXPushRuleKindContent pattern:pattern conditions:nil notify:notify soundName:sound highlight:highlight];
@@ -528,7 +528,8 @@ NSString *const kMXNotificationCenterAllOtherRoomMessagesRuleID = @".m.rule.mess
                 sound:(BOOL)sound
             highlight:(BOOL)highlight
 {
-    [self addRuleWithId:ruleId kind:kind pattern:pattern conditions:conditions notify:notify soundName:@"default" highlight:highlight];
+    NSString *soundName = sound ? @"default" : nil;
+    [self addRuleWithId:ruleId kind:kind pattern:pattern conditions:conditions notify:notify soundName:soundName highlight:highlight];
 }
 
 - (void)addRuleWithId:(NSString*)ruleId

--- a/MatrixSDK/NotificationCenter/MXNotificationCenter.m
+++ b/MatrixSDK/NotificationCenter/MXNotificationCenter.m
@@ -434,6 +434,32 @@ NSString *const kMXNotificationCenterAllOtherRoomMessagesRuleID = @".m.rule.mess
     }
 }
 
+- (void)updatePushRuleActions:(NSString*)ruleId
+                         kind:(MXPushRuleKind)kind
+                       notify:(BOOL)notify
+                    soundName:(NSString*)soundName
+                    highlight:(BOOL)highlight
+{
+    
+    NSArray *actions = [self encodeActionsWithNotify:notify soundName:soundName highlight:highlight];
+    [mxSession.matrixRestClient updateActionsForPushRule:ruleId
+                                                   scope:kMXPushRuleScopeStringGlobal
+                                                    kind:kind
+                                                 actions:actions
+                                                 success:^{
+        // Refresh locally rules
+        [self refreshRules:^{
+            [[NSNotificationCenter defaultCenter] postNotificationName:kMXNotificationCenterDidUpdateRules object:self userInfo:nil];
+        } failure:^(NSError *error) {
+            [[NSNotificationCenter defaultCenter] postNotificationName:kMXNotificationCenterDidFailRulesUpdate object:self userInfo:@{kMXNotificationCenterErrorKey:error}];
+        }];
+    }
+                                                 failure:^(NSError *error) {
+        [[NSNotificationCenter defaultCenter] postNotificationName:kMXNotificationCenterDidFailRulesUpdate object:self userInfo:@{kMXNotificationCenterErrorKey:error}];
+    }];
+}
+
+
 - (void)addContentRule:(NSString *)pattern
                 notify:(BOOL)notify
                  sound:(BOOL)sound
@@ -458,6 +484,15 @@ NSString *const kMXNotificationCenterAllOtherRoomMessagesRuleID = @".m.rule.mess
     }
     
     [self addRuleWithId:ruleId kind:MXPushRuleKindContent pattern:pattern conditions:nil notify:notify sound:sound highlight:highlight];
+}
+
+- (void)addContentRuleWithMatchingRuleIdAndPattern:(NSString *)pattern
+                notify:(BOOL)notify
+                 sound:(NSString *)sound
+             highlight:(BOOL)highlight
+{
+    NSString *ruleId = [MXTools encodeURIComponent:pattern];
+    [self addRuleWithId:ruleId kind:MXPushRuleKindContent pattern:pattern conditions:nil notify:notify soundName:sound highlight:highlight];
 }
 
 - (void)addRoomRule:(NSString *)roomId
@@ -489,31 +524,24 @@ NSString *const kMXNotificationCenterAllOtherRoomMessagesRuleID = @".m.rule.mess
                  kind:(MXPushRuleKind)kind
               pattern:(NSString *)pattern
            conditions:(NSArray<NSDictionary *> *)conditions
-                notify:(BOOL)notify
-                 sound:(BOOL)sound
-             highlight:(BOOL)highlight
+               notify:(BOOL)notify
+                sound:(BOOL)sound
+            highlight:(BOOL)highlight
+{
+    [self addRuleWithId:ruleId kind:kind pattern:pattern conditions:conditions notify:notify soundName:@"default" highlight:highlight];
+}
+
+- (void)addRuleWithId:(NSString*)ruleId
+                 kind:(MXPushRuleKind)kind
+              pattern:(NSString *)pattern
+           conditions:(NSArray<NSDictionary *> *)conditions
+               notify:(BOOL)notify
+            soundName:(NSString *)soundName
+            highlight:(BOOL)highlight
 {
     [[NSNotificationCenter defaultCenter] postNotificationName:kMXNotificationCenterWillUpdateRules object:self userInfo:nil];
     
-    NSMutableArray *actions = [NSMutableArray array];
-    if (notify)
-    {
-        [actions addObject:@"notify"];
-    }
-    else
-    {
-        [actions addObject:@"dont_notify"];
-    }
-    
-    if (sound)
-    {
-        [actions addObject:@{@"set_tweak": @"sound", @"value": @"default"}];
-    }
-    
-    if (highlight)
-    {
-        [actions addObject:@{@"set_tweak": @"highlight"}];
-    }
+    NSArray *actions = [self encodeActionsWithNotify:notify soundName:soundName highlight:highlight];
     
     [mxSession.matrixRestClient addPushRule:ruleId scope:kMXPushRuleScopeStringGlobal kind:kind actions:actions pattern:pattern conditions:conditions success:^{
         
@@ -531,6 +559,35 @@ NSString *const kMXNotificationCenterAllOtherRoomMessagesRuleID = @".m.rule.mess
     }];
 }
 
+- (NSArray*)encodeActionsWithNotify:(BOOL)notify
+                          soundName:(NSString *)sound
+                          highlight:(BOOL)highlight
+{
+    NSMutableArray *actions = [NSMutableArray array];
+    if (notify)
+    {
+        [actions addObject:@"notify"];
+        
+        if (sound)
+        {
+            [actions addObject:@{@"set_tweak": @"sound", @"value": sound}];
+        }
+        
+        if (highlight)
+        {
+            [actions addObject:@{@"set_tweak": @"highlight"}];
+        }
+        else
+        {
+            [actions addObject:@{@"set_tweak": @"highlight", @"value": @NO}];
+        }
+    }
+    else
+    {
+        [actions addObject:@"dont_notify"];
+    }
+    return actions;
+}
 
 #pragma mark - Private methods
 // Check if the event should be notified to the listeners

--- a/changelog.d/4467.feature
+++ b/changelog.d/4467.feature
@@ -1,0 +1,1 @@
+MxNotificationCenter: For new account notification settings and keywords support, added updatePushRuleActions and addContentRuleWithMatchingRuleIdAndPattern. Also fixed the url encoding on ruleId.


### PR DESCRIPTION
These update to `MxNotificationCenter` are for new account notification settings and keywords support.
(https://github.com/vector-im/element-ios/issues/4467, https://github.com/vector-im/element-ios/issues/4468 and https://github.com/vector-im/element-ios/issues/4469 )

### What was changed
- Added `updatePushRuleActions` for updating rule actions.
- Added `addContentRuleWithMatchingRuleIdAndPattern` for creating content rules for keywords. An existing function existed but with a different behaviour. I added clarifying comment to each.
- RuleId is included in a number of requests as a path parameter. Keywords allows input from the user so can contain special characters(like whitespace) that needed to be encoded. So added the encoding for each of those apis.
