### PR TITLE
MXSession: Make `directRooms` atomic and copying

### DIFF
--- a/MatrixSDK/MXSession.h
+++ b/MatrixSDK/MXSession.h
@@ -922,7 +922,7 @@ typedef void (^MXOnBackgroundSyncFail)(NSError *error);
  
  A dictionary where the keys are the user IDs and values are lists of room ID strings.
  */
-@property (nonatomic, readonly) NSDictionary<NSString*, NSArray<NSString*>*> *directRooms;
+@property (atomic, copy, readonly) NSDictionary<NSString*, NSArray<NSString*>*> *directRooms;
 
 /**
  Return the first joined direct chat listed in account data for this user.

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -1720,8 +1720,10 @@ typedef void (^MXOnResumeDone)(void);
                 NSDictionary<NSString*, NSArray<NSString*>*> *directRooms;
                 MXJSONModelSetDictionary(directRooms, event[@"content"]);
 
-                if (directRooms != self.directRooms
-                    && ![directRooms isEqualToDictionary:self.directRooms])
+                NSDictionary<NSString*, NSArray<NSString*>*> *tmpDirectRooms = self.directRooms;
+                
+                if (directRooms != tmpDirectRooms
+                    && ![directRooms isEqualToDictionary:tmpDirectRooms])
                 {
                     // Collect previous direct rooms ids
                     NSMutableSet<NSString*> *directRoomIds = [NSMutableSet set];
@@ -2636,10 +2638,12 @@ typedef void (^MXOnResumeDone)(void);
                                                success:(void (^)(void))success
                                                failure:(void (^)(NSError *))failure
 {
+    NSDictionary<NSString*, NSArray<NSString*>*> *tmpDirectRooms = self.directRooms;
+
     // If there is no change, do nothing
-    if (self.directRooms == directRooms
-        || [self.directRooms isEqualToDictionary:directRooms]
-        || (self.directRooms == nil && directRooms.count == 0))
+    if (tmpDirectRooms == directRooms
+        || [tmpDirectRooms isEqualToDictionary:directRooms]
+        || (tmpDirectRooms == nil && directRooms.count == 0))
     {
         if (success)
         {

--- a/changelog.d/4911.bugfix
+++ b/changelog.d/4911.bugfix
@@ -1,0 +1,1 @@
+MXSession: Make `directRooms` property atomic and copying.


### PR DESCRIPTION
Fix vector-im/element-ios#4911