### PR TITLE
🐛 Protect the `spacesPerId` variable by a barrier

### DIFF
--- a/changelog.d/1350.bugfix
+++ b/changelog.d/1350.bugfix
@@ -1,0 +1,1 @@
+🐛 Protect the spacesPerId variable by a barrier - Fixes Thread 1: EXC_BAD_ACCESS crash that would occur whenever multiple concurrent threads would attempt to mutate spacesPerId at the same time


### PR DESCRIPTION
Fixes Thread 1: EXC_BAD_ACCESS crash that would occur whenever multiple concurrent threads would attempt to mutate `spacesPerId` at the same time.

Signed-off-by: Frantisek Hetes f.hetes@gmail.com