### PR TITLE
Fix Reply Event Content for just Thread-Aware Clients

### DIFF
--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -1946,10 +1946,13 @@ NSInteger const kMXRoomAlreadyJoinedErrorCode = 9001;
         NSDictionary *relatesToDict = nil;
         if (eventToReply.threadIdentifier)
         {
-            //  TODO: This will change when we support in-thread replies
             relatesToDict = @{
                 @"rel_type": MXEventRelationTypeThread,
-                @"event_id" : eventToReply.threadIdentifier
+                @"event_id" : eventToReply.threadIdentifier,
+                @"m.in_reply_to" :
+                    @{
+                        @"event_id" : eventId
+                    }
             };
         }
         else

--- a/changelog.d/5007.bugfix
+++ b/changelog.d/5007.bugfix
@@ -1,0 +1,1 @@
+MXRoom: Fix reply event content for just thread-aware clients.


### PR DESCRIPTION
Improves vector-im/element-ios#5007