### PR TITLE
🐛Pass `--no-rate-limit` flag to start script during nightly build script

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -94,7 +94,7 @@ jobs:
           source .synapse/bin/activate
           pip install synapse matrix-synapse
           curl -sL https://raw.githubusercontent.com/matrix-org/synapse/develop/demo/start.sh \
-            | sed s/127.0.0.1/0.0.0.0/g | bash
+            | sed s/127.0.0.1/0.0.0.0/g | bash -s -- "--no-rate-limit"
 
       - name: Bundle install
         run: |

--- a/changelog.d/1352.build
+++ b/changelog.d/1352.build
@@ -1,0 +1,1 @@
+Use the --no-rate-limit flag as mentioned in the README


### PR DESCRIPTION
Since nightly script ran into rate limit and doesn't get far. Progress on https://github.com/matrix-org/matrix-ios-sdk/issues/1352


### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request contains a changelog file in ./changelog.d. See https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
