### PR TITLE
Update MXAnalyticsDelegate and MXTaskProfile

### DIFF
--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -709,6 +709,8 @@
 		91CC0FCB26A033AE00C2A387 /* MXURLPreview.h in Headers */ = {isa = PBXBuildFile; fileRef = 91CC0FC826A033AE00C2A387 /* MXURLPreview.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		91CC0FCC26A033AE00C2A387 /* MXURLPreview.m in Sources */ = {isa = PBXBuildFile; fileRef = 91CC0FC926A033AE00C2A387 /* MXURLPreview.m */; };
 		91CC0FCD26A033AE00C2A387 /* MXURLPreview.m in Sources */ = {isa = PBXBuildFile; fileRef = 91CC0FC926A033AE00C2A387 /* MXURLPreview.m */; };
+		91F0685D2767CA420079F8FA /* MXTaskProfileName.h in Headers */ = {isa = PBXBuildFile; fileRef = 91F0685C2767C9FF0079F8FA /* MXTaskProfileName.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		91F0685E2767CA430079F8FA /* MXTaskProfileName.h in Headers */ = {isa = PBXBuildFile; fileRef = 91F0685C2767C9FF0079F8FA /* MXTaskProfileName.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		92634B7F1EF2A37A00DB9F60 /* MXCallAudioSessionConfigurator.h in Headers */ = {isa = PBXBuildFile; fileRef = 92634B7E1EF2A37A00DB9F60 /* MXCallAudioSessionConfigurator.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		92634B821EF2E3C400DB9F60 /* MXCallKitConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 92634B801EF2E3C400DB9F60 /* MXCallKitConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		92634B831EF2E3C400DB9F60 /* MXCallKitConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 92634B811EF2E3C400DB9F60 /* MXCallKitConfiguration.m */; };
@@ -2207,6 +2209,7 @@
 		918D30B6273951F400A16405 /* MXStoreService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXStoreService.swift; sourceTree = "<group>"; };
 		91CC0FC826A033AE00C2A387 /* MXURLPreview.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXURLPreview.h; sourceTree = "<group>"; };
 		91CC0FC926A033AE00C2A387 /* MXURLPreview.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXURLPreview.m; sourceTree = "<group>"; };
+		91F0685C2767C9FF0079F8FA /* MXTaskProfileName.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXTaskProfileName.h; sourceTree = "<group>"; };
 		92634B7E1EF2A37A00DB9F60 /* MXCallAudioSessionConfigurator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXCallAudioSessionConfigurator.h; sourceTree = "<group>"; };
 		92634B801EF2E3C400DB9F60 /* MXCallKitConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXCallKitConfiguration.h; sourceTree = "<group>"; };
 		92634B811EF2E3C400DB9F60 /* MXCallKitConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXCallKitConfiguration.m; sourceTree = "<group>"; };
@@ -2910,6 +2913,7 @@
 				323F878B25553D84009E9E67 /* MXTaskProfile.h */,
 				323F878C25553D84009E9E67 /* MXTaskProfile.m */,
 				323F879525554FF2009E9E67 /* MXTaskProfile_Private.h */,
+				91F0685C2767C9FF0079F8FA /* MXTaskProfileName.h */,
 			);
 			path = Profiling;
 			sourceTree = "<group>";
@@ -4474,6 +4478,7 @@
 				32AF928A240EA3880008A0FD /* MXSecretShareSend.h in Headers */,
 				B14EECE52577F76100448735 /* MXLoginSSOFlow.h in Headers */,
 				EC8A53E025B1BCC6004E0802 /* MXThirdPartyProtocolInstance.h in Headers */,
+				91F0685D2767CA420079F8FA /* MXTaskProfileName.h in Headers */,
 				B1798D0624091A0100308A8F /* MXBase64Tools.h in Headers */,
 				32133015228AF4EF0070BA9B /* MXRealmAggregationsStore.h in Headers */,
 				32CE6FB81A409B1F00317F1E /* MXFileStoreMetaData.h in Headers */,
@@ -4872,6 +4877,7 @@
 				EC60EDDB265CFF0600B39A4E /* MXInvitedRoomSync.h in Headers */,
 				B14EF2C82397E90400758AF0 /* MXCallManager.h in Headers */,
 				B14EF2C92397E90400758AF0 /* MXRealmReactionRelation.h in Headers */,
+				91F0685E2767CA430079F8FA /* MXTaskProfileName.h in Headers */,
 				B14EF2CA2397E90400758AF0 /* MXAnalyticsDelegate.h in Headers */,
 				ECD289A626EB980200F268CF /* MXRoomSummaryDataTypes.h in Headers */,
 				B14EF2CB2397E90400758AF0 /* MXCallAudioSessionConfigurator.h in Headers */,

--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
@@ -227,8 +227,7 @@ static NSUInteger preloadOptions;
             // If metaData is still defined, we can load rooms data
             if (self->metaData)
             {                
-                MXTaskProfile *taskProfile = [MXSDKOptions.sharedInstance.profiler startMeasuringTaskWithName:MXTaskProfileNameStartupStorePreload
-                                                                                                     category:MXTaskProfileCategoryStartup];
+                MXTaskProfile *taskProfile = [MXSDKOptions.sharedInstance.profiler startMeasuringTaskWithName:MXTaskProfileNameStartupStorePreload];
                 
                 MXLogDebug(@"[MXFileStore] Start data loading from files");
 

--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
@@ -227,7 +227,8 @@ static NSUInteger preloadOptions;
             // If metaData is still defined, we can load rooms data
             if (self->metaData)
             {                
-                MXTaskProfile *taskProfile = [MXSDKOptions.sharedInstance.profiler startMeasuringTaskWithName:kMXAnalyticsStartupStorePreload category:kMXAnalyticsStartupCategory];
+                MXTaskProfile *taskProfile = [MXSDKOptions.sharedInstance.profiler startMeasuringTaskWithName:MXTaskProfileNameStartupStorePreload
+                                                                                                     category:MXTaskProfileCategoryStartup];
                 
                 MXLogDebug(@"[MXFileStore] Start data loading from files");
 

--- a/MatrixSDK/MXEnumConstants.h
+++ b/MatrixSDK/MXEnumConstants.h
@@ -217,31 +217,3 @@ typedef enum : NSUInteger
  The matrix.to base URL.
  */
 FOUNDATION_EXPORT NSString *const kMXMatrixDotToUrl;
-
-
-#pragma mark - Analytics
-
-/**
- Timing stats relative to app startup.
- */
-FOUNDATION_EXPORT NSString *const kMXAnalyticsStartupCategory;
-
-// Duration of the initial /sync request
-FOUNDATION_EXPORT NSString *const kMXAnalyticsStartupInitialSync;
-
-// Duration of the first /sync when resuming the app
-FOUNDATION_EXPORT NSString *const kMXAnalyticsStartupIncrementalSync;
-
-// Time to preload data in the MXStore
-FOUNDATION_EXPORT NSString *const kMXAnalyticsStartupStorePreload;
-
-// Time to mount all objects from the store (it includes kMXAnalyticsStartupStorePreload time)
-FOUNDATION_EXPORT NSString *const kMXAnalyticsStartupMountData;
-
-// Duration of the the display of the app launch screen
-FOUNDATION_EXPORT NSString *const kMXAnalyticsStartupLaunchScreen;
-
-// Metrics related to the initial sync request
-FOUNDATION_EXPORT NSString *const kMXAnalyticsInitialSyncCategory;
-FOUNDATION_EXPORT NSString *const kMXAnalyticsInitialSyncRequest;
-FOUNDATION_EXPORT NSString *const kMXAnalyticsInitialSyncParsing;

--- a/MatrixSDK/MXEnumConstants.h
+++ b/MatrixSDK/MXEnumConstants.h
@@ -227,7 +227,7 @@ FOUNDATION_EXPORT NSString *const kMXMatrixDotToUrl;
 FOUNDATION_EXPORT NSString *const kMXAnalyticsStartupCategory;
 
 // Duration of the initial /sync request
-FOUNDATION_EXPORT NSString *const kMXAnalyticsStartupInititialSync;
+FOUNDATION_EXPORT NSString *const kMXAnalyticsStartupInitialSync;
 
 // Duration of the first /sync when resuming the app
 FOUNDATION_EXPORT NSString *const kMXAnalyticsStartupIncrementalSync;
@@ -245,26 +245,3 @@ FOUNDATION_EXPORT NSString *const kMXAnalyticsStartupLaunchScreen;
 FOUNDATION_EXPORT NSString *const kMXAnalyticsInitialSyncCategory;
 FOUNDATION_EXPORT NSString *const kMXAnalyticsInitialSyncRequest;
 FOUNDATION_EXPORT NSString *const kMXAnalyticsInitialSyncParsing;
-
-/**
- Overall stats category.
- */
-FOUNDATION_EXPORT NSString *const kMXAnalyticsStatsCategory;
-
-// The number of room the user is in
-FOUNDATION_EXPORT NSString *const kMXAnalyticsStatsRooms;
-
-//  VoIP
-
-/**
- Overall VoIP category.
- */
-FOUNDATION_EXPORT NSString *const kMXAnalyticsVoipCategory;
-
-//  VoIP event names
-FOUNDATION_EXPORT NSString *const kMXAnalyticsVoipNameCallError;
-FOUNDATION_EXPORT NSString *const kMXAnalyticsVoipNameCallHangup;
-FOUNDATION_EXPORT NSString *const kMXAnalyticsVoipNameCallEnded;
-FOUNDATION_EXPORT NSString *const kMXAnalyticsVoipNamePlaceCall;
-FOUNDATION_EXPORT NSString *const kMXAnalyticsVoipNamePlaceConferenceCall;
-FOUNDATION_EXPORT NSString *const kMXAnalyticsVoipNameReceiveCall;

--- a/MatrixSDK/MXEnumConstants.m
+++ b/MatrixSDK/MXEnumConstants.m
@@ -75,18 +75,3 @@ NSString *const kMXRoomGuestAccessForbidden = @"forbidden";
 NSString *const kMXRoomMessageFormatHTML = @"org.matrix.custom.html";
 
 NSString *const kMXMatrixDotToUrl = @"https://matrix.to";
-
-
-#pragma mark - Analytics
-
-NSString *const kMXAnalyticsStartupCategory = @"startup";
-
-NSString *const kMXAnalyticsStartupInitialSync = @"initialSync";
-NSString *const kMXAnalyticsStartupIncrementalSync = @"incrementalSync";
-NSString *const kMXAnalyticsStartupStorePreload = @"storePreload";
-NSString *const kMXAnalyticsStartupMountData = @"mountData";
-NSString *const kMXAnalyticsStartupLaunchScreen = @"launchScreen";
-
-NSString *const kMXAnalyticsInitialSyncCategory = @"initialSync";
-NSString *const kMXAnalyticsInitialSyncRequest = @"request";
-NSString *const kMXAnalyticsInitialSyncParsing = @"parsing";

--- a/MatrixSDK/MXEnumConstants.m
+++ b/MatrixSDK/MXEnumConstants.m
@@ -81,7 +81,7 @@ NSString *const kMXMatrixDotToUrl = @"https://matrix.to";
 
 NSString *const kMXAnalyticsStartupCategory = @"startup";
 
-NSString *const kMXAnalyticsStartupInititialSync = @"initialSync";
+NSString *const kMXAnalyticsStartupInitialSync = @"initialSync";
 NSString *const kMXAnalyticsStartupIncrementalSync = @"incrementalSync";
 NSString *const kMXAnalyticsStartupStorePreload = @"storePreload";
 NSString *const kMXAnalyticsStartupMountData = @"mountData";
@@ -90,16 +90,3 @@ NSString *const kMXAnalyticsStartupLaunchScreen = @"launchScreen";
 NSString *const kMXAnalyticsInitialSyncCategory = @"initialSync";
 NSString *const kMXAnalyticsInitialSyncRequest = @"request";
 NSString *const kMXAnalyticsInitialSyncParsing = @"parsing";
-
-NSString *const kMXAnalyticsStatsCategory = @"stats";
-NSString *const kMXAnalyticsStatsRooms = @"rooms";
-
-//  VoIP
-NSString *const kMXAnalyticsVoipCategory = @"voip";
-
-NSString *const kMXAnalyticsVoipNameCallError = @"callError";
-NSString *const kMXAnalyticsVoipNameCallHangup = @"callHangup";
-NSString *const kMXAnalyticsVoipNameCallEnded = @"callEnded";
-NSString *const kMXAnalyticsVoipNamePlaceCall = @"placeCall";
-NSString *const kMXAnalyticsVoipNamePlaceConferenceCall = @"placeConferenceCall";
-NSString *const kMXAnalyticsVoipNameReceiveCall = @"receiveCall";

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -3419,8 +3419,8 @@ MXAuthAction;
     MXTaskProfile *initialSyncRequestTaskProfile;
     if (!token)
     {
-        initialSyncRequestTaskProfile = [profiler startMeasuringTaskWithName:kMXAnalyticsInitialSyncRequest
-                                                                    category:kMXAnalyticsInitialSyncCategory];
+        initialSyncRequestTaskProfile = [profiler startMeasuringTaskWithName:MXTaskProfileNameInitialSyncRequest
+                                                                    category:MXTaskProfileCategoryInitialSync];
     }
     
     MXWeakify(self);
@@ -3451,8 +3451,8 @@ MXAuthAction;
                 MXTaskProfile *initialSyncParsingTaskProfile;
                 if (!token)
                 {
-                    initialSyncParsingTaskProfile = [profiler startMeasuringTaskWithName:kMXAnalyticsInitialSyncParsing
-                                                                                category:kMXAnalyticsInitialSyncCategory];
+                    initialSyncParsingTaskProfile = [profiler startMeasuringTaskWithName:MXTaskProfileNameInitialSyncParsing
+                                                                                category:MXTaskProfileCategoryInitialSync];
                 }
                 
                 MXJSONModelSetMXJSONModel(syncResponse, MXSyncResponse, JSONResponse);

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -3419,8 +3419,7 @@ MXAuthAction;
     MXTaskProfile *initialSyncRequestTaskProfile;
     if (!token)
     {
-        initialSyncRequestTaskProfile = [profiler startMeasuringTaskWithName:MXTaskProfileNameInitialSyncRequest
-                                                                    category:MXTaskProfileCategoryInitialSync];
+        initialSyncRequestTaskProfile = [profiler startMeasuringTaskWithName:MXTaskProfileNameInitialSyncRequest];
     }
     
     MXWeakify(self);
@@ -3451,8 +3450,7 @@ MXAuthAction;
                 MXTaskProfile *initialSyncParsingTaskProfile;
                 if (!token)
                 {
-                    initialSyncParsingTaskProfile = [profiler startMeasuringTaskWithName:MXTaskProfileNameInitialSyncParsing
-                                                                                category:MXTaskProfileCategoryInitialSync];
+                    initialSyncParsingTaskProfile = [profiler startMeasuringTaskWithName:MXTaskProfileNameInitialSyncParsing];
                 }
                 
                 MXJSONModelSetMXJSONModel(syncResponse, MXSyncResponse, JSONResponse);

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -351,7 +351,8 @@ typedef void (^MXOnResumeDone)(void);
     self.roomListDataManager = [[MXSDKOptions.sharedInstance.roomListDataManagerClass alloc] init];
 
     NSDate *startDate = [NSDate date];
-    MXTaskProfile *taskProfile = [MXSDKOptions.sharedInstance.profiler startMeasuringTaskWithName:kMXAnalyticsStartupMountData category:kMXAnalyticsStartupCategory];
+    MXTaskProfile *taskProfile = [MXSDKOptions.sharedInstance.profiler startMeasuringTaskWithName:MXTaskProfileNameStartupMountData
+                                                                                         category:MXTaskProfileCategoryStartup];
 
     MXWeakify(self);
     [self.store openWithCredentials:matrixRestClient.credentials onComplete:^{
@@ -1368,8 +1369,9 @@ typedef void (^MXOnResumeDone)(void);
         if (!self->firstSyncDone)
         {
             BOOL isInitialSync = !self.isEventStreamInitialised;
-            syncTaskProfile = [MXSDKOptions.sharedInstance.profiler startMeasuringTaskWithName:isInitialSync ? kMXAnalyticsStartupInitialSync : kMXAnalyticsStartupIncrementalSync
-                                                                                      category:kMXAnalyticsStartupCategory];
+            MXTaskProfileName taskName = isInitialSync ? MXTaskProfileCategoryInitialSync : MXTaskProfileNameStartupIncrementalSync;
+            syncTaskProfile = [MXSDKOptions.sharedInstance.profiler startMeasuringTaskWithName:taskName
+                                                                                      category:MXTaskProfileCategoryStartup];
         }
         
         NSString * streamToken = self.store.eventStreamToken;

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -351,8 +351,7 @@ typedef void (^MXOnResumeDone)(void);
     self.roomListDataManager = [[MXSDKOptions.sharedInstance.roomListDataManagerClass alloc] init];
 
     NSDate *startDate = [NSDate date];
-    MXTaskProfile *taskProfile = [MXSDKOptions.sharedInstance.profiler startMeasuringTaskWithName:MXTaskProfileNameStartupMountData
-                                                                                         category:MXTaskProfileCategoryStartup];
+    MXTaskProfile *taskProfile = [MXSDKOptions.sharedInstance.profiler startMeasuringTaskWithName:MXTaskProfileNameStartupMountData];
 
     MXWeakify(self);
     [self.store openWithCredentials:matrixRestClient.credentials onComplete:^{
@@ -1369,9 +1368,8 @@ typedef void (^MXOnResumeDone)(void);
         if (!self->firstSyncDone)
         {
             BOOL isInitialSync = !self.isEventStreamInitialised;
-            MXTaskProfileName taskName = isInitialSync ? MXTaskProfileCategoryInitialSync : MXTaskProfileNameStartupIncrementalSync;
-            syncTaskProfile = [MXSDKOptions.sharedInstance.profiler startMeasuringTaskWithName:taskName
-                                                                                      category:MXTaskProfileCategoryStartup];
+            MXTaskProfileName taskName = isInitialSync ? MXTaskProfileNameStartupInitialSync : MXTaskProfileNameStartupIncrementalSync;
+            syncTaskProfile = [MXSDKOptions.sharedInstance.profiler startMeasuringTaskWithName:taskName];
         }
         
         NSString * streamToken = self.store.eventStreamToken;
@@ -2137,6 +2135,7 @@ typedef void (^MXOnResumeDone)(void);
             // The first /sync response for this room may have happened before the
             // homeserver answer to the createRoom request.
             success(room);
+            [MXSDKOptions.sharedInstance.analyticsDelegate trackCreatedRoomAsDM:NO];
         }
         else
         {
@@ -2153,6 +2152,7 @@ typedef void (^MXOnResumeDone)(void);
                     
                     success(room);
                     [[NSNotificationCenter defaultCenter] removeObserver:initialSyncObserver];
+                    [MXSDKOptions.sharedInstance.analyticsDelegate trackCreatedRoomAsDM:NO];
                 }
             }];
         }
@@ -2203,6 +2203,7 @@ typedef void (^MXOnResumeDone)(void);
         
         // Tag the room as direct
         tagRoomAsDirectChat(room);
+        [MXSDKOptions.sharedInstance.analyticsDelegate trackCreatedRoomAsDM:YES];
     }
     else
     {
@@ -2222,6 +2223,7 @@ typedef void (^MXOnResumeDone)(void);
                 tagRoomAsDirectChat(room);
                 
                 [[NSNotificationCenter defaultCenter] removeObserver:initialSyncObserver];
+                [MXSDKOptions.sharedInstance.analyticsDelegate trackCreatedRoomAsDM:YES];
             }
         }];
     }
@@ -2318,6 +2320,8 @@ typedef void (^MXOnResumeDone)(void);
             // The /sync corresponding to this join may have happened before the
             // homeserver answer to the joinRoom request.
             success(room);
+            [MXSDKOptions.sharedInstance.analyticsDelegate trackJoinedRoomAsDM:room.summary.isDirect
+                                                                   memberCount:room.summary.membersCount.joined];
         }
         else
         {
@@ -2331,6 +2335,8 @@ typedef void (^MXOnResumeDone)(void);
                 {
                     success(room);
                     [[NSNotificationCenter defaultCenter] removeObserver:initialSyncObserver];
+                    [MXSDKOptions.sharedInstance.analyticsDelegate trackJoinedRoomAsDM:room.summary.isDirect
+                                                                           memberCount:room.summary.membersCount.joined];
                 }
             }];
         }

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -1368,8 +1368,8 @@ typedef void (^MXOnResumeDone)(void);
         if (!self->firstSyncDone)
         {
             BOOL isInitialSync = !self.isEventStreamInitialised;
-            syncTaskProfile = [MXSDKOptions.sharedInstance.profiler startMeasuringTaskWithName:isInitialSync ? kMXAnalyticsStartupInititialSync : kMXAnalyticsStartupIncrementalSync
-                                                            category:kMXAnalyticsStartupCategory];
+            syncTaskProfile = [MXSDKOptions.sharedInstance.profiler startMeasuringTaskWithName:isInitialSync ? kMXAnalyticsStartupInitialSync : kMXAnalyticsStartupIncrementalSync
+                                                                                      category:kMXAnalyticsStartupCategory];
         }
         
         NSString * streamToken = self.store.eventStreamToken;
@@ -1402,10 +1402,10 @@ typedef void (^MXOnResumeDone)(void);
     }
     
     dispatch_group_notify(initialSyncDispatchGroup, dispatch_get_main_queue(), ^{
-        BOOL wasfirstSync = NO;
+        BOOL wasFirstSync = NO;
         if (!self->firstSyncDone && syncTaskProfile)
         {
-            wasfirstSync = YES;
+            wasFirstSync = YES;
             self->firstSyncDone = YES;
             
             // Contextualise the profiling with the amount of received information
@@ -1435,13 +1435,6 @@ typedef void (^MXOnResumeDone)(void);
         }
         
         [self handleSyncResponse:syncResponse completion:^{
-            
-            if (wasfirstSync)
-            {
-                [[MXSDKOptions sharedInstance].analyticsDelegate trackValue:@(self->rooms.count)
-                                                                   category:kMXAnalyticsStatsCategory
-                                                                       name:kMXAnalyticsStatsRooms];
-            }
             
             dispatch_group_t dispatchGroupLastMessage = dispatch_group_create();
             

--- a/MatrixSDK/Utils/MXAnalyticsDelegate.h
+++ b/MatrixSDK/Utils/MXAnalyticsDelegate.h
@@ -50,24 +50,31 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Report that a call has started.
  
- @param call The call that has started.
+ @param isVideo Whether the call is a video call
+ @param numberOfParticipants The number of participants in the call
+ @param isIncoming Whether the call is an incoming call (NO if placed by the user).
  */
-- (void)trackCallStarted:(MXCall *)call;
+- (void)trackCallStartedWithVideo:(BOOL)isVideo numberOfParticipants:(NSInteger)numberOfParticipants incoming:(BOOL)isIncoming;
 
 /**
  Report that a call has ended.
  
- @param call The call that has started.
+ @param duration The duration of the call in milliseconds
+ @param isVideo Whether the call is a video call
+ @param numberOfParticipants The number of participants in the call
+ @param isIncoming Whether the call is an incoming call (NO if placed by the user).
  */
-- (void)trackCallEnded:(MXCall *)call;
+- (void)trackCallEndedWithDuration:(NSInteger)duration video:(BOOL)isVideo numberOfParticipants:(NSInteger)numberOfParticipants incoming:(BOOL)isIncoming;
 
 /**
  Report that a call encountered an error.
  
- @param call The call that has started.
  @param reason The call hangup reason.
+ @param isVideo Whether the call is a video call
+ @param numberOfParticipants The number of participants in the call
+ @param isIncoming Whether the call is an incoming call (NO if placed by the user).
  */
-- (void)trackCallError:(MXCall *)call withReason:(MXCallHangupReason)reason;
+- (void)trackCallErrorWithReason:(MXCallHangupReason)reason video:(BOOL)isVideo numberOfParticipants:(NSInteger)numberOfParticipants incoming:(BOOL)isIncoming;
 
 - (void)trackContactsAccessGranted:(BOOL)granted;
 

--- a/MatrixSDK/Utils/MXAnalyticsDelegate.h
+++ b/MatrixSDK/Utils/MXAnalyticsDelegate.h
@@ -18,6 +18,7 @@
 #import <Foundation/Foundation.h>
 
 #import "MXCallHangupEventContent.h"
+#import "MXTaskProfile.h"
 
 @class MXCall;
 
@@ -45,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param category the category the task belongs to.
  @param name the name of the task.
  */
-- (void)trackDuration:(NSTimeInterval)seconds category:(NSString*)category name:(NSString*)name;
+- (void)trackDuration:(NSTimeInterval)seconds category:(MXTaskProfileCategory)category name:(MXTaskProfileName)name;
 
 /**
  Report that a call has started.

--- a/MatrixSDK/Utils/MXAnalyticsDelegate.h
+++ b/MatrixSDK/Utils/MXAnalyticsDelegate.h
@@ -17,6 +17,10 @@
 
 #import <Foundation/Foundation.h>
 
+#import "MXCallHangupEventContent.h"
+
+@class MXCall;
+
 NS_ASSUME_NONNULL_BEGIN
 
 /**
@@ -44,15 +48,28 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)trackDuration:(NSTimeInterval)seconds category:(NSString*)category name:(NSString*)name;
 
 /**
- Report a value.
+ Report that a call has started.
  
- An example is the user's room count.
- 
- @param value the number to report.
- @param category the category the value belongs to.
- @param name the name of the value.
+ @param call The call that has started.
  */
-- (void)trackValue:(NSNumber*)value category:(NSString*)category name:(NSString*)name;
+- (void)trackCallStarted:(MXCall *)call;
+
+/**
+ Report that a call has ended.
+ 
+ @param call The call that has started.
+ */
+- (void)trackCallEnded:(MXCall *)call;
+
+/**
+ Report that a call encountered an error.
+ 
+ @param call The call that has started.
+ @param reason The call hangup reason.
+ */
+- (void)trackCallError:(MXCall *)call withReason:(MXCallHangupReason)reason;
+
+- (void)trackContactsAccessGranted:(BOOL)granted;
 
 @end
 

--- a/MatrixSDK/Utils/MXAnalyticsDelegate.h
+++ b/MatrixSDK/Utils/MXAnalyticsDelegate.h
@@ -20,8 +20,6 @@
 #import "MXCallHangupEventContent.h"
 #import "MXTaskProfile.h"
 
-@class MXCall;
-
 NS_ASSUME_NONNULL_BEGIN
 
 /**
@@ -42,11 +40,11 @@ NS_ASSUME_NONNULL_BEGIN
  
  An example is the time to load data from the local store at startup.
  
- @param seconds the duration in seconds.
- @param category the category the task belongs to.
+ @param milliseconds the duration in milliseconds.
  @param name the name of the task.
+ @param units the number of items the were completed during the task
  */
-- (void)trackDuration:(NSTimeInterval)seconds category:(MXTaskProfileCategory)category name:(MXTaskProfileName)name;
+- (void)trackDuration:(NSInteger)milliseconds name:(MXTaskProfileName)name units:(NSUInteger)units;
 
 /**
  Report that a call has started.
@@ -77,6 +75,26 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)trackCallErrorWithReason:(MXCallHangupReason)reason video:(BOOL)isVideo numberOfParticipants:(NSInteger)numberOfParticipants incoming:(BOOL)isIncoming;
 
+/**
+ Report that a room was created.
+ 
+ @param isDM Whether the room is direct or not.
+ */
+- (void)trackCreatedRoomAsDM:(BOOL)isDM;
+
+/**
+ Report that a room was joined.
+ 
+ @param isDM Whether the room is direct or not.
+ @param memberCount The number of members in the room.
+ */
+- (void)trackJoinedRoomAsDM:(BOOL)isDM memberCount:(NSUInteger)memberCount;
+
+/**
+ Report whether the user granted or rejected access to their contacts.
+ 
+ @param granted YES if access was granted, NO if it was rejected.
+ */
 - (void)trackContactsAccessGranted:(BOOL)granted;
 
 @end

--- a/MatrixSDK/Utils/Profiling/MXBaseProfiler.m
+++ b/MatrixSDK/Utils/Profiling/MXBaseProfiler.m
@@ -40,7 +40,7 @@
     return self;
 }
 
-- (MXTaskProfile *)startMeasuringTaskWithName:(nonnull NSString *)name category:(nonnull NSString *)category
+- (MXTaskProfile *)startMeasuringTaskWithName:(MXTaskProfileName)name category:(MXTaskProfileCategory)category
 {
     MXTaskProfile *taskProfile = [[MXTaskProfile alloc] initWithName:name category:category];
     

--- a/MatrixSDK/Utils/Profiling/MXBaseProfiler.m
+++ b/MatrixSDK/Utils/Profiling/MXBaseProfiler.m
@@ -40,9 +40,9 @@
     return self;
 }
 
-- (MXTaskProfile *)startMeasuringTaskWithName:(MXTaskProfileName)name category:(MXTaskProfileCategory)category
+- (MXTaskProfile *)startMeasuringTaskWithName:(MXTaskProfileName)name
 {
-    MXTaskProfile *taskProfile = [[MXTaskProfile alloc] initWithName:name category:category];
+    MXTaskProfile *taskProfile = [[MXTaskProfile alloc] initWithName:name];
     
     @synchronized (taskProfiles)
     {
@@ -56,18 +56,18 @@
 {
     [taskProfile markAsCompleted];
     
-    MXLogDebug(@"[MXBaseProfiler] Task %@ - %@ for %@ units completed in %.3fms%@",
-          taskProfile.category,
+    NSNumber *durationMS = [NSNumber numberWithDouble:taskProfile.duration * 1000];
+    
+    MXLogDebug(@"[MXBaseProfiler] Task %@ for %@ units completed in %.3fms%@",
           taskProfile.name,
           @(taskProfile.units),
-          taskProfile.duration * 1000,
+          durationMS.doubleValue,
           taskProfile.paused ? @" (but it was paused)" : @"");
           
     // Do not send a task that was paused to analytics. Data is often not valid
     if (!taskProfile.paused)
     {
-        // TODO: Send units information (but Matomo does not support additional contextual data)
-        [self.analytics trackDuration:taskProfile.duration category:taskProfile.category name:taskProfile.name];
+        [self.analytics trackDuration:durationMS.integerValue name:taskProfile.name units:taskProfile.units];
     }
     
     @synchronized (taskProfiles)
@@ -104,13 +104,13 @@
 
 #pragma mark - Private
 
-- (nullable MXTaskProfile*)taskProfileWithName:(NSString*)name category:(NSString*)category
+- (nullable MXTaskProfile*)taskProfileWithName:(NSString*)name
 {
     MXTaskProfile *taskProfile;
     
     @synchronized (taskProfiles)
     {
-        taskProfile = [taskProfiles filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"name == %@ && category == %@", name, category]].firstObject;
+        taskProfile = [taskProfiles filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"name == %@", name]].firstObject;
     }
     return taskProfile;
 }

--- a/MatrixSDK/Utils/Profiling/MXProfiler.h
+++ b/MatrixSDK/Utils/Profiling/MXProfiler.h
@@ -27,9 +27,8 @@ NS_ASSUME_NONNULL_BEGIN
  Start measuring a task.
  
  @param name the name of the task.
- @param category the category the task belongs to.
  */
-- (MXTaskProfile *)startMeasuringTaskWithName:(MXTaskProfileName)name category:(MXTaskProfileCategory)category;
+- (MXTaskProfile *)startMeasuringTaskWithName:(MXTaskProfileName)name;
 
 /**
  Stop the clock for a task.
@@ -42,9 +41,8 @@ NS_ASSUME_NONNULL_BEGIN
  Retrieve the profile of a given task.
  
  @param name the name of the task.
- @param category the category the task belongs to.
  */
-- (nullable MXTaskProfile*)taskProfileWithName:(MXTaskProfileName)name category:(MXTaskProfileCategory)category;
+- (nullable MXTaskProfile*)taskProfileWithName:(MXTaskProfileName)name;
 
 /**
  Cancel a task profiling.

--- a/MatrixSDK/Utils/Profiling/MXProfiler.h
+++ b/MatrixSDK/Utils/Profiling/MXProfiler.h
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param name the name of the task.
  @param category the category the task belongs to.
  */
-- (MXTaskProfile *)startMeasuringTaskWithName:(NSString*)name category:(NSString*)category;
+- (MXTaskProfile *)startMeasuringTaskWithName:(MXTaskProfileName)name category:(MXTaskProfileCategory)category;
 
 /**
  Stop the clock for a task.
@@ -44,7 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param name the name of the task.
  @param category the category the task belongs to.
  */
-- (nullable MXTaskProfile*)taskProfileWithName:(NSString*)name category:(NSString*)category;
+- (nullable MXTaskProfile*)taskProfileWithName:(MXTaskProfileName)name category:(MXTaskProfileCategory)category;
 
 /**
  Cancel a task profiling.

--- a/MatrixSDK/Utils/Profiling/MXTaskProfile.h
+++ b/MatrixSDK/Utils/Profiling/MXTaskProfile.h
@@ -18,13 +18,33 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef NSString *const MXTaskProfileCategory NS_TYPED_EXTENSIBLE_ENUM;
+// Timing stats relative to app startup.
+static MXTaskProfileCategory const MXTaskProfileCategoryStartup = @"startup";
+// Metrics related to the initial sync request
+static MXTaskProfileCategory const MXTaskProfileCategoryInitialSync = @"initialSync";
+
+typedef NSString *const MXTaskProfileName NS_TYPED_EXTENSIBLE_ENUM;
+// Duration of the initial /sync request
+static MXTaskProfileName const MXTaskProfileNameStartupInitialSync = @"initialSync";
+// Duration of the first /sync when resuming the app
+static MXTaskProfileName const MXTaskProfileNameStartupIncrementalSync = @"incrementalSync";
+// Time to preload data in the MXStore
+static MXTaskProfileName const MXTaskProfileNameStartupStorePreload = @"storePreload";
+// Time to mount all objects from the store (it includes kMXAnalyticsStartupStorePreload time)
+static MXTaskProfileName const MXTaskProfileNameStartupMountData = @"mountData";
+// Duration of the the display of the app launch screen
+static MXTaskProfileName const MXTaskProfileNameStartupLaunchScreen = @"launchScreen";
+static MXTaskProfileName const MXTaskProfileNameInitialSyncRequest = @"request";
+static MXTaskProfileName const MXTaskProfileNameInitialSyncParsing = @"parsing";
+
 @interface MXTaskProfile : NSObject
 
 // Task name
-@property (nonatomic, readonly) NSString *name;
+@property (nonatomic, readonly) MXTaskProfileName name;
 
 // Category to group related tasks
-@property (nonatomic, readonly) NSString *category;
+@property (nonatomic, readonly) MXTaskProfileCategory category;
 
 // Task timing
 @property (nonatomic, readonly) NSDate *startDate;

--- a/MatrixSDK/Utils/Profiling/MXTaskProfile.h
+++ b/MatrixSDK/Utils/Profiling/MXTaskProfile.h
@@ -15,26 +15,9 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "MXTaskProfileName.h"
 
 NS_ASSUME_NONNULL_BEGIN
-
-typedef NSString *const MXTaskProfileName NS_TYPED_EXTENSIBLE_ENUM;
-/// The duration of the initial /sync request.
-static MXTaskProfileName const MXTaskProfileNameStartupInitialSync = @"startup: initialSync";
-/// The duration of the first /sync when resuming the app.
-static MXTaskProfileName const MXTaskProfileNameStartupIncrementalSync = @"startup: incrementalSync";
-/// The time taken to preload data in the MXStore.
-static MXTaskProfileName const MXTaskProfileNameStartupStorePreload = @"startup: storePreload";
-/// The time to mount all objects from the store (it includes MXTaskProfileNameStartupStorePreload time).
-static MXTaskProfileName const MXTaskProfileNameStartupMountData = @"startup: mountData";
-/// The duration of the the display of the app launch screen
-static MXTaskProfileName const MXTaskProfileNameStartupLaunchScreen = @"startup: launchScreen";
-/// The time spent waiting for a response to an initial /sync request.
-static MXTaskProfileName const MXTaskProfileNameInitialSyncRequest = @"initialSync: request";
-/// The time spent parsing the response from an initial /sync request.
-static MXTaskProfileName const MXTaskProfileNameInitialSyncParsing = @"initialSync: parsing";
-/// The time taken to display an event in the timeline that was opened from a notification.
-static MXTaskProfileName const MXTaskProfileNameNotificationsOpenEvent = @"notifications: openEvent";
 
 @interface MXTaskProfile : NSObject
 

--- a/MatrixSDK/Utils/Profiling/MXTaskProfile.h
+++ b/MatrixSDK/Utils/Profiling/MXTaskProfile.h
@@ -18,33 +18,28 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef NSString *const MXTaskProfileCategory NS_TYPED_EXTENSIBLE_ENUM;
-// Timing stats relative to app startup.
-static MXTaskProfileCategory const MXTaskProfileCategoryStartup = @"startup";
-// Metrics related to the initial sync request
-static MXTaskProfileCategory const MXTaskProfileCategoryInitialSync = @"initialSync";
-
 typedef NSString *const MXTaskProfileName NS_TYPED_EXTENSIBLE_ENUM;
-// Duration of the initial /sync request
-static MXTaskProfileName const MXTaskProfileNameStartupInitialSync = @"initialSync";
-// Duration of the first /sync when resuming the app
-static MXTaskProfileName const MXTaskProfileNameStartupIncrementalSync = @"incrementalSync";
-// Time to preload data in the MXStore
-static MXTaskProfileName const MXTaskProfileNameStartupStorePreload = @"storePreload";
-// Time to mount all objects from the store (it includes kMXAnalyticsStartupStorePreload time)
-static MXTaskProfileName const MXTaskProfileNameStartupMountData = @"mountData";
-// Duration of the the display of the app launch screen
-static MXTaskProfileName const MXTaskProfileNameStartupLaunchScreen = @"launchScreen";
-static MXTaskProfileName const MXTaskProfileNameInitialSyncRequest = @"request";
-static MXTaskProfileName const MXTaskProfileNameInitialSyncParsing = @"parsing";
+/// The duration of the initial /sync request.
+static MXTaskProfileName const MXTaskProfileNameStartupInitialSync = @"startup: initialSync";
+/// The duration of the first /sync when resuming the app.
+static MXTaskProfileName const MXTaskProfileNameStartupIncrementalSync = @"startup: incrementalSync";
+/// The time taken to preload data in the MXStore.
+static MXTaskProfileName const MXTaskProfileNameStartupStorePreload = @"startup: storePreload";
+/// The time to mount all objects from the store (it includes MXTaskProfileNameStartupStorePreload time).
+static MXTaskProfileName const MXTaskProfileNameStartupMountData = @"startup: mountData";
+/// The duration of the the display of the app launch screen
+static MXTaskProfileName const MXTaskProfileNameStartupLaunchScreen = @"startup: launchScreen";
+/// The time spent waiting for a response to an initial /sync request.
+static MXTaskProfileName const MXTaskProfileNameInitialSyncRequest = @"initialSync: request";
+/// The time spent parsing the response from an initial /sync request.
+static MXTaskProfileName const MXTaskProfileNameInitialSyncParsing = @"initialSync: parsing";
+/// The time taken to display an event in the timeline that was opened from a notification.
+static MXTaskProfileName const MXTaskProfileNameNotificationsOpenEvent = @"notifications: openEvent";
 
 @interface MXTaskProfile : NSObject
 
 // Task name
 @property (nonatomic, readonly) MXTaskProfileName name;
-
-// Category to group related tasks
-@property (nonatomic, readonly) MXTaskProfileCategory category;
 
 // Task timing
 @property (nonatomic, readonly) NSDate *startDate;

--- a/MatrixSDK/Utils/Profiling/MXTaskProfile.m
+++ b/MatrixSDK/Utils/Profiling/MXTaskProfile.m
@@ -18,23 +18,18 @@
 
 @interface MXTaskProfile ()
 
-// Task name
 @property (nonatomic) MXTaskProfileName name;
-
-// Category to group related tasks
-@property (nonatomic) MXTaskProfileCategory category;
 
 @end
 
 @implementation MXTaskProfile
 
-- (instancetype)initWithName:(MXTaskProfileName)name category:(MXTaskProfileCategory)category
+- (instancetype)initWithName:(MXTaskProfileName)name
 {
     self = [self init];
     if (self)
     {
         self.name = name;
-        self.category = category;
         _startDate = [NSDate date];
         _paused = NO;
         _units = 1;

--- a/MatrixSDK/Utils/Profiling/MXTaskProfile.m
+++ b/MatrixSDK/Utils/Profiling/MXTaskProfile.m
@@ -16,15 +16,25 @@
 
 #import "MXTaskProfile.h"
 
+@interface MXTaskProfile ()
+
+// Task name
+@property (nonatomic) MXTaskProfileName name;
+
+// Category to group related tasks
+@property (nonatomic) MXTaskProfileCategory category;
+
+@end
+
 @implementation MXTaskProfile
 
-- (instancetype)initWithName:(NSString *)name category:(NSString *)category
+- (instancetype)initWithName:(MXTaskProfileName)name category:(MXTaskProfileCategory)category
 {
     self = [self init];
     if (self)
     {
-        _name = name;
-        _category = category;
+        self.name = name;
+        self.category = category;
         _startDate = [NSDate date];
         _paused = NO;
         _units = 1;

--- a/MatrixSDK/Utils/Profiling/MXTaskProfileName.h
+++ b/MatrixSDK/Utils/Profiling/MXTaskProfileName.h
@@ -1,0 +1,33 @@
+// 
+// Copyright 2021 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+typedef NSString *const MXTaskProfileName NS_TYPED_EXTENSIBLE_ENUM;
+/// The duration of the initial /sync request.
+static MXTaskProfileName const MXTaskProfileNameStartupInitialSync = @"startup: initialSync";
+/// The duration of the first /sync when resuming the app.
+static MXTaskProfileName const MXTaskProfileNameStartupIncrementalSync = @"startup: incrementalSync";
+/// The time taken to preload data in the MXStore.
+static MXTaskProfileName const MXTaskProfileNameStartupStorePreload = @"startup: storePreload";
+/// The time to mount all objects from the store (it includes MXTaskProfileNameStartupStorePreload time).
+static MXTaskProfileName const MXTaskProfileNameStartupMountData = @"startup: mountData";
+/// The duration of the the display of the app launch screen
+static MXTaskProfileName const MXTaskProfileNameStartupLaunchScreen = @"startup: launchScreen";
+/// The time spent waiting for a response to an initial /sync request.
+static MXTaskProfileName const MXTaskProfileNameInitialSyncRequest = @"initialSync: request";
+/// The time spent parsing the response from an initial /sync request.
+static MXTaskProfileName const MXTaskProfileNameInitialSyncParsing = @"initialSync: parsing";
+/// The time taken to display an event in the timeline that was opened from a notification.
+static MXTaskProfileName const MXTaskProfileNameNotificationsOpenEvent = @"notifications: openEvent";

--- a/MatrixSDK/Utils/Profiling/MXTaskProfile_Private.h
+++ b/MatrixSDK/Utils/Profiling/MXTaskProfile_Private.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MXTaskProfile ()
 
-- (instancetype)initWithName:(MXTaskProfileName)name category:(MXTaskProfileCategory)category;
+- (instancetype)initWithName:(MXTaskProfileName)name;
 
 - (void)markAsCompleted;
 

--- a/MatrixSDK/Utils/Profiling/MXTaskProfile_Private.h
+++ b/MatrixSDK/Utils/Profiling/MXTaskProfile_Private.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MXTaskProfile ()
 
-- (instancetype)initWithName:(NSString *)name category:(NSString *)category;
+- (instancetype)initWithName:(MXTaskProfileName)name category:(MXTaskProfileCategory)category;
 
 - (void)markAsCompleted;
 

--- a/MatrixSDK/VoIP/MXCall.m
+++ b/MatrixSDK/VoIP/MXCall.m
@@ -272,7 +272,9 @@ NSString *const kMXCallSupportsTransferringStatusDidChange = @"kMXCallSupportsTr
 
     [self setState:MXCallStateWaitLocalMedia reason:nil];
     
-    [MXSDKOptions.sharedInstance.analyticsDelegate trackCallStarted:self];
+    [MXSDKOptions.sharedInstance.analyticsDelegate trackCallStartedWithVideo:self.isVideoCall
+                                                        numberOfParticipants:self.room.summary.membersCount.joined
+                                                                    incoming:self.isIncoming];
 
     MXWeakify(self);
     [callStackCallOperationQueue addOperationWithBlock:^{
@@ -540,7 +542,10 @@ NSString *const kMXCallSupportsTransferringStatusDidChange = @"kMXCallSupportsTr
             //  Send the hangup event
             MXWeakify(self);
             [_callSignalingRoom sendEventOfType:kMXEventTypeStringCallHangup content:content localEcho:nil success:^(NSString *eventId) {
-                [MXSDKOptions.sharedInstance.analyticsDelegate trackCallEnded:self];
+                [MXSDKOptions.sharedInstance.analyticsDelegate trackCallEndedWithDuration:self.duration
+                                                                                    video:self.isVideoCall
+                                                                     numberOfParticipants:self.room.summary.membersCount.joined
+                                                                                 incoming:self.isIncoming];
                 
                 terminateBlock();
             } failure:^(NSError *error) {
@@ -804,7 +809,10 @@ NSString *const kMXCallSupportsTransferringStatusDidChange = @"kMXCallSupportsTr
         // Store the total duration
         totalCallDuration = self.duration;
         
-        [MXSDKOptions.sharedInstance.analyticsDelegate trackCallEnded:self];
+        [MXSDKOptions.sharedInstance.analyticsDelegate trackCallEndedWithDuration:self.duration
+                                                                            video:self.isVideoCall
+                                                             numberOfParticipants:self.room.summary.membersCount.joined
+                                                                         incoming:self.isIncoming];
         
         // Terminate the call at the stack level
         [callStackCall end];
@@ -1107,7 +1115,9 @@ NSString *const kMXCallSupportsTransferringStatusDidChange = @"kMXCallSupportsTr
     // Store if it is voice or video call
     self.isVideoCall = callInviteEventContent.isVideoCall;
     
-    [MXSDKOptions.sharedInstance.analyticsDelegate trackCallStarted:self];
+    [MXSDKOptions.sharedInstance.analyticsDelegate trackCallStartedWithVideo:self.isVideoCall
+                                                        numberOfParticipants:self.room.summary.membersCount.joined
+                                                                    incoming:self.isIncoming];
 
     [self setState:MXCallStateWaitLocalMedia reason:nil];
     
@@ -1647,7 +1657,10 @@ NSString *const kMXCallSupportsTransferringStatusDidChange = @"kMXCallSupportsTr
     if ([_delegate respondsToSelector:@selector(call:didEncounterError:reason:)])
     {
         [_delegate call:self didEncounterError:error reason:reason];
-        [MXSDKOptions.sharedInstance.analyticsDelegate trackCallError:self withReason:reason];
+        [MXSDKOptions.sharedInstance.analyticsDelegate trackCallErrorWithReason:reason
+                                                                          video:self.isVideoCall
+                                                           numberOfParticipants:self.room.summary.membersCount.joined
+                                                                       incoming:self.isIncoming];
     }
     else
     {

--- a/MatrixSDK/VoIP/MXCall.m
+++ b/MatrixSDK/VoIP/MXCall.m
@@ -272,11 +272,7 @@ NSString *const kMXCallSupportsTransferringStatusDidChange = @"kMXCallSupportsTr
 
     [self setState:MXCallStateWaitLocalMedia reason:nil];
     
-    NSString *eventName = _isConferenceCall ? kMXAnalyticsVoipNamePlaceConferenceCall : kMXAnalyticsVoipNamePlaceCall;
-    
-    [[MXSDKOptions sharedInstance].analyticsDelegate trackValue:@(video)
-                                                       category:kMXAnalyticsVoipCategory
-                                                           name:eventName];
+    [MXSDKOptions.sharedInstance.analyticsDelegate trackCallStarted:self];
 
     MXWeakify(self);
     [callStackCallOperationQueue addOperationWithBlock:^{
@@ -544,9 +540,7 @@ NSString *const kMXCallSupportsTransferringStatusDidChange = @"kMXCallSupportsTr
             //  Send the hangup event
             MXWeakify(self);
             [_callSignalingRoom sendEventOfType:kMXEventTypeStringCallHangup content:content localEcho:nil success:^(NSString *eventId) {
-                [[MXSDKOptions sharedInstance].analyticsDelegate trackValue:@(reason)
-                                                                   category:kMXAnalyticsVoipCategory
-                                                                       name:kMXAnalyticsVoipNameCallHangup];
+                [MXSDKOptions.sharedInstance.analyticsDelegate trackCallEnded:self];
                 
                 terminateBlock();
             } failure:^(NSError *error) {
@@ -810,9 +804,7 @@ NSString *const kMXCallSupportsTransferringStatusDidChange = @"kMXCallSupportsTr
         // Store the total duration
         totalCallDuration = self.duration;
         
-        [[MXSDKOptions sharedInstance].analyticsDelegate trackValue:@(_endReason)
-                                                           category:kMXAnalyticsVoipCategory
-                                                               name:kMXAnalyticsVoipNameCallEnded];
+        [MXSDKOptions.sharedInstance.analyticsDelegate trackCallEnded:self];
         
         // Terminate the call at the stack level
         [callStackCall end];
@@ -1115,9 +1107,7 @@ NSString *const kMXCallSupportsTransferringStatusDidChange = @"kMXCallSupportsTr
     // Store if it is voice or video call
     self.isVideoCall = callInviteEventContent.isVideoCall;
     
-    [[MXSDKOptions sharedInstance].analyticsDelegate trackValue:@(_isVideoCall)
-                                                       category:kMXAnalyticsVoipCategory
-                                                           name:kMXAnalyticsVoipNameReceiveCall];
+    [MXSDKOptions.sharedInstance.analyticsDelegate trackCallStarted:self];
 
     [self setState:MXCallStateWaitLocalMedia reason:nil];
     
@@ -1657,10 +1647,7 @@ NSString *const kMXCallSupportsTransferringStatusDidChange = @"kMXCallSupportsTr
     if ([_delegate respondsToSelector:@selector(call:didEncounterError:reason:)])
     {
         [_delegate call:self didEncounterError:error reason:reason];
-        
-        [[MXSDKOptions sharedInstance].analyticsDelegate trackValue:@(reason)
-                                                           category:kMXAnalyticsVoipCategory
-                                                               name:kMXAnalyticsVoipNameCallError];
+        [MXSDKOptions.sharedInstance.analyticsDelegate trackCallError:self withReason:reason];
     }
     else
     {

--- a/changelog.d/5035.api
+++ b/changelog.d/5035.api
@@ -1,0 +1,1 @@
+MXAnalyticsDelegate: The generic methods have been replaced with type safe ones for each event tracked.

--- a/changelog.d/5035.change
+++ b/changelog.d/5035.change
@@ -1,0 +1,1 @@
+MXTaskProfile: Add an MXTaskProfileName enum instead of individual strings for Name and Category.


### PR DESCRIPTION
As part of https://github.com/vector-im/element-ios/issues/5035, this PR makes 2 changes.

- `MXAnalyticsDelegate` now provides specific methods per event reported as the new [matrix-analytics-events](https://github.com/matrix-org/matrix-analytics-events) schema should be followed more strictly.
- `MXTaskProfile` has been updated to use a single `MXTaskProfileName` enum instead of separate `name` and `category` strings in order to switch on the task name.