### PR TITLE
🐛 Hangup call with MXCallHangupReasonInviteTimeout reason when invite expires

### DIFF
--- a/MatrixSDK/VoIP/MXCall.m
+++ b/MatrixSDK/VoIP/MXCall.m
@@ -1672,25 +1672,12 @@ NSString *const kMXCallSupportsTransferringStatusDidChange = @"kMXCallSupportsTr
     
     if (inviteExpirationTimer)
     {
+        [inviteExpirationTimer invalidate];
         inviteExpirationTimer = nil;
+    }
 
-        if (!_isIncoming)
-        {
-            // Terminate the call at the stack level we initiated
-            [callStackCall end];
-        }
-
-        // Send the notif that the call expired to the app
-        [self setState:MXCallStateInviteExpired reason:nil];
-        
-        // Set appropriate call end reason
-        _endReason = MXCallEndReasonMissed;
-
-        // And set the final state: MXCallStateEnded
-        [self setState:MXCallStateEnded reason:nil];
-
-        // The call manager can now ignore this call
-        [callManager removeCall:self];
+    if (!_isIncoming) { // hang up on the side of the caller (call initiator)
+      [self hangupWithReason: MXCallHangupReasonInviteTimeout];
     }
 }
 


### PR DESCRIPTION
The iOS client MatrixSDK is using a 30 second timer that is initiated whenever a call invite is sent. Once it fires the state is set to ended, but only locally, and no `.callHangup` with inviteTimeout reason is sent. The PR corrects this to be in line with the [`m.call.hangup` event specification](https://spec.matrix.org/v1.1/client-server-api/#mcallhangup):
> `invite_timeout` for when the other party did not answer in time

Signed-off-by: Frantisek Hetes f.hetes@gmail.com