### PR TITLE
Fixes vector-im/element-ios/issues/5120 - Fixed fallback key signature validation.

### DIFF
--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -2928,6 +2928,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
         // Sign the fallback key
         NSMutableDictionary *signedKey = [NSMutableDictionary dictionary];
         signedKey[@"key"] = fallbackKey[kMXKeyCurve25519Type][keyId];
+        signedKey[@"fallback"] = @(YES);
         signedKey[@"signatures"] = [self signObject:signedKey];
         
         fallbackKeyJson[[NSString stringWithFormat:@"%@:%@", kMXKeySignedCurve25519Type, keyId]] = signedKey;

--- a/changelog.d/5120.bugfix
+++ b/changelog.d/5120.bugfix
@@ -1,0 +1,1 @@
+Fixed fallback key signature validation.


### PR DESCRIPTION
Storing full MXKey dictionary so we can use all fields when checking the signature.
Added integration test to exercise currently failing paths.