### PR TITLE
Fix DTMF

### DIFF
--- a/MatrixSDK/VoIP/CallStack/MXCallStackCall.h
+++ b/MatrixSDK/VoIP/CallStack/MXCallStackCall.h
@@ -151,19 +151,9 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Creates a task to send given DTMF tones in the call. If there is a task already running, it'll be canceled.
  @param tones DTMF tones to be sent. Allowed characters: [0-9], [A-D], '#', `*`. Case insensitive. Comma (',') will cause a 2 seconds delay before sending next character.
- @param duration Duration for each character of tones (in milliseconds).
-    Allowed interval is from 70 ms to 6000 ms inclusively.
-    If given value is outside of these limits, it'll be limited to them.
-    Pass 0 to use default value or last used value.
- @param interToneGap Duration for gap between each character of tones (in milliseconds).
-    Must be at least 50 ms.
-    If given value is lower than 50 ms, it'll be limited to that value.
-    Pass 0 to use default value or last used value.
  @returns Whether the operation succeeded or not.
  */
-- (BOOL)sendDTMF:(NSString * _Nonnull)tones
-        duration:(NSUInteger)duration
-    interToneGap:(NSUInteger)interToneGap;
+- (BOOL)sendDTMF:(NSString * _Nonnull)tones;
 
 #pragma mark - Properties
 /**

--- a/MatrixSDK/VoIP/MXCall.h
+++ b/MatrixSDK/VoIP/MXCall.h
@@ -217,19 +217,9 @@ extern NSString *const kMXCallSupportsTransferringStatusDidChange;
 /**
  Creates a task to send given DTMF tones in the call. If there is a task already running, it'll be canceled.
  @param tones DTMF tones to be sent. Allowed characters: [0-9], [A-D], '#', `*`. Case insensitive. Comma (',') will cause a 2 seconds delay before sending next character.
- @param duration Duration for each character of tones (in milliseconds).
-    Allowed interval is from 70 ms to 6000 ms inclusively.
-    If given value is outside of these limits, it'll be limited to them.
-    Pass 0 to use default value or last used value.
- @param interToneGap Duration for gap between each character of tones (in milliseconds).
-    Must be at least 50 ms.
-    If given value is lower than 50 ms, it'll be limited to that value.
-    Pass 0 to use default value or last used value.
  @returns Whether the operation succeeded or not.
  */
-- (BOOL)sendDTMF:(NSString * _Nonnull)tones
-        duration:(NSUInteger)duration
-    interToneGap:(NSUInteger)interToneGap;
+- (BOOL)sendDTMF:(NSString * _Nonnull)tones;
 
 #pragma mark - Properties
 /**

--- a/MatrixSDK/VoIP/MXCall.m
+++ b/MatrixSDK/VoIP/MXCall.m
@@ -746,10 +746,8 @@ NSString *const kMXCallSupportsTransferringStatusDidChange = @"kMXCallSupportsTr
 }
 
 - (BOOL)sendDTMF:(NSString * _Nonnull)tones
-        duration:(NSUInteger)duration
-    interToneGap:(NSUInteger)interToneGap
 {
-    return [callStackCall sendDTMF:tones duration:duration interToneGap:interToneGap];
+    return [callStackCall sendDTMF:tones];
 }
 
 #pragma mark - Properties

--- a/changelog.d/5375.bugfix
+++ b/changelog.d/5375.bugfix
@@ -1,0 +1,1 @@
+Fixes DTMF(dial tones) during voice calls. 


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-ios/issues/5375
with https://github.com/vector-im/element-ios/pull/5376

I decided to match the implementation of android:
- We don't make use of the additional parameters and it complicates the logic a bit, so simplified the signature.
- android loops though the senders to get the dtmf sender which seems slightly more robust
- Android just hardcodes the duration and gap, copied the values.
- The input is NSTimeInterval which is seconds rather than ms. This differs from the android webrtc api which passes as ms.