### PR TITLE
Only count joined rooms when profiling sync performance.

### DIFF
--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -3437,7 +3437,7 @@ MXAuthAction;
             MXJSONModelSetDictionary(join, rooms[@"join"]);
             MXJSONModelSetDictionary(invite, rooms[@"invite"]);
             MXJSONModelSetDictionary(leave, rooms[@"leave"]);
-            initialSyncRequestTaskProfile.units = join.count + invite.count + leave.count;
+            initialSyncRequestTaskProfile.units = join.count;
             
             [profiler stopMeasuringTaskWithProfile:initialSyncRequestTaskProfile];
         }
@@ -3458,7 +3458,7 @@ MXAuthAction;
                 if (initialSyncParsingTaskProfile)
                 {
                     // Contextualise the profiling with the amount of received information
-                    initialSyncParsingTaskProfile.units = syncResponse.rooms.join.count + syncResponse.rooms.invite.count + syncResponse.rooms.leave.count;
+                    initialSyncParsingTaskProfile.units = syncResponse.rooms.join.count;
                     
                     [profiler stopMeasuringTaskWithProfile:initialSyncParsingTaskProfile];
                 }

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -1399,7 +1399,7 @@ typedef void (^MXOnResumeDone)(void);
             self->firstSyncDone = YES;
             
             // Contextualise the profiling with the amount of received information
-            syncTaskProfile.units = syncResponse.rooms.join.count + syncResponse.rooms.invite.count + syncResponse.rooms.leave.count;
+            syncTaskProfile.units = syncResponse.rooms.join.count;
             
             [MXSDKOptions.sharedInstance.profiler stopMeasuringTaskWithProfile:syncTaskProfile];
         }

--- a/changelog.d/5429.change
+++ b/changelog.d/5429.change
@@ -1,0 +1,1 @@
+Only count joined rooms when profiling sync performance.


### PR DESCRIPTION
Fixes #5429.