### PR TITLE
MXRoomSummary: `markAllAsReadLocally` method

### DIFF
--- a/MatrixSDK/Data/MXRoomSummary.h
+++ b/MatrixSDK/Data/MXRoomSummary.h
@@ -317,6 +317,11 @@ FOUNDATION_EXPORT NSUInteger const MXRoomSummaryPaginationChunkSize;
  */
 - (void)markAllAsRead;
 
+/**
+ Mark all messages as read locally. Does not update read markers.
+ */
+- (void)markAllAsReadLocally;
+
 /// Update membership transition state and notify update if needed
 /// @param membershipTransitionState The new membership transition state value
 - (void)updateMembershipTransitionState:(MXMembershipTransitionState)membershipTransitionState;

--- a/MatrixSDK/Data/MXRoomSummary.m
+++ b/MatrixSDK/Data/MXRoomSummary.m
@@ -592,7 +592,20 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
 
 - (void)markAllAsRead
 {
-    [self.room markAllAsRead];
+    [self markAllAsReadUpdatingReadMarker:YES];
+}
+
+- (void)markAllAsReadLocally
+{
+    [self markAllAsReadUpdatingReadMarker:NO];
+}
+
+- (void)markAllAsReadUpdatingReadMarker:(BOOL)updateReadMarker
+{
+    if (updateReadMarker)
+    {
+        [self.room markAllAsRead];
+    }
     
     _notificationCount = 0;
     _highlightCount = 0;

--- a/changelog.d/4822.change
+++ b/changelog.d/4822.change
@@ -1,0 +1,1 @@
+MXRoomSummary: Introduce `markAllAsReadLocally` method.


### PR DESCRIPTION
Adds `markAllAsReadLocally` method to `MXRoomSummary` class. Part of vector-im/element-ios#4822