### PR TITLE
Expose MXEncryptedAttachments in umbrella header

### DIFF
--- a/MatrixSDK/MatrixSDK.h
+++ b/MatrixSDK/MatrixSDK.h
@@ -68,6 +68,7 @@ FOUNDATION_EXPORT NSString *MatrixSDKVersion;
 #import "MXKeyVerificationRequestByDMJSONModel.h"
 #import "MXSASKeyVerificationStart.h"
 #import "MXQRCodeKeyVerificationStart.h"
+#import "MXEncryptedAttachments.h"
 
 #import "MXAes.h"
 

--- a/changelog.d/1278.change
+++ b/changelog.d/1278.change
@@ -1,0 +1,1 @@
+Expose MXEncryptedAttachments in umbrella header


### PR DESCRIPTION
This is currently a missing interface and would require any Swift project to create a bridging header with the specific import.

Signed-off-by: Frantisek Hetes f.hetes@gmail.com