### PR TITLE
Add an error parameter to the failure of convertVideoAssetToMP4:

### DIFF
--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -1395,11 +1395,7 @@ NSInteger const kMXRoomAlreadyJoinedErrorCode = 9001;
                     }
                 } failure:onFailure];
             }
-        } failure:^{
-
-            onFailure(nil);
-
-        }];
+        } failure:onFailure];
 
     }];
 

--- a/MatrixSDK/Utils/MXTools.h
+++ b/MatrixSDK/Utils/MXTools.h
@@ -251,7 +251,7 @@ FOUNDATION_EXPORT NSString *const kMXToolsRegexStringForMatrixGroupIdentifier;
 + (void)convertVideoToMP4:(NSURL*)videoLocalURL
        withTargetFileSize:(NSInteger)targetFileSize
                   success:(void(^)(NSURL *videoLocalURL, NSString *mimetype, CGSize size, double durationInMs))success
-                  failure:(void(^)(void))failure;
+                  failure:(void(^)(NSError *error))failure;
 
 /**
  Convert from a video to a MP4 video container.
@@ -268,7 +268,7 @@ FOUNDATION_EXPORT NSString *const kMXToolsRegexStringForMatrixGroupIdentifier;
 + (void)convertVideoAssetToMP4:(AVAsset*)videoAsset
             withTargetFileSize:(NSInteger)targetFileSize
                        success:(void(^)(NSURL *videoLocalURL, NSString *mimetype, CGSize size, double durationInMs))success
-                       failure:(void(^)(void))failure;
+                       failure:(void(^)(NSError *error))failure;
 
 #pragma mark - JSON Serialisation
 

--- a/MatrixSDK/Utils/MXTools.m
+++ b/MatrixSDK/Utils/MXTools.m
@@ -822,7 +822,7 @@ static NSMutableDictionary *fileExtensionByContentType = nil;
 + (void)convertVideoToMP4:(NSURL*)videoLocalURL
        withTargetFileSize:(NSInteger)targetFileSize
                   success:(void(^)(NSURL *videoLocalURL, NSString *mimetype, CGSize size, double durationInMs))success
-                  failure:(void(^)(void))failure
+                  failure:(void(^)(NSError *error))failure
 {
     AVURLAsset *videoAsset = [AVURLAsset assetWithURL:videoLocalURL];
     [self convertVideoAssetToMP4:videoAsset withTargetFileSize:targetFileSize success:success failure:failure];
@@ -831,7 +831,7 @@ static NSMutableDictionary *fileExtensionByContentType = nil;
 + (void)convertVideoAssetToMP4:(AVAsset*)videoAsset
             withTargetFileSize:(NSInteger)targetFileSize
                        success:(void(^)(NSURL *videoLocalURL, NSString *mimetype, CGSize size, double durationInMs))success
-                       failure:(void(^)(void))failure
+                       failure:(void(^)(NSError *error))failure
 {
     NSParameterAssert(success);
     NSParameterAssert(failure);
@@ -912,7 +912,12 @@ static NSMutableDictionary *fileExtensionByContentType = nil;
                     
                     // Remove output file (if any)
                     [[NSFileManager defaultManager] removeItemAtPath:[outputVideoLocalURL path] error:nil];
-                    failure();
+                    
+                    NSError *error = [[NSError alloc] initWithDomain:AVFoundationErrorDomain code:0 userInfo:@{
+                        NSLocalizedDescriptionKey: @"Unable to calculate video size."
+                    }];
+                    
+                    failure(exportSession.error ?: error);
                 }
             }
             else
@@ -922,7 +927,7 @@ static NSMutableDictionary *fileExtensionByContentType = nil;
                 
                 // Remove output file (if any)
                 [[NSFileManager defaultManager] removeItemAtPath:[outputVideoLocalURL path] error:nil];
-                failure();
+                failure(exportSession.error);
             }
         });
         

--- a/changelog.d/4749.api
+++ b/changelog.d/4749.api
@@ -1,0 +1,1 @@
+MXTools: Add an error parameter to the failure of +convertVideoAssetToMP4:withTargetFileSize:success:failure:


### PR DESCRIPTION
Part of https://github.com/vector-im/element-ios/issues/4749, this adds the ability to distinguish whether a video failed to encode or failed to send.
