### PR TITLE
Ignore number of highlights, notifications and unreads when sorting rooms

### DIFF
--- a/MatrixSDK/Data/MXRoomSummary.m
+++ b/MatrixSDK/Data/MXRoomSummary.m
@@ -744,6 +744,21 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
     return updated;
 }
 
+- (BOOL)hasAnyUnread
+{
+    return _localUnreadEventCount > 0;
+}
+
+- (BOOL)hasAnyNotification
+{
+    return _notificationCount > 0;
+}
+
+- (BOOL)hasAnyHighlight
+{
+    return _highlightCount > 0;
+}
+
 #pragma mark - Server sync
 - (void)handleStateEvents:(NSArray<MXEvent *> *)stateEvents
 {

--- a/MatrixSDK/Data/MXRoomSummaryProtocol.h
+++ b/MatrixSDK/Data/MXRoomSummaryProtocol.h
@@ -103,6 +103,15 @@ NS_ASSUME_NONNULL_BEGIN
 /// It is based on the notificationCount field in /sync response.
 @property (nonatomic, readonly) NSUInteger highlightCount;
 
+/// Flag indicating the room has any unread (`localUnreadEventCount` > 0)
+@property (nonatomic, readonly) BOOL hasAnyUnread;
+
+/// Flag indicating the room has any notification (`notificationCount` > 0)
+@property (nonatomic, readonly) BOOL hasAnyNotification;
+
+/// Flag indicating the room has any highlight (`highlightCount` > 0)
+@property (nonatomic, readonly) BOOL hasAnyHighlight;
+
 /// Indicate if the room is tagged as a direct chat.
 @property (nonatomic, readonly) BOOL isDirect;
 

--- a/MatrixSDK/Data/RoomList/MXRoomListDataSortOptions.swift
+++ b/MatrixSDK/Data/RoomList/MXRoomListDataSortOptions.swift
@@ -91,12 +91,12 @@ public struct MXRoomListDataSortOptions: Equatable {
         }
         
         if missedNotificationsFirst {
-            result.append(NSSortDescriptor(keyPath: \MXRoomSummaryProtocol.highlightCount, ascending: false))
-            result.append(NSSortDescriptor(keyPath: \MXRoomSummaryProtocol.notificationCount, ascending: false))
+            result.append(NSSortDescriptor(keyPath: \MXRoomSummaryProtocol.hasAnyHighlight, ascending: false))
+            result.append(NSSortDescriptor(keyPath: \MXRoomSummaryProtocol.hasAnyNotification, ascending: false))
         }
         
         if unreadMessagesFirst {
-            result.append(NSSortDescriptor(keyPath: \MXRoomSummaryProtocol.localUnreadEventCount, ascending: false))
+            result.append(NSSortDescriptor(keyPath: \MXRoomSummaryProtocol.hasAnyUnread, ascending: false))
         }
         
         if lastEventDate {

--- a/MatrixSDKTests/Mocks/MockRoomSummary.swift
+++ b/MatrixSDKTests/Mocks/MockRoomSummary.swift
@@ -59,6 +59,18 @@ internal class MockRoomSummary: NSObject, MXRoomSummaryProtocol {
     
     var highlightCount: UInt = 0
     
+    var hasAnyUnread: Bool {
+        return localUnreadEventCount > 0
+    }
+    
+    var hasAnyNotification: Bool {
+        return notificationCount > 0
+    }
+    
+    var hasAnyHighlight: Bool {
+        return highlightCount > 0
+    }
+    
     var isDirect: Bool {
         return isTyped(.direct)
     }

--- a/changelog.d/5105.bugfix
+++ b/changelog.d/5105.bugfix
@@ -1,1 +1,1 @@
-Fix room ordering regression.
+MXRoomListDataSortOptions: Fix room ordering regression.


### PR DESCRIPTION
Part of vector-im/element-ios#5105

Ignores number of highlights, notifications and unreadCounts. Sorts according to only existence of them.