### PR TITLE
Group highlights/notifications/unread rooms instead of sorting.

### DIFF
--- a/MatrixSDK/Data/RoomList/MXRoomListDataSortOptions.swift
+++ b/MatrixSDK/Data/RoomList/MXRoomListDataSortOptions.swift
@@ -91,12 +91,12 @@ public struct MXRoomListDataSortOptions: Equatable {
         }
         
         if missedNotificationsFirst {
-            result.append(NSSortDescriptor(keyPath: \MXRoomSummaryProtocol.highlightCount, ascending: false))
-            result.append(NSSortDescriptor(keyPath: \MXRoomSummaryProtocol.notificationCount, ascending: false))
+            result.append(NSSortDescriptor(keyPath: \MXRoomSummaryProtocol.highlightCount, ascending: false, comparator: groupNonZeroCountComparator()))
+            result.append(NSSortDescriptor(keyPath: \MXRoomSummaryProtocol.notificationCount, ascending: false, comparator: groupNonZeroCountComparator()))
         }
         
         if unreadMessagesFirst {
-            result.append(NSSortDescriptor(keyPath: \MXRoomSummaryProtocol.localUnreadEventCount, ascending: false))
+            result.append(NSSortDescriptor(keyPath: \MXRoomSummaryProtocol.localUnreadEventCount, ascending: false, comparator: groupNonZeroCountComparator()))
         }
         
         if lastEventDate {
@@ -108,5 +108,20 @@ public struct MXRoomListDataSortOptions: Equatable {
         }
         
         return result
+    }
+    
+    func groupNonZeroCountComparator() -> Comparator {
+        return {
+            guard let lhs = $0 as? Int, let rhs = $1 as? Int else { return .orderedSame }
+            
+            switch (lhs, rhs) {
+            case (1..., 0):
+                return .orderedDescending
+            case (0, 1...):
+                return .orderedAscending
+            default:
+                return .orderedSame
+            }
+        }
     }
 }

--- a/changelog.d/5105.bugfix
+++ b/changelog.d/5105.bugfix
@@ -1,1 +1,1 @@
-Fix room ordering regression.
+Fix invite and room ordering regression.


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-ios/issues/5105.

Highlight/notification/unread counts were being used to sort rooms instead of grouping them.