### PR TITLE
Fix for the in-call screen freezing on a new PSTN call

### DIFF
--- a/MatrixSDK/MXSession.h
+++ b/MatrixSDK/MXSession.h
@@ -923,7 +923,17 @@ typedef void (^MXOnBackgroundSyncFail)(NSError *error);
 
  @return the MXRoom instance.
  */
-- (MXRoom  *)roomWithRoomId:(NSString*)roomId;
+- (MXRoom *)roomWithRoomId:(NSString*)roomId;
+
+/**
+ Get the MXRoom instance of a room.
+ Create it if does not exist yet.
+ 
+ @param roomId The id to the user.
+ 
+ @return the MXRoom instance.
+ */
+- (MXRoom *)getOrCreateRoom:(NSString*)roomId;
 
 /**
  Get the MXRoom instance of the room that owns the passed room alias.

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -2562,6 +2562,11 @@ typedef void (^MXOnResumeDone)(void);
     }
 }
 
+- (MXRoom *)getOrCreateRoom:(NSString*)roomId
+{
+    return [self getOrCreateRoom:roomId notify:YES];
+}
+
 - (MXRoom *)roomWithAlias:(NSString *)alias
 {
     MXRoom *theRoom;

--- a/MatrixSDK/VoIP/MXCall.m
+++ b/MatrixSDK/VoIP/MXCall.m
@@ -126,7 +126,10 @@ NSString *const kMXCallSupportsTransferringStatusDidChange = @"kMXCallSupportsTr
     {
         callManager = theCallManager;
 
-        _room = [callManager.mxSession roomWithRoomId:roomId];
+        // PSTN calls received in the terminated app state(with the room automatically created
+        // and joined server-side) will not necessarily be synced and stored locally yet.
+        _room = [callManager.mxSession getOrCreateRoom: roomId];
+        
         _callSignalingRoom = [callManager.mxSession roomWithRoomId:callSignalingRoomId];
 
         _callId = [[NSUUID UUID] UUIDString];

--- a/changelog.d/5223.bugfix
+++ b/changelog.d/5223.bugfix
@@ -1,0 +1,1 @@
+Fix for the in-call screen freezing on a new PSTN call.


### PR DESCRIPTION
Resolves https://github.com/vector-im/element-ios/issues/5223

Incoming PSTN calls can now have rooms automatically created and joined server-side.

If the incoming voip call is from a number you have not seen before(or if you have since left the room) and the app is in the terminated state, when you receive the voip push you may not have created a room for the given roomID yet.

In the same way as we exposed `MXSession.getOrCreateUser` for use in calling for such cases a user had not been seen, I've followed the same pattern for rooms, creating the room if does not exist.

Previously `MXCall.room` was null causing an invalid initialization of the call flow.