### PR TITLE
Use classic instead of semantic imports

### DIFF
--- a/MatrixSDK/ContentScan/Data/MXAntivirusScanStatusFormatter.h
+++ b/MatrixSDK/ContentScan/Data/MXAntivirusScanStatusFormatter.h
@@ -14,7 +14,7 @@
  limitations under the License.
  */
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import "MXAntivirusScanStatus.h"
 
 /**

--- a/MatrixSDK/ContentScan/Data/MXEventScan.h
+++ b/MatrixSDK/ContentScan/Data/MXEventScan.h
@@ -14,7 +14,7 @@
  limitations under the License.
  */
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import "MXAntivirusScanStatus.h"
 
 @class MXMediaScan;

--- a/MatrixSDK/ContentScan/Data/MXMediaScan.h
+++ b/MatrixSDK/ContentScan/Data/MXMediaScan.h
@@ -14,7 +14,7 @@
  limitations under the License.
  */
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import "MXAntivirusScanStatus.h"
 
 /**

--- a/MatrixSDK/ContentScan/Data/Store/MXEventScanStore.h
+++ b/MatrixSDK/ContentScan/Data/Store/MXEventScanStore.h
@@ -14,7 +14,7 @@
  limitations under the License.
  */
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import "MXAntivirusScanStatus.h"
 #import "MXEventScanStoreDelegate.h"
 

--- a/MatrixSDK/ContentScan/Data/Store/MXMediaScanStore.h
+++ b/MatrixSDK/ContentScan/Data/Store/MXMediaScanStore.h
@@ -14,7 +14,7 @@
  limitations under the License.
  */
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import "MXAntivirusScanStatus.h"
 #import "MXMediaScan.h"
 #import "MXMediaScanStoreDelegate.h"

--- a/MatrixSDK/ContentScan/Data/Store/MXMediaScanStoreDelegate.h
+++ b/MatrixSDK/ContentScan/Data/Store/MXMediaScanStoreDelegate.h
@@ -14,7 +14,7 @@
  limitations under the License.
  */
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 @class MXMediaScanStore, MXMediaScan;
 

--- a/MatrixSDK/ContentScan/Data/Store/Realm/Event/MXRealmEventScanMapper.h
+++ b/MatrixSDK/ContentScan/Data/Store/Realm/Event/MXRealmEventScanMapper.h
@@ -14,7 +14,7 @@
  limitations under the License.
  */
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #import "MXEventScan.h"
 #import "MXRealmEventScan.h"

--- a/MatrixSDK/ContentScan/Data/Store/Realm/Event/MXRealmEventScanStore.h
+++ b/MatrixSDK/ContentScan/Data/Store/Realm/Event/MXRealmEventScanStore.h
@@ -14,7 +14,7 @@
  limitations under the License.
  */
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import "MXEventScanStore.h"
 #import "MXScanRealmProvider.h"
 

--- a/MatrixSDK/ContentScan/Data/Store/Realm/Media/MXRealmMediaScanStore.h
+++ b/MatrixSDK/ContentScan/Data/Store/Realm/Media/MXRealmMediaScanStore.h
@@ -14,7 +14,7 @@
  limitations under the License.
  */
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import "MXAntivirusScanStatus.h"
 #import "MXMediaScanStore.h"
 #import "MXRealmMediaScan.h"

--- a/MatrixSDK/ContentScan/MXScanManager.h
+++ b/MatrixSDK/ContentScan/MXScanManager.h
@@ -14,7 +14,7 @@
  limitations under the License.
  */
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #pragma mark - Constants
 

--- a/MatrixSDK/Crypto/Dehydration/MXDehydrationService.h
+++ b/MatrixSDK/Crypto/Dehydration/MXDehydrationService.h
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 @class MXCrypto;
 @class MXRestClient;

--- a/MatrixSDK/Data/MXRoomNameDefaultStringLocalizer.h
+++ b/MatrixSDK/Data/MXRoomNameDefaultStringLocalizer.h
@@ -14,7 +14,7 @@
  limitations under the License.
  */
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #import "MXRoomNameStringLocalizerProtocol.h"
 

--- a/MatrixSDK/Data/MXRoomNameStringLocalizerProtocol.h
+++ b/MatrixSDK/Data/MXRoomNameStringLocalizerProtocol.h
@@ -14,7 +14,7 @@
  limitations under the License.
  */
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/MatrixSDK/Data/MXSendReplyEventDefaultStringLocalizer.h
+++ b/MatrixSDK/Data/MXSendReplyEventDefaultStringLocalizer.h
@@ -14,7 +14,7 @@
  limitations under the License.
  */
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import "MXSendReplyEventStringLocalizerProtocol.h"
 
 /**

--- a/MatrixSDK/Data/MXSendReplyEventStringLocalizerProtocol.h
+++ b/MatrixSDK/Data/MXSendReplyEventStringLocalizerProtocol.h
@@ -14,7 +14,7 @@
  limitations under the License.
  */
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/MatrixSDK/Utils/Realm/MXRealmHelper.h
+++ b/MatrixSDK/Utils/Realm/MXRealmHelper.h
@@ -14,7 +14,7 @@
  limitations under the License.
  */
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 @class RLMRealmConfiguration;
 

--- a/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.h
+++ b/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.h
@@ -16,7 +16,7 @@
 
 #if TARGET_OS_IPHONE
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.m
+++ b/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.m
@@ -18,9 +18,9 @@
 
 #import "MXCallKitAdapter.h"
 
-@import AVFoundation;
-@import CallKit;
-@import UIKit;
+#import <AVFoundation/AVFoundation.h>
+#import <CallKit/CallKit.h>
+#import <UIKit/UIKit.h>
 
 #import "MXCall.h"
 #import "MXCallAudioSessionConfigurator.h"

--- a/MatrixSDK/VoIP/CallKit/MXCallKitConfiguration.h
+++ b/MatrixSDK/VoIP/CallKit/MXCallKitConfiguration.h
@@ -14,7 +14,7 @@
  limitations under the License.
  */
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/changelog.d/5046.misc
+++ b/changelog.d/5046.misc
@@ -1,0 +1,1 @@
+Replace semantic imports with classic ones to enable use of the SDK in Kotlin Multiplatform Mobile projects


### PR DESCRIPTION
This replaces all semantic import statements with classic ones. Semantic imports are currently not supported in Kotlin Multiplatform Mobile projects which makes the SDK unusable in these cases.

Fixes: vector-im/element-ios#5046

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request contains a changelog file in ./changelog.d. See https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
