### PR TITLE
Update JitsiMeetSDK pod.

### DIFF
--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -57,7 +57,7 @@ Pod::Spec.new do |s|
     #ss.ios.dependency 'GoogleWebRTC', '~>1.1.21820'
     
     # Use WebRTC framework included in Jitsi Meet SDK
-    ss.ios.dependency 'JitsiMeetSDK', ' 3.5.0'
+    ss.ios.dependency 'JitsiMeetSDK', ' 3.10.2'
 
     # JitsiMeetSDK has not yet binaries for arm64 simulator
     ss.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }

--- a/changelog.d/4939.change
+++ b/changelog.d/4939.change
@@ -1,0 +1,1 @@
+Pods: Update JitsiMeetSDK.


### PR DESCRIPTION
Part of https://github.com/vector-im/element-ios/issues/4939.

There isn't anything in way of a changelog, so tested the following calls:
- **1:1 for WebRTC:** iOS / Web / Android
- **Jitsi:** iOS & Web & Desktop