### PR TITLE
MXSession: Introduce `pauseable` property

### DIFF
--- a/MatrixSDK/MXSession.h
+++ b/MatrixSDK/MXSession.h
@@ -492,6 +492,11 @@ FOUNDATION_EXPORT NSString *const kMXSessionNoRoomTag;
  */
 @property (nonatomic, readonly) MXSpaceService *spaceService;
 
+/**
+ Flag indicating the session can be paused.
+ */
+@property (nonatomic, readonly, getter=isPauseable) BOOL pauseable;
+
 #pragma mark - Class methods
 
 /**
@@ -550,8 +555,8 @@ FOUNDATION_EXPORT NSString *const kMXSessionNoRoomTag;
  Pause the session events stream.
  This action may be delayed by using `retainPreventPause`.
  
- Caution: this action is ignored if the session state is not MXSessionStateRunning
- or MXSessionStateBackgroundSyncInProgress.
+ Caution: this action is ignored if the session is not pauseable.
+ @see pauseable.
  
  No more live events will be received by the listeners.
  */

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -1545,14 +1545,12 @@ typedef void (^MXOnResumeDone)(void);
         {
             MXLogDebug(@"[MXSession] The connection has been cancelled in state %@", @(_state));
 
-            if (_state == MXSessionStateSyncInProgress)
+            if (self.isPauseable)
             {
                 // This happens when the SDK cannot make any more requests because the app is in background
                 // and the background task is expired or going to expire.
                 // The app should have paused the SDK before but it did not. So, pause the SDK ourselves.
-                // Note that we need to come back to MXSessionStatePauseRequested in order to be able to pause.
                 MXLogDebug(@"[MXSession] -> Go to pause");
-                [self setState:MXSessionStatePauseRequested];
                 [self pause];
             }
         }

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -894,11 +894,18 @@ typedef void (^MXOnResumeDone)(void);
     return _store.syncFilterId;
 }
 
+- (BOOL)isPauseable
+{
+    return _state == MXSessionStateRunning
+        || _state == MXSessionStateBackgroundSyncInProgress
+        || _state == MXSessionStatePauseRequested;
+}
+
 - (void)pause
 {
     MXLogDebug(@"[MXSession] pause the event stream in state %tu", _state);
 
-    if (_state == MXSessionStateRunning || _state == MXSessionStateBackgroundSyncInProgress || _state == MXSessionStatePauseRequested)
+    if (self.isPauseable)
     {
         // Check that none required the session to keep running even if the app goes in
         // background

--- a/changelog.d/4834.bugfix
+++ b/changelog.d/4834.bugfix
@@ -1,0 +1,1 @@
+MXSession: Introduce `pauseable` property and pause the session gracefully when sync request cancelled.


### PR DESCRIPTION
Part of vector-im/element-ios#4834