### PR TITLE
Add missing synthesis for `areAllIdentityServerTermsAgreed`.

### DIFF
--- a/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryStore.m
+++ b/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryStore.m
@@ -35,7 +35,7 @@
 
 @implementation MXMemoryStore
 
-@synthesize eventStreamToken, userAccountData, syncFilterId, homeserverWellknown;
+@synthesize eventStreamToken, userAccountData, syncFilterId, homeserverWellknown, areAllIdentityServerTermsAgreed;
 
 - (instancetype)init
 {

--- a/changelog.d/sdk-1264.bugfix
+++ b/changelog.d/sdk-1264.bugfix
@@ -1,0 +1,1 @@
+MXMemoryStore: Add missing synthesize for `areAllIdentityServerTermsAgreed`.


### PR DESCRIPTION
Fixes #1264.