### PR TITLE
Value semantics on room list fetch sort and filter options

### DIFF
--- a/MatrixSDK/Data/RoomList/MXRoomListDataFetchOptions.swift
+++ b/MatrixSDK/Data/RoomList/MXRoomListDataFetchOptions.swift
@@ -26,13 +26,17 @@ public final class MXRoomListDataFetchOptions: NSObject {
     /// Filter options. Related fetcher will be refreshed automatically when updated.
     public var filterOptions: MXRoomListDataFilterOptions {
         didSet {
-            fetcher?.refresh()
+            if filterOptions != oldValue {
+                fetcher?.refresh()
+            }
         }
     }
     /// Sort options. Related fetcher will be refreshed automatically when updated.
     public var sortOptions: MXRoomListDataSortOptions {
         didSet {
-            fetcher?.refresh()
+            if sortOptions != oldValue {
+                fetcher?.refresh()
+            }
         }
     }
     /// Pagination options
@@ -55,7 +59,5 @@ public final class MXRoomListDataFetchOptions: NSObject {
         self.paginationOptions = paginationOptions
         self.async = async
         super.init()
-        self.filterOptions.fetchOptions = self
-        self.sortOptions.fetchOptions = self
     }
 }

--- a/MatrixSDK/Data/RoomList/MXRoomListDataFilterOptions.swift
+++ b/MatrixSDK/Data/RoomList/MXRoomListDataFilterOptions.swift
@@ -16,64 +16,27 @@
 
 import Foundation
 
-@objcMembers
 /// Filter options to be used with fetch options. See `MXRoomListDataFetchOptions`.
-public final class MXRoomListDataFilterOptions: NSObject {
+public struct MXRoomListDataFilterOptions: Equatable {
     
     /// Value to be used not to specify any type for initializer
     public static let emptyDataTypes: MXRoomSummaryDataTypes = []
-    
-    /// Weak reference to the fetch options
-    internal weak var fetchOptions: MXRoomListDataFetchOptions?
-    
+        
     /// Data types to fetch. Related fetcher will be refreshed automatically when updated.
-    public var dataTypes: MXRoomSummaryDataTypes {
-        didSet {
-            if onlySuggested {
-                //  only suggested rooms are filtered, data types are not valid
-                return
-            }
-            if dataTypes != oldValue {
-                refreshFetcher()
-            }
-        }
-    }
+    public var dataTypes: MXRoomSummaryDataTypes
+    
     /// Data types not to fetch. Related fetcher will be refreshed automatically when updated.
-    public var notDataTypes: MXRoomSummaryDataTypes {
-        didSet {
-            if onlySuggested {
-                //  only suggested rooms are filtered, not data types are not valid
-                return
-            }
-            if notDataTypes != oldValue {
-                refreshFetcher()
-            }
-        }
-    }
+    public var notDataTypes: MXRoomSummaryDataTypes
+    
     /// Search query. Related fetcher will be refreshed automatically when updated.
-    public var query: String? {
-        didSet {
-            if query != oldValue {
-                refreshFetcher()
-            }
-        }
-    }
+    public var query: String?
+    
     /// Space for room list data. Related fetcher will be refreshed automatically when updated.
-    public var space: MXSpace? {
-        didSet {
-            if space != oldValue {
-                refreshFetcher()
-            }
-        }
-    }
+    public var space: MXSpace?
+    
     /// Show all rooms when `space` is not provided. Related fetcher will be refreshed automatically when updated.
-    public var showAllRoomsInHomeSpace: Bool {
-        didSet {
-            if showAllRoomsInHomeSpace != oldValue {
-                refreshFetcher()
-            }
-        }
-    }
+    public var showAllRoomsInHomeSpace: Bool
+    
     /// Flag to filter only suggested rooms, if set to `true`, `dataTypes` and `notDataTypes` are not valid.
     public let onlySuggested: Bool
     
@@ -94,7 +57,6 @@ public final class MXRoomListDataFilterOptions: NSObject {
         self.query = query
         self.space = space
         self.showAllRoomsInHomeSpace = showAllRoomsInHomeSpace
-        super.init()
     }
     
     /// Just to be used for in-memory data
@@ -178,13 +140,5 @@ public final class MXRoomListDataFilterOptions: NSObject {
         }
         return NSCompoundPredicate(type: .and,
                                    subpredicates: subpredicates)
-    }
-    
-    /// Refresh fetcher after updates
-    private func refreshFetcher() {
-        guard let fetcher = fetchOptions?.fetcher else {
-            return
-        }
-        fetcher.refresh()
     }
 }

--- a/MatrixSDK/Data/RoomList/MXRoomListDataSortOptions.swift
+++ b/MatrixSDK/Data/RoomList/MXRoomListDataSortOptions.swift
@@ -16,75 +16,36 @@
 
 import Foundation
 
-@objcMembers
 /// Sort options to be used with fetch options. See `MXRoomListDataFetchOptions`.
-public final class MXRoomListDataSortOptions: NSObject {
-    /// Weak reference to the fetch options
-    internal weak var fetchOptions: MXRoomListDataFetchOptions?
-    
+public struct MXRoomListDataSortOptions: Equatable {
+
     /// Flag to sort by suggested room flag: suggested rooms will come later
     /// Related fetcher will be refreshed automatically when updated.
-    public var suggested: Bool {
-        didSet {
-            if suggested != oldValue {
-                refreshFetcher()
-            }
-        }
-    }
+    public var suggested: Bool
+    
     /// Flag to sort by invite status: invited rooms will come first
     /// Related fetcher will be refreshed automatically when updated.
-    public var invitesFirst: Bool {
-        didSet {
-            if invitesFirst != oldValue {
-                refreshFetcher()
-            }
-        }
-    }
+    public var invitesFirst: Bool
+    
     /// Flag to sort by sent status: rooms having unsent messages will come first
     /// Related fetcher will be refreshed automatically when updated.
-    public var sentStatus: Bool {
-        didSet {
-            if sentStatus != oldValue {
-                refreshFetcher()
-            }
-        }
-    }
+    public var sentStatus: Bool
+    
     /// Flag to sort by last event date: most recent rooms will come first
     /// Related fetcher will be refreshed automatically when updated.
-    public var lastEventDate: Bool {
-        didSet {
-            if lastEventDate != oldValue {
-                refreshFetcher()
-            }
-        }
-    }
+    public var lastEventDate: Bool
+    
     /// Flag to sort by favorite tag order: rooms having "bigger" tags will come first
     /// Related fetcher will be refreshed automatically when updated.
-    public var favoriteTag: Bool {
-        didSet {
-            if favoriteTag != oldValue {
-                refreshFetcher()
-            }
-        }
-    }
+    public var favoriteTag: Bool
+    
     /// Flag to sort by missed notifications count: rooms having more missed notification count will come first
     /// Related fetcher will be refreshed automatically when updated.
-    public var missedNotificationsFirst: Bool {
-        didSet {
-            if missedNotificationsFirst != oldValue {
-                refreshFetcher()
-            }
-        }
-    }
+    public var missedNotificationsFirst: Bool
+    
     /// Flag to sort by unread count: rooms having unread messages will come first
     /// Related fetcher will be refreshed automatically when updated.
-    public var unreadMessagesFirst: Bool {
-        didSet {
-            if unreadMessagesFirst != oldValue {
-                refreshFetcher()
-            }
-        }
-    }
+    public var unreadMessagesFirst: Bool
     
     /// Initializer
     /// - Parameters:
@@ -106,7 +67,6 @@ public final class MXRoomListDataSortOptions: NSObject {
         self.suggested = suggested
         self.missedNotificationsFirst = missedNotificationsFirst
         self.unreadMessagesFirst = unreadMessagesFirst
-        super.init()
     }
     
     /// Just to be used for in-memory data
@@ -148,13 +108,5 @@ public final class MXRoomListDataSortOptions: NSObject {
         }
         
         return result
-    }
-    
-    /// Refresh fetcher after updates
-    private func refreshFetcher() {
-        guard let fetcher = fetchOptions?.fetcher else {
-            return
-        }
-        fetcher.refresh()
     }
 }

--- a/changelog.d/4384.change
+++ b/changelog.d/4384.change
@@ -1,0 +1,1 @@
+Made room list fetch sort and filter options structs. Removed fetch options references from them and made them equatable. Comparing them in the fetch options before refreshing the fetchers.


### PR DESCRIPTION
Made room list fetch sort and filter options structs. 
Removed fetch options references from them and made them equatable. 
Comparing them in the fetch options before refreshing the fetchers.