### PR TITLE
Various poll tweaks.

### DIFF
--- a/MatrixSDK/Contrib/Swift/JSONModels/MXEvent.swift
+++ b/MatrixSDK/Contrib/Swift/JSONModels/MXEvent.swift
@@ -73,6 +73,10 @@ public enum MXEventType: Equatable, Hashable {
     case keyVerificationDone
     case taggedEvents
     case spaceChild
+    
+    case pollStart
+    case pollResponse
+    case pollEnd
 
     case custom(String)
     
@@ -123,6 +127,10 @@ public enum MXEventType: Equatable, Hashable {
         case .taggedEvents: return kMXEventTypeStringTaggedEvents
         case .spaceChild: return kMXEventTypeStringSpaceChild
             
+        case .pollStart: return kMXEventTypeStringPollStartMSC3381
+        case .pollResponse: return kMXEventTypeStringPollResponseMSC3381
+        case .pollEnd: return kMXEventTypeStringPollEndMSC3381
+            
         // Swift converts any constant with the suffix "Notification" as the type `Notification.Name`
         // The original value can be reached using the `rawValue` property.
         case .typing: return NSNotification.Name.mxEventTypeStringTyping.rawValue
@@ -130,10 +138,23 @@ public enum MXEventType: Equatable, Hashable {
         case .custom(let string): return string
         }
     }
-
+    
     public init(identifier: String) {
-        let events: [MXEventType] = [.roomName, .roomTopic, .roomAvatar, .roomMember, .roomCreate, .roomJoinRules, .roomPowerLevels, .roomAliases, .roomCanonicalAlias, .roomEncrypted, .roomEncryption, .roomGuestAccess, .roomHistoryVisibility, .roomKey, .roomForwardedKey, .roomKeyRequest, .roomMessage, .roomMessageFeedback, .roomRedaction, .roomThirdPartyInvite, .roomTag, .presence, .typing, .callInvite, .callCandidates, .callAnswer, .callSelectAnswer, .callHangup, .callReject, .callNegotiate, .callReplaces, .callRejectReplacement, .callAssertedIdentity, .callAssertedIdentityUnstable, .receipt, .roomTombStone, .taggedEvents]
-        self = events.first(where: { $0.identifier == identifier }) ?? .custom(identifier)
+        let events: [MXEventType] = [.roomName, .roomTopic, .roomAvatar, .roomMember, .roomCreate, .roomJoinRules, .roomPowerLevels, .roomAliases, .roomCanonicalAlias, .roomEncrypted, .roomEncryption, .roomGuestAccess, .roomHistoryVisibility, .roomKey, .roomForwardedKey, .roomKeyRequest, .roomMessage, .roomMessageFeedback, .roomRedaction, .roomThirdPartyInvite, .roomTag, .presence, .typing, .callInvite, .callCandidates, .callAnswer, .callSelectAnswer, .callHangup, .callReject, .callNegotiate, .callReplaces, .callRejectReplacement, .callAssertedIdentity, .callAssertedIdentityUnstable, .reaction, .receipt, .roomTombStone, .keyVerificationStart, .keyVerificationAccept, .keyVerificationKey, .keyVerificationMac, .keyVerificationCancel, .keyVerificationDone, .taggedEvents, .spaceChild, .pollStart, .pollResponse, .pollEnd]
+        
+        if let type = events.first(where: { $0.identifier == identifier }) {
+            self = type
+        } else {
+            if identifier == kMXEventTypeStringPollStart {
+                self = .pollStart
+            } else if identifier == kMXEventTypeStringPollResponse {
+                self = .pollResponse
+            } else if identifier == kMXEventTypeStringPollEnd {
+                self = .pollEnd
+            } else {
+                self = .custom(identifier)
+            }
+        }
     }
 }
 

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -2303,7 +2303,7 @@ NSInteger const kMXRoomAlreadyJoinedErrorCode = 9001;
         }
     }
 
-    return [self sendEventOfType:kMXEventTypeStringPollStart content:content.JSONDictionary localEcho:localEcho success:success failure:failure];
+    return [self sendEventOfType:[MXTools eventTypeString:MXEventTypePollStart] content:content.JSONDictionary localEcho:localEcho success:success failure:failure];
 }
 
 - (MXHTTPOperation *)sendPollResponseForEvent:(MXEvent *)pollStartEvent
@@ -2313,7 +2313,7 @@ NSInteger const kMXRoomAlreadyJoinedErrorCode = 9001;
                                       failure:(void (^)(NSError *))failure
 {
     NSParameterAssert(pollStartEvent);
-    NSAssert([pollStartEvent.type isEqualToString:kMXEventTypeStringPollStart], @"Invalid event type");
+    NSAssert(pollStartEvent.eventType == MXEventTypePollStart, @"Invalid event type");
     NSParameterAssert(answerIdentifiers);
     
     for (NSString *answerIdentifier in answerIdentifiers)
@@ -2332,7 +2332,7 @@ NSInteger const kMXRoomAlreadyJoinedErrorCode = 9001;
         kMXMessageContentKeyExtensiblePollResponse: @{ kMXMessageContentKeyExtensiblePollAnswers: answerIdentifiers }
     };
     
-    return [self sendEventOfType:kMXEventTypeStringPollResponse content:content localEcho:localEcho success:success failure:failure];
+    return [self sendEventOfType:[MXTools eventTypeString:MXEventTypePollResponse] content:content localEcho:localEcho success:success failure:failure];
 }
 
 - (MXHTTPOperation *)sendPollEndForEvent:(MXEvent *)pollStartEvent
@@ -2341,7 +2341,7 @@ NSInteger const kMXRoomAlreadyJoinedErrorCode = 9001;
                                  failure:(void (^)(NSError *))failure
 {
     NSParameterAssert(pollStartEvent);
-    NSAssert([pollStartEvent.type isEqualToString:kMXEventTypeStringPollStart], @"Invalid event type");
+    NSAssert(pollStartEvent.eventType == MXEventTypePollStart, @"Invalid event type");
     
     MXEventContentRelatesTo *relatesTo = [[MXEventContentRelatesTo alloc] initWithRelationType:MXEventRelationTypeReference
                                                                                        eventId:pollStartEvent.eventId];
@@ -2351,7 +2351,7 @@ NSInteger const kMXRoomAlreadyJoinedErrorCode = 9001;
         kMXMessageContentKeyExtensiblePollEnd: @{}
     };
     
-    return [self sendEventOfType:kMXEventTypeStringPollEnd content:content localEcho:localEcho success:success failure:failure];
+    return [self sendEventOfType:[MXTools eventTypeString:MXEventTypePollEnd] content:content localEcho:localEcho success:success failure:failure];
 }
 
 #pragma mark - Message order preserving

--- a/MatrixSDK/JSONModels/Event/Content/MXEventContentPollStart.m
+++ b/MatrixSDK/JSONModels/Event/Content/MXEventContentPollStart.m
@@ -39,7 +39,7 @@
     NSDictionary *content = JSONDictionary[kMXMessageContentKeyExtensiblePollStart];
     
     NSString *question, *kind;
-    MXJSONModelSetString(question, content[kMXMessageContentKeyExtensiblePollQuestion]);
+    MXJSONModelSetString(question, content[kMXMessageContentKeyExtensiblePollQuestion][kMXMessageContentKeyExtensibleText]);
     MXJSONModelSetString(kind, content[kMXMessageContentKeyExtensiblePollKind]);
     
     NSNumber *maxSelections;
@@ -57,7 +57,7 @@
 {
     NSMutableDictionary *content = [NSMutableDictionary dictionary];
     
-    content[kMXMessageContentKeyExtensiblePollQuestion] = self.question;
+    content[kMXMessageContentKeyExtensiblePollQuestion] = @{kMXMessageContentKeyExtensibleText: self.question};
     content[kMXMessageContentKeyExtensiblePollKind] = self.kind;
     content[kMXMessageContentKeyExtensiblePollMaxSelections] = self.maxSelections;
     

--- a/MatrixSDK/JSONModels/MXEvent.h
+++ b/MatrixSDK/JSONModels/MXEvent.h
@@ -92,6 +92,8 @@ typedef NS_ENUM(NSInteger, MXEventType)
     MXEventTypeTaggedEvents,
     MXEventTypeSpaceChild,
     MXEventTypePollStart,
+    MXEventTypePollResponse,
+    MXEventTypePollEnd,
 
     // The event is a custom event. Refer to its `MXEventTypeString` version
     MXEventTypeCustom = 1000
@@ -170,9 +172,13 @@ FOUNDATION_EXPORT NSString *const kMXEventTypeStringAutoJoinKey;
 FOUNDATION_EXPORT NSString *const kMXEventTypeStringSuggestedKey;
 
 // Polls
+FOUNDATION_EXPORT NSString *const kMXEventTypeStringPollStartMSC3381;
 FOUNDATION_EXPORT NSString *const kMXEventTypeStringPollStart;
+FOUNDATION_EXPORT NSString *const kMXEventTypeStringPollResponseMSC3381;
 FOUNDATION_EXPORT NSString *const kMXEventTypeStringPollResponse;
+FOUNDATION_EXPORT NSString *const kMXEventTypeStringPollEndMSC3381;
 FOUNDATION_EXPORT NSString *const kMXEventTypeStringPollEnd;
+
 
 /**
  Types of room messages

--- a/MatrixSDK/JSONModels/MXEvent.h
+++ b/MatrixSDK/JSONModels/MXEvent.h
@@ -91,6 +91,7 @@ typedef NS_ENUM(NSInteger, MXEventType)
     MXEventTypeSecretStorageDefaultKey,
     MXEventTypeTaggedEvents,
     MXEventTypeSpaceChild,
+    MXEventTypePollStart,
 
     // The event is a custom event. Refer to its `MXEventTypeString` version
     MXEventTypeCustom = 1000

--- a/MatrixSDK/JSONModels/MXEvent.m
+++ b/MatrixSDK/JSONModels/MXEvent.m
@@ -86,9 +86,12 @@ NSString *const kMXEventTypeStringSpaceChild            = @"m.space.child";
 NSString *const kMXEventTypeStringAutoJoinKey           = @"auto_join";
 NSString *const kMXEventTypeStringSuggestedKey          = @"suggested";
 
-NSString *const kMXEventTypeStringPollStart    = @"org.matrix.msc3381.poll.start";
-NSString *const kMXEventTypeStringPollResponse = @"org.matrix.msc3381.poll.response";
-NSString *const kMXEventTypeStringPollEnd      = @"org.matrix.msc3381.poll.end";
+NSString *const kMXEventTypeStringPollStartMSC3381    = @"org.matrix.msc3381.poll.start";
+NSString *const kMXEventTypeStringPollStart           = @"m.poll.start";
+NSString *const kMXEventTypeStringPollResponseMSC3381 = @"org.matrix.msc3381.poll.response";
+NSString *const kMXEventTypeStringPollResponse        = @"m.poll.response";
+NSString *const kMXEventTypeStringPollEndMSC3381      = @"org.matrix.msc3381.poll.end";
+NSString *const kMXEventTypeStringPollEnd             = @"m.poll.end";
 
 NSString *const kMXMessageTypeText                   = @"m.text";
 NSString *const kMXMessageTypeEmote                  = @"m.emote";

--- a/MatrixSDK/Room/Polls/PollAggregator.swift
+++ b/MatrixSDK/Room/Polls/PollAggregator.swift
@@ -96,7 +96,8 @@ public class PollAggregator {
             
             self.events.append(contentsOf: response.chunk)
             
-            self.eventListener = self.room.listen(toEventsOfTypes: [kMXEventTypeStringPollResponse, kMXEventTypeStringPollEnd]) { [weak self] event, direction, state in
+            let eventTypes = [kMXEventTypeStringPollResponse, kMXEventTypeStringPollResponseMSC3381, kMXEventTypeStringPollEnd, kMXEventTypeStringPollEndMSC3381]
+            self.eventListener = self.room.listen(toEventsOfTypes: eventTypes) { [weak self] event, direction, state in
                 guard let self = self,
                       let event = event,
                       let relatedEventId = event.relatesTo?.eventId,

--- a/MatrixSDK/Room/Polls/PollAggregator.swift
+++ b/MatrixSDK/Room/Polls/PollAggregator.swift
@@ -97,7 +97,10 @@ public class PollAggregator {
             self.events.append(contentsOf: response.chunk)
             
             self.eventListener = self.room.listen(toEventsOfTypes: [kMXEventTypeStringPollResponse, kMXEventTypeStringPollEnd]) { [weak self] event, direction, state in
-                guard let self = self, let event = event else {
+                guard let self = self,
+                      let event = event,
+                      let relatedEventId = event.relatesTo?.eventId,
+                      relatedEventId == self.pollStartEvent.eventId else {
                     return
                 }
                 

--- a/MatrixSDK/Room/Polls/PollAggregator.swift
+++ b/MatrixSDK/Room/Polls/PollAggregator.swift
@@ -17,11 +17,11 @@
 import Foundation
 
 /// PollAggregator errors 
-enum PollAggregatorError: Error {
+public enum PollAggregatorError: Error {
     case invalidPollStartEvent
 }
 
-protocol PollAggregatorDelegate: AnyObject {
+public protocol PollAggregatorDelegate: AnyObject {
     func pollAggregatorDidStartLoading(_ aggregator: PollAggregator)
     func pollAggregatorDidEndLoading(_ aggregator: PollAggregator)
     func pollAggregator(_ aggregator: PollAggregator, didFailWithError: Error)
@@ -34,7 +34,7 @@ protocol PollAggregatorDelegate: AnyObject {
  I will also listen for `mxRoomDidFlushData` and reload all data to avoid gappy sync problems
 */
 
-class PollAggregator {
+public class PollAggregator {
     
     private let session: MXSession
     private let room: MXRoom
@@ -45,19 +45,19 @@ class PollAggregator {
     private var eventListener: Any!
     private var events: [MXEvent] = []
     
-    private(set) var poll: PollProtocol! {
+    public private(set) var poll: PollProtocol! {
         didSet {
             delegate?.pollAggregatorDidUpdateData(self)
         }
     }
     
-    var delegate: PollAggregatorDelegate?
+    public var delegate: PollAggregatorDelegate?
     
     deinit {
         room.removeListener(eventListener)
     }
     
-    init(session: MXSession, room: MXRoom, pollStartEvent: MXEvent) throws {
+    public init(session: MXSession, room: MXRoom, pollStartEvent: MXEvent) throws {
         self.session = session
         self.room = room
         self.pollStartEvent = pollStartEvent

--- a/MatrixSDK/Room/Polls/PollAggregator.swift
+++ b/MatrixSDK/Room/Polls/PollAggregator.swift
@@ -70,7 +70,7 @@ public class PollAggregator {
         
         pollBuilder = PollBuilder()
         
-        poll = pollBuilder.build(pollStartEventContent: self.pollStartEventContent, events: self.events)
+        poll = pollBuilder.build(pollStartEventContent: self.pollStartEventContent, events: self.events, currentUserIdentifier: session.myUserId)
         
         reloadData()
         
@@ -103,10 +103,10 @@ public class PollAggregator {
                 
                 self.events.append(event)
                 
-                self.poll = self.pollBuilder.build(pollStartEventContent: self.pollStartEventContent, events: self.events)
+                self.poll = self.pollBuilder.build(pollStartEventContent: self.pollStartEventContent, events: self.events, currentUserIdentifier: self.session.myUserId)
             } as Any
             
-            self.poll = self.pollBuilder.build(pollStartEventContent: self.pollStartEventContent, events: self.events)
+            self.poll = self.pollBuilder.build(pollStartEventContent: self.pollStartEventContent, events: self.events, currentUserIdentifier: self.session.myUserId)
             
             self.delegate?.pollAggregatorDidEndLoading(self)
             

--- a/MatrixSDK/Room/Polls/PollBuilder.swift
+++ b/MatrixSDK/Room/Polls/PollBuilder.swift
@@ -35,12 +35,12 @@ struct PollBuilder {
             return option
         }
         
-        let stopEvent = events.filter { $0.type == kMXEventTypeStringPollEnd }.first
+        let stopEvent = events.filter { $0.eventType == __MXEventType.pollEnd }.first
         poll.isClosed = (stopEvent != nil)
         
         var filteredEvents = events.filter { event in
             guard
-                let eventContent = event.content, event.type == kMXEventTypeStringPollResponse,
+                let eventContent = event.content, event.eventType == __MXEventType.pollResponse,
                 let answer = eventContent[kMXMessageContentKeyExtensiblePollResponse] as? [String: [String]],
                 let _ = answer[kMXMessageContentKeyExtensiblePollAnswers] else {
                 return false

--- a/MatrixSDK/Room/Polls/PollBuilder.swift
+++ b/MatrixSDK/Room/Polls/PollBuilder.swift
@@ -35,7 +35,7 @@ struct PollBuilder {
             return option
         }
         
-        let stopEvent = events.filter { $0.eventType == __MXEventType.pollEnd }.first
+        let stopEvent = events.filter { $0.eventType == .pollEnd }.first
         poll.isClosed = (stopEvent != nil)
         
         var filteredEvents = events.filter { event in

--- a/MatrixSDK/Room/Polls/PollBuilder.swift
+++ b/MatrixSDK/Room/Polls/PollBuilder.swift
@@ -17,12 +17,12 @@
 import Foundation
 
 struct PollBuilder {
-    func build(pollStartEventContent: MXEventContentPollStart, events: [MXEvent], currentUserIdentifer: String? = nil) -> PollProtocol {
+    func build(pollStartEventContent: MXEventContentPollStart, events: [MXEvent], currentUserIdentifier: String) -> PollProtocol {
         
         let poll = Poll()
         
         poll.text = pollStartEventContent.question
-        poll.maxAllowedSelections = pollStartEventContent.maxSelections.uintValue
+        poll.maxAllowedSelections = max(1, pollStartEventContent.maxSelections.uintValue)
         poll.kind = (pollStartEventContent.kind == kMXMessageContentKeyExtensiblePollKindUndisclosed ? .undisclosed : .disclosed)
         
         var answerOptionIdentifiers = [String]()
@@ -95,7 +95,7 @@ struct PollBuilder {
                 }
             }
             
-            if groupedUserAnswers.key == currentUserIdentifer {
+            if groupedUserAnswers.key == currentUserIdentifier {
                 currentUserAnswers = groupedUserAnswers.value
             }
             

--- a/MatrixSDK/Room/Polls/PollModels.swift
+++ b/MatrixSDK/Room/Polls/PollModels.swift
@@ -16,12 +16,12 @@
 
 import Foundation
 
-enum PollKind {
+public enum PollKind {
     case disclosed
     case undisclosed
 }
 
-protocol PollAnswerOptionProtocol {
+public protocol PollAnswerOptionProtocol {
     var id: String { get }
     var text: String { get }
     var count: UInt { get }
@@ -29,12 +29,13 @@ protocol PollAnswerOptionProtocol {
     var isCurrentUserSelection: Bool { get }
 }
 
-protocol PollProtocol {
+public protocol PollProtocol {
     var text: String { get }
     var answerOptions: [PollAnswerOptionProtocol] { get }
     var kind: PollKind { get }
     var maxAllowedSelections: UInt { get }
     var isClosed: Bool { get }
+    var totalAnswerCount: UInt { get }
 }
 
 class PollAnswerOption: PollAnswerOptionProtocol {

--- a/MatrixSDK/Utils/MXTools.m
+++ b/MatrixSDK/Utils/MXTools.m
@@ -43,8 +43,8 @@ NSString *const kMXToolsRegexStringForMatrixGroupIdentifier     = @"\\+[A-Z0-9=_
 
 #pragma mark - MXTools static private members
 // Mapping from MXEventTypeString to MXEventType and vice versa
-static NSDictionary<MXEventTypeString, NSNumber*> *eventTypeMapStringToEnum;
-static NSArray<MXEventTypeString> *eventTypeMapEnumToString;
+static NSDictionary<MXEventTypeString, NSNumber *> *eventTypeMapStringToEnum;
+static NSDictionary<NSNumber *, MXEventTypeString> *eventTypeMapEnumToString;
 
 static NSRegularExpression *isEmailAddressRegex;
 static NSRegularExpression *isMatrixUserIdentifierRegex;
@@ -70,75 +70,145 @@ NSCharacterSet *uriComponentCharset;
 {
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
+        
+        eventTypeMapEnumToString = @{
+            @(MXEventTypeRoomName) : kMXEventTypeStringRoomName,
+            @(MXEventTypeRoomTopic) : kMXEventTypeStringRoomTopic,
+            @(MXEventTypeRoomAvatar) : kMXEventTypeStringRoomAvatar,
+            @(MXEventTypeRoomBotOptions) : kMXEventTypeStringRoomBotOptions,
+            @(MXEventTypeRoomMember) : kMXEventTypeStringRoomMember,
+            @(MXEventTypeRoomCreate) : kMXEventTypeStringRoomCreate,
+            @(MXEventTypeRoomJoinRules) : kMXEventTypeStringRoomJoinRules,
+            @(MXEventTypeRoomPowerLevels) : kMXEventTypeStringRoomPowerLevels,
+            @(MXEventTypeRoomAliases) : kMXEventTypeStringRoomAliases,
+            @(MXEventTypeRoomCanonicalAlias) : kMXEventTypeStringRoomCanonicalAlias,
+            @(MXEventTypeRoomEncrypted) : kMXEventTypeStringRoomEncrypted,
+            @(MXEventTypeRoomEncryption) : kMXEventTypeStringRoomEncryption,
+            @(MXEventTypeRoomGuestAccess) : kMXEventTypeStringRoomGuestAccess,
+            @(MXEventTypeRoomHistoryVisibility) : kMXEventTypeStringRoomHistoryVisibility,
+            @(MXEventTypeRoomKey) : kMXEventTypeStringRoomKey,
+            @(MXEventTypeRoomForwardedKey) : kMXEventTypeStringRoomForwardedKey,
+            @(MXEventTypeRoomKeyRequest) : kMXEventTypeStringRoomKeyRequest,
+            @(MXEventTypeRoomMessage) : kMXEventTypeStringRoomMessage,
+            @(MXEventTypeRoomMessageFeedback) : kMXEventTypeStringRoomMessageFeedback,
+            @(MXEventTypeRoomPlumbing) : kMXEventTypeStringRoomPlumbing,
+            @(MXEventTypeRoomRedaction) : kMXEventTypeStringRoomRedaction,
+            @(MXEventTypeRoomThirdPartyInvite) : kMXEventTypeStringRoomThirdPartyInvite,
+            @(MXEventTypeRoomRelatedGroups) : kMXEventTypeStringRoomRelatedGroups,
+            @(MXEventTypeRoomPinnedEvents) : kMXEventTypeStringRoomPinnedEvents,
+            @(MXEventTypeRoomTag) : kMXEventTypeStringRoomTag,
+            @(MXEventTypeRoomTombStone) : kMXEventTypeStringRoomTombStone,
+            
+            @(MXEventTypePresence) : kMXEventTypeStringPresence,
+            @(MXEventTypeTypingNotification) : kMXEventTypeStringTypingNotification,
+            @(MXEventTypeReaction) : kMXEventTypeStringReaction,
+            @(MXEventTypeReceipt) : kMXEventTypeStringReceipt,
+            @(MXEventTypeRead) : kMXEventTypeStringRead,
+            @(MXEventTypeReadMarker) : kMXEventTypeStringReadMarker,
+            @(MXEventTypeSticker) : kMXEventTypeStringSticker,
+            @(MXEventTypeTaggedEvents) : kMXEventTypeStringTaggedEvents,
+            @(MXEventTypeSpaceChild) : kMXEventTypeStringSpaceChild,
+            
+            @(MXEventTypeCallInvite) : kMXEventTypeStringCallInvite,
+            @(MXEventTypeCallCandidates) : kMXEventTypeStringCallCandidates,
+            @(MXEventTypeCallAnswer) : kMXEventTypeStringCallAnswer,
+            @(MXEventTypeCallSelectAnswer) : kMXEventTypeStringCallSelectAnswer,
+            @(MXEventTypeCallHangup) : kMXEventTypeStringCallHangup,
+            @(MXEventTypeCallReject) : kMXEventTypeStringCallReject,
+            @(MXEventTypeCallNegotiate) : kMXEventTypeStringCallNegotiate,
+            @(MXEventTypeCallReplaces) : kMXEventTypeStringCallReplaces,
+            @(MXEventTypeCallRejectReplacement) : kMXEventTypeStringCallRejectReplacement,
+            @(MXEventTypeCallAssertedIdentity) : kMXEventTypeStringCallAssertedIdentity,
+            @(MXEventTypeCallAssertedIdentityUnstable) : kMXEventTypeStringCallAssertedIdentityUnstable,
+            
+            @(MXEventTypeKeyVerificationRequest) : kMXEventTypeStringKeyVerificationRequest,
+            @(MXEventTypeKeyVerificationReady) : kMXEventTypeStringKeyVerificationReady,
+            @(MXEventTypeKeyVerificationStart) : kMXEventTypeStringKeyVerificationStart,
+            @(MXEventTypeKeyVerificationAccept) : kMXEventTypeStringKeyVerificationAccept,
+            @(MXEventTypeKeyVerificationKey) : kMXEventTypeStringKeyVerificationKey,
+            @(MXEventTypeKeyVerificationMac) : kMXEventTypeStringKeyVerificationMac,
+            @(MXEventTypeKeyVerificationCancel) : kMXEventTypeStringKeyVerificationCancel,
+            @(MXEventTypeKeyVerificationDone) : kMXEventTypeStringKeyVerificationDone,
+            
+            @(MXEventTypeSecretRequest) : kMXEventTypeStringSecretRequest,
+            @(MXEventTypeSecretSend) : kMXEventTypeStringSecretSend,
+            @(MXEventTypeSecretStorageDefaultKey) : kMXEventTypeStringSecretStorageDefaultKey,
+            
+            @(MXEventTypePollStart) : kMXEventTypeStringPollStartMSC3381,
+            @(MXEventTypePollResponse) : kMXEventTypeStringPollResponseMSC3381,
+            @(MXEventTypePollEnd) : kMXEventTypeStringPollEndMSC3381,
+        };
 
-        eventTypeMapEnumToString = @[
-                                kMXEventTypeStringRoomName,
-                                kMXEventTypeStringRoomTopic,
-                                kMXEventTypeStringRoomAvatar,
-                                kMXEventTypeStringRoomBotOptions,
-                                kMXEventTypeStringRoomMember,
-                                kMXEventTypeStringRoomCreate,
-                                kMXEventTypeStringRoomJoinRules,
-                                kMXEventTypeStringRoomPowerLevels,
-                                kMXEventTypeStringRoomAliases,
-                                kMXEventTypeStringRoomCanonicalAlias,
-                                kMXEventTypeStringRoomEncrypted,
-                                kMXEventTypeStringRoomEncryption,
-                                kMXEventTypeStringRoomGuestAccess,
-                                kMXEventTypeStringRoomHistoryVisibility,
-                                kMXEventTypeStringRoomKey,
-                                kMXEventTypeStringRoomForwardedKey,
-                                kMXEventTypeStringRoomKeyRequest,
-                                kMXEventTypeStringRoomMessage,
-                                kMXEventTypeStringRoomMessageFeedback,
-                                kMXEventTypeStringRoomPlumbing,
-                                kMXEventTypeStringRoomRedaction,
-                                kMXEventTypeStringRoomThirdPartyInvite,
-                                kMXEventTypeStringRoomRelatedGroups,
-                                kMXEventTypeStringRoomPinnedEvents,
-                                kMXEventTypeStringRoomTag,
-                                kMXEventTypeStringPresence,
-                                kMXEventTypeStringTypingNotification,
-                                kMXEventTypeStringReaction,
-                                kMXEventTypeStringReceipt,
-                                kMXEventTypeStringRead,
-                                kMXEventTypeStringReadMarker,
-                                kMXEventTypeStringCallInvite,
-                                kMXEventTypeStringCallCandidates,
-                                kMXEventTypeStringCallAnswer,
-                                kMXEventTypeStringCallSelectAnswer,
-                                kMXEventTypeStringCallHangup,
-                                kMXEventTypeStringCallReject,
-                                kMXEventTypeStringCallNegotiate,
-                                kMXEventTypeStringCallReplaces,
-                                kMXEventTypeStringCallRejectReplacement,
-                                kMXEventTypeStringCallAssertedIdentity,
-                                kMXEventTypeStringCallAssertedIdentityUnstable,
-                                kMXEventTypeStringSticker,
-                                kMXEventTypeStringRoomTombStone,
-                                kMXEventTypeStringKeyVerificationRequest,
-                                kMXEventTypeStringKeyVerificationReady,
-                                kMXEventTypeStringKeyVerificationStart,
-                                kMXEventTypeStringKeyVerificationAccept,
-                                kMXEventTypeStringKeyVerificationKey,
-                                kMXEventTypeStringKeyVerificationMac,
-                                kMXEventTypeStringKeyVerificationCancel,
-                                kMXEventTypeStringKeyVerificationDone,
-                                kMXEventTypeStringSecretRequest,
-                                kMXEventTypeStringSecretSend,
-                                kMXEventTypeStringSecretStorageDefaultKey,
-                                kMXEventTypeStringTaggedEvents,
-                                kMXEventTypeStringSpaceChild,
-                                kMXEventTypeStringPollStart,
-                                ];
-
-        NSMutableDictionary *map = [NSMutableDictionary dictionaryWithCapacity:eventTypeMapEnumToString.count];
-        for (NSUInteger i = 0; i <eventTypeMapEnumToString.count; i++)
-        {
-            MXEventTypeString type = eventTypeMapEnumToString[i];
-            map[type] = @(i);
-        }
-        eventTypeMapStringToEnum = map;
+        eventTypeMapStringToEnum = @{
+            kMXEventTypeStringRoomName : @(MXEventTypeRoomName),
+            kMXEventTypeStringRoomTopic : @(MXEventTypeRoomTopic),
+            kMXEventTypeStringRoomAvatar : @(MXEventTypeRoomAvatar),
+            kMXEventTypeStringRoomBotOptions : @(MXEventTypeRoomBotOptions),
+            kMXEventTypeStringRoomMember : @(MXEventTypeRoomMember),
+            kMXEventTypeStringRoomCreate : @(MXEventTypeRoomCreate),
+            kMXEventTypeStringRoomJoinRules : @(MXEventTypeRoomJoinRules),
+            kMXEventTypeStringRoomPowerLevels : @(MXEventTypeRoomPowerLevels),
+            kMXEventTypeStringRoomAliases : @(MXEventTypeRoomAliases),
+            kMXEventTypeStringRoomCanonicalAlias : @(MXEventTypeRoomCanonicalAlias),
+            kMXEventTypeStringRoomEncrypted : @(MXEventTypeRoomEncrypted),
+            kMXEventTypeStringRoomEncryption : @(MXEventTypeRoomEncryption),
+            kMXEventTypeStringRoomGuestAccess : @(MXEventTypeRoomGuestAccess),
+            kMXEventTypeStringRoomHistoryVisibility : @(MXEventTypeRoomHistoryVisibility),
+            kMXEventTypeStringRoomKey : @(MXEventTypeRoomKey),
+            kMXEventTypeStringRoomForwardedKey : @(MXEventTypeRoomForwardedKey),
+            kMXEventTypeStringRoomKeyRequest : @(MXEventTypeRoomKeyRequest),
+            kMXEventTypeStringRoomMessage : @(MXEventTypeRoomMessage),
+            kMXEventTypeStringRoomMessageFeedback : @(MXEventTypeRoomMessageFeedback),
+            kMXEventTypeStringRoomPlumbing : @(MXEventTypeRoomPlumbing),
+            kMXEventTypeStringRoomRedaction : @(MXEventTypeRoomRedaction),
+            kMXEventTypeStringRoomThirdPartyInvite : @(MXEventTypeRoomThirdPartyInvite),
+            kMXEventTypeStringRoomRelatedGroups : @(MXEventTypeRoomRelatedGroups),
+            kMXEventTypeStringRoomPinnedEvents : @(MXEventTypeRoomPinnedEvents),
+            kMXEventTypeStringRoomTag : @(MXEventTypeRoomTag),
+            kMXEventTypeStringRoomTombStone : @(MXEventTypeRoomTombStone),
+            
+            kMXEventTypeStringPresence : @(MXEventTypePresence),
+            kMXEventTypeStringTypingNotification : @(MXEventTypeTypingNotification),
+            kMXEventTypeStringReaction : @(MXEventTypeReaction),
+            kMXEventTypeStringReceipt : @(MXEventTypeReceipt),
+            kMXEventTypeStringRead : @(MXEventTypeRead),
+            kMXEventTypeStringReadMarker : @(MXEventTypeReadMarker),
+            kMXEventTypeStringSticker : @(MXEventTypeSticker),
+            kMXEventTypeStringTaggedEvents : @(MXEventTypeTaggedEvents),
+            kMXEventTypeStringSpaceChild : @(MXEventTypeSpaceChild),
+            
+            kMXEventTypeStringCallInvite : @(MXEventTypeCallInvite),
+            kMXEventTypeStringCallCandidates : @(MXEventTypeCallCandidates),
+            kMXEventTypeStringCallAnswer : @(MXEventTypeCallAnswer),
+            kMXEventTypeStringCallSelectAnswer : @(MXEventTypeCallSelectAnswer),
+            kMXEventTypeStringCallHangup : @(MXEventTypeCallHangup),
+            kMXEventTypeStringCallReject : @(MXEventTypeCallReject),
+            kMXEventTypeStringCallNegotiate : @(MXEventTypeCallNegotiate),
+            kMXEventTypeStringCallReplaces : @(MXEventTypeCallReplaces),
+            kMXEventTypeStringCallRejectReplacement : @(MXEventTypeCallRejectReplacement),
+            kMXEventTypeStringCallAssertedIdentity : @(MXEventTypeCallAssertedIdentity),
+            kMXEventTypeStringCallAssertedIdentityUnstable : @(MXEventTypeCallAssertedIdentityUnstable),
+            
+            kMXEventTypeStringKeyVerificationRequest : @(MXEventTypeKeyVerificationRequest),
+            kMXEventTypeStringKeyVerificationReady : @(MXEventTypeKeyVerificationReady),
+            kMXEventTypeStringKeyVerificationStart : @(MXEventTypeKeyVerificationStart),
+            kMXEventTypeStringKeyVerificationAccept : @(MXEventTypeKeyVerificationAccept),
+            kMXEventTypeStringKeyVerificationKey : @(MXEventTypeKeyVerificationKey),
+            kMXEventTypeStringKeyVerificationMac : @(MXEventTypeKeyVerificationMac),
+            kMXEventTypeStringKeyVerificationCancel : @(MXEventTypeKeyVerificationCancel),
+            kMXEventTypeStringKeyVerificationDone : @(MXEventTypeKeyVerificationDone),
+            
+            kMXEventTypeStringSecretRequest : @(MXEventTypeSecretRequest),
+            kMXEventTypeStringSecretSend : @(MXEventTypeSecretSend),
+            kMXEventTypeStringSecretStorageDefaultKey : @(MXEventTypeSecretStorageDefaultKey),
+            
+            kMXEventTypeStringPollStart : @(MXEventTypePollStart),
+            kMXEventTypeStringPollStartMSC3381 : @(MXEventTypePollStart),
+            kMXEventTypeStringPollResponse : @(MXEventTypePollResponse),
+            kMXEventTypeStringPollResponseMSC3381 : @(MXEventTypePollResponse),
+            kMXEventTypeStringPollEnd : @(MXEventTypePollEnd),
+            kMXEventTypeStringPollEndMSC3381 : @(MXEventTypePollEnd),
+        };
 
         isEmailAddressRegex =  [NSRegularExpression regularExpressionWithPattern:[NSString stringWithFormat:@"^%@$", kMXToolsRegexStringForEmailAddress]
                                                                          options:NSRegularExpressionCaseInsensitive error:nil];
@@ -170,11 +240,7 @@ NSCharacterSet *uriComponentCharset;
 
 + (MXEventTypeString)eventTypeString:(MXEventType)eventType
 {
-    if (eventType < eventTypeMapEnumToString.count)
-    {
-        return eventTypeMapEnumToString[eventType];
-    }
-    return nil;
+    return eventTypeMapEnumToString[@(eventType)];
 }
 
 + (MXEventType)eventType:(MXEventTypeString)eventTypeString

--- a/MatrixSDK/Utils/MXTools.m
+++ b/MatrixSDK/Utils/MXTools.m
@@ -128,7 +128,8 @@ NSCharacterSet *uriComponentCharset;
                                 kMXEventTypeStringSecretSend,
                                 kMXEventTypeStringSecretStorageDefaultKey,
                                 kMXEventTypeStringTaggedEvents,
-                                kMXEventTypeStringSpaceChild
+                                kMXEventTypeStringSpaceChild,
+                                kMXEventTypeStringPollStart,
                                 ];
 
         NSMutableDictionary *map = [NSMutableDictionary dictionaryWithCapacity:eventTypeMapEnumToString.count];

--- a/MatrixSDKTests/MXPollBuilderTests.swift
+++ b/MatrixSDKTests/MXPollBuilderTests.swift
@@ -25,7 +25,7 @@ class MXPollBuilderTest: XCTestCase {
         events.append(MXEvent(fromJSON: pollResponseEventWithSender("Alice", answerIdentifiers: ["1"]))!)
         events.append(MXEvent(fromJSON: pollResponseEventWithSender("Bob", answerIdentifiers: ["1"]))!)
         
-        let poll = builder.build(pollStartEventContent: pollStartEventContent(maxSelections: 7), events: events)
+        let poll = builder.build(pollStartEventContent: pollStartEventContent(maxSelections: 7), events: events, currentUserIdentifier: "")
         XCTAssertEqual(poll.maxAllowedSelections, 7)
         XCTAssertEqual(poll.text, "Question")
         XCTAssertEqual(poll.kind, .disclosed)
@@ -44,7 +44,7 @@ class MXPollBuilderTest: XCTestCase {
         events.append(MXEvent(fromJSON: pollResponseEventWithSender("Bob", timestamp: 0, answerIdentifiers: ["1"]))!)
         events.append(MXEvent(fromJSON: pollResponseEventWithSender("Bob", timestamp: 1, answerIdentifiers: []))!)
         
-        let poll = builder.build(pollStartEventContent: pollStartEventContent(), events: events)
+        let poll = builder.build(pollStartEventContent: pollStartEventContent(), events: events, currentUserIdentifier: "")
         XCTAssertEqual(poll.answerOptions.first?.count, 0)
         XCTAssertEqual(poll.answerOptions.last?.count, 0)
     }
@@ -54,7 +54,7 @@ class MXPollBuilderTest: XCTestCase {
         events.append(MXEvent(fromJSON: pollResponseEventWithSender("Bob", timestamp: 0, answerIdentifiers: ["1"]))!)
         events.append(MXEvent(fromJSON: pollResponseEventWithSender("Bob", timestamp: 1, answerIdentifiers: ["1", "2"]))!)
         
-        let poll = builder.build(pollStartEventContent: pollStartEventContent(), events: events)
+        let poll = builder.build(pollStartEventContent: pollStartEventContent(), events: events, currentUserIdentifier: "")
         XCTAssertEqual(poll.answerOptions.first?.count, 0)
         XCTAssertEqual(poll.answerOptions.last?.count, 0)
     }
@@ -64,7 +64,7 @@ class MXPollBuilderTest: XCTestCase {
         events.append(MXEvent(fromJSON: pollResponseEventWithSender("Bob", timestamp: 0, answerIdentifiers: ["1"]))!)
         events.append(MXEvent(fromJSON: pollResponseEventWithSender("Bob", timestamp: 1, answerIdentifiers: ["1", "2", "3"]))!)
         
-        let poll = builder.build(pollStartEventContent: pollStartEventContent(), events: events)
+        let poll = builder.build(pollStartEventContent: pollStartEventContent(), events: events, currentUserIdentifier: "")
         XCTAssertEqual(poll.answerOptions.first?.count, 0)
         XCTAssertEqual(poll.answerOptions.last?.count, 0)
     }
@@ -73,7 +73,7 @@ class MXPollBuilderTest: XCTestCase {
         var events = [MXEvent]()
         events.append(MXEvent(fromJSON: pollResponseEventWithSender("Bob", answerIdentifiers: ["1", "1", "1"]))!)
         
-        let poll = builder.build(pollStartEventContent: pollStartEventContent(maxSelections: 100), events: events)
+        let poll = builder.build(pollStartEventContent: pollStartEventContent(maxSelections: 100), events: events, currentUserIdentifier: "")
         XCTAssertEqual(poll.answerOptions.first?.count, 1)
         XCTAssertEqual(poll.answerOptions.last?.count, 0)
     }
@@ -82,7 +82,7 @@ class MXPollBuilderTest: XCTestCase {
         var events = [MXEvent]()
         events.append(MXEvent(fromJSON: pollResponseEventWithSender("Bob", answerIdentifiers: ["1", "1", "2", "1", "2", "2", "1", "2"]))!)
         
-        let poll = builder.build(pollStartEventContent: pollStartEventContent(maxSelections: 100), events: events)
+        let poll = builder.build(pollStartEventContent: pollStartEventContent(maxSelections: 100), events: events, currentUserIdentifier: "")
         XCTAssertEqual(poll.answerOptions.first?.count, 1)
         XCTAssertEqual(poll.answerOptions.last?.count, 1)
     }
@@ -95,7 +95,7 @@ class MXPollBuilderTest: XCTestCase {
         events.append(MXEvent(fromJSON: pollResponseEventWithSender("Bob", timestamp: 1, answerIdentifiers: []))!) // Too few
         events.append(MXEvent(fromJSON: pollResponseEventWithSender("Bob", timestamp: 3, answerIdentifiers: ["1", "2"]))!) // Too many
         
-        let poll = builder.build(pollStartEventContent: pollStartEventContent(), events: events)
+        let poll = builder.build(pollStartEventContent: pollStartEventContent(), events: events, currentUserIdentifier: "")
         XCTAssertEqual(poll.answerOptions.first?.count, 0)
         XCTAssertEqual(poll.answerOptions.last?.count, 1)
     }
@@ -111,7 +111,7 @@ class MXPollBuilderTest: XCTestCase {
         events.append(MXEvent(fromJSON: pollResponseEventWithSender("Bob", timestamp: 10, answerIdentifiers: []))!)
         events.append(MXEvent(fromJSON: pollResponseEventWithSender("Alice", timestamp:10, answerIdentifiers: ["1", "2"]))!)
         
-        let poll = builder.build(pollStartEventContent: pollStartEventContent(maxSelections: 10), events: events)
+        let poll = builder.build(pollStartEventContent: pollStartEventContent(maxSelections: 10), events: events, currentUserIdentifier: "")
         
         XCTAssert(poll.isClosed)
         
@@ -126,7 +126,7 @@ class MXPollBuilderTest: XCTestCase {
         var events = [MXEvent]()
         events.append(MXEvent(fromJSON: pollResponseEventWithSender("Bob", answerIdentifiers: ["1"]))!)
         
-        let poll = builder.build(pollStartEventContent: pollStartEventContent(maxSelections: 7), events: events, currentUserIdentifer: "Bob")
+        let poll = builder.build(pollStartEventContent: pollStartEventContent(maxSelections: 7), events: events, currentUserIdentifier: "Bob")
         XCTAssertEqual(poll.answerOptions.first?.isCurrentUserSelection, true)
         XCTAssertEqual(poll.answerOptions.last?.isCurrentUserSelection, false)
     }
@@ -136,7 +136,7 @@ class MXPollBuilderTest: XCTestCase {
         events.append(MXEvent(fromJSON: pollResponseEventWithSender("Bob", timestamp: 0, answerIdentifiers: ["1"]))!)
         events.append(MXEvent(fromJSON: pollResponseEventWithSender("Bob", timestamp: 1, answerIdentifiers: ["2", "1"]))!)
         
-        let poll = builder.build(pollStartEventContent: pollStartEventContent(maxSelections: 7), events: events, currentUserIdentifer: "Bob")
+        let poll = builder.build(pollStartEventContent: pollStartEventContent(maxSelections: 7), events: events, currentUserIdentifier: "Bob")
         XCTAssertEqual(poll.answerOptions.first?.isCurrentUserSelection, true)
         XCTAssertEqual(poll.answerOptions.last?.isCurrentUserSelection, true)
     }

--- a/MatrixSDKTests/MXPollRelationTests.m
+++ b/MatrixSDKTests/MXPollRelationTests.m
@@ -93,7 +93,7 @@
 // Make sure that's still the case.
 - (void)testNoPollRelationPagination
 {
-    NSUInteger totalAnswers = 5;
+    NSUInteger totalAnswers = 100;
     
     [self createScenarioForBob:^(MXSession *mxSession, MXRoom *room, XCTestExpectation *expectation, MXEvent *pollStartEvent, MXEventContentPollStart *pollStartContent) {
         dispatch_group_t dispatchGroup = dispatch_group_create();


### PR DESCRIPTION
* added poll start even type enum value, fixed poll question key path, made aggregator and models public
*  Made user identifier mandatory, defaulting maxSelections to 1 as per msc.
* Only listen to events relating to the original poll in the poll aggregator event listener.
* Better unstable prefix event type handling.