### PR TITLE
Don't allow upgraded rooms that are hidden to become unhidden again.

### DIFF
--- a/MatrixSDK/Data/MXRoomSummaryUpdater.m
+++ b/MatrixSDK/Data/MXRoomSummaryUpdater.m
@@ -297,7 +297,7 @@
         {
             BOOL isReplacementRoomJoined = replacementRoomSummary.membership == MXMembershipJoin;
                         
-            if (isReplacementRoomJoined && summary.hiddenFromUser == NO)
+            if (isReplacementRoomJoined)
             {
                 summary.hiddenFromUser = YES;
                 updated = YES;                

--- a/MatrixSDK/Data/MXRoomSummaryUpdater.m
+++ b/MatrixSDK/Data/MXRoomSummaryUpdater.m
@@ -216,7 +216,20 @@
                 
                 summary.roomTypeString = roomTypeString;
                 summary.roomType = [self.roomTypeMapper roomTypeFrom:roomTypeString];
-                summary.hiddenFromUser = [self shouldHideRoomWithRoomTypeString:roomTypeString];
+                
+                // In most instances a create event shouldn't have a tombstone in its state.
+                if (roomState.tombStoneContent == nil)
+                {
+                    summary.hiddenFromUser = [self shouldHideRoomWithRoomTypeString:roomTypeString];
+                }
+                // If it does the entire room state is likely being refreshed after a limited sync.
+                // We don't want to unhide the room if it's already hidden. If it needs to be hidden
+                // checkRoomCreateStateEventPredecessor… and checkForTombStoneStateEvent… will have
+                // already been called by this stage.
+                else if ([self shouldHideRoomWithRoomTypeString:roomTypeString])
+                {
+                    summary.hiddenFromUser = YES;
+                }
                 
                 updated = YES;
                 [self checkRoomCreateStateEventPredecessorAndUpdateObsoleteRoomSummaryIfNeededWithCreateContent:createContent summary:summary session:session roomState:roomState];

--- a/MatrixSDK/Data/MXRoomSummaryUpdater.m
+++ b/MatrixSDK/Data/MXRoomSummaryUpdater.m
@@ -310,8 +310,6 @@
     if (createContent.roomPredecessorInfo)
     {
         MXRoomSummary *obsoleteRoomSummary = [session roomSummaryWithRoomId:createContent.roomPredecessorInfo.roomId];
-     
-        BOOL obsoleteRoomHiddenFromUserFormerValue = obsoleteRoomSummary.hiddenFromUser;
         
         BOOL isRoomJoined = summary.membership == MXMembershipJoin; 
         

--- a/MatrixSDK/Data/MXRoomSummaryUpdater.m
+++ b/MatrixSDK/Data/MXRoomSummaryUpdater.m
@@ -320,7 +320,7 @@
         {
             obsoleteRoomSummary.hiddenFromUser = YES;
             [obsoleteRoomSummary save:YES];
-        }                
+        }
     }
 }
 

--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
@@ -27,7 +27,7 @@
 #import "MXSDKOptions.h"
 #import "MXTools.h"
 
-static NSUInteger const kMXFileVersion = 75;
+static NSUInteger const kMXFileVersion = 76;
 
 static NSString *const kMXFileStoreFolder = @"MXFileStore";
 static NSString *const kMXFileStoreMedaDataFile = @"MXFileStore";

--- a/changelog.d/5080.bugfix
+++ b/changelog.d/5080.bugfix
@@ -1,0 +1,1 @@
+MXRoomSummaryUpdater: Fix upgraded rooms being marked as visible if the tombstone event comes in as part of a limited sync.


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-ios/issues/5080

When a room has been upgraded with the device in the background, if a limited sync response comes in for that room a call to `MXRoomSummary`'s `resetRoomStateData` method is made. This recomputes the room state including the room's `create` event which was unhiding the room immediately after it had been hidden.

The PR fixes that and bumps the file store version to force all room state to be recomputed.