### PR TITLE
Update Realm pod.

### DIFF
--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -40,7 +40,7 @@ Pod::Spec.new do |s|
 
       # Requirements for e2e encryption
       ss.dependency 'OLMKit', '~> 3.2.5'
-      ss.dependency 'Realm', '10.7.6'
+      ss.dependency 'Realm', '10.16.0'
       ss.dependency 'libbase58', '~> 0.1.4'
   end
 

--- a/Podfile
+++ b/Podfile
@@ -10,7 +10,7 @@ abstract_target 'MatrixSDK' do
     pod 'OLMKit', '~> 3.2.5', :inhibit_warnings => true
     #pod 'OLMKit', :path => '../olm/OLMKit.podspec'
     
-    pod 'Realm', '10.7.6'
+    pod 'Realm', '10.16.0'
     pod 'libbase58', '~> 0.1.4'
     
     target 'MatrixSDK-iOS' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -34,9 +34,9 @@ PODS:
     - OLMKit/olmcpp (= 3.2.5)
   - OLMKit/olmc (3.2.5)
   - OLMKit/olmcpp (3.2.5)
-  - Realm (10.7.6):
-    - Realm/Headers (= 10.7.6)
-  - Realm/Headers (10.7.6)
+  - Realm (10.16.0):
+    - Realm/Headers (= 10.16.0)
+  - Realm/Headers (10.16.0)
   - SwiftyBeaver (1.9.5)
 
 DEPENDENCIES:
@@ -45,7 +45,7 @@ DEPENDENCIES:
   - libbase58 (~> 0.1.4)
   - OHHTTPStubs (~> 9.1.0)
   - OLMKit (~> 3.2.5)
-  - Realm (= 10.7.6)
+  - Realm (= 10.16.0)
   - SwiftyBeaver (= 1.9.5)
 
 SPEC REPOS:
@@ -64,9 +64,9 @@ SPEC CHECKSUMS:
   libbase58: 7c040313537b8c44b6e2d15586af8e21f7354efd
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   OLMKit: 9fb4799c4a044dd2c06bda31ec31a12191ad30b5
-  Realm: ed860452717c8db8f4bf832b6807f7f2ce708839
+  Realm: b6027801398f3743fc222f096faa85281b506e6c
   SwiftyBeaver: 84069991dd5dca07d7069100985badaca7f0ce82
 
-PODFILE CHECKSUM: ca61b137d30e689c0afb8cb0ffe424c3e276bab6
+PODFILE CHECKSUM: ea9778919e01b860c6b9fae81f500df82de7ad60
 
 COCOAPODS: 1.10.1

--- a/changelog.d/4939.change
+++ b/changelog.d/4939.change
@@ -1,1 +1,1 @@
-Pods: Update JitsiMeetSDK.
+Pods: Update JitsiMeetSDK and Realm.


### PR DESCRIPTION
This updates Realm from 10.7.6 to 10.16.0. One note to make is that [v10.8.0](https://github.com/realm/realm-cocoa/releases/tag/v10.8.0) introduces a file format change which isn't backwards compatible. Otherwise I've checked:
- Integration tests for Crypto/Cross-signing/Dehydration and no additional tests fail (1 more seems to pass now).
- Sending messages from a new account
- Verifying that new account from an existing one (both sides)
- Creating a secure backup.
- Logging into an existing account.

Nothing to report from any of the above.