### PR TITLE
✨ Add missing "user_busy" MXCallHangupEvent

### DIFF
--- a/MatrixSDK/JSONModels/Call/Events/MXCallHangupEventContent.h
+++ b/MatrixSDK/JSONModels/Call/Events/MXCallHangupEventContent.h
@@ -20,6 +20,7 @@
 typedef NS_ENUM(NSInteger, MXCallHangupReason)
 {
     MXCallHangupReasonUserHangup,
+    MXCallHangupReasonUserBusy,
     MXCallHangupReasonIceFailed,
     MXCallHangupReasonInviteTimeout,
     MXCallHangupReasonIceTimeout,
@@ -32,6 +33,7 @@ typedef NSString * MXCallHangupReasonString NS_REFINED_FOR_SWIFT;
 NS_ASSUME_NONNULL_BEGIN
 
 FOUNDATION_EXPORT NSString *const kMXCallHangupReasonStringUserHangup;
+FOUNDATION_EXPORT NSString *const kMXCallHangupReasonStringUserBusy;
 FOUNDATION_EXPORT NSString *const kMXCallHangupReasonStringIceFailed;
 FOUNDATION_EXPORT NSString *const kMXCallHangupReasonStringInviteTimeout;
 FOUNDATION_EXPORT NSString *const kMXCallHangupReasonStringIceTimeout;

--- a/MatrixSDK/JSONModels/Call/Events/MXCallHangupEventContent.m
+++ b/MatrixSDK/JSONModels/Call/Events/MXCallHangupEventContent.m
@@ -18,6 +18,7 @@
 #import "MXTools.h"
 
 NSString *const kMXCallHangupReasonStringUserHangup = @"user_hangup";
+NSString *const kMXCallHangupReasonStringUserBusy = @"user_busy";
 NSString *const kMXCallHangupReasonStringIceFailed = @"ice_failed";
 NSString *const kMXCallHangupReasonStringInviteTimeout = @"invite_timeout";
 NSString *const kMXCallHangupReasonStringIceTimeout = @"ice_timeout";

--- a/MatrixSDK/Utils/MXTools.m
+++ b/MatrixSDK/Utils/MXTools.m
@@ -396,6 +396,9 @@ NSCharacterSet *uriComponentCharset;
         case MXCallHangupReasonUserHangup:
             string = kMXCallHangupReasonStringUserHangup;
             break;
+        case MXCallHangupReasonUserBusy:
+            string = kMXCallHangupReasonStringUserBusy;
+            break;
         case MXCallHangupReasonIceFailed:
             string = kMXCallHangupReasonStringIceFailed;
             break;

--- a/changelog.d/1342.feature
+++ b/changelog.d/1342.feature
@@ -1,0 +1,1 @@
+Add missing "user_busy" MXCallHangupEvent


### PR DESCRIPTION
Missing `MXCallHangupEvent` in iOS MatrixSDK but available in:
- js sdk - [source](https://github.com/matrix-org/matrix-js-sdk/blob/16ca09eed8114d4ef213e3396215e3bef140bc66/src/webrtc/call.ts#L210)
- android sdk - [source](https://github.com/matrix-org/matrix-android-sdk2/blob/c6a636397c51c8be712a08353e54af07cbe2759e/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/call/EndCallReason.kt#L45)

Signed-off-by: Frantisek Hetes f.hetes@gmail.com