### PR TITLE
Add a fileSizeToString method using NSByteCountFormatter.

### DIFF
--- a/MatrixSDK/Utils/MXTools.h
+++ b/MatrixSDK/Utils/MXTools.h
@@ -194,6 +194,13 @@ FOUNDATION_EXPORT NSString *const kMXToolsRegexStringForMatrixGroupIdentifier;
 + (long long)roundFileSize:(long long)filesize;
 
 /**
+ Return file size in string format using `NSByteCountFormatter`.
+ 
+ @param fileSize the file size in bytes.
+ */
++ (NSString*)fileSizeToString:(long)fileSize;
+
+/**
  Return file size in string format.
  
  @param fileSize the file size in bytes.

--- a/MatrixSDK/Utils/MXTools.m
+++ b/MatrixSDK/Utils/MXTools.m
@@ -636,6 +636,17 @@ NSCharacterSet *uriComponentCharset;
     return roundedFileSize;
 }
 
++ (NSString*)fileSizeToString:(long)fileSize
+{
+    if (fileSize < 0)
+    {
+        return @"";
+    }
+    
+    NSByteCountFormatter *formatter = [NSByteCountFormatter new];
+    return [formatter stringFromByteCount:fileSize];
+}
+
 + (NSString*)fileSizeToString:(long)fileSize round:(BOOL)round
 {
     if (fileSize < 0)

--- a/changelog.d/4479.change
+++ b/changelog.d/4479.change
@@ -1,0 +1,1 @@
+MXTools: Add fileSizeToString function that uses NSByteCountFormatter.


### PR DESCRIPTION
As part of https://github.com/vector-im/element-ios/pull/4721, this adds a second version of `fileSizeToString` to `MXTools` that formats the file size using `NSByteCountFormatter` with the default settings. This gives a nicer string to read as it automatically chooses the appropriate number of significant figures to show, will localise better and will use multiples of 1000 rather than 1024 to match the system size calculation.

I would have updated `fileSizeToString:round:` to use `NSByteCountFormatter` however the `round` parameter wouldn't have a defined behaviour in this instance.

![Frame 1](https://user-images.githubusercontent.com/6060466/132244375-ab9adc81-70d7-4235-8c79-9e191528fbdc.png)

