### PR TITLE
Tests: Improve tests suites execution time

### DIFF
--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -1654,6 +1654,7 @@
 		322691351E5EFF8700966A6E /* MXDeviceListOperationsPool.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MXDeviceListOperationsPool.m; path = MatrixSDK/Crypto/Data/MXDeviceListOperationsPool.m; sourceTree = SOURCE_ROOT; };
 		3229534F25A5F7220012FCF0 /* MXBackgroundCryptoStore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXBackgroundCryptoStore.h; sourceTree = "<group>"; };
 		3229535025A5F7220012FCF0 /* MXBackgroundCryptoStore.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXBackgroundCryptoStore.m; sourceTree = "<group>"; };
+		322985CD26FAFC58001890BC /* MatrixSDKTestsSwiftHeader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MatrixSDKTestsSwiftHeader.h; sourceTree = "<group>"; };
 		322A51B41D9AB15900C8536D /* MXCrypto.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXCrypto.h; sourceTree = "<group>"; };
 		322A51B51D9AB15900C8536D /* MXCrypto.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXCrypto.m; sourceTree = "<group>"; };
 		322A51C11D9AC8FE00C8536D /* MXCryptoAlgorithms.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXCryptoAlgorithms.h; sourceTree = "<group>"; };
@@ -1989,7 +1990,7 @@
 		32C6F92D19DD814400EA4E9C /* MatrixSDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MatrixSDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		32C6F93119DD814400EA4E9C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		32C6F93219DD814400EA4E9C /* MatrixSDK.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MatrixSDK.h; sourceTree = "<group>"; };
-		32C6F93819DD814400EA4E9C /* MatrixSDKTests-iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "MatrixSDKTests-iOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		32C6F93819DD814400EA4E9C /* MatrixSDKTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MatrixSDKTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		32C6F93B19DD814400EA4E9C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		32C78B65256CFC4D008130B1 /* MXCryptoVersion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXCryptoVersion.h; sourceTree = "<group>"; };
 		32C78B66256CFC4D008130B1 /* MXCryptoMigration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXCryptoMigration.m; sourceTree = "<group>"; };
@@ -2224,7 +2225,7 @@
 		B1A026FF26162110001AADFF /* MXSpaceChildrenResponse.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXSpaceChildrenResponse.m; sourceTree = "<group>"; };
 		B1C854ED25E7B492005867D0 /* MXRoomType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXRoomType.h; sourceTree = "<group>"; };
 		B1DDC9D52418098200D208E3 /* MXIncomingSASTransaction_Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXIncomingSASTransaction_Private.h; sourceTree = "<group>"; };
-		B1E09A0E2397FA950057C069 /* MatrixSDKTests-macOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "MatrixSDKTests-macOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		B1E09A0E2397FA950057C069 /* MatrixSDKTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MatrixSDKTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B1F939F426289F2600D0E525 /* MXSpaceChildContentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXSpaceChildContentTests.swift; sourceTree = "<group>"; };
 		B57EF0A39A7649D55CA1208A /* libPods-MatrixSDK-MatrixSDK-iOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-MatrixSDK-MatrixSDK-iOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		BD0431D223F108AED4C70A42 /* Pods-SDK-MatrixSDK-iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SDK-MatrixSDK-iOS.debug.xcconfig"; path = "Target Support Files/Pods-SDK-MatrixSDK-iOS/Pods-SDK-MatrixSDK-iOS.debug.xcconfig"; sourceTree = "<group>"; };
@@ -3351,9 +3352,9 @@
 			isa = PBXGroup;
 			children = (
 				32C6F92D19DD814400EA4E9C /* MatrixSDK.framework */,
-				32C6F93819DD814400EA4E9C /* MatrixSDKTests-iOS.xctest */,
+				32C6F93819DD814400EA4E9C /* MatrixSDKTests.xctest */,
 				B14EF36B2397E90400758AF0 /* MatrixSDK.framework */,
-				B1E09A0E2397FA950057C069 /* MatrixSDKTests-macOS.xctest */,
+				B1E09A0E2397FA950057C069 /* MatrixSDKTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -3488,6 +3489,7 @@
 				B1F939F426289F2600D0E525 /* MXSpaceChildContentTests.swift */,
 				3A7B8CFD267FCD9B00D9DD96 /* MXDehydrationTests.m */,
 				ECB6FA8D267CFF4300A941E4 /* MXCredentialsUnitTests.swift */,
+				322985CD26FAFC58001890BC /* MatrixSDKTestsSwiftHeader.h */,
 			);
 			path = MatrixSDKTests;
 			sourceTree = "<group>";
@@ -4853,7 +4855,7 @@
 			);
 			name = "MatrixSDKTests-iOS";
 			productName = MatrixSDKTests;
-			productReference = 32C6F93819DD814400EA4E9C /* MatrixSDKTests-iOS.xctest */;
+			productReference = 32C6F93819DD814400EA4E9C /* MatrixSDKTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		B14EF1C72397E90400758AF0 /* MatrixSDK-macOS */ = {
@@ -4892,7 +4894,7 @@
 			);
 			name = "MatrixSDKTests-macOS";
 			productName = "MatrixSDKTests-macOS";
-			productReference = B1E09A0E2397FA950057C069 /* MatrixSDKTests-macOS.xctest */;
+			productReference = B1E09A0E2397FA950057C069 /* MatrixSDKTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
@@ -6142,7 +6144,7 @@
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.matrix.$(PRODUCT_NAME:rfc1034identifier)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = MatrixSDKTests;
 				SDKROOT = iphoneos;
 				SWIFT_OBJC_BRIDGING_HEADER = "$(SRCROOT)/MatrixSDKTests/MatrixSDKTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -6167,7 +6169,7 @@
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.matrix.$(PRODUCT_NAME:rfc1034identifier)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = MatrixSDKTests;
 				SDKROOT = iphoneos;
 				SWIFT_OBJC_BRIDGING_HEADER = "$(SRCROOT)/MatrixSDKTests/MatrixSDKTests-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -6250,7 +6252,7 @@
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "matrix.org.MatrixSDKTests-macOS";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = MatrixSDKTests;
 				SDKROOT = macosx;
 				SWIFT_OBJC_BRIDGING_HEADER = "$(SRCROOT)/MatrixSDKTests/MatrixSDKTests-Bridging-Header.h";
 			};
@@ -6279,7 +6281,7 @@
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "matrix.org.MatrixSDKTests-macOS";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = MatrixSDKTests;
 				SDKROOT = macosx;
 				SWIFT_OBJC_BRIDGING_HEADER = "$(SRCROOT)/MatrixSDKTests/MatrixSDKTests-Bridging-Header.h";
 			};

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -111,6 +111,8 @@
 		322985CC26FAF898001890BC /* MXSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 322985CA26FAF898001890BC /* MXSession.swift */; };
 		322985CF26FBAE7B001890BC /* TestObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 322985CE26FBAE7B001890BC /* TestObserver.swift */; };
 		322985D026FBAE7B001890BC /* TestObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 322985CE26FBAE7B001890BC /* TestObserver.swift */; };
+		322985D226FC9E61001890BC /* MXSessionTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 322985D126FC9E61001890BC /* MXSessionTracker.swift */; };
+		322985D326FC9E61001890BC /* MXSessionTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 322985D126FC9E61001890BC /* MXSessionTracker.swift */; };
 		322A51B61D9AB15900C8536D /* MXCrypto.h in Headers */ = {isa = PBXBuildFile; fileRef = 322A51B41D9AB15900C8536D /* MXCrypto.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		322A51B71D9AB15900C8536D /* MXCrypto.m in Sources */ = {isa = PBXBuildFile; fileRef = 322A51B51D9AB15900C8536D /* MXCrypto.m */; };
 		322A51C31D9AC8FE00C8536D /* MXCryptoAlgorithms.h in Headers */ = {isa = PBXBuildFile; fileRef = 322A51C11D9AC8FE00C8536D /* MXCryptoAlgorithms.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1661,6 +1663,7 @@
 		322985CA26FAF898001890BC /* MXSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXSession.swift; sourceTree = "<group>"; };
 		322985CD26FAFC58001890BC /* MatrixSDKTestsSwiftHeader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MatrixSDKTestsSwiftHeader.h; sourceTree = "<group>"; };
 		322985CE26FBAE7B001890BC /* TestObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestObserver.swift; sourceTree = "<group>"; };
+		322985D126FC9E61001890BC /* MXSessionTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXSessionTracker.swift; sourceTree = "<group>"; };
 		322A51B41D9AB15900C8536D /* MXCrypto.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXCrypto.h; sourceTree = "<group>"; };
 		322A51B51D9AB15900C8536D /* MXCrypto.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXCrypto.m; sourceTree = "<group>"; };
 		322A51C11D9AC8FE00C8536D /* MXCryptoAlgorithms.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXCryptoAlgorithms.h; sourceTree = "<group>"; };
@@ -2647,6 +2650,7 @@
 			children = (
 				322985CA26FAF898001890BC /* MXSession.swift */,
 				322985CE26FBAE7B001890BC /* TestObserver.swift */,
+				322985D126FC9E61001890BC /* MXSessionTracker.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -5446,6 +5450,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				329E808F22512DF500A48C3A /* MXCryptoKeyVerificationTests.m in Sources */,
+				322985D226FC9E61001890BC /* MXSessionTracker.swift in Sources */,
 				32B477822638133C00EA5800 /* MXFilterUnitTests.m in Sources */,
 				322985CF26FBAE7B001890BC /* TestObserver.swift in Sources */,
 				32DC15D71A8DFF0D006F9AD3 /* MXNotificationCenterTests.m in Sources */,
@@ -5882,6 +5887,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B1E09A282397FD010057C069 /* MXMockCallStackCall.m in Sources */,
+				322985D326FC9E61001890BC /* MXSessionTracker.swift in Sources */,
 				B1E09A392397FD7D0057C069 /* MXMyUserTests.m in Sources */,
 				322985D026FBAE7B001890BC /* TestObserver.swift in Sources */,
 				B1E09A202397FCE90057C069 /* MXCryptoBackupTests.m in Sources */,

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -107,6 +107,10 @@
 		3229535225A5F7220012FCF0 /* MXBackgroundCryptoStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 3229534F25A5F7220012FCF0 /* MXBackgroundCryptoStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3229535325A5F7220012FCF0 /* MXBackgroundCryptoStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 3229535025A5F7220012FCF0 /* MXBackgroundCryptoStore.m */; };
 		3229535425A5F7220012FCF0 /* MXBackgroundCryptoStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 3229535025A5F7220012FCF0 /* MXBackgroundCryptoStore.m */; };
+		322985CB26FAF898001890BC /* MXSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 322985CA26FAF898001890BC /* MXSession.swift */; };
+		322985CC26FAF898001890BC /* MXSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 322985CA26FAF898001890BC /* MXSession.swift */; };
+		322985CF26FBAE7B001890BC /* TestObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 322985CE26FBAE7B001890BC /* TestObserver.swift */; };
+		322985D026FBAE7B001890BC /* TestObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 322985CE26FBAE7B001890BC /* TestObserver.swift */; };
 		322A51B61D9AB15900C8536D /* MXCrypto.h in Headers */ = {isa = PBXBuildFile; fileRef = 322A51B41D9AB15900C8536D /* MXCrypto.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		322A51B71D9AB15900C8536D /* MXCrypto.m in Sources */ = {isa = PBXBuildFile; fileRef = 322A51B51D9AB15900C8536D /* MXCrypto.m */; };
 		322A51C31D9AC8FE00C8536D /* MXCryptoAlgorithms.h in Headers */ = {isa = PBXBuildFile; fileRef = 322A51C11D9AC8FE00C8536D /* MXCryptoAlgorithms.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1654,7 +1658,9 @@
 		322691351E5EFF8700966A6E /* MXDeviceListOperationsPool.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MXDeviceListOperationsPool.m; path = MatrixSDK/Crypto/Data/MXDeviceListOperationsPool.m; sourceTree = SOURCE_ROOT; };
 		3229534F25A5F7220012FCF0 /* MXBackgroundCryptoStore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXBackgroundCryptoStore.h; sourceTree = "<group>"; };
 		3229535025A5F7220012FCF0 /* MXBackgroundCryptoStore.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXBackgroundCryptoStore.m; sourceTree = "<group>"; };
+		322985CA26FAF898001890BC /* MXSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXSession.swift; sourceTree = "<group>"; };
 		322985CD26FAFC58001890BC /* MatrixSDKTestsSwiftHeader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MatrixSDKTestsSwiftHeader.h; sourceTree = "<group>"; };
+		322985CE26FBAE7B001890BC /* TestObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestObserver.swift; sourceTree = "<group>"; };
 		322A51B41D9AB15900C8536D /* MXCrypto.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXCrypto.h; sourceTree = "<group>"; };
 		322A51B51D9AB15900C8536D /* MXCrypto.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXCrypto.m; sourceTree = "<group>"; };
 		322A51C11D9AC8FE00C8536D /* MXCryptoAlgorithms.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXCryptoAlgorithms.h; sourceTree = "<group>"; };
@@ -2636,6 +2642,15 @@
 			path = Trust;
 			sourceTree = "<group>";
 		};
+		322985C526FA66FD001890BC /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				322985CA26FAF898001890BC /* MXSession.swift */,
+				322985CE26FBAE7B001890BC /* TestObserver.swift */,
+			);
+			path = Utils;
+			sourceTree = "<group>";
+		};
 		322A51B31D9AB13E00C8536D /* Crypto */ = {
 			isa = PBXGroup;
 			children = (
@@ -3410,6 +3425,7 @@
 		32C6F93919DD814400EA4E9C /* MatrixSDKTests */ = {
 			isa = PBXGroup;
 			children = (
+				322985C526FA66FD001890BC /* Utils */,
 				3298ABD42637FA3100E40B06 /* TestPlans */,
 				32B477422638128700EA5800 /* MXAggregatedEditsUnitTests.m */,
 				32B477442638128700EA5800 /* MXAggregatedReferenceUnitTests.m */,
@@ -5431,6 +5447,7 @@
 			files = (
 				329E808F22512DF500A48C3A /* MXCryptoKeyVerificationTests.m in Sources */,
 				32B477822638133C00EA5800 /* MXFilterUnitTests.m in Sources */,
+				322985CF26FBAE7B001890BC /* TestObserver.swift in Sources */,
 				32DC15D71A8DFF0D006F9AD3 /* MXNotificationCenterTests.m in Sources */,
 				329571991B024D2B00ABB3BA /* MXMockCallStack.m in Sources */,
 				3281E8A819E41A2000976E1A /* MatrixSDKTestsData.m in Sources */,
@@ -5491,6 +5508,7 @@
 				32D8CAC219DEE6ED002AF8A0 /* MXRestClientNoAuthAPITests.m in Sources */,
 				32FCAB4D19E578860049C555 /* MXRestClientTests.m in Sources */,
 				32C78BA7256D227D008130B1 /* MXCryptoMigrationTests.m in Sources */,
+				322985CB26FAF898001890BC /* MXSession.swift in Sources */,
 				32EEA83F2603CA140041425B /* MXRestClientExtensionsTests.m in Sources */,
 				32C03CB62123076F00D92712 /* DirectRoomTests.m in Sources */,
 				329FB17C1A0A963700A5E88E /* MXRoomMemberTests.m in Sources */,
@@ -5865,6 +5883,7 @@
 			files = (
 				B1E09A282397FD010057C069 /* MXMockCallStackCall.m in Sources */,
 				B1E09A392397FD7D0057C069 /* MXMyUserTests.m in Sources */,
+				322985D026FBAE7B001890BC /* TestObserver.swift in Sources */,
 				B1E09A202397FCE90057C069 /* MXCryptoBackupTests.m in Sources */,
 				B1E09A3B2397FD820057C069 /* MXStoreNoStoreTests.m in Sources */,
 				32B4778E2638133D00EA5800 /* MXFilterUnitTests.m in Sources */,
@@ -5925,6 +5944,7 @@
 				B1E09A312397FD750057C069 /* MXSessionTests.m in Sources */,
 				32B477902638133D00EA5800 /* MXAggregatedReferenceUnitTests.m in Sources */,
 				B1E09A322397FD750057C069 /* MXRoomTests.m in Sources */,
+				322985CC26FAF898001890BC /* MXSession.swift in Sources */,
 				32C78BA8256D227D008130B1 /* MXCryptoMigrationTests.m in Sources */,
 				B1E09A2F2397FD750057C069 /* MXErrorUnitTests.m in Sources */,
 				B1660F1D260A20B900C3AA12 /* MXSpaceServiceTest.swift in Sources */,

--- a/MatrixSDK.xcodeproj/xcshareddata/xcschemes/MatrixSDK-iOS.xcscheme
+++ b/MatrixSDK.xcodeproj/xcshareddata/xcschemes/MatrixSDK-iOS.xcscheme
@@ -29,7 +29,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "32C6F93719DD814400EA4E9C"
-               BuildableName = "MatrixSDKTests-iOS.xctest"
+               BuildableName = "MatrixSDKTests.xctest"
                BlueprintName = "MatrixSDKTests-iOS"
                ReferencedContainer = "container:MatrixSDK.xcodeproj">
             </BuildableReference>
@@ -57,7 +57,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "32C6F93719DD814400EA4E9C"
-               BuildableName = "MatrixSDKTests-iOS.xctest"
+               BuildableName = "MatrixSDKTests.xctest"
                BlueprintName = "MatrixSDKTests-iOS"
                ReferencedContainer = "container:MatrixSDK.xcodeproj">
             </BuildableReference>

--- a/MatrixSDK.xcodeproj/xcshareddata/xcschemes/MatrixSDK-macOS.xcscheme
+++ b/MatrixSDK.xcodeproj/xcshareddata/xcschemes/MatrixSDK-macOS.xcscheme
@@ -64,9 +64,6 @@
          <TestPlanReference
             reference = "container:MatrixSDKTests/TestPlans/UnitTestsWithSanitizers.xctestplan">
          </TestPlanReference>
-         <TestPlanReference
-            reference = "container:MatrixSDKTests/TestPlans/MinimalIntegrationTests.xctestplan">
-         </TestPlanReference>
       </TestPlans>
       <Testables>
          <TestableReference

--- a/MatrixSDK.xcodeproj/xcshareddata/xcschemes/MatrixSDK-macOS.xcscheme
+++ b/MatrixSDK.xcodeproj/xcshareddata/xcschemes/MatrixSDK-macOS.xcscheme
@@ -29,7 +29,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "B1E09A0D2397FA950057C069"
-               BuildableName = "MatrixSDKTests-macOS.xctest"
+               BuildableName = "MatrixSDKTests.xctest"
                BlueprintName = "MatrixSDKTests-macOS"
                ReferencedContainer = "container:MatrixSDK.xcodeproj">
             </BuildableReference>
@@ -64,6 +64,9 @@
          <TestPlanReference
             reference = "container:MatrixSDKTests/TestPlans/UnitTestsWithSanitizers.xctestplan">
          </TestPlanReference>
+         <TestPlanReference
+            reference = "container:MatrixSDKTests/TestPlans/MinimalIntegrationTests.xctestplan">
+         </TestPlanReference>
       </TestPlans>
       <Testables>
          <TestableReference
@@ -71,7 +74,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "B1E09A0D2397FA950057C069"
-               BuildableName = "MatrixSDKTests-macOS.xctest"
+               BuildableName = "MatrixSDKTests.xctest"
                BlueprintName = "MatrixSDKTests-macOS"
                ReferencedContainer = "container:MatrixSDK.xcodeproj">
             </BuildableReference>

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -426,7 +426,14 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 
         [self->roomDecryptors removeAllObjects];
         self->roomDecryptors = nil;
-
+        
+        self->_backup = nil;
+        self->_keyVerificationManager = nil;
+        self->_recoveryService = nil;
+        self->_secretStorage = nil;
+        self->_secretShareManager = nil;
+        self->_crossSigning = nil;
+        
         self->_myDevice = nil;
 
         MXLogDebug(@"[MXCrypto] close: done");

--- a/MatrixSDKTests/MXAccountDataTests.m
+++ b/MatrixSDKTests/MXAccountDataTests.m
@@ -81,6 +81,7 @@
     [matrixSDKTestsData doMXRestClientTestWithBobAndAliceInARoom:self readyToTest:^(MXRestClient *bobRestClient, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
         MXSession *bobSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        [matrixSDKTestsData retain:bobSession];
 
         MXFileStore *store = [[MXFileStore alloc] init];
         [bobSession setStore:store success:^{
@@ -100,6 +101,7 @@
 
                                 // Check the information have been permanently stored
                                 MXSession *bobSession2 = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+                                [matrixSDKTestsData retain:bobSession2];
                                 MXFileStore *store2 = [[MXFileStore alloc] init];
                                 [bobSession2 setStore:store2 success:^{
 
@@ -144,6 +146,7 @@
     [matrixSDKTestsData doMXRestClientTestWithBobAndAliceInARoom:self readyToTest:^(MXRestClient *bobRestClient, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
         MXSession *bobSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        [matrixSDKTestsData retain:bobSession];
 
         MXFileStore *store = [[MXFileStore alloc] init];
         [bobSession setStore:store success:^{
@@ -165,6 +168,7 @@
 
                                 // Check the information have been permanently stored
                                 MXSession *bobSession2 = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+                                [matrixSDKTestsData retain:bobSession2];
                                 MXFileStore *store2 = [[MXFileStore alloc] init];
                                 [bobSession2 setStore:store2 success:^{
 

--- a/MatrixSDKTests/MXAggregatedEditsTests.m
+++ b/MatrixSDKTests/MXAggregatedEditsTests.m
@@ -293,6 +293,7 @@ static NSString* const kEditedMarkdownMessageFormattedText = @"<strong>I meant H
 
         // - Do an initial sync
         mxSession = [[MXSession alloc] initWithMatrixRestClient:restClient];
+        [matrixSDKTestsData retain:mxSession];
         [mxSession setStore:[[MXMemoryStore alloc] init] success:^{
 
             [mxSession start:^{
@@ -340,6 +341,7 @@ static NSString* const kEditedMarkdownMessageFormattedText = @"<strong>I meant H
         
         // - Do an initial sync
         mxSession = [[MXSession alloc] initWithMatrixRestClient:restClient];
+        [matrixSDKTestsData retain:mxSession];
         [mxSession setStore:[[MXMemoryStore alloc] init] success:^{
             
             [mxSession start:^{

--- a/MatrixSDKTests/MXAggregatedReactionTests.m
+++ b/MatrixSDKTests/MXAggregatedReactionTests.m
@@ -126,6 +126,7 @@
 
         // - Do an initial sync
         MXSession *mxSession2 = [[MXSession alloc] initWithMatrixRestClient:restClient];
+        [matrixSDKTestsData retain:mxSession2];
         [mxSession2 setStore:[[MXMemoryStore alloc] init] success:^{
 
             [mxSession2 start:^{
@@ -227,6 +228,7 @@
 
         // - Do an initial sync
         mxSession = [[MXSession alloc] initWithMatrixRestClient:restClient];
+        [matrixSDKTestsData retain:mxSession];
         [mxSession setStore:[[MXMemoryStore alloc] init] success:^{
 
             [mxSession start:^{
@@ -377,6 +379,7 @@
 
         // - Do an initial sync
         mxSession = [[MXSession alloc] initWithMatrixRestClient:restClient];
+        [matrixSDKTestsData retain:mxSession];
         [mxSession setStore:[[MXMemoryStore alloc] init] success:^{
 
             [mxSession start:^{

--- a/MatrixSDKTests/MXAggregatedReferenceTests.m
+++ b/MatrixSDKTests/MXAggregatedReferenceTests.m
@@ -134,6 +134,7 @@ static NSString* const kThreadedMessage1Text = @"Morning!";
 
         // - Do an initial sync
         mxSession = [[MXSession alloc] initWithMatrixRestClient:restClient];
+        [matrixSDKTestsData retain:mxSession];
         [mxSession setStore:[[MXMemoryStore alloc] init] success:^{
 
             [mxSession start:^{

--- a/MatrixSDKTests/MXBackgroundSyncServiceTests.swift
+++ b/MatrixSDKTests/MXBackgroundSyncServiceTests.swift
@@ -109,6 +109,7 @@ class MXBackgroundSyncServiceTests: XCTestCase {
 
                             // - Bob restarts their MXSession
                             let newBobSession = MXSession(matrixRestClient: MXRestClient(credentials: bobCredentials, unrecognizedCertificateHandler: nil))
+                            self.testData.retain(newBobSession)
                             newBobSession?.setStore(bobStore, completion: { (_) in
                                 newBobSession?.start(withSyncFilterId: bobStore.syncFilterId, completion: { (_) in
                                     
@@ -198,6 +199,7 @@ class MXBackgroundSyncServiceTests: XCTestCase {
                             
                             // - Bob restarts their MXSession
                             let newBobSession = MXSession(matrixRestClient: MXRestClient(credentials: bobCredentials, unrecognizedCertificateHandler: nil))
+                            self.testData.retain(newBobSession)
                             newBobSession?.setStore(bobStore, completion: { (_) in
                                 newBobSession?.start(withSyncFilterId: bobStore.syncFilterId, completion: { (_) in
                                     
@@ -306,6 +308,7 @@ class MXBackgroundSyncServiceTests: XCTestCase {
                                         
                                         // - Bob restarts their MXSession
                                         let newBobSession = MXSession(matrixRestClient: MXRestClient(credentials: bobCredentials, unrecognizedCertificateHandler: nil))
+                                        self.testData.retain(newBobSession)
                                         newBobSession?.setStore(bobStore, completion: { (_) in
                                             newBobSession?.start(withSyncFilterId: bobStore.syncFilterId, completion: { (_) in
                                                 // -> The message is available from MXSession and no more from MXBackgroundSyncService
@@ -1315,6 +1318,7 @@ class MXBackgroundSyncServiceTests: XCTestCase {
                     expectation.fulfill()
                     return
                 }
+                self.testData.retain(bobSession2)
                 bobSession2.setStore(MXFileStore(), completion: { _ in
                     bobSession2.start(completion: { (_) in
                         

--- a/MatrixSDKTests/MXCrossSigningTests.m
+++ b/MatrixSDKTests/MXCrossSigningTests.m
@@ -1239,6 +1239,7 @@
             
             // - Stop Alice first device
             MXSession *aliceSession2 = [[MXSession alloc] initWithMatrixRestClient:aliceSession.matrixRestClient];
+            [matrixSDKTestsData retain:aliceSession2];
             [aliceSession close];
             
             // - Reset XS on this new device

--- a/MatrixSDKTests/MXCryptoBackupTests.m
+++ b/MatrixSDKTests/MXCryptoBackupTests.m
@@ -944,6 +944,7 @@
 
                 // - Restart alice session
                 MXSession *aliceSession2 = [[MXSession alloc] initWithMatrixRestClient:aliceSession.matrixRestClient];
+                [matrixSDKTestsData retain:aliceSession2];
                 [aliceSession close];
                 [aliceSession2 start:nil failure:^(NSError * _Nonnull error) {
                     XCTFail(@"The request should not fail - NSError: %@", error);
@@ -1445,6 +1446,7 @@
                     
                     // - Restart the session
                     MXSession *aliceSession2 = [[MXSession alloc] initWithMatrixRestClient:aliceSession.matrixRestClient];
+                    [matrixSDKTestsData retain:aliceSession2];
                     [aliceSession close];
                     [aliceSession2 start:^{
                         XCTAssertTrue(aliceSession2.crypto.backup.hasPrivateKeyInCryptoStore);

--- a/MatrixSDKTests/MXCryptoTests.m
+++ b/MatrixSDKTests/MXCryptoTests.m
@@ -2953,8 +2953,8 @@
 
         // - Restart the session
         MXSession *aliceSession2 = [[MXSession alloc] initWithMatrixRestClient:aliceSession.matrixRestClient];
-        [matrixSDKTestsData retain:aliceSession2]
-        ;
+        [matrixSDKTestsData retain:aliceSession2];
+        
         [aliceSession close];
         [aliceSession2 start:^{
             MXOlmOutboundGroupSession *outboundSession = [aliceSession2.crypto.store outboundGroupSessionWithRoomId:roomId];

--- a/MatrixSDKTests/MXCryptoTests.m
+++ b/MatrixSDKTests/MXCryptoTests.m
@@ -221,6 +221,8 @@
             MXFileStore *store = [[MXFileStore alloc] init];
 
             mxSession2 = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+            [matrixSDKTestsData retain:mxSession2];
+            
             [mxSession2 setStore:store success:^{
 
                 XCTAssert(mxSession2.crypto, @"MXSession must recall that it has crypto engaged");
@@ -484,6 +486,7 @@
         aliceSession = nil;
 
         MXSession *aliceSession2 = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
+        [matrixSDKTestsData retain:aliceSession2];
 
         aliceSessionToClose = aliceSession2;
 
@@ -646,6 +649,7 @@
         bobSession = nil;
 
         bobSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        [matrixSDKTestsData retain:bobSession];
 
         aliceSessionToClose = aliceSession;
         bobSessionToClose = bobSession;
@@ -2034,6 +2038,7 @@
             // This forces her to use a new megolm session for sending message "11"
             // This will move the olm session ratchet to share this new megolm session
             MXSession *aliceSession1 = [[MXSession alloc] initWithMatrixRestClient:aliceSession.matrixRestClient];
+            
             [aliceSession close];
             [aliceSession1 setStore:[[MXFileStore alloc] init] success:^{
                 [aliceSession1 start:^{
@@ -2047,6 +2052,8 @@
                         // - Simulate Alice using a backup of her OS and make her crypto state like after the first message
                         // Relaunch again alice
                         MXSession *aliceSession2 = [[MXSession alloc] initWithMatrixRestClient:aliceSession1.matrixRestClient];
+                        [matrixSDKTestsData retain:aliceSession2];
+                        
                         [aliceSession1 close];
                         [aliceSession2 setStore:[[MXFileStore alloc] init] success:^{
                             [aliceSession2 start:^{
@@ -2507,6 +2514,8 @@
 //                    [aliceSession close];
 //
 //                    aliceSession2 = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
+//                    [matrixSDKTestsData retain:aliceSession2];
+//
 //                    [aliceSession2 start:^{
 //
 //                        aliceSession2.crypto.warnOnUnknowDevices = NO;
@@ -2537,6 +2546,8 @@
 //                    [aliceSession2 close];
 //
 //                    aliceSession3 = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
+//                    [matrixSDKTestsData retain:aliceSession3];
+//
 //                    [aliceSession3 start:^{
 //
 //                        aliceSession3.crypto.warnOnUnknowDevices = NO;
@@ -3055,6 +3066,8 @@
 
         // - Restart the session
         MXSession *aliceSession2 = [[MXSession alloc] initWithMatrixRestClient:aliceSession.matrixRestClient];
+        [matrixSDKTestsData retain:aliceSession2]
+        ;
         [aliceSession close];
         [aliceSession2 start:^{
             MXOlmOutboundGroupSession *outboundSession = [aliceSession2.crypto.store outboundGroupSessionWithRoomId:roomId];
@@ -3088,6 +3101,8 @@
 
         // - Restart the session
         MXSession *aliceSession2 = [[MXSession alloc] initWithMatrixRestClient:aliceSession.matrixRestClient];
+        [matrixSDKTestsData retain:aliceSession2];
+        
         [aliceSession close];
         [aliceSession2 start:^{
             MXOlmOutboundGroupSession *outboundSession = [aliceSession2.crypto.store outboundGroupSessionWithRoomId:roomId];

--- a/MatrixSDKTests/MXDehydrationTests.m
+++ b/MatrixSDKTests/MXDehydrationTests.m
@@ -289,6 +289,7 @@
                         MXRestClient *aliceRestClient = aliceSession2.matrixRestClient;
                         
                         MXSession *aliceSession3 = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
+                        [self.matrixSDKTestsData retain:aliceSession3];
                         
                         [aliceSession2 close];
                         

--- a/MatrixSDKTests/MXEventTests.m
+++ b/MatrixSDKTests/MXEventTests.m
@@ -101,6 +101,7 @@
     [matrixSDKTestsData doMXRestClientTestWithBobAndARoomWithMessages:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
         
         mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        [matrixSDKTestsData retain:mxSession];
 
         [mxSession start:^{
 

--- a/MatrixSDKTests/MXEventTests.m
+++ b/MatrixSDKTests/MXEventTests.m
@@ -23,8 +23,6 @@
 @interface MXEventTests : XCTestCase
 {
     MatrixSDKTestsData *matrixSDKTestsData;
-
-    MXSession *mxSession;
 }
 
 @end
@@ -40,12 +38,6 @@
 
 - (void)tearDown
 {
-    if (mxSession)
-    {
-        [mxSession close];
-        mxSession = nil;
-    }
-
     matrixSDKTestsData = nil;
     
     [super tearDown];
@@ -100,7 +92,7 @@
 {
     [matrixSDKTestsData doMXRestClientTestWithBobAndARoomWithMessages:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
         
-        mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
         [matrixSDKTestsData retain:mxSession];
 
         [mxSession start:^{

--- a/MatrixSDKTests/MXEventTimelineTests.m
+++ b/MatrixSDKTests/MXEventTimelineTests.m
@@ -24,8 +24,6 @@
 @interface MXEventTimelineTests : XCTestCase
 {
     MatrixSDKTestsData *matrixSDKTestsData;
-
-    MXSession *mxSession;
 }
 @end
 
@@ -42,12 +40,6 @@ NSString *theInitialEventMessage = @"The initial timelime event";
 
 - (void)tearDown
 {
-    if (mxSession)
-    {
-        [mxSession close];
-        mxSession = nil;
-    }
-
     matrixSDKTestsData = nil;
 
     [super tearDown];
@@ -55,8 +47,7 @@ NSString *theInitialEventMessage = @"The initial timelime event";
 
 - (void)doTestWithARoomOf41Messages:(XCTestCase*)testCase readyToTest:(void (^)(MXRoom *room, XCTestExpectation *expectation, NSString *initialEventId))readyToTest
 {
-    [matrixSDKTestsData doMXSessionTestWithBobAndARoomWithMessages:self readyToTest:^(MXSession *mxSession2, MXRoom *room, XCTestExpectation *expectation) {
-        mxSession = mxSession2;
+    [matrixSDKTestsData doMXSessionTestWithBobAndARoomWithMessages:self readyToTest:^(MXSession *mxSession, MXRoom *room, XCTestExpectation *expectation) {
 
         // Add 20 messages to the room
         [matrixSDKTestsData for:mxSession.matrixRestClient andRoom:room.roomId sendMessages:20 testCase:testCase success:^{

--- a/MatrixSDKTests/MXLazyLoadingTests.m
+++ b/MatrixSDKTests/MXLazyLoadingTests.m
@@ -884,6 +884,7 @@ Common initial conditions:
 
         MXFileStore *store = [[MXFileStore alloc] init];
         __block MXSession *aliceSession2 = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
+        [matrixSDKTestsData retain:aliceSession2];
         [aliceSession2 setStore:store success:^{
             [aliceSession2 start:^{
 
@@ -948,6 +949,7 @@ Common initial conditions:
 
                             MXFileStore *store = [[MXFileStore alloc] init];
                             MXSession *aliceSession3 = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
+                            [matrixSDKTestsData retain:aliceSession3];
                             [aliceSession3 setStore:store success:^{
                                 [aliceSession3 start:^{
 

--- a/MatrixSDKTests/MXMyUserTests.m
+++ b/MatrixSDKTests/MXMyUserTests.m
@@ -71,6 +71,7 @@
     [matrixSDKTestsData doMXRestClientTestWithAlice:self readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation) {
 
         mxSession = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
+        [matrixSDKTestsData retain:mxSession];
 
         XCTAssertNil(mxSession.myUser, @"There should be no myUser while initialSync is not done");
 
@@ -108,6 +109,7 @@
     [matrixSDKTestsData doMXRestClientTestWithAlice:self readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation) {
 
         mxSession = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
+        [matrixSDKTestsData retain:mxSession];
 
         [mxSession start:^{
 
@@ -144,6 +146,7 @@
     [matrixSDKTestsData doMXRestClientTestWithAlice:self readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation) {
 
         mxSession = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
+        [matrixSDKTestsData retain:mxSession];
 
         [mxSession start:^{
 

--- a/MatrixSDKTests/MXMyUserTests.m
+++ b/MatrixSDKTests/MXMyUserTests.m
@@ -24,8 +24,6 @@
 @interface MXMyUserTests : XCTestCase
 {
     MatrixSDKTestsData *matrixSDKTestsData;
-
-    MXSession *mxSession;
 }
 @end
 
@@ -40,12 +38,6 @@
 
 - (void)tearDown
 {
-    if (mxSession)
-    {
-        [mxSession close];
-        mxSession = nil;
-    }
-
     matrixSDKTestsData = nil;
     
     [super tearDown];
@@ -53,9 +45,7 @@
 
 - (void)testMXSessionMyUser
 {
-    [matrixSDKTestsData doMXSessionTestWithBobAndARoomWithMessages:self readyToTest:^(MXSession *mxSession2, MXRoom *room, XCTestExpectation *expectation) {
-
-        mxSession = mxSession2;
+    [matrixSDKTestsData doMXSessionTestWithBobAndARoomWithMessages:self readyToTest:^(MXSession *mxSession, MXRoom *room, XCTestExpectation *expectation) {
 
         XCTAssertNotNil(mxSession.myUser);
 
@@ -70,7 +60,7 @@
 {
     [matrixSDKTestsData doMXRestClientTestWithAlice:self readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation) {
 
-        mxSession = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
+        MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
         [matrixSDKTestsData retain:mxSession];
 
         XCTAssertNil(mxSession.myUser, @"There should be no myUser while initialSync is not done");
@@ -108,7 +98,7 @@
 {
     [matrixSDKTestsData doMXRestClientTestWithAlice:self readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation) {
 
-        mxSession = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
+        MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
         [matrixSDKTestsData retain:mxSession];
 
         [mxSession start:^{
@@ -145,7 +135,7 @@
 {
     [matrixSDKTestsData doMXRestClientTestWithAlice:self readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation) {
 
-        mxSession = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
+        MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
         [matrixSDKTestsData retain:mxSession];
 
         [mxSession start:^{
@@ -181,9 +171,7 @@
 
 - (void)testIdenticon
 {
-    [matrixSDKTestsData doMXSessionTestWithBobAndARoomWithMessages:self readyToTest:^(MXSession *mxSession2, MXRoom *room, XCTestExpectation *expectation) {
-
-        mxSession = mxSession2;
+    [matrixSDKTestsData doMXSessionTestWithBobAndARoomWithMessages:self readyToTest:^(MXSession *mxSession, MXRoom *room, XCTestExpectation *expectation) {
 
         MXUser *myUser = [mxSession userWithUserId:mxSession.matrixRestClient.credentials.userId];
 

--- a/MatrixSDKTests/MXNotificationCenterTests.m
+++ b/MatrixSDKTests/MXNotificationCenterTests.m
@@ -26,8 +26,6 @@
 @interface MXNotificationCenterTests : XCTestCase
 {
     MatrixSDKTestsData *matrixSDKTestsData;
-
-    MXSession *mxSession;
 }
 
 @end
@@ -43,12 +41,6 @@
 
 - (void)tearDown
 {
-    if (mxSession)
-    {
-        [mxSession close];
-        mxSession = nil;
-    }
-
     matrixSDKTestsData = nil;
     
     [super tearDown];
@@ -58,7 +50,7 @@
 {
     [matrixSDKTestsData doMXRestClientTestWithBob:self readyToTest:^(MXRestClient *bobRestClient, XCTestExpectation *expectation) {
 
-        mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
         [matrixSDKTestsData retain:mxSession];
 
         XCTAssertNotNil(mxSession.notificationCenter);
@@ -84,9 +76,7 @@
 
 - (void)testNoNotificationsOnUserEvents
 {
-    [matrixSDKTestsData doMXSessionTestWithBobAndARoomWithMessages:self readyToTest:^(MXSession *mxSession2, MXRoom *room, XCTestExpectation *expectation) {
-
-        mxSession = mxSession2;
+    [matrixSDKTestsData doMXSessionTestWithBobAndARoomWithMessages:self readyToTest:^(MXSession *mxSession, MXRoom *room, XCTestExpectation *expectation) {
 
         [mxSession.notificationCenter listenToNotifications:^(MXEvent *event, MXRoomState *roomState, MXPushRule *rule) {
 
@@ -114,8 +104,6 @@
 - (void)testNoNotificationsOnPresenceOrTypingEvents
 {
     [matrixSDKTestsData doMXSessionTestWithBobAndAliceInARoom:self readyToTest:^(MXSession *bobSession, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
-
-        mxSession = bobSession;
 
         [bobSession.notificationCenter listenToNotifications:^(MXEvent *event, MXRoomState *roomState, MXPushRule *rule) {
 
@@ -153,16 +141,14 @@
 // While this ticket is not fixed, make sure the SDK workrounds it
 - (void)testDefaultPushOnAllNonYouMessagesRule
 {
-    [matrixSDKTestsData doMXSessionTestWithBobAndAliceInARoom:self readyToTest:^(MXSession *bobSession, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
-
-        mxSession = bobSession;
+    [matrixSDKTestsData doMXSessionTestWithBobAndAliceInARoom:self readyToTest:^(MXSession *mxSession, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
         MXRoom *room = [mxSession roomWithRoomId:roomId];
         [room liveTimeline:^(MXEventTimeline *liveTimeline) {
 
             [liveTimeline listenToEventsOfTypes:@[kMXEventTypeStringRoomMember] onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
 
-                [bobSession.notificationCenter listenToNotifications:^(MXEvent *event, MXRoomState *roomState, MXPushRule *rule) {
+                [mxSession.notificationCenter listenToNotifications:^(MXEvent *event, MXRoomState *roomState, MXPushRule *rule) {
 
                     // We must be alerted by the default content HS rule on any message
                     XCTAssertEqual(rule.kind, MXPushRuleKindUnderride);
@@ -244,8 +230,6 @@
 {
     [matrixSDKTestsData doMXSessionTestWithBobAndAliceInARoom:self readyToTest:^(MXSession *bobSession, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
-        mxSession = bobSession;
-
         MXSession *aliceSession = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
         [matrixSDKTestsData retain:aliceSession];
         
@@ -270,7 +254,7 @@
 
                 }];
 
-                MXRoom *roomBobSide = [mxSession roomWithRoomId:roomId];
+                MXRoom *roomBobSide = [bobSession roomWithRoomId:roomId];
                 [roomBobSide sendTextMessage:messageFromBob success:^(NSString *eventId) {
 
                 } failure:^(NSError *error) {
@@ -294,8 +278,6 @@
 - (void)testDefaultRoomMemberCountCondition
 {
     [matrixSDKTestsData doMXSessionTestWithBobAndAliceInARoom:self readyToTest:^(MXSession *bobSession, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
-
-        mxSession = bobSession;
 
         NSString *messageFromAlice = @"We are two peoples in this room";
 
@@ -329,8 +311,6 @@
 {
     [matrixSDKTestsData doMXSessionTestWithBobAndAliceInARoom:self readyToTest:^(MXSession *bobSession, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
-        mxSession = bobSession;
-
         NSString *messageFromAlice = @"We are two peoples in this room";
 
         id listener = [bobSession.notificationCenter listenToNotifications:^(MXEvent *event, MXRoomState *roomState, MXPushRule *rule) {
@@ -361,8 +341,6 @@
 - (void)testRuleMatchingEvent
 {
     [matrixSDKTestsData doMXSessionTestWithBobAndAliceInARoom:self readyToTest:^(MXSession *bobSession, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
-
-        mxSession = bobSession;
 
         MXSession *aliceSession = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
         [matrixSDKTestsData retain:aliceSession];
@@ -398,7 +376,7 @@
                     }
                 }];
 
-                MXRoom *roomBobSide = [mxSession roomWithRoomId:roomId];
+                MXRoom *roomBobSide = [bobSession roomWithRoomId:roomId];
                 [roomBobSide sendTextMessage:messageFromBob success:^(NSString *eventId) {
 
                 } failure:^(NSError *error) {

--- a/MatrixSDKTests/MXNotificationCenterTests.m
+++ b/MatrixSDKTests/MXNotificationCenterTests.m
@@ -59,6 +59,7 @@
     [matrixSDKTestsData doMXRestClientTestWithBob:self readyToTest:^(MXRestClient *bobRestClient, XCTestExpectation *expectation) {
 
         mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        [matrixSDKTestsData retain:mxSession];
 
         XCTAssertNotNil(mxSession.notificationCenter);
         XCTAssertNil(mxSession.notificationCenter.rules);
@@ -246,6 +247,8 @@
         mxSession = bobSession;
 
         MXSession *aliceSession = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
+        [matrixSDKTestsData retain:aliceSession];
+        
         [aliceSession start:^{
 
             // Change alice name
@@ -362,6 +365,8 @@
         mxSession = bobSession;
 
         MXSession *aliceSession = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
+        [matrixSDKTestsData retain:aliceSession];
+        
         [aliceSession start:^{
 
             // Change alice name

--- a/MatrixSDKTests/MXPeekingRoomTests.m
+++ b/MatrixSDKTests/MXPeekingRoomTests.m
@@ -29,8 +29,6 @@
 @interface MXPeekingRoomTests : XCTestCase
 {
     MatrixSDKTestsData *matrixSDKTestsData;
-
-    MXSession *mxSession;
 }
 @end
 
@@ -45,12 +43,6 @@
 
 - (void)tearDown
 {
-    if (mxSession)
-    {
-        [mxSession close];
-        mxSession = nil;
-    }
-
     matrixSDKTestsData = nil;
 
     [super tearDown];
@@ -62,9 +54,7 @@
 
         [room setHistoryVisibility:kMXRoomHistoryVisibilityWorldReadable success:^{
 
-            [matrixSDKTestsData doMXSessionTestWithAlice:nil readyToTest:^(MXSession *aliceSession, XCTestExpectation *expectation2) {
-
-                mxSession = aliceSession;
+            [matrixSDKTestsData doMXSessionTestWithAlice:nil readyToTest:^(MXSession *mxSession, XCTestExpectation *expectation2) {
 
                 XCTAssertEqual(mxSession.rooms.count, 0);
 
@@ -103,9 +93,7 @@
 
         [room setHistoryVisibility:kMXRoomHistoryVisibilityWorldReadable success:^{
 
-            [matrixSDKTestsData doMXSessionTestWithAlice:nil readyToTest:^(MXSession *aliceSession, XCTestExpectation *expectation2) {
-
-                mxSession = aliceSession;
+            [matrixSDKTestsData doMXSessionTestWithAlice:nil readyToTest:^(MXSession *mxSession, XCTestExpectation *expectation2) {
 
                 XCTAssertEqual(mxSession.rooms.count, 0);
 
@@ -142,9 +130,7 @@
 {
     [matrixSDKTestsData doMXSessionTestWithBobAndThePublicRoom:self readyToTest:^(MXSession *mxSession2, MXRoom *room, XCTestExpectation *expectation) {
 
-        [matrixSDKTestsData doMXSessionTestWithAlice:nil readyToTest:^(MXSession *aliceSession, XCTestExpectation *expectation2) {
-
-            mxSession = aliceSession;
+        [matrixSDKTestsData doMXSessionTestWithAlice:nil readyToTest:^(MXSession *mxSession, XCTestExpectation *expectation2) {
 
             XCTAssertEqual(mxSession.rooms.count, 0);
 
@@ -166,9 +152,7 @@
 
 - (void)testPeekingWithMemberAlreadyInRoom
 {
-    [matrixSDKTestsData doMXSessionTestWithBobAndThePublicRoom:self readyToTest:^(MXSession *mxSession2, MXRoom *room, XCTestExpectation *expectation) {
-
-        mxSession = mxSession2;
+    [matrixSDKTestsData doMXSessionTestWithBobAndThePublicRoom:self readyToTest:^(MXSession *mxSession, MXRoom *room, XCTestExpectation *expectation) {
 
         XCTAssertEqual(mxSession.rooms.count, 1);
         XCTAssertEqual(room.summary.membersCount.members, 1);

--- a/MatrixSDKTests/MXRoomMemberTests.m
+++ b/MatrixSDKTests/MXRoomMemberTests.m
@@ -23,8 +23,6 @@
 @interface MXRoomMemberTests : XCTestCase
 {
     MatrixSDKTestsData *matrixSDKTestsData;
-    
-    MXSession *mxSession;
 }
 @end
 
@@ -39,12 +37,6 @@
 
 - (void)tearDown
 {
-    if (mxSession)
-    {
-        [mxSession close];
-        mxSession = nil;
-    }
-    
     matrixSDKTestsData = nil;
     
     [super tearDown];

--- a/MatrixSDKTests/MXRoomStateDynamicTests.m
+++ b/MatrixSDKTests/MXRoomStateDynamicTests.m
@@ -23,8 +23,6 @@
 @interface MXRoomStateDynamicTests : XCTestCase
 {
     MatrixSDKTestsData *matrixSDKTestsData;
-
-    MXSession *mxSession;
 }
 @end
 
@@ -39,12 +37,6 @@
 
 - (void)tearDown
 {
-    if (mxSession)
-    {
-        [mxSession close];
-        mxSession = nil;
-    }
-
     matrixSDKTestsData = nil;
     
     [super tearDown];
@@ -111,7 +103,7 @@
         
         [self createScenario1:bobRestClient inRoom:roomId expectation:expectation onComplete:^{
             
-            mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+            MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
             [matrixSDKTestsData retain:mxSession];
             
             [mxSession start:^{
@@ -198,7 +190,7 @@
 {
     [matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
         
-        mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
         [matrixSDKTestsData retain:mxSession];
         
         [mxSession start:^{

--- a/MatrixSDKTests/MXRoomStateDynamicTests.m
+++ b/MatrixSDKTests/MXRoomStateDynamicTests.m
@@ -112,6 +112,7 @@
         [self createScenario1:bobRestClient inRoom:roomId expectation:expectation onComplete:^{
             
             mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+            [matrixSDKTestsData retain:mxSession];
             
             [mxSession start:^{
                 
@@ -198,6 +199,7 @@
     [matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
         
         mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        [matrixSDKTestsData retain:mxSession];
         
         [mxSession start:^{
             
@@ -385,6 +387,7 @@
         [self createScenario2:bobRestClient inRoom:roomId expectation:expectation onComplete:^(MXRestClient *aliceRestClient) {
             
             mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+            [matrixSDKTestsData retain:mxSession];
             
             [mxSession start:^{
                 
@@ -565,6 +568,7 @@
     [matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
         
         mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        [matrixSDKTestsData retain:mxSession];
         
         [mxSession start:^{
             

--- a/MatrixSDKTests/MXRoomStateTests.m
+++ b/MatrixSDKTests/MXRoomStateTests.m
@@ -95,6 +95,8 @@
         [bobRestClient setRoomTopic:roomId topic:@"My topic" success:^{
             
             mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
+            [matrixSDKTestsData retain:mxSession];
+            
             [mxSession start:^{
                 
                 MXRoom *room = [mxSession roomWithRoomId:roomId];
@@ -126,6 +128,8 @@
         MXRestClient *bobRestClient2 = bobRestClient;
         
         mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
+        [matrixSDKTestsData retain:mxSession];
+        
         [mxSession start:^{
             
             MXRoom *room = [mxSession roomWithRoomId:roomId];
@@ -174,6 +178,8 @@
         [bobRestClient setRoomAvatar:roomId avatar:@"http://matrix.org/matrix.png" success:^{
 
             mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
+            [matrixSDKTestsData retain:mxSession];
+            
             [mxSession start:^{
 
                 MXRoom *room = [mxSession roomWithRoomId:roomId];
@@ -205,6 +211,8 @@
         MXRestClient *bobRestClient2 = bobRestClient;
 
         mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
+        [matrixSDKTestsData retain:mxSession];
+        
         [mxSession start:^{
 
             MXRoom *room = [mxSession roomWithRoomId:roomId];
@@ -251,6 +259,8 @@
         [bobRestClient setRoomName:roomId name:@"My room name" success:^{
             
             mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
+            [matrixSDKTestsData retain:mxSession];
+            
             [mxSession start:^{
                 
                 MXRoom *room = [mxSession roomWithRoomId:roomId];
@@ -283,6 +293,8 @@
         MXRestClient *bobRestClient2 = bobRestClient;
         
         mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
+        [matrixSDKTestsData retain:mxSession];
+        
         [mxSession start:^{
             
             MXRoom *room = [mxSession roomWithRoomId:roomId];
@@ -329,6 +341,8 @@
         [bobRestClient setRoomHistoryVisibility:roomId historyVisibility:kMXRoomHistoryVisibilityWorldReadable success:^{
 
             mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
+            [matrixSDKTestsData retain:mxSession];
+            
             [mxSession start:^{
 
                 MXRoom *room = [mxSession roomWithRoomId:roomId];
@@ -361,6 +375,8 @@
         MXRestClient *bobRestClient2 = bobRestClient;
 
         mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
+        [matrixSDKTestsData retain:mxSession];
+        
         [mxSession start:^{
 
             MXRoom *room = [mxSession roomWithRoomId:roomId];
@@ -408,6 +424,8 @@
         [bobRestClient setRoomJoinRule:roomId joinRule:kMXRoomJoinRulePublic success:^{
 
             mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
+            [matrixSDKTestsData retain:mxSession];
+            
             [mxSession start:^{
 
                 MXRoom *room = [mxSession roomWithRoomId:roomId];
@@ -439,6 +457,8 @@
         MXRestClient *bobRestClient2 = bobRestClient;
 
         mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
+        [matrixSDKTestsData retain:mxSession];
+        
         [mxSession start:^{
 
             MXRoom *room = [mxSession roomWithRoomId:roomId];
@@ -486,6 +506,8 @@
         [bobRestClient setRoomGuestAccess:roomId guestAccess:kMXRoomGuestAccessCanJoin success:^{
 
             mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
+            [matrixSDKTestsData retain:mxSession];
+            
             [mxSession start:^{
 
                 MXRoom *room = [mxSession roomWithRoomId:roomId];
@@ -517,6 +539,8 @@
         MXRestClient *bobRestClient2 = bobRestClient;
 
         mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
+        [matrixSDKTestsData retain:mxSession];
+        
         [mxSession start:^{
 
             MXRoom *room = [mxSession roomWithRoomId:roomId];
@@ -569,6 +593,8 @@
             [bobRestClient2 setRoomCanonicalAlias:roomId canonicalAlias:roomAlias success:^{
                 
                 mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
+                [matrixSDKTestsData retain:mxSession];
+                
                 [mxSession start:^{
                     
                     MXRoom *room = [mxSession roomWithRoomId:roomId];
@@ -611,6 +637,8 @@
         MXRestClient *bobRestClient2 = bobRestClient;
         
         mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
+        [matrixSDKTestsData retain:mxSession];
+        
         [mxSession start:^{
             
             MXRoom *room = [mxSession roomWithRoomId:roomId];
@@ -676,6 +704,8 @@
     [matrixSDKTestsData doMXRestClientTestInABobRoomAndANewTextMessage:self newTextMessage:@"This is a text message for recents" onReadyToTest:^(MXRestClient *bobRestClient, NSString *roomId, NSString *new_text_message_eventId, XCTestExpectation *expectation) {
         
         mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        [matrixSDKTestsData retain:mxSession];
+        
         [mxSession start:^{
             
             MXRoom *room = [mxSession roomWithRoomId:roomId];
@@ -969,6 +999,7 @@
             [matrixSDKTestsData doMXRestClientTestWithAlice:nil readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation2) {
                 
                 mxSession = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
+                [matrixSDKTestsData retain:mxSession];
                 
                 [mxSession start:^{
                     
@@ -1050,6 +1081,7 @@
             [matrixSDKTestsData doMXRestClientTestWithAlice:nil readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation2) {
                 
                 mxSession = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
+                [matrixSDKTestsData retain:mxSession];
                 
                 [mxSession start:^{
                     
@@ -1111,6 +1143,7 @@
     [matrixSDKTestsData doMXRestClientTestWithBobAndAliceInARoom:self readyToTest:^(MXRestClient *bobRestClient, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
         mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        [matrixSDKTestsData retain:mxSession];
 
         [mxSession start:^{
 
@@ -1175,6 +1208,8 @@
     [matrixSDKTestsData doMXRestClientTestWithAlice:self readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation) {
 
         mxSession = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
+        [matrixSDKTestsData retain:mxSession];
+        
         [mxSession start:^{
 
             __block NSString *newRoomId;
@@ -1229,6 +1264,8 @@
     [matrixSDKTestsData doMXRestClientTestWithAlice:self readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation) {
 
         mxSession = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
+        [matrixSDKTestsData retain:mxSession];
+        
         [mxSession start:^{
 
             __block NSString *newRoomId;

--- a/MatrixSDKTests/MXRoomStateTests.m
+++ b/MatrixSDKTests/MXRoomStateTests.m
@@ -30,8 +30,6 @@
 @interface MXRoomStateTests : XCTestCase
 {
     MatrixSDKTestsData *matrixSDKTestsData;
-
-    MXSession *mxSession;
 }
 @end
 
@@ -46,12 +44,6 @@
 
 - (void)tearDown
 {
-    if (mxSession)
-    {
-        [mxSession close];
-        mxSession = nil;
-    }
-    
     matrixSDKTestsData = nil;
     
     [super tearDown];
@@ -59,9 +51,7 @@
 
 - (void)testIsJoinRulePublic
 {
-    [matrixSDKTestsData doMXSessionTestWithBobAndThePublicRoom:self readyToTest:^(MXSession *mxSession2, MXRoom *room, XCTestExpectation *expectation) {
-
-        mxSession = mxSession2;
+    [matrixSDKTestsData doMXSessionTestWithBobAndThePublicRoom:self readyToTest:^(MXSession *mxSession, MXRoom *room, XCTestExpectation *expectation) {
 
         [room state:^(MXRoomState *roomState) {
 
@@ -74,9 +64,7 @@
 
 - (void)testIsJoinRulePublicForAPrivateRoom
 {
-    [matrixSDKTestsData doMXSessionTestWithBobAndARoomWithMessages:self readyToTest:^(MXSession *mxSession2, MXRoom *room, XCTestExpectation *expectation) {
-        
-        mxSession = mxSession2;
+    [matrixSDKTestsData doMXSessionTestWithBobAndARoomWithMessages:self readyToTest:^(MXSession *mxSession, MXRoom *room, XCTestExpectation *expectation) {
 
         [room state:^(MXRoomState *roomState) {
             XCTAssertFalse(roomState.isJoinRulePublic, @"This room join rule must be private");
@@ -94,7 +82,7 @@
         
         [bobRestClient setRoomTopic:roomId topic:@"My topic" success:^{
             
-            mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
+            MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
             [matrixSDKTestsData retain:mxSession];
             
             [mxSession start:^{
@@ -127,7 +115,7 @@
         
         MXRestClient *bobRestClient2 = bobRestClient;
         
-        mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
+        MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
         [matrixSDKTestsData retain:mxSession];
         
         [mxSession start:^{
@@ -177,7 +165,7 @@
 
         [bobRestClient setRoomAvatar:roomId avatar:@"http://matrix.org/matrix.png" success:^{
 
-            mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
+            MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
             [matrixSDKTestsData retain:mxSession];
             
             [mxSession start:^{
@@ -210,7 +198,7 @@
 
         MXRestClient *bobRestClient2 = bobRestClient;
 
-        mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
+        MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
         [matrixSDKTestsData retain:mxSession];
         
         [mxSession start:^{
@@ -258,7 +246,7 @@
         
         [bobRestClient setRoomName:roomId name:@"My room name" success:^{
             
-            mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
+            MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
             [matrixSDKTestsData retain:mxSession];
             
             [mxSession start:^{
@@ -292,7 +280,7 @@
         
         MXRestClient *bobRestClient2 = bobRestClient;
         
-        mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
+        MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
         [matrixSDKTestsData retain:mxSession];
         
         [mxSession start:^{
@@ -340,7 +328,7 @@
 
         [bobRestClient setRoomHistoryVisibility:roomId historyVisibility:kMXRoomHistoryVisibilityWorldReadable success:^{
 
-            mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
+            MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
             [matrixSDKTestsData retain:mxSession];
             
             [mxSession start:^{
@@ -374,7 +362,7 @@
 
         MXRestClient *bobRestClient2 = bobRestClient;
 
-        mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
+        MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
         [matrixSDKTestsData retain:mxSession];
         
         [mxSession start:^{
@@ -423,7 +411,7 @@
 
         [bobRestClient setRoomJoinRule:roomId joinRule:kMXRoomJoinRulePublic success:^{
 
-            mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
+            MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
             [matrixSDKTestsData retain:mxSession];
             
             [mxSession start:^{
@@ -456,7 +444,7 @@
 
         MXRestClient *bobRestClient2 = bobRestClient;
 
-        mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
+        MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
         [matrixSDKTestsData retain:mxSession];
         
         [mxSession start:^{
@@ -505,7 +493,7 @@
 
         [bobRestClient setRoomGuestAccess:roomId guestAccess:kMXRoomGuestAccessCanJoin success:^{
 
-            mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
+            MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
             [matrixSDKTestsData retain:mxSession];
             
             [mxSession start:^{
@@ -538,7 +526,7 @@
 
         MXRestClient *bobRestClient2 = bobRestClient;
 
-        mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
+        MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
         [matrixSDKTestsData retain:mxSession];
         
         [mxSession start:^{
@@ -592,7 +580,7 @@
             // Use this alias as the canonical alias
             [bobRestClient2 setRoomCanonicalAlias:roomId canonicalAlias:roomAlias success:^{
                 
-                mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
+                MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
                 [matrixSDKTestsData retain:mxSession];
                 
                 [mxSession start:^{
@@ -636,7 +624,7 @@
         
         MXRestClient *bobRestClient2 = bobRestClient;
         
-        mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
+        MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
         [matrixSDKTestsData retain:mxSession];
         
         [mxSession start:^{
@@ -703,7 +691,7 @@
 {
     [matrixSDKTestsData doMXRestClientTestInABobRoomAndANewTextMessage:self newTextMessage:@"This is a text message for recents" onReadyToTest:^(MXRestClient *bobRestClient, NSString *roomId, NSString *new_text_message_eventId, XCTestExpectation *expectation) {
         
-        mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
         [matrixSDKTestsData retain:mxSession];
         
         [mxSession start:^{
@@ -741,9 +729,7 @@
 
 - (void)testMemberName
 {
-    [matrixSDKTestsData doMXSessionTestWithBobAndThePublicRoom:self readyToTest:^(MXSession *mxSession2, MXRoom *room, XCTestExpectation *expectation) {
-        
-        mxSession = mxSession2;
+    [matrixSDKTestsData doMXSessionTestWithBobAndThePublicRoom:self readyToTest:^(MXSession *mxSession, MXRoom *room, XCTestExpectation *expectation) {
 
         NSString *bobUserId = matrixSDKTestsData.bobCredentials.userId;
 
@@ -766,9 +752,7 @@
 
 - (void)testStateEvents
 {
-    [matrixSDKTestsData doMXSessionTestWithBobAndARoomWithMessages:self readyToTest:^(MXSession *mxSession2, MXRoom *room, XCTestExpectation *expectation) {
-        
-        mxSession = mxSession2;
+    [matrixSDKTestsData doMXSessionTestWithBobAndARoomWithMessages:self readyToTest:^(MXSession *mxSession, MXRoom *room, XCTestExpectation *expectation) {
 
         [room state:^(MXRoomState *roomState) {
             XCTAssertNotNil(roomState.stateEvents);
@@ -781,9 +765,7 @@
 
 - (void)testAliases
 {
-    [matrixSDKTestsData doMXSessionTestWithBobAndThePublicRoom:self readyToTest:^(MXSession *mxSession2, MXRoom *room, XCTestExpectation *expectation) {
-        
-        mxSession = mxSession2;
+    [matrixSDKTestsData doMXSessionTestWithBobAndThePublicRoom:self readyToTest:^(MXSession *mxSession, MXRoom *room, XCTestExpectation *expectation) {
 
         [room state:^(MXRoomState *roomState) {
             XCTAssertNotNil(roomState.aliases);
@@ -868,9 +850,7 @@
         
         [self createInviteByUserScenario:bobRestClient inRoom:roomId inviteAlice:YES expectation:expectation onComplete:^{
             
-            [matrixSDKTestsData doMXSessionTestWithAlice:nil andStore:[MXMemoryStore new] readyToTest:^(MXSession *aliceSession, XCTestExpectation *expectation2) {
-                
-                mxSession = aliceSession;
+            [matrixSDKTestsData doMXSessionTestWithAlice:nil andStore:[MXMemoryStore new] readyToTest:^(MXSession *mxSession, XCTestExpectation *expectation2) {
                 
                 MXRoom *newRoom = [mxSession roomWithRoomId:roomId];
                 
@@ -883,7 +863,7 @@
 
                 [newRoom members:^(MXRoomMembers *roomMembers) {
 
-                    MXRoomMember *alice = [roomMembers memberWithUserId:aliceSession.myUserId];
+                    MXRoomMember *alice = [roomMembers memberWithUserId:mxSession.myUserId];
                     XCTAssertNotNil(alice);
                     XCTAssertEqual(alice.membership, MXMembershipInvite);
                     XCTAssert([alice.originUserId isEqualToString:bobRestClient.credentials.userId], @"Wrong inviter: %@", alice.originUserId);
@@ -918,9 +898,7 @@
 {
     [matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
         
-        [matrixSDKTestsData doMXSessionTestWithAlice:nil andStore:[MXMemoryStore new] readyToTest:^(MXSession *aliceSession, XCTestExpectation *expectation2) {
-            
-            mxSession = aliceSession;
+        [matrixSDKTestsData doMXSessionTestWithAlice:nil andStore:[MXMemoryStore new] readyToTest:^(MXSession *mxSession, XCTestExpectation *expectation2) {
             
             __block MXRoom *newRoom;
             __block id listener;
@@ -943,7 +921,7 @@
                         
                         [newRoom members:^(MXRoomMembers *roomMembers) {
                             
-                            MXRoomMember *alice = [roomMembers memberWithUserId:aliceSession.myUserId];
+                            MXRoomMember *alice = [roomMembers memberWithUserId:mxSession.myUserId];
                             XCTAssertNotNil(alice);
                             XCTAssertEqual(alice.membership, MXMembershipInvite);
                             XCTAssert([alice.originUserId isEqualToString:bobRestClient.credentials.userId], @"Wrong inviter: %@", alice.originUserId);
@@ -998,7 +976,7 @@
             
             [matrixSDKTestsData doMXRestClientTestWithAlice:nil readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation2) {
                 
-                mxSession = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
+                MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
                 [matrixSDKTestsData retain:mxSession];
                 
                 [mxSession start:^{
@@ -1080,7 +1058,7 @@
             
             [matrixSDKTestsData doMXRestClientTestWithAlice:nil readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation2) {
                 
-                mxSession = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
+                MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
                 [matrixSDKTestsData retain:mxSession];
                 
                 [mxSession start:^{
@@ -1142,7 +1120,7 @@
 {
     [matrixSDKTestsData doMXRestClientTestWithBobAndAliceInARoom:self readyToTest:^(MXRestClient *bobRestClient, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
-        mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
         [matrixSDKTestsData retain:mxSession];
 
         [mxSession start:^{
@@ -1207,7 +1185,7 @@
 {
     [matrixSDKTestsData doMXRestClientTestWithAlice:self readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation) {
 
-        mxSession = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
+        MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
         [matrixSDKTestsData retain:mxSession];
         
         [mxSession start:^{
@@ -1263,7 +1241,7 @@
 - (void)testRoomStateWhenARoomHasBeenJoinedOnAnotherMatrixClientAndNotifications {
     [matrixSDKTestsData doMXRestClientTestWithAlice:self readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation) {
 
-        mxSession = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
+        MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
         [matrixSDKTestsData retain:mxSession];
         
         [mxSession start:^{
@@ -1314,22 +1292,20 @@
 - (void)testDeallocation
 {
     __weak __block MXRoomState *weakState;
-    [matrixSDKTestsData doMXSessionTestWithBobAndThePublicRoom:self readyToTest:^(MXSession *mxSession2, MXRoom *room, XCTestExpectation *expectation) {
-        mxSession = mxSession2;
+    [matrixSDKTestsData doMXSessionTestWithBobAndThePublicRoom:self readyToTest:^(MXSession *mxSession, MXRoom *room, XCTestExpectation *expectation) {
         [room state:^(MXRoomState *roomState) {
             weakState = roomState;
             XCTAssertNotNil(weakState);
             [expectation fulfill];
         }];
-        [mxSession2 close]; // Force room deallocation
     }];
     XCTAssertNil(weakState);
 }
 
 - (void)testCopying
 {
-    [matrixSDKTestsData doMXSessionTestWithBobAndThePublicRoom:self readyToTest:^(MXSession *mxSession2, MXRoom *room, XCTestExpectation *expectation) {
-        mxSession = mxSession2;
+    [matrixSDKTestsData doMXSessionTestWithBobAndThePublicRoom:self readyToTest:^(MXSession *mxSession, MXRoom *room, XCTestExpectation *expectation) {
+
         [room state:^(MXRoomState *roomState) {
             MXRoomState *roomStateCopy = [roomState copy];
             XCTAssertEqual(roomStateCopy.members.members.count, roomState.members.members.count);

--- a/MatrixSDKTests/MXRoomSummaryTests.m
+++ b/MatrixSDKTests/MXRoomSummaryTests.m
@@ -286,6 +286,7 @@ NSString *uisiString = @"The sender's device has not sent us the keys for this m
         [mxSession close];
 
         MXSession *mxSession2 = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        [matrixSDKTestsData retain:mxSession2];
         [mxSession2 setStore:[[MXMemoryStore alloc] init] success:^{
 
             // Start a new session by loading no message
@@ -344,6 +345,7 @@ NSString *uisiString = @"The sender's device has not sent us the keys for this m
             [mxSession close];
 
             MXSession *mxSession2 = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+            [matrixSDKTestsData retain:mxSession2];
 
             // Configure the updater so that it refuses room messages as last message
             mxSession2.roomSummaryUpdateDelegate = self;
@@ -410,6 +412,7 @@ NSString *uisiString = @"The sender's device has not sent us the keys for this m
         [mxSession close];
 
         MXSession *mxSession2 = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        [matrixSDKTestsData retain:mxSession2];
         [mxSession2 setStore:[[MXMemoryStore alloc] init] success:^{
 
             // Start a new session by loading no message
@@ -1040,6 +1043,7 @@ NSString *uisiString = @"The sender's device has not sent us the keys for this m
                         // Restarting the session with a new MXMemoryStore is equivalent to
                         // clearing the cache of MXFileStore
                         MXSession *mxSession2 = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+                        [matrixSDKTestsData retain:mxSession2];
                         [mxSession2 setStore:[[MXMemoryStore alloc] init] success:^{
 
                             MXRoomSummaryUpdater *defaultUpdater = [MXRoomSummaryUpdater roomSummaryUpdaterForSession:mxSession2];
@@ -1187,6 +1191,7 @@ NSString *uisiString = @"The sender's device has not sent us the keys for this m
 
                         // Then reopen a session on this store
                         MXSession *aliceSession2 = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
+                        [matrixSDKTestsData retain:aliceSession2];
                         [aliceSession2 setStore:[[MXFileStore alloc] init] success:^{
 
                             [aliceSession2 start:^{
@@ -1270,6 +1275,7 @@ NSString *uisiString = @"The sender's device has not sent us the keys for this m
 
                     // Then reopen a session
                     MXSession *aliceSession2 = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
+                    [matrixSDKTestsData retain:aliceSession2];
                     [aliceSession2 setStore:[[MXFileStore alloc] init] success:^{
 
                         [aliceSession2 start:^{

--- a/MatrixSDKTests/MXRoomTests.m
+++ b/MatrixSDKTests/MXRoomTests.m
@@ -29,8 +29,6 @@
 @interface MXRoomTests : XCTestCase
 {
     MatrixSDKTestsData *matrixSDKTestsData;
-
-    MXSession *mxSession;
 }
 
 @end
@@ -46,12 +44,6 @@
 
 - (void)tearDown
 {
-    if (mxSession)
-    {
-        [mxSession close];
-        mxSession = nil;
-    }
-
     matrixSDKTestsData = nil;
     
     [super tearDown];
@@ -60,9 +52,7 @@
 
 - (void)testListenerForAllLiveEvents
 {
-    [matrixSDKTestsData doMXSessionTestWithBobAndThePublicRoom:self readyToTest:^(MXSession *mxSession2, MXRoom *room, XCTestExpectation *expectation) {
-        
-        mxSession = mxSession2;
+    [matrixSDKTestsData doMXSessionTestWithBobAndThePublicRoom:self readyToTest:^(MXSession *mxSession, MXRoom *room, XCTestExpectation *expectation) {
 
         __block NSString *sentMessageEventID;
         __block NSString *receivedMessageEventID;
@@ -117,9 +107,7 @@
 
 - (void)testListenerForRoomMessageLiveEvents
 {
-    [matrixSDKTestsData doMXSessionTestWithBobAndThePublicRoom:self readyToTest:^(MXSession *mxSession2, MXRoom *room, XCTestExpectation *expectation) {
-        
-        mxSession = mxSession2;
+    [matrixSDKTestsData doMXSessionTestWithBobAndThePublicRoom:self readyToTest:^(MXSession *mxSession, MXRoom *room, XCTestExpectation *expectation) {
 
         __block NSString *sentMessageEventID;
         __block NSString *receivedMessageEventID;
@@ -174,9 +162,7 @@
 
 - (void)testLeave
 {
-    [matrixSDKTestsData doMXSessionTestWithBobAndARoomWithMessages:self readyToTest:^(MXSession *mxSession2, MXRoom *room, XCTestExpectation *expectation) {
-        
-        mxSession = mxSession2;
+    [matrixSDKTestsData doMXSessionTestWithBobAndARoomWithMessages:self readyToTest:^(MXSession *mxSession, MXRoom *room, XCTestExpectation *expectation) {
         
         NSString *roomId = room.roomId;
 
@@ -211,7 +197,7 @@
 
         [matrixSDKTestsData doMXRestClientTestWithAlice:nil readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation2) {
 
-            mxSession = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
+            MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
             [matrixSDKTestsData retain:mxSession];
 
             [bobRestClient inviteUser:aliceRestClient.credentials.userId toRoom:roomId success:^{
@@ -255,7 +241,7 @@
 {
     [matrixSDKTestsData doMXRestClientTestWithBobAndAliceInARoom:self readyToTest:^(MXRestClient *bobRestClient, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
-        mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
         [matrixSDKTestsData retain:mxSession];
         [mxSession start:^{
 
@@ -288,7 +274,7 @@
 {
     [matrixSDKTestsData doMXRestClientTestWithBobAndARoomWithMessages:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
-        mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
         [matrixSDKTestsData retain:mxSession];
 
         [mxSession startWithSyncFilter:[MXFilterJSONModel syncFilterWithMessageLimit:0] onServerSyncDone:^{
@@ -332,7 +318,7 @@
 {
     [matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
-        mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
         [matrixSDKTestsData retain:mxSession];
         
         [mxSession start:^{
@@ -367,8 +353,7 @@
 
 - (void)testAddAndRemoveTag
 {
-    [matrixSDKTestsData doMXSessionTestWithBobAndARoomWithMessages:self readyToTest:^(MXSession *mxSession2, MXRoom *room, XCTestExpectation *expectation) {
-        mxSession = mxSession2;
+    [matrixSDKTestsData doMXSessionTestWithBobAndARoomWithMessages:self readyToTest:^(MXSession *mxSession, MXRoom *room, XCTestExpectation *expectation) {
 
         NSString *tag = @"aTag";
         NSString *order = @"0.5";
@@ -415,8 +400,7 @@
 
 - (void)testReplaceTag
 {
-    [matrixSDKTestsData doMXSessionTestWithBobAndARoomWithMessages:self readyToTest:^(MXSession *mxSession2, MXRoom *room, XCTestExpectation *expectation) {
-        mxSession = mxSession2;
+    [matrixSDKTestsData doMXSessionTestWithBobAndARoomWithMessages:self readyToTest:^(MXSession *mxSession, MXRoom *room, XCTestExpectation *expectation) {
 
         NSString *tag = @"aTag";
         NSString *order = @"0.5";
@@ -458,7 +442,7 @@
 {
     [matrixSDKTestsData doMXRestClientTestInABobRoomAndANewTextMessage:self newTextMessage:@"This is a text message for tagged events" onReadyToTest:^(MXRestClient *bobRestClient, NSString *roomId, NSString *new_text_message_eventId, XCTestExpectation *expectation) {
         
-        mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
         [matrixSDKTestsData retain:mxSession];
         
         [mxSession start:^{
@@ -501,7 +485,7 @@
 {
     [matrixSDKTestsData doMXRestClientTestInABobRoomAndANewTextMessage:self newTextMessage:@"This is a text message for tagged events" onReadyToTest:^(MXRestClient *bobRestClient, NSString *roomId, NSString *new_text_message_eventId, XCTestExpectation *expectation) {
         
-        mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
         [matrixSDKTestsData retain:mxSession];
         
         [mxSession start:^{
@@ -558,7 +542,7 @@
 {
     [matrixSDKTestsData doMXRestClientTestInABobRoomAndANewTextMessage:self newTextMessage:@"This is a text message for tagged events" onReadyToTest:^(MXRestClient *bobRestClient, NSString *roomId, NSString *new_text_message_eventId, XCTestExpectation *expectation) {
         
-        mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
         [matrixSDKTestsData retain:mxSession];
         
         [mxSession start:^{
@@ -620,7 +604,7 @@
 
         [bobRestClient setRoomDirectoryVisibility:roomId directoryVisibility:kMXRoomDirectoryVisibilityPublic success:^{
 
-            mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
+            MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
             [matrixSDKTestsData retain:mxSession];
             
             [mxSession start:^{
@@ -658,7 +642,7 @@
 
         MXRestClient *bobRestClient2 = bobRestClient;
 
-        mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
+        MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
         [matrixSDKTestsData retain:mxSession];
         
         [mxSession start:^{

--- a/MatrixSDKTests/MXRoomTests.m
+++ b/MatrixSDKTests/MXRoomTests.m
@@ -212,6 +212,7 @@
         [matrixSDKTestsData doMXRestClientTestWithAlice:nil readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation2) {
 
             mxSession = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
+            [matrixSDKTestsData retain:mxSession];
 
             [bobRestClient inviteUser:aliceRestClient.credentials.userId toRoom:roomId success:^{
 
@@ -255,6 +256,7 @@
     [matrixSDKTestsData doMXRestClientTestWithBobAndAliceInARoom:self readyToTest:^(MXRestClient *bobRestClient, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
         mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        [matrixSDKTestsData retain:mxSession];
         [mxSession start:^{
 
             MXRoom *room = [mxSession roomWithRoomId:roomId];
@@ -287,6 +289,7 @@
     [matrixSDKTestsData doMXRestClientTestWithBobAndARoomWithMessages:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
         mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        [matrixSDKTestsData retain:mxSession];
 
         [mxSession startWithSyncFilter:[MXFilterJSONModel syncFilterWithMessageLimit:0] onServerSyncDone:^{
             
@@ -330,6 +333,8 @@
     [matrixSDKTestsData doMXRestClientTestWithBobAndARoom:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
         mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        [matrixSDKTestsData retain:mxSession];
+        
         [mxSession start:^{
 
             MXRoom *room = [mxSession roomWithRoomId:roomId];
@@ -454,6 +459,8 @@
     [matrixSDKTestsData doMXRestClientTestInABobRoomAndANewTextMessage:self newTextMessage:@"This is a text message for tagged events" onReadyToTest:^(MXRestClient *bobRestClient, NSString *roomId, NSString *new_text_message_eventId, XCTestExpectation *expectation) {
         
         mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        [matrixSDKTestsData retain:mxSession];
+        
         [mxSession start:^{
             
             MXRoom *room = [mxSession roomWithRoomId:roomId];
@@ -495,6 +502,8 @@
     [matrixSDKTestsData doMXRestClientTestInABobRoomAndANewTextMessage:self newTextMessage:@"This is a text message for tagged events" onReadyToTest:^(MXRestClient *bobRestClient, NSString *roomId, NSString *new_text_message_eventId, XCTestExpectation *expectation) {
         
         mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        [matrixSDKTestsData retain:mxSession];
+        
         [mxSession start:^{
             
             MXRoom *room = [mxSession roomWithRoomId:roomId];
@@ -550,6 +559,8 @@
     [matrixSDKTestsData doMXRestClientTestInABobRoomAndANewTextMessage:self newTextMessage:@"This is a text message for tagged events" onReadyToTest:^(MXRestClient *bobRestClient, NSString *roomId, NSString *new_text_message_eventId, XCTestExpectation *expectation) {
         
         mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        [matrixSDKTestsData retain:mxSession];
+        
         [mxSession start:^{
             
             MXRoom *room = [mxSession roomWithRoomId:roomId];
@@ -610,6 +621,8 @@
         [bobRestClient setRoomDirectoryVisibility:roomId directoryVisibility:kMXRoomDirectoryVisibilityPublic success:^{
 
             mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
+            [matrixSDKTestsData retain:mxSession];
+            
             [mxSession start:^{
 
                 MXRoom *room = [mxSession roomWithRoomId:roomId];
@@ -646,6 +659,8 @@
         MXRestClient *bobRestClient2 = bobRestClient;
 
         mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient2];
+        [matrixSDKTestsData retain:mxSession];
+        
         [mxSession start:^{
 
             MXRoom *room = [mxSession roomWithRoomId:roomId];

--- a/MatrixSDKTests/MXSessionTests.m
+++ b/MatrixSDKTests/MXSessionTests.m
@@ -36,8 +36,6 @@
 {
     MatrixSDKTestsData *matrixSDKTestsData;
 
-    MXSession *mxSession;
-
     id observer;
 }
 @end
@@ -53,12 +51,6 @@
 
 - (void)tearDown
 {
-    if (mxSession)
-    {
-        [mxSession close];
-        mxSession = nil;
-    }
-
     if (observer)
     {
         [[NSNotificationCenter defaultCenter] removeObserver:observer];
@@ -114,7 +106,7 @@
 
         MXCredentials *credentials = [MXCredentials initialSyncCacheCredentialsFrom:matrixSDKTestsData.bobCredentials];
         id<MXSyncResponseStore> cache = [[MXSyncResponseFileStore alloc] initWithCredentials:credentials];
-        mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        __block MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
         
         //  listen for session state change notification
         __block id observer = [[NSNotificationCenter defaultCenter] addObserverForName:kMXSessionStateDidChangeNotification object:nil queue:nil usingBlock:^(NSNotification * _Nonnull note) {
@@ -126,7 +118,6 @@
                 
                 //  2. simulate an unexpected session close (like a crash)
                 [mxSession close];
-                mxSession = nil;
                 
                 XCTAssertGreaterThan(cache.syncResponseIds.count,
                                      0,
@@ -186,7 +177,7 @@
         // Room with a tag with "oranges" order
         [bobRestClient createRoom:nil visibility:kMXRoomDirectoryVisibilityPrivate roomAlias:alias topic:nil success:^(MXCreateRoomResponse *response) {
 
-            mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+            MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
             [matrixSDKTestsData retain:mxSession];
             [mxSession start:^{
 
@@ -227,7 +218,7 @@
 {
     [matrixSDKTestsData doMXRestClientTestWihBobAndSeveralRoomsAndMessages:self readyToTest:^(MXRestClient *bobRestClient, XCTestExpectation *expectation) {
         
-        mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
         [matrixSDKTestsData retain:mxSession];
         
         // The listener must catch at least these events
@@ -304,7 +295,7 @@
 {
     [matrixSDKTestsData doMXRestClientTestWihBobAndSeveralRoomsAndMessages:self readyToTest:^(MXRestClient *bobRestClient, XCTestExpectation *expectation) {
         
-        mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
         [matrixSDKTestsData retain:mxSession];
         
         // Listen to m.room.message only
@@ -346,7 +337,7 @@
     // Make sure Alice and Bob have activities
     [matrixSDKTestsData doMXRestClientTestWithBobAndAliceInARoom:self readyToTest:^(MXRestClient *bobRestClient, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
         
-        mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
         [matrixSDKTestsData retain:mxSession];
         
         __block MXSession *mxSession2 = mxSession;
@@ -405,7 +396,7 @@
     // Make sure Alice and Bob have activities
     [matrixSDKTestsData doMXRestClientTestWithBobAndAliceInARoom:self readyToTest:^(MXRestClient *bobRestClient, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
-        mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
         [matrixSDKTestsData retain:mxSession];
 
         [mxSession start:^{
@@ -467,7 +458,7 @@
 
         MXMemoryStore *store = [[MXMemoryStore alloc] init];
 
-        mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
         [matrixSDKTestsData retain:mxSession];
 
         [mxSession setStore:store success:^{
@@ -479,7 +470,6 @@
                 XCTAssertGreaterThan(storeRoomsCount, 0);
 
                 [mxSession close];
-                mxSession = nil;
 
                 // Create another random room to create more data server side
                 [bobRestClient createRoom:nil visibility:kMXRoomDirectoryVisibilityPrivate roomAlias:nil topic:nil success:^(MXCreateRoomResponse *response) {
@@ -512,7 +502,7 @@
     // Make sure Alice and Bob have activities
     [matrixSDKTestsData doMXRestClientTestWithBobAndAliceInARoom:self readyToTest:^(MXRestClient *bobRestClient, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
-        mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
         [matrixSDKTestsData retain:mxSession];
 
         [mxSession start:^{
@@ -584,7 +574,7 @@
     // Make sure Alice and Bob have activities
     [matrixSDKTestsData doMXRestClientTestWithBobAndAliceInARoom:self readyToTest:^(MXRestClient *bobRestClient, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
-        mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
         [matrixSDKTestsData retain:mxSession];
 
         [mxSession start:^{
@@ -650,6 +640,7 @@
 {
     [matrixSDKTestsData doMXRestClientTestInABobRoomAndANewTextMessage:self newTextMessage:@"This is a text message for recents" onReadyToTest:^(MXRestClient *bobRestClient, NSString *roomId, NSString *new_text_message_eventId, XCTestExpectation *expectation) {
 
+        MXSession *mxSession;
         __block MXSessionState previousSessionState = MXSessionStateInitialised;
         [[NSNotificationCenter defaultCenter] addObserverForName:kMXSessionStateDidChangeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *note) {
 
@@ -682,7 +673,6 @@
                     [mxSession close];
                     XCTAssertEqual(MXSessionStateClosed, mxSession.state);
 
-                    mxSession = nil;
                     [expectation fulfill];
                 });
 
@@ -704,9 +694,7 @@
 
 - (void)testCreateRoom
 {
-    [matrixSDKTestsData doMXSessionTestWithBob:self readyToTest:^(MXSession *mxSession2, XCTestExpectation *expectation) {
-
-        mxSession = mxSession2;
+    [matrixSDKTestsData doMXSessionTestWithBob:self readyToTest:^(MXSession *mxSession, XCTestExpectation *expectation) {
 
         // Create a random room with no params
         [mxSession createRoom:nil visibility:nil roomAlias:nil topic:nil success:^(MXRoom *room) {
@@ -729,9 +717,7 @@
 
 - (void)testDidSyncNotification
 {
-    [matrixSDKTestsData doMXSessionTestWithBobAndARoom:self andStore:[[MXMemoryStore alloc] init] readyToTest:^(MXSession *mxSession2, MXRoom *room, XCTestExpectation *expectation) {
-
-        mxSession = mxSession2;
+    [matrixSDKTestsData doMXSessionTestWithBobAndARoom:self andStore:[[MXMemoryStore alloc] init] readyToTest:^(MXSession *mxSession, MXRoom *room, XCTestExpectation *expectation) {
 
         observer = [[NSNotificationCenter defaultCenter] addObserverForName:kMXSessionDidSyncNotification object:mxSession queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
 
@@ -759,8 +745,7 @@
 // -> Check latter sync response does not contain anything but the event stream token
 - (void)testEmptySyncResponse
 {
-    [matrixSDKTestsData doMXSessionTestWithBob:self readyToTest:^(MXSession *mxSession2, XCTestExpectation *expectation) {
-        mxSession = mxSession2;
+    [matrixSDKTestsData doMXSessionTestWithBob:self readyToTest:^(MXSession *mxSession, XCTestExpectation *expectation) {
         
         __block BOOL isFirst = YES;
 
@@ -794,11 +779,9 @@
 
 - (void)testCreateRoomWithInvite
 {
-    [matrixSDKTestsData doMXSessionTestWithBob:self readyToTest:^(MXSession *mxSession2, XCTestExpectation *expectation) {
+    [matrixSDKTestsData doMXSessionTestWithBob:self readyToTest:^(MXSession *mxSession, XCTestExpectation *expectation) {
         
         [matrixSDKTestsData doMXRestClientTestWithAlice:nil readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation2) {
-            
-            mxSession = mxSession2;
             
             // Create a random room with no params
             MXRoomCreationParameters *parameters = [MXRoomCreationParameters new];
@@ -849,11 +832,9 @@
 
 - (void)testCreateDirectRoom
 {
-    [matrixSDKTestsData doMXSessionTestWithBob:self readyToTest:^(MXSession *mxSession2, XCTestExpectation *expectation) {
+    [matrixSDKTestsData doMXSessionTestWithBob:self readyToTest:^(MXSession *mxSession, XCTestExpectation *expectation) {
         
         [matrixSDKTestsData doMXRestClientTestWithAlice:nil readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation2) {
-            
-            mxSession = mxSession2;
             
             // Create a random room with no params
             MXRoomCreationParameters *parameters = [MXRoomCreationParameters parametersForDirectRoomWithUser:matrixSDKTestsData.aliceCredentials.userId];
@@ -884,6 +865,7 @@
                     XCTAssertTrue(succeed);
                     
                     // Force sync to get direct rooms list
+                    // CRASH
                     [mxSession startWithSyncFilter:[MXFilterJSONModel syncFilterWithMessageLimit:0]
                                   onServerSyncDone:^{
                         
@@ -924,9 +906,7 @@
 
 - (void)testPrivateDirectRoomWithUserId
 {
-    [matrixSDKTestsData doMXSessionTestWithBobAndAliceInARoom:self readyToTest:^(MXSession *bobSession, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
-        
-        mxSession = bobSession;
+    [matrixSDKTestsData doMXSessionTestWithBobAndAliceInARoom:self readyToTest:^(MXSession *mxSession, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
         MXRoom *room = [mxSession roomWithRoomId:roomId];
         [room setIsDirect:YES withUserId:aliceRestClient.credentials.userId success:^{
@@ -963,7 +943,7 @@
 
         [matrixSDKTestsData doMXRestClientTestWithAlice:nil readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation2) {
 
-            mxSession = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
+            MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
             [matrixSDKTestsData retain:mxSession];
             [mxSession start:^{
 
@@ -990,7 +970,7 @@
 {
     [matrixSDKTestsData doMXRestClientTestWithBob:self readyToTest:^(MXRestClient *bobRestClient, XCTestExpectation *expectation) {
 
-        mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
         [matrixSDKTestsData retain:mxSession];
         [mxSession start:^{
 
@@ -1026,7 +1006,7 @@
 
         [matrixSDKTestsData doMXRestClientTestWithAlice:nil readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation2) {
 
-            mxSession = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
+            MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
             [matrixSDKTestsData retain:mxSession];
             [mxSession start:^{
 
@@ -1063,7 +1043,7 @@
 
         [matrixSDKTestsData doMXRestClientTestWithAlice:nil readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation2) {
 
-            mxSession = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
+            MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
             [matrixSDKTestsData retain:mxSession];
             [mxSession start:^{
 
@@ -1119,7 +1099,7 @@
 
 
                                 // Do the test
-                                mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+                                MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
                                 [matrixSDKTestsData retain:mxSession];
                                 [mxSession start:^{
 
@@ -1211,7 +1191,7 @@
                     [bobRestClient addTag:tag withOrder:@"0.2" toRoom:response.roomId success:^{
 
                         // Do the tests
-                        mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+                        MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
                         [matrixSDKTestsData retain:mxSession];
                         [mxSession start:^{
 
@@ -1259,7 +1239,7 @@
                 [bobRestClient createRoom:nil visibility:kMXRoomDirectoryVisibilityPrivate roomAlias:nil topic:@"Not tagged" success:^(MXCreateRoomResponse *response) {
 
                     // Do the test
-                    mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+                    MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
                     [matrixSDKTestsData retain:mxSession];
                     [mxSession start:^{
 
@@ -1319,7 +1299,7 @@
                             [bobRestClient addTag:tag withOrder:@"0.3" toRoom:response.roomId success:^{
 
                                 // Do the tests
-                                mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+                                MXSession *mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
                                 [matrixSDKTestsData retain:mxSession];
                                 [mxSession start:^{
 
@@ -1384,9 +1364,7 @@
 
 - (void)testInvitedRooms
 {
-    [matrixSDKTestsData doMXSessionTestWithBobAndAliceInARoom:self readyToTest:^(MXSession *bobSession, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
-
-        mxSession = bobSession;
+    [matrixSDKTestsData doMXSessionTestWithBobAndAliceInARoom:self readyToTest:^(MXSession *mxSession, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
         NSUInteger prevInviteCount = mxSession.invitedRooms.count;
 
@@ -1437,7 +1415,7 @@
 
             testRoomId = response.roomId;
 
-            [aliceRestClient inviteUser:bobSession.matrixRestClient.credentials.userId toRoom:testRoomId success:^{
+            [aliceRestClient inviteUser:mxSession.matrixRestClient.credentials.userId toRoom:testRoomId success:^{
 
             } failure:^(NSError *error) {
                 XCTFail(@"Cannot set up intial test conditions - error: %@", error);
@@ -1453,9 +1431,7 @@
 
 - (void)testToDeviceEvents
 {
-    [matrixSDKTestsData doMXSessionTestWithBobAndAliceInARoom:self readyToTest:^(MXSession *bobSession, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
-
-        mxSession = bobSession;
+    [matrixSDKTestsData doMXSessionTestWithBobAndAliceInARoom:self readyToTest:^(MXSession *mxSession, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
         observer = [[NSNotificationCenter defaultCenter] addObserverForName:kMXSessionOnToDeviceEventNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
 

--- a/MatrixSDKTests/MXSessionTests.m
+++ b/MatrixSDKTests/MXSessionTests.m
@@ -134,6 +134,7 @@
                 
                 //  3. recreate the session
                 mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+                [matrixSDKTestsData retain:mxSession];
 
                 [mxSession setStore:store success:^{
                     [mxSession start:^{
@@ -186,6 +187,7 @@
         [bobRestClient createRoom:nil visibility:kMXRoomDirectoryVisibilityPrivate roomAlias:alias topic:nil success:^(MXCreateRoomResponse *response) {
 
             mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+            [matrixSDKTestsData retain:mxSession];
             [mxSession start:^{
 
                 MXRoom *room = [mxSession roomWithRoomId:response.roomId];
@@ -226,6 +228,7 @@
     [matrixSDKTestsData doMXRestClientTestWihBobAndSeveralRoomsAndMessages:self readyToTest:^(MXRestClient *bobRestClient, XCTestExpectation *expectation) {
         
         mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        [matrixSDKTestsData retain:mxSession];
         
         // The listener must catch at least these events
         __block NSMutableArray *expectedEvents =
@@ -302,6 +305,7 @@
     [matrixSDKTestsData doMXRestClientTestWihBobAndSeveralRoomsAndMessages:self readyToTest:^(MXRestClient *bobRestClient, XCTestExpectation *expectation) {
         
         mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        [matrixSDKTestsData retain:mxSession];
         
         // Listen to m.room.message only
         // We should not see events coming before (m.room.create, and all state events)
@@ -343,6 +347,7 @@
     [matrixSDKTestsData doMXRestClientTestWithBobAndAliceInARoom:self readyToTest:^(MXRestClient *bobRestClient, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
         
         mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        [matrixSDKTestsData retain:mxSession];
         
         __block MXSession *mxSession2 = mxSession;
         __block NSUInteger lastAliceActivity = -1;
@@ -401,6 +406,7 @@
     [matrixSDKTestsData doMXRestClientTestWithBobAndAliceInARoom:self readyToTest:^(MXRestClient *bobRestClient, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
         mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        [matrixSDKTestsData retain:mxSession];
 
         [mxSession start:^{
 
@@ -462,6 +468,7 @@
         MXMemoryStore *store = [[MXMemoryStore alloc] init];
 
         mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        [matrixSDKTestsData retain:mxSession];
 
         [mxSession setStore:store success:^{
 
@@ -506,6 +513,7 @@
     [matrixSDKTestsData doMXRestClientTestWithBobAndAliceInARoom:self readyToTest:^(MXRestClient *bobRestClient, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
         mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        [matrixSDKTestsData retain:mxSession];
 
         [mxSession start:^{
 
@@ -577,6 +585,7 @@
     [matrixSDKTestsData doMXRestClientTestWithBobAndAliceInARoom:self readyToTest:^(MXRestClient *bobRestClient, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
         mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        [matrixSDKTestsData retain:mxSession];
 
         [mxSession start:^{
 
@@ -653,6 +662,7 @@
         }];
 
         mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        [matrixSDKTestsData retain:mxSession];
         XCTAssertEqual(MXSessionStateInitialised, mxSession.state);
 
         [mxSession start:^{
@@ -954,6 +964,7 @@
         [matrixSDKTestsData doMXRestClientTestWithAlice:nil readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation2) {
 
             mxSession = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
+            [matrixSDKTestsData retain:mxSession];
             [mxSession start:^{
 
                 // Listen to Alice's MXSessionNewRoomNotification event
@@ -980,6 +991,7 @@
     [matrixSDKTestsData doMXRestClientTestWithBob:self readyToTest:^(MXRestClient *bobRestClient, XCTestExpectation *expectation) {
 
         mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        [matrixSDKTestsData retain:mxSession];
         [mxSession start:^{
 
             observer = [[NSNotificationCenter defaultCenter] addObserverForName:kMXSessionNewRoomNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *note) {
@@ -1015,6 +1027,7 @@
         [matrixSDKTestsData doMXRestClientTestWithAlice:nil readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation2) {
 
             mxSession = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
+            [matrixSDKTestsData retain:mxSession];
             [mxSession start:^{
 
                 // Listen to Alice's MXSessionNewRoomNotification event
@@ -1051,6 +1064,7 @@
         [matrixSDKTestsData doMXRestClientTestWithAlice:nil readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation2) {
 
             mxSession = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
+            [matrixSDKTestsData retain:mxSession];
             [mxSession start:^{
 
                 // Listen to Alice's kMXRoomInitialSyncNotification event
@@ -1106,6 +1120,7 @@
 
                                 // Do the test
                                 mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+                                [matrixSDKTestsData retain:mxSession];
                                 [mxSession start:^{
 
                                     NSDictionary<NSString*, NSArray<MXRoom*>*> *roomByTags = [mxSession roomsByTags];
@@ -1197,6 +1212,7 @@
 
                         // Do the tests
                         mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+                        [matrixSDKTestsData retain:mxSession];
                         [mxSession start:^{
 
                             NSArray<MXRoom*> *roomsWithTag = [mxSession roomsWithTag:tag];
@@ -1244,6 +1260,7 @@
 
                     // Do the test
                     mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+                    [matrixSDKTestsData retain:mxSession];
                     [mxSession start:^{
 
                         NSDictionary<NSString*, NSArray<MXRoom*>*> *roomByTags = [mxSession roomsByTags];
@@ -1303,6 +1320,7 @@
 
                                 // Do the tests
                                 mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+                                [matrixSDKTestsData retain:mxSession];
                                 [mxSession start:^{
 
                                     NSString *orderForFirstPosition = [mxSession tagOrderToBeAtIndex:0 from:NSNotFound withTag:tag];

--- a/MatrixSDKTests/MXStoreTests.m
+++ b/MatrixSDKTests/MXStoreTests.m
@@ -83,6 +83,8 @@
         }
 
         mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        [matrixSDKTestsData retain:mxSession];
+        
         [mxSession setStore:store success:^{
 
             [mxSession start:^{
@@ -123,6 +125,7 @@
             }
 
             mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+            [matrixSDKTestsData retain:mxSession];
 
             [mxSession setStore:store success:^{
                 [mxSession start:^{
@@ -163,6 +166,7 @@
         }
 
         mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        [matrixSDKTestsData retain:mxSession];
 
         [mxSession setStore:store success:^{
 
@@ -1022,6 +1026,7 @@
 
             // Let's (and verify) MXSession start update the store with user information
             mxSession = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
+            [matrixSDKTestsData retain:mxSession];
 
             [mxSession setStore:store success:^{
 
@@ -1093,6 +1098,7 @@
 
             // Let's (and verify) MXSession start update the store with user information
             mxSession = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
+            [matrixSDKTestsData retain:mxSession];
 
             [mxSession setStore:store success:^{
 
@@ -1181,6 +1187,8 @@
 
             // Do a 1st [mxSession start] to fill the store
             mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+            [matrixSDKTestsData retain:mxSession];
+            
             [mxSession setStore:store success:^{
 
                 [mxSession start:^{
@@ -1202,6 +1210,7 @@
                             __block BOOL onStoreDataReadyCalled;
 
                             MXSession *mxSession2 = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+                            [matrixSDKTestsData retain:mxSession2];
 
                             [mxSession2 setStore:store2 success:^{
                                 onStoreDataReadyCalled = YES;
@@ -1268,6 +1277,8 @@
         id<MXStore> store = [[mxStoreClass alloc] init];
 
         mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        [matrixSDKTestsData retain:mxSession];
+        
         [mxSession setStore:store success:^{
 
             [mxSession start:^{
@@ -1326,6 +1337,8 @@
         id<MXStore> store = [[mxStoreClass alloc] init];
 
         mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        [matrixSDKTestsData retain:mxSession];
+        
         [mxSession setStore:store success:^{
             [mxSession start:^{
 
@@ -1391,6 +1404,8 @@
 
         // Do a 1st [mxSession start] to fill the store
         mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        [matrixSDKTestsData retain:mxSession];
+        
         [mxSession setStore:store success:^{
             [mxSession startWithSyncFilter:[MXFilterJSONModel syncFilterWithMessageLimit:5] onServerSyncDone:^{
 
@@ -1410,6 +1425,7 @@
                         id<MXStore> store2 = [[mxStoreClass alloc] init];
 
                         mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+                        [matrixSDKTestsData retain:mxSession];
                         [mxSession setStore:store2 success:^{
 
                             XCTAssertEqualObjects(roomPaginationToken, [store2 paginationTokenOfRoom:roomId], @"The store must keep the pagination token");
@@ -1454,6 +1470,8 @@
         id<MXStore> bobStore1 = [[mxStoreClass alloc] init];
 
         mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+        [matrixSDKTestsData retain:mxSession];
+        
         [mxSession setStore:bobStore1 success:^{
             [mxSession start:^{
 
@@ -1545,6 +1563,8 @@
 
                                     // Do a 1st [mxSession start] to fill the store
                                     mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+                                    [matrixSDKTestsData retain:mxSession];
+                                    
                                     [mxSession setStore:store success:^{
                                         [mxSession start:^{
 
@@ -1555,6 +1575,8 @@
                                             id<MXStore> store2 = [[mxStoreClass alloc] init];
 
                                             mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+                                            [matrixSDKTestsData retain:mxSession];
+                                            
                                             [mxSession setStore:store2 success:^{
 
                                                 NSArray<MXRoom*> *roomsWithTagTag1 = [mxSession roomsWithTag:tag1];
@@ -1643,6 +1665,8 @@
 
                 // Do a 1st [mxSession start] to fill the store
                 mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+                [matrixSDKTestsData retain:mxSession];
+                
                 [mxSession setStore:store success:^{
                     [mxSession start:^{
 

--- a/MatrixSDKTests/MXUserTests.m
+++ b/MatrixSDKTests/MXUserTests.m
@@ -60,6 +60,7 @@
             [aliceRestClient sendTextMessageToRoom:roomId text:@"Hi Bob!" success:^(NSString *eventId) {
 
                 mxSession = [[MXSession alloc] initWithMatrixRestClient:bobRestClient];
+                [matrixSDKTestsData retain:mxSession];
 
                 // Start the session
                 [mxSession start:^{
@@ -216,6 +217,7 @@
     [matrixSDKTestsData doMXRestClientTestWithAlice:self readyToTest:^(MXRestClient *aliceRestClient, XCTestExpectation *expectation) {
 
         mxSession = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
+        [matrixSDKTestsData retain:mxSession];
 
         XCTAssertNil(mxSession.myUser);
 
@@ -266,6 +268,8 @@
 //        [mxSession close];
 //
 //        mxSession = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
+//        [matrixSDKTestsData retain:mxSession];
+//
 //        [mxSession start:^{
 //
 //            [mxSession.myUser listenToUserUpdate:^(MXEvent *event) {
@@ -302,6 +306,8 @@
 //        [mxSession close];
 //
 //        mxSession = [[MXSession alloc] initWithMatrixRestClient:aliceRestClient];
+//        [matrixSDKTestsData retain:mxSession];
+//
 //        [mxSession start:^{
 //
 //            [mxSession.myUser listenToUserUpdate:^(MXEvent *event) {

--- a/MatrixSDKTests/MXVoIPTests.m
+++ b/MatrixSDKTests/MXVoIPTests.m
@@ -25,8 +25,6 @@
 @interface MXVoIPTests : XCTestCase
 {
     MatrixSDKTestsData *matrixSDKTestsData;
-
-    MXSession *mxSession;
 }
 
 @end
@@ -42,12 +40,6 @@
 
 - (void)tearDown
 {
-    if (mxSession)
-    {
-        [mxSession close];
-        mxSession = nil;
-    }
-
     matrixSDKTestsData = nil;
     
     [super tearDown];
@@ -57,9 +49,8 @@
 #pragma mark - Tests with no call stack
 - (void)testNoVoIPStackMXRoomCall
 {
-    [matrixSDKTestsData doMXSessionTestWithBobAndAliceInARoom:self readyToTest:^(MXSession *bobSession, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
+    [matrixSDKTestsData doMXSessionTestWithBobAndAliceInARoom:self readyToTest:^(MXSession *mxSession, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
-        mxSession = bobSession;
         MXRoom *room = [mxSession roomWithRoomId:roomId];
 
         // Make sure there is no VoIP stack
@@ -79,9 +70,7 @@
 
 - (void)testNoVoIPStackOnCallInvite
 {
-    [matrixSDKTestsData doMXSessionTestWithBobAndAliceInARoom:self readyToTest:^(MXSession *bobSession, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
-
-        mxSession = bobSession;
+    [matrixSDKTestsData doMXSessionTestWithBobAndAliceInARoom:self readyToTest:^(MXSession *mxSession, MXRestClient *aliceRestClient, NSString *roomId, XCTestExpectation *expectation) {
 
         // Make sure there is no VoIP stack
         mxSession.callManager.callStack = nil;
@@ -98,8 +87,8 @@
                                           },
                                   @"version": kMXCallVersion,
                                   @"lifetime": @(30 * 1000),
-                                  @"invitee": bobSession.myUserId,
-                                  @"party_id": bobSession.myDeviceId
+                                  @"invitee": mxSession.myUserId,
+                                  @"party_id": mxSession.myDeviceId
                                   };
 
 

--- a/MatrixSDKTests/MatrixSDKTestsData.h
+++ b/MatrixSDKTests/MatrixSDKTestsData.h
@@ -173,7 +173,14 @@ onUnrecognizedCertificateBlock:(MXHTTPClientOnUnrecognizedCertificate)onUnrecogn
 
 
 #pragma mark Reference keeping
+
+/// Close automatically MXSession instances created by MatrixSDKTestsData.
+/// True by default.
+/// Those instances are closed on MatrixSDKTestsData.deinit()
+@property (nonatomic) BOOL autoCloseMXSessions;
+
 // Retain an object for the life of this MatrixSDKTestsData instance
 - (void)retain:(NSObject*)object;
+- (void)release:(NSObject*)object;
 
 @end

--- a/MatrixSDKTests/MatrixSDKTestsData.m
+++ b/MatrixSDKTests/MatrixSDKTestsData.m
@@ -1028,7 +1028,7 @@ onUnrecognizedCertificateBlock:(MXHTTPClientOnUnrecognizedCertificate)onUnrecogn
 
 - (void)release:(NSObject*)object
 {
-    [self.retainedObjects addObject:object];
+    [self.retainedObjects removeObject:object];
 }
 
 - (void)releaseRetainedObjects

--- a/MatrixSDKTests/MatrixSDKTestsData.m
+++ b/MatrixSDKTests/MatrixSDKTestsData.m
@@ -21,6 +21,7 @@
 #import "MXRestClient.h"
 #import "MXError.h"
 #import "MXNoStore.h"
+#import "MatrixSDKTestsSwiftHeader.h"
 
 // Do not bother with retain cycles warnings in tests
 #pragma clang diagnostic push
@@ -56,6 +57,12 @@ NSString * const kMXTestsAliceAvatarURL = @"mxc://matrix.org/kciiXusgZFKuNLIfLqm
 @end
 
 @implementation MatrixSDKTestsData
+
++ (void)load
+{
+    // Be sure there is no open MXSession instances when ending a test
+    [TestObserver.shared trackMXSessions];
+}
 
 - (id)init
 {

--- a/MatrixSDKTests/MatrixSDKTestsData.m
+++ b/MatrixSDKTests/MatrixSDKTestsData.m
@@ -70,6 +70,7 @@ NSString * const kMXTestsAliceAvatarURL = @"mxc://matrix.org/kciiXusgZFKuNLIfLqm
     {
         _startDate = [NSDate date];
         _retainedObjects = [NSMutableArray array];
+        _autoCloseMXSessions = YES;
     }
     
     return self;
@@ -77,7 +78,7 @@ NSString * const kMXTestsAliceAvatarURL = @"mxc://matrix.org/kciiXusgZFKuNLIfLqm
 
 - (void)dealloc
 {
-    _retainedObjects = [NSMutableArray array];
+    [self releaseRetainedObjects];
 }
 
 - (void)getBobCredentials:(XCTestCase*)testCase
@@ -1023,6 +1024,27 @@ onUnrecognizedCertificateBlock:(MXHTTPClientOnUnrecognizedCertificate)onUnrecogn
 - (void)retain:(NSObject*)object
 {
     [self.retainedObjects addObject:object];
+}
+
+- (void)release:(NSObject*)object
+{
+    [self.retainedObjects addObject:object];
+}
+
+- (void)releaseRetainedObjects
+{
+    if (_autoCloseMXSessions)
+    {
+        for (NSObject *object in _retainedObjects)
+        {
+            if ([object isKindOfClass:MXSession.class])
+            {
+                MXSession *mxSession = (MXSession*)object;
+                [mxSession close];
+            }
+        }
+    }
+    _retainedObjects = nil;
 }
 
 @end

--- a/MatrixSDKTests/MatrixSDKTestsE2EData.m
+++ b/MatrixSDKTests/MatrixSDKTestsE2EData.m
@@ -26,14 +26,13 @@
 #import "MXNoStore.h"
 
 @interface MatrixSDKTestsE2EData ()
-{
-    MatrixSDKTestsData *matrixSDKTestsData;
-}
+
+@property (nonatomic, weak) MatrixSDKTestsData *matrixSDKTestsData;
 
 @end
 
 @implementation MatrixSDKTestsE2EData
-@synthesize messagesFromAlice, messagesFromBob;
+@synthesize matrixSDKTestsData, messagesFromAlice, messagesFromBob;
 
 - (instancetype)initWithMatrixSDKTestsData:(MatrixSDKTestsData *)theMatrixSDKTestsData
 {

--- a/MatrixSDKTests/MatrixSDKTestsSwiftHeader.h
+++ b/MatrixSDKTests/MatrixSDKTestsSwiftHeader.h
@@ -1,0 +1,28 @@
+// 
+// Copyright 2021 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#ifndef MatrixSDKTestsSwiftHeader_h
+#define MatrixSDKTestsSwiftHeader_h
+
+
+#if __has_include(<MatrixSDKTests/MatrixSDKTests-Swift.h>)
+#import <MatrixSDKTests/MatrixSDKTests-Swift.h>
+#elif __has_include("MatrixSDKTests-Swift.h")
+#import "MatrixSDKTests-Swift.h"
+#else
+#endif
+
+#endif /* MatrixSDKTestsSwiftHeader_h */

--- a/MatrixSDKTests/Utils/MXSession.swift
+++ b/MatrixSDKTests/Utils/MXSession.swift
@@ -1,0 +1,128 @@
+// 
+// Copyright 2021 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+// A structure that represents a tracked MXSession
+struct TrackedMXSession {
+    /// A human readable id for the MXSession
+    let userDeviceId: String
+    
+    /// The call stack that instantiated it
+    let callStack: [String]
+}
+
+
+/// An extension to track alive MXSession instances in a static way.
+/// A MXSession is considered alive between its init and close.
+extension MXSession {
+    
+    // MARK: - Public
+    
+    /// Start tracking open MXSession instances.
+    @objc
+    class func trackOpenMXSessions() {
+        // Swizzle init and close methods to track active MXSessions
+        swizzleMethods(orignalSelector: #selector(MXSession.init(matrixRestClient:)),
+                       swizzledSelector: #selector(MXSession.trackInit(matrixRestClient:)))
+        swizzleMethods(orignalSelector: #selector(MXSession.close),
+                       swizzledSelector: #selector(MXSession.trackClose))
+    }
+    
+    @objc
+    class var openMXSessionsCount: Int {
+        get {
+            trackedMXSessions.count
+        }
+    }
+    
+    /// Reset MXSession instances already tracked.
+    @objc
+    class func resetOpenMXSessions() {
+        trackedMXSessions.removeAll()
+    }
+    
+    /// Print all open MXSession instances.
+    @objc
+    class func logOpenMXSessions() {
+        for (trackId, trackedMXSession) in trackedMXSessions {
+            MXLog.error("MXSession(\(trackId)) for user \(trackedMXSession.userDeviceId) is not closed. It was created from:")
+            trackedMXSession.callStack.forEach { call in
+                MXLog.error("    - \(call)")
+            }
+        }
+    }
+    
+    // MARK: - Private
+    
+    // MARK: Properties
+    
+    /// All open sessions
+    private static var trackedMXSessions = Dictionary<String, TrackedMXSession>()
+
+    /// Id that identifies the MXSession instance
+    private var trackId: String {
+        // Let's use the MXSession pointer to track it
+        "\(Unmanaged.passUnretained(self).toOpaque())"
+    }
+
+    /// Human readable id
+    private var userDeviceId: String {
+        get {
+            // Manage string properties that are actually optional
+            [myUserId, myDeviceId]
+                .compactMap { $0 }
+                .joined(separator: ":")
+        }
+    }
+    
+    
+    // MARK: - Swizzling
+    
+    /// Exchange 2 methods implementations
+    /// - Parameters:
+    ///   - orignalSelector: the original method
+    ///   - swizzledSelector: the replacing method
+    private class func swizzleMethods(orignalSelector: Selector, swizzledSelector: Selector) {
+        guard
+            let originalMethod = class_getInstanceMethod(MXSession.self, orignalSelector),
+            let swizzledMethod = class_getInstanceMethod(MXSession.self, swizzledSelector)
+        else { return }
+        method_exchangeImplementations(originalMethod, swizzledMethod)
+    }
+
+    /// Swizzled version of MXSession.init(matrixRestClient:)
+    @objc
+    private func trackInit(matrixRestClient: MXRestClient) -> MXSession {
+        // Call the original method. Note that implementations are exchanged
+        _ = self.trackInit(matrixRestClient: matrixRestClient)
+        
+        // And keep the call stack that created the session
+        let trackedMXSession = TrackedMXSession(userDeviceId: userDeviceId, callStack: Thread.callStackSymbols)
+        MXSession.trackedMXSessions.updateValue(trackedMXSession, forKey: self.trackId)
+
+        return self
+    }
+    
+    /// Swizzled version of MXSession.close()
+    @objc
+    private func trackClose() {
+        // Call the original method. Note that implementations are exchanged
+        self.trackClose()
+        
+        MXSession.trackedMXSessions.removeValue(forKey:  self.trackId)
+    }
+}

--- a/MatrixSDKTests/Utils/MXSession.swift
+++ b/MatrixSDKTests/Utils/MXSession.swift
@@ -33,9 +33,9 @@ extension MXSession {
     /// Start tracking open MXSession instances.
     class func trackOpenMXSessions() {
         // Swizzle init and close methods to track active MXSessions
-        swizzleMethods(orignalSelector: #selector(MXSession.init(matrixRestClient:)),
+        swizzleMethods(originalSelector: #selector(MXSession.init(matrixRestClient:)),
                        swizzledSelector: #selector(MXSession.trackInit(matrixRestClient:)))
-        swizzleMethods(orignalSelector: #selector(MXSession.close),
+        swizzleMethods(originalSelector: #selector(MXSession.close),
                        swizzledSelector: #selector(MXSession.trackClose))
     }
     
@@ -49,7 +49,7 @@ extension MXSession {
     ///   - swizzledSelector: the replacing method
     private class func swizzleMethods(originalSelector: Selector, swizzledSelector: Selector) {
         guard
-            let originalMethod = class_getInstanceMethod(MXSession.self, orignalSelector),
+            let originalMethod = class_getInstanceMethod(MXSession.self, originalSelector),
             let swizzledMethod = class_getInstanceMethod(MXSession.self, swizzledSelector)
         else { return }
         method_exchangeImplementations(originalMethod, swizzledMethod)

--- a/MatrixSDKTests/Utils/MXSession.swift
+++ b/MatrixSDKTests/Utils/MXSession.swift
@@ -47,7 +47,7 @@ extension MXSession {
     /// - Parameters:
     ///   - orignalSelector: the original method
     ///   - swizzledSelector: the replacing method
-    private class func swizzleMethods(orignalSelector: Selector, swizzledSelector: Selector) {
+    private class func swizzleMethods(originalSelector: Selector, swizzledSelector: Selector) {
         guard
             let originalMethod = class_getInstanceMethod(MXSession.self, orignalSelector),
             let swizzledMethod = class_getInstanceMethod(MXSession.self, swizzledSelector)

--- a/MatrixSDKTests/Utils/MXSessionTracker.swift
+++ b/MatrixSDKTests/Utils/MXSessionTracker.swift
@@ -1,0 +1,85 @@
+// 
+// Copyright 2021 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+/// A structure that represents a tracked MXSession
+struct TrackedMXSession {
+    /// A human readable id for the MXSession
+    let userDeviceId: String
+    
+    /// The call stack that instantiated it
+    let callStack: [String]
+}
+
+/// The singleton that tracks MXSessions life from init(matrixRestClient:) to close()
+/// It can detect MXSession leaks that continue to run in background.
+class MXSessionTracker {
+    
+    // MARK: - Public
+    
+    static let shared = MXSessionTracker()
+    
+    func trackMXSessions() {
+        MXSession.trackOpenMXSessions()
+        MXSession.initCloseDelegate = self
+    }
+    
+    var openMXSessionsCount: Int {
+        get {
+            trackedMXSessions.count
+        }
+    }
+    
+    func resetOpenMXSessions() {
+        trackedMXSessions.removeAll()
+    }
+    
+    func printOpenMXSessions() {
+        for (trackId, trackedMXSession) in trackedMXSessions {
+            MXLog.error("MXSession(\(trackId)) for user \(trackedMXSession.userDeviceId) is not closed. It was created from:")
+            trackedMXSession.callStack.forEach { call in
+                MXLog.error("    - \(call)")
+            }
+        }
+    }
+    
+    // MARK: - Private
+    
+    /// All open sessions
+    private var trackedMXSessions = Dictionary<String, TrackedMXSession>()
+    
+    func trackMXSession(mxSession: MXSession, callStack: [String]) {
+        let trackedMXSession = TrackedMXSession(userDeviceId: mxSession.userDeviceId, callStack: callStack)
+        trackedMXSessions.updateValue(trackedMXSession, forKey: mxSession.trackId)
+    }
+    
+    func untrackMXSession(mxSession: MXSession) {
+        trackedMXSessions.removeValue(forKey:  mxSession.trackId)
+    }
+}
+
+extension MXSessionTracker: MXSessionInitCloseDelegate {
+    
+    func didInit(mxSession: MXSession, callStack: [String]) {
+        trackMXSession(mxSession: mxSession, callStack: callStack)
+    }
+    
+    func willClose(mxSession: MXSession) {
+        untrackMXSession(mxSession: mxSession)
+    }
+}
+

--- a/MatrixSDKTests/Utils/MXSessionTracker.swift
+++ b/MatrixSDKTests/Utils/MXSessionTracker.swift
@@ -60,7 +60,7 @@ class MXSessionTracker {
     // MARK: - Private
     
     /// All open sessions
-    private var trackedMXSessions = Dictionary<String, TrackedMXSession>()
+    private var trackedMXSessions = [String: TrackedMXSession]()
     
     func trackMXSession(mxSession: MXSession, callStack: [String]) {
         let trackedMXSession = TrackedMXSession(userDeviceId: mxSession.userDeviceId, callStack: callStack)

--- a/MatrixSDKTests/Utils/TestObserver.swift
+++ b/MatrixSDKTests/Utils/TestObserver.swift
@@ -39,13 +39,12 @@ class TestObserver: NSObject {
 
 extension TestObserver: XCTestObservation {
     func testCaseDidFinish(_ testCase: XCTestCase) {
-        // Crash in caa
         let count = mxSessionTracker.openMXSessionsCount
         if count > 0 {
             mxSessionTracker.printOpenMXSessions()
             
             // All MXSessions must be closed at the end of the test
-            // Else, they will continue to run in background and affect tests performance
+            // Else, they will continue to run in background and affect tests execution performance
             fatalError("Test \(testCase.name) did not close \(count) MXSession instances")
         }
     }

--- a/MatrixSDKTests/Utils/TestObserver.swift
+++ b/MatrixSDKTests/Utils/TestObserver.swift
@@ -23,25 +23,26 @@ import XCTest
 class TestObserver: NSObject {
     static let shared = TestObserver()
     
-    var initialised: Bool = false
+    var mxSessionTracker: MXSessionTracker {
+        get {
+            MXSessionTracker.shared
+        }
+    }
     
     /// Launch the tracking on open MXSessions
     /// There will be `fatalError()` if there are still open MXSession at the end of a test
     func trackMXSessions() {
-        if !initialised {
-            MXSession.trackOpenMXSessions()
-            XCTestObservationCenter.shared.addTestObserver(self)
-            initialised = true
-        }
+        mxSessionTracker.trackMXSessions()
+        XCTestObservationCenter.shared.addTestObserver(self)
     }
 }
 
 extension TestObserver: XCTestObservation {
     func testCaseDidFinish(_ testCase: XCTestCase) {
         // Crash in caa
-        let count = MXSession.openMXSessionsCount
+        let count = mxSessionTracker.openMXSessionsCount
         if count > 0 {
-            MXSession.logOpenMXSessions()
+            mxSessionTracker.printOpenMXSessions()
             
             // All MXSessions must be closed at the end of the test
             // Else, they will continue to run in background and affect tests performance

--- a/MatrixSDKTests/Utils/TestObserver.swift
+++ b/MatrixSDKTests/Utils/TestObserver.swift
@@ -1,0 +1,51 @@
+// 
+// Copyright 2021 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+import XCTest
+
+/// TestObserver offers additional checks on tests
+@objcMembers
+class TestObserver: NSObject {
+    static let shared = TestObserver()
+    
+    var initialised: Bool = false
+    
+    /// Launch the tracking on open MXSessions
+    /// There will be `fatalError()` if there are still open MXSession at the end of a test
+    func trackMXSessions() {
+        if !initialised {
+            MXSession.trackOpenMXSessions()
+            XCTestObservationCenter.shared.addTestObserver(self)
+            initialised = true
+        }
+    }
+}
+
+extension TestObserver: XCTestObservation {
+    func testCaseDidFinish(_ testCase: XCTestCase) {
+        // Crash in caa
+        let count = MXSession.openMXSessionsCount
+        if count > 0 {
+            MXSession.logOpenMXSessions()
+            
+            // All MXSessions must be closed at the end of the test
+            // Else, they will continue to run in background and affect tests performance
+            fatalError("Test \(testCase.name) did not close \(count) MXSession instances")
+        }
+    }
+}

--- a/changelog.d/4875.change
+++ b/changelog.d/4875.change
@@ -1,0 +1,1 @@
+Tests: Improve tests suites execution time by fixing leaked MXSession instances that continued to run in background.


### PR DESCRIPTION
by fixing leaked MXSession instances that continued to run in background.

Fix https://github.com/vector-im/element-ios/issues/4875.

There are 2 main changes:
- MXSessions created by MatrixSDKTestsData are now automatically closed on `deinit`. Tests creators do not need to bother with it anymore. All old `MXSession.close()` management in oldest tests has been removed to follow this new patter,
- There are new tools, `TestObserver` and `MXSessionTracker` to check that all MXSessions have been closed at the end of the test.
