### PR TITLE
Add missing `#import "TargetConditionals.h"` in `MXCallKitAdapter`

### DIFF
--- a/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.h
+++ b/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.h
@@ -14,6 +14,7 @@
  limitations under the License.
  */
 
+#import "TargetConditionals.h"
 #if TARGET_OS_IPHONE
 
 #import <Foundation/Foundation.h>


### PR DESCRIPTION
Add missing `#import "TargetConditionals.h"` in `MXCallKitAdapter`

Signed-off-by: Frantisek Hetes f.hetes@gmail.com