### PR TITLE
Update Fastfile to use Xcode 13.2 on CI.

### DIFF
--- a/changelog.d/4883.build
+++ b/changelog.d/4883.build
@@ -1,0 +1,1 @@
+Update Fastfile to use Xcode 13.2 on CI.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -18,7 +18,7 @@ platform :ios do
 
   before_all do
     # Ensure used Xcode version
-    xcversion(version: "~> 12.5")
+    xcversion(version: "~> 13.2")
   end
 
   #### Pod ####


### PR DESCRIPTION
As part of https://github.com/vector-im/element-ios/issues/4883, this PR updates to use Xcode 13.2 on CI.