### PR TITLE
#4431 - Reuse background tasks in more CryptoStore operations, use newer Realm transaction API. Added more failure logs to MXSession.

### DIFF
--- a/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
+++ b/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
@@ -530,13 +530,13 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
             }
             else
             {
-                MXLogDebug(@"[MXRealmCryptoStore] performAccountOperationWithBlock. Error: Cannot build OLMAccount");
+                MXLogError(@"[MXRealmCryptoStore] performAccountOperationWithBlock. Error: Cannot build OLMAccount");
                 block(nil);
             }
         }
         else
         {
-            MXLogDebug(@"[MXRealmCryptoStore] performAccountOperationWithBlock. Error: No OLMAccount yet");
+            MXLogError(@"[MXRealmCryptoStore] performAccountOperationWithBlock. Error: No OLMAccount yet");
             block(nil);
         }
     }];
@@ -887,7 +887,7 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
         }
         else
         {
-            MXLogDebug(@"[MXRealmCryptoStore] performSessionOperationWithDevice. Error: olm session %@ not found", sessionId);
+            MXLogError(@"[MXRealmCryptoStore] performSessionOperationWithDevice. Error: olm session %@ not found", sessionId);
             block(nil);
         }
     }];
@@ -1004,13 +1004,13 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
             }
             else
             {
-                MXLogDebug(@"[MXRealmCryptoStore] performSessionOperationWithGroupSessionWithId. Error: Cannot build MXOlmInboundGroupSession for megolm session %@", sessionId);
+                MXLogError(@"[MXRealmCryptoStore] performSessionOperationWithGroupSessionWithId. Error: Cannot build MXOlmInboundGroupSession for megolm session %@", sessionId);
                 block(nil);
             }
         }
         else
         {
-            MXLogDebug(@"[MXRealmCryptoStore] performSessionOperationWithGroupSessionWithId. Error: megolm session %@ not found", sessionId);
+            MXLogError(@"[MXRealmCryptoStore] performSessionOperationWithGroupSessionWithId. Error: megolm session %@ not found", sessionId);
             block(nil);
         }
     }];

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -795,7 +795,7 @@ typedef void (^MXOnResumeDone)(void);
         } failure:^(NSError *error) {
             MXStrongifyAndReturnIfNil(self);
             
-            MXLogError(@"[MXSession] startWithSyncFilterId: Failed with error %@", error);
+            MXLogError(@"[MXSession] startWithSyncFilterId: setStore failed with error: %@", error);
 
             [self setState:MXSessionStateInitialSyncFailed];
             failure(error);
@@ -1596,7 +1596,7 @@ typedef void (^MXOnResumeDone)(void);
         if ([error.domain isEqualToString:NSURLErrorDomain]
             && code == kCFURLErrorCancelled)
         {
-            MXLogError(@"[MXSession] The connection has been cancelled in state: %@", [MXTools readableSessionState:_state]);
+            MXLogDebug(@"[MXSession] The connection has been cancelled in state: %@", [MXTools readableSessionState:_state]);
 
             // This happens when the SDK cannot make any more requests because the app is in background
             // and the background task is expired or going to expire.

--- a/changelog.d/4431.change
+++ b/changelog.d/4431.change
@@ -1,0 +1,1 @@
+MXRealmCryptoStore: Reuse background tasks and use new api for remaining perform operations.


### PR DESCRIPTION
* reuse background tasks in more CryptoStore operations
* use newer Realm transaction API
* added more failure logs to MXSession.