### PR TITLE
Release 0.20.11

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,25 @@
+## Changes in 0.20.11 (2021-12-03)
+
+✨ Features
+
+- Moved from /space to /hierarchy API to support pagination ([#4893](https://github.com/vector-im/element-ios/issues/4893))
+- Adds clientPermalinkBaseUrl for a custom permalink base url. ([#4981](https://github.com/vector-im/element-ios/issues/4981))
+- Added poll specific event sending methods, event aggregator and model builder. ([#5114](https://github.com/vector-im/element-ios/issues/5114))
+
+🐛 Bugfixes
+
+- Initialize imagesCacheLruCache before caching - caching operations would fail silently because cache was not initialized ([#1281](https://github.com/vector-im/element-ios/issues/1281))
+- MXRoom: Fix reply event content for just thread-aware clients. ([#5007](https://github.com/vector-im/element-ios/issues/5007))
+- Add ability to get roomAccountData from MXBackgroundSyncService to fix badge bug from virtual rooms. ([#5155](https://github.com/vector-im/element-ios/issues/5155))
+- Fixed duplicated children ids in MXSpaces ([#5181](https://github.com/vector-im/element-ios/issues/5181))
+- Do not expose headers that should be use privately inside the framework. ([#5194](https://github.com/vector-im/element-ios/issues/5194))
+- Fix for the in-call screen freezing on a new PSTN call. ([#5223](https://github.com/vector-im/element-ios/issues/5223))
+
+🧱 Build
+
+- Build: Update to Xcode 12.5 in the Fastfile and macOS 11 in the GitHub actions. ([#5195](https://github.com/vector-im/element-ios/issues/5195))
+
+
 ## Changes in 0.20.10 (2021-11-17)
 
 🙌 Improvements

--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "MatrixSDK"
-  s.version      = "0.20.10"
+  s.version      = "0.20.11"
   s.summary      = "The iOS SDK to build apps compatible with Matrix (https://www.matrix.org)"
 
   s.description  = <<-DESC

--- a/MatrixSDK/MatrixSDKVersion.m
+++ b/MatrixSDK/MatrixSDKVersion.m
@@ -16,4 +16,4 @@
 
 #import <Foundation/Foundation.h>
 
-NSString *const MatrixSDKVersion = @"0.20.10";
+NSString *const MatrixSDKVersion = @"0.20.11";

--- a/changelog.d/1281.bugfix
+++ b/changelog.d/1281.bugfix
@@ -1,1 +1,0 @@
-Initialize imagesCacheLruCache before caching - caching operations would fail silently because cache was not initialized

--- a/changelog.d/4893.feature
+++ b/changelog.d/4893.feature
@@ -1,1 +1,0 @@
-Moved from /space to /hierarchy API to support pagination

--- a/changelog.d/4981.feature
+++ b/changelog.d/4981.feature
@@ -1,1 +1,0 @@
-Adds clientPermalinkBaseUrl for a custom permalink base url.

--- a/changelog.d/5007.bugfix
+++ b/changelog.d/5007.bugfix
@@ -1,1 +1,0 @@
-MXRoom: Fix reply event content for just thread-aware clients.

--- a/changelog.d/5114.feature
+++ b/changelog.d/5114.feature
@@ -1,1 +1,0 @@
-Added poll specific event sending methods, event aggregator and model builder.

--- a/changelog.d/5155.bugfix
+++ b/changelog.d/5155.bugfix
@@ -1,1 +1,0 @@
-Add ability to get roomAccountData from MXBackgroundSyncService to fix badge bug from virtual rooms.

--- a/changelog.d/5181.bugfix
+++ b/changelog.d/5181.bugfix
@@ -1,1 +1,0 @@
-Fixed duplicated children ids in MXSpaces

--- a/changelog.d/5194.bugfix
+++ b/changelog.d/5194.bugfix
@@ -1,1 +1,0 @@
-Do not expose headers that should be use privately inside the framework.

--- a/changelog.d/5195.build
+++ b/changelog.d/5195.build
@@ -1,1 +1,0 @@
-Build: Update to Xcode 12.5 in the Fastfile and macOS 11 in the GitHub actions.

--- a/changelog.d/5223.bugfix
+++ b/changelog.d/5223.bugfix
@@ -1,1 +1,0 @@
-Fix for the in-call screen freezing on a new PSTN call.


### PR DESCRIPTION
This PR prepares the release of MatrixSDK v0.20.11.

Notes:
- This PR targets `release/0.20.11/master`, which has been cut from `master`.
- It includes changes to the `Podfile`, but _not_ the corresponding changes to `Podfile.lock`, as `pod install` hasn't yet been run.
  This is because the `Podfile` targets future versions of dependencies yet to be released, so `pod install` wouldn't be able to find them yet.
- When the CI runs its checks, it will temporarily point to the pending release branches of those dependencies beforehand
- It is only during `release:finish` that `pod update` will be run -- updating the `Podfile.lock`
to use the now officially released dependencies -- before ultimately merging `release/0.20.11/master` into `master` to tag the release.

---

➡️  Once this PR is merged, you will need to first ensure that the products this one depends on are fully released,
   then run `bundle exec rake release:finish` to close this release.

💡 If you want to review _only_ the changes made since the release branch was cut from `develop`,
   you can [check those here](https://github.com/matrix-org/matrix-ios-sdk/compare/develop...release/0.20.11/release)
