### PR TITLE
Initialize imagesCacheLruCache before caching

### DIFF
--- a/MatrixSDK/Utils/Media/MXMediaManager.m
+++ b/MatrixSDK/Utils/Media/MXMediaManager.m
@@ -155,6 +155,11 @@ static MXLRUCache* imagesCacheLruCache = nil;
 + (void)cacheImage:(NSImage *)image withCachePath:(NSString *)filePath
 #endif
 {
+    if (!imagesCacheLruCache)
+    {
+        imagesCacheLruCache = [[MXLRUCache alloc] initWithCapacity:20];
+    }
+    
     [imagesCacheLruCache put:filePath object:image];
 }
 

--- a/changelog.d/1281.bugfix
+++ b/changelog.d/1281.bugfix
@@ -1,0 +1,1 @@
+Initialize imagesCacheLruCache before caching - caching operations would fail silently because cache was not initialized


### PR DESCRIPTION
Caching operations would fail silently because cache was not initialized.

Signed-off-by: Frantisek Hetes f.hetes@gmail.com