### PR TITLE
Static location sharing - part 2

### DIFF
--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -2415,16 +2415,14 @@ NSInteger const kMXRoomAlreadyJoinedErrorCode = 9001;
                                       success:(void (^)(NSString *))success
                                       failure:(void (^)(NSError *))failure
 {
+    MXEventContentLocation *locationContent = [[MXEventContentLocation alloc] initWithAssetType:MXEventAssetTypeUser
+                                                                                       latitude:latitude
+                                                                                      longitude:longitude
+                                                                                    description:description];
+    
     NSMutableDictionary *content = [NSMutableDictionary dictionary];
-    content[kMXMessageTypeKey] = kMXMessageTypeLocation;
-    
-    MXEventContentLocation *locationContent = [[MXEventContentLocation alloc] initWithLatitude:latitude
-                                                                                     longitude:longitude
-                                                                                   description:description];
-    
-    content[kMXMessageContentKeyExtensibleLocationMSC3488] = locationContent.JSONDictionary;
-    
-    content[kMXMessageGeoURIKey] = locationContent.geoURI;
+
+    [content addEntriesFromDictionary:locationContent.JSONDictionary];
     
     NSString *fallbackText = [NSString stringWithFormat:@"%@ was at %@ as of %@", self.mxSession.myUser.displayname, locationContent.geoURI, NSDate.date];
     content[kMXMessageBodyKey] = fallbackText;

--- a/MatrixSDK/JSONModels/Event/Content/MXEventContentLocation.h
+++ b/MatrixSDK/JSONModels/Event/Content/MXEventContentLocation.h
@@ -20,7 +20,15 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef NS_ENUM(NSUInteger, MXEventAssetType)
+{
+    MXEventAssetTypeUser,
+    MXEventAssetTypeGeneric
+};
+
 @interface MXEventContentLocation: MXJSONModel
+
+@property (nonatomic, readonly) MXEventAssetType assetType;
 
 @property (nonatomic, readonly) double latitude;
 
@@ -30,9 +38,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly, nullable) NSString *locationDescription;
 
-- (instancetype)initWithLatitude:(double)latitude
-                       longitude:(double)longitude
-                     description:(nullable NSString *)description;
+- (instancetype)initWithAssetType:(MXEventAssetType)assetType
+                         latitude:(double)latitude
+                        longitude:(double)longitude
+                      description:(nullable NSString *)description;
 
 @end
 

--- a/MatrixSDK/JSONModels/Event/Content/MXEventContentLocation.m
+++ b/MatrixSDK/JSONModels/Event/Content/MXEventContentLocation.m
@@ -87,9 +87,9 @@
     double longitude = [locationComponents.lastObject doubleValue];
     
     return [[MXEventContentLocation alloc] initWithAssetType:assetType
-                                               latitude:latitude
-                                                  longitude:longitude
-                                                description:description];
+                                                    latitude:latitude
+                                                   longitude:longitude
+                                                 description:description];
 }
 
 - (NSDictionary *)JSONDictionary

--- a/MatrixSDK/JSONModels/Event/Content/MXEventContentLocation.m
+++ b/MatrixSDK/JSONModels/Event/Content/MXEventContentLocation.m
@@ -40,7 +40,7 @@
 {
     NSString *description;
     NSString *geoURIString;
-    MXEventAssetType assetType = MXEventAssetTypeGeneric;
+    MXEventAssetType assetType = MXEventAssetTypeUser;
     
     NSDictionary *locationDictionary = JSONDictionary[kMXMessageContentKeyExtensibleLocationMSC3488];
     if (locationDictionary == nil)
@@ -48,25 +48,38 @@
         locationDictionary = JSONDictionary[kMXMessageContentKeyExtensibleLocation];
     }
     
-    if (locationDictionary) {
+    if (locationDictionary)
+    {
         MXJSONModelSetString(geoURIString, locationDictionary[kMXMessageContentKeyExtensibleLocationURI]);
         MXJSONModelSetString(description, locationDictionary[kMXMessageContentKeyExtensibleLocationDescription]);
-    } else if ([JSONDictionary[kMXMessageTypeKey] isEqualToString:kMXMessageTypeLocation]) {
+    }
+    else if ([JSONDictionary[kMXMessageTypeKey] isEqualToString:kMXMessageTypeLocation])
+    {
         MXJSONModelSetString(geoURIString, JSONDictionary[kMXMessageGeoURIKey]);
-    } else {
+    }
+    else
+    {
         return nil;
     }
     
-    if ([JSONDictionary[kMXMessageContentKeyExtensibleAsset][kMXMessageContentKeyExtensibleAssetType] isEqualToString:kMXMessageContentKeyExtensibleAssetTypeUser] ||
-        [JSONDictionary[kMXMessageContentKeyExtensibleAssetMSC3488][kMXMessageContentKeyExtensibleAssetType] isEqualToString:kMXMessageContentKeyExtensibleAssetTypeUser])
+    NSDictionary *assetDictionary = JSONDictionary[kMXMessageContentKeyExtensibleAssetMSC3488];
+    if (assetDictionary == nil)
     {
-        assetType = MXEventAssetTypeUser;
+        assetDictionary = JSONDictionary[kMXMessageContentKeyExtensibleAsset];
+    }
+    
+    if (assetDictionary)
+    {
+        if (![assetDictionary[kMXMessageContentKeyExtensibleAssetType] isEqualToString:kMXMessageContentKeyExtensibleAssetTypeUser]) {
+            assetType = MXEventAssetTypeGeneric;
+        }
     }
     
     NSString *locationString = [[geoURIString componentsSeparatedByString:@":"].lastObject componentsSeparatedByString:@";"].firstObject;
     NSArray *locationComponents = [locationString componentsSeparatedByString:@","];
     
-    if (locationComponents.count != 2) {
+    if (locationComponents.count != 2)
+    {
         return nil;
     }
     

--- a/MatrixSDK/JSONModels/Event/Content/MXEventContentLocation.m
+++ b/MatrixSDK/JSONModels/Event/Content/MXEventContentLocation.m
@@ -36,21 +36,23 @@
 
 + (instancetype)modelFromJSON:(NSDictionary *)JSONDictionary
 {
+    NSString *description;
+    NSString *geoURIString;
+    
     NSDictionary *locationContent = JSONDictionary[kMXMessageContentKeyExtensibleLocationMSC3488];
     if (locationContent == nil)
     {
         locationContent = JSONDictionary[kMXMessageContentKeyExtensibleLocation];
     }
     
-    if  (locationContent == nil) {
+    if (locationContent) {
+        MXJSONModelSetString(description, locationContent[kMXMessageContentKeyExtensibleLocationDescription]);
+        MXJSONModelSetString(geoURIString, locationContent[kMXMessageContentKeyExtensibleLocationURI]);
+    } else if ([JSONDictionary[kMXMessageTypeKey] isEqualToString:kMXMessageTypeLocation]) {
+        MXJSONModelSetString(geoURIString, JSONDictionary[kMXMessageGeoURIKey]);
+    } else {
         return nil;
     }
-    
-    NSString *description;
-    MXJSONModelSetString(description, locationContent[kMXMessageContentKeyExtensibleLocationDescription]);
-    
-    NSString *geoURIString;
-    MXJSONModelSetString(geoURIString, locationContent[kMXMessageContentKeyExtensibleLocationURI]);
     
     NSString *locationString = [[geoURIString componentsSeparatedByString:@":"].lastObject componentsSeparatedByString:@";"].firstObject;
     

--- a/MatrixSDK/JSONModels/Event/Content/MXEventContentLocation.m
+++ b/MatrixSDK/JSONModels/Event/Content/MXEventContentLocation.m
@@ -19,12 +19,14 @@
 
 @implementation MXEventContentLocation
 
-- (instancetype)initWithLatitude:(double)latitude
-                       longitude:(double)longitude
-                     description:(NSString *)description
+- (instancetype)initWithAssetType:(MXEventAssetType)assetType
+                         latitude:(double)latitude
+                        longitude:(double)longitude
+                      description:(NSString *)description
 {
     if (self = [super init])
     {
+        _assetType = assetType;
         _latitude = latitude;
         _longitude = longitude;
         _locationDescription = description;
@@ -38,24 +40,30 @@
 {
     NSString *description;
     NSString *geoURIString;
+    MXEventAssetType assetType = MXEventAssetTypeGeneric;
     
-    NSDictionary *locationContent = JSONDictionary[kMXMessageContentKeyExtensibleLocationMSC3488];
-    if (locationContent == nil)
+    NSDictionary *locationDictionary = JSONDictionary[kMXMessageContentKeyExtensibleLocationMSC3488];
+    if (locationDictionary == nil)
     {
-        locationContent = JSONDictionary[kMXMessageContentKeyExtensibleLocation];
+        locationDictionary = JSONDictionary[kMXMessageContentKeyExtensibleLocation];
     }
     
-    if (locationContent) {
-        MXJSONModelSetString(description, locationContent[kMXMessageContentKeyExtensibleLocationDescription]);
-        MXJSONModelSetString(geoURIString, locationContent[kMXMessageContentKeyExtensibleLocationURI]);
+    if (locationDictionary) {
+        MXJSONModelSetString(geoURIString, locationDictionary[kMXMessageContentKeyExtensibleLocationURI]);
+        MXJSONModelSetString(description, locationDictionary[kMXMessageContentKeyExtensibleLocationDescription]);
     } else if ([JSONDictionary[kMXMessageTypeKey] isEqualToString:kMXMessageTypeLocation]) {
         MXJSONModelSetString(geoURIString, JSONDictionary[kMXMessageGeoURIKey]);
     } else {
         return nil;
     }
     
-    NSString *locationString = [[geoURIString componentsSeparatedByString:@":"].lastObject componentsSeparatedByString:@";"].firstObject;
+    if ([JSONDictionary[kMXMessageContentKeyExtensibleAsset][kMXMessageContentKeyExtensibleAssetType] isEqualToString:kMXMessageContentKeyExtensibleAssetTypeUser] ||
+        [JSONDictionary[kMXMessageContentKeyExtensibleAssetMSC3488][kMXMessageContentKeyExtensibleAssetType] isEqualToString:kMXMessageContentKeyExtensibleAssetTypeUser])
+    {
+        assetType = MXEventAssetTypeUser;
+    }
     
+    NSString *locationString = [[geoURIString componentsSeparatedByString:@":"].lastObject componentsSeparatedByString:@";"].firstObject;
     NSArray *locationComponents = [locationString componentsSeparatedByString:@","];
     
     if (locationComponents.count != 2) {
@@ -65,7 +73,8 @@
     double latitude = [locationComponents.firstObject doubleValue];
     double longitude = [locationComponents.lastObject doubleValue];
     
-    return [[MXEventContentLocation alloc] initWithLatitude:latitude
+    return [[MXEventContentLocation alloc] initWithAssetType:assetType
+                                               latitude:latitude
                                                   longitude:longitude
                                                 description:description];
 }
@@ -74,9 +83,15 @@
 {
     NSMutableDictionary *content = [NSMutableDictionary dictionary];
     
-    content[kMXMessageContentKeyExtensibleLocationURI] = self.geoURI;
+    NSMutableDictionary *locationContent = [NSMutableDictionary dictionary];
+    locationContent[kMXMessageContentKeyExtensibleLocationURI] = self.geoURI;
+    locationContent[kMXMessageContentKeyExtensibleLocationDescription] = self.locationDescription;
+    content[kMXMessageContentKeyExtensibleLocationMSC3488] = locationContent;
     
-    content[kMXMessageContentKeyExtensibleLocationDescription] = self.locationDescription;
+    content[kMXMessageContentKeyExtensibleAssetMSC3488] = @{ kMXMessageContentKeyExtensibleAssetType: kMXMessageContentKeyExtensibleAssetTypeUser };
+    
+    content[kMXMessageTypeKey] = kMXMessageTypeLocation;
+    content[kMXMessageGeoURIKey] = self.geoURI;
     
     return content;
 }

--- a/MatrixSDK/JSONModels/MXEvent.h
+++ b/MatrixSDK/JSONModels/MXEvent.h
@@ -266,6 +266,13 @@ FOUNDATION_EXPORT NSString *const kMXMessageContentKeyExtensibleLocationMSC3488;
 FOUNDATION_EXPORT NSString *const kMXMessageContentKeyExtensibleLocationURI;
 FOUNDATION_EXPORT NSString *const kMXMessageContentKeyExtensibleLocationDescription;
 
+// Assets
+
+FOUNDATION_EXPORT NSString *const kMXMessageContentKeyExtensibleAsset;
+FOUNDATION_EXPORT NSString *const kMXMessageContentKeyExtensibleAssetMSC3488;
+FOUNDATION_EXPORT NSString *const kMXMessageContentKeyExtensibleAssetType;
+FOUNDATION_EXPORT NSString *const kMXMessageContentKeyExtensibleAssetTypeUser;
+
 /**
  The internal event state used to handle the different steps of the event sending.
  */

--- a/MatrixSDK/JSONModels/MXEvent.m
+++ b/MatrixSDK/JSONModels/MXEvent.m
@@ -176,6 +176,13 @@ NSString *const kMXMessageContentKeyExtensibleLocationMSC3488 = @"org.matrix.msc
 NSString *const kMXMessageContentKeyExtensibleLocationURI = @"uri";
 NSString *const kMXMessageContentKeyExtensibleLocationDescription = @"description";
 
+// Assets
+
+NSString *const kMXMessageContentKeyExtensibleAsset = @"m.asset";
+NSString *const kMXMessageContentKeyExtensibleAssetMSC3488 = @"org.matrix.msc3488.asset";
+NSString *const kMXMessageContentKeyExtensibleAssetType = @"type";
+NSString *const kMXMessageContentKeyExtensibleAssetTypeUser = @"m.self";
+
 #pragma mark - MXEvent
 @interface MXEvent ()
 {

--- a/changelog.d/5298.feature
+++ b/changelog.d/5298.feature
@@ -1,0 +1,1 @@
+Added static location sharing sending and rendering support.


### PR DESCRIPTION
Added support for 
- old "m.location" events
- `m.asset` `type`
- both stable and undstable keys