### PR TITLE
MXCrossSigning.setupWithPassword failure block not called from the main thread

### DIFF
--- a/MatrixSDK/Crypto/CrossSigning/MXCrossSigning.m
+++ b/MatrixSDK/Crypto/CrossSigning/MXCrossSigning.m
@@ -86,7 +86,14 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
         
         [self setupWithAuthParams:authParams success:success failure:failure];
         
-    } failure:failure];
+    } failure:^(NSError *error) {
+        if (failure)
+        {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                failure(error);
+            });
+        }
+    }
 }
 
 - (void)setupWithAuthParams:(NSDictionary*)authParams

--- a/MatrixSDK/Crypto/CrossSigning/MXCrossSigning.m
+++ b/MatrixSDK/Crypto/CrossSigning/MXCrossSigning.m
@@ -93,7 +93,7 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
                 failure(error);
             });
         }
-    }
+    }];
 }
 
 - (void)setupWithAuthParams:(NSDictionary*)authParams

--- a/changelog.d/4804.bugfix
+++ b/changelog.d/4804.bugfix
@@ -1,0 +1,1 @@
+MXCrossSigning.setupWithPassword failure block not called from the main thread.


### PR DESCRIPTION
Fix https://github.com/vector-im/element-ios/issues/4804.
