### PR TITLE
Defense against encryption state issues

### DIFF
--- a/MatrixSDK/Crypto/MXCrypto.h
+++ b/MatrixSDK/Crypto/MXCrypto.h
@@ -600,7 +600,17 @@ extern NSString *const MXDeviceListDidUpdateUsersDevicesNotification;
  */
 - (BOOL)isBlacklistUnverifiedDevicesInRoom:(NSString *)roomId;
 
+
 /**
+ Tells if a room is encrypted according to the crypo module.
+ It is different than the summary or state store. The crypto store
+ is more restrictive and can never be reverted to an unsuported algorithm
+ So prefer this when deciding if an event should be sent encrypted as a protection
+ against state broken/reset issues.
+ */
+- (BOOL)isRoomEncrypted:(NSString *)roomId;
+
+/**he
  Set the blacklist of unverified devices in a room.
  
  @param roomId the room id.

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -1881,7 +1881,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 - (BOOL)isRoomEncrypted:(NSString *)roomId
 {
 #ifdef MX_CRYPTO
-    return [_store algorithmForRoom:roomId] != NULL;
+    return [_store algorithmForRoom:roomId] != nil;
 #else
     return NO;
 #endif

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -488,7 +488,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
                 {
                     // If the crypto has been enabled after the initialSync (the global one or the one for this room),
                     // the algorithm has not been initialised yet. So, do it now from room state information
-                    algorithm = roomState.encryptionAlgorithm;
+                    algorithm = [self->_store algorithmForRoom:room.roomId];
                     if (algorithm)
                     {
                         [self setEncryptionInRoom:room.roomId withMembers:userIds algorithm:algorithm inhibitDeviceQuery:NO];
@@ -1873,6 +1873,15 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 {
 #ifdef MX_CRYPTO
     return [_store blacklistUnverifiedDevicesInRoom:roomId];
+#else
+    return NO;
+#endif
+}
+
+- (BOOL)isRoomEncrypted:(NSString *)roomId
+{
+#ifdef MX_CRYPTO
+    return [_store algorithmForRoom:roomId] != NULL;
 #else
     return NO;
 #endif

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -590,7 +590,7 @@ NSInteger const kMXRoomAlreadyJoinedErrorCode = 9001;
 
     // Check whether the content must be encrypted before sending
     if (mxSession.crypto
-        && self.summary.isEncrypted
+        && [mxSession.crypto isRoomEncrypted:self.summary.roomId]
         && [self isEncryptionRequiredForEventType:eventTypeString])
     {
         // Check whether the provided content is already encrypted
@@ -952,7 +952,7 @@ NSInteger const kMXRoomAlreadyJoinedErrorCode = 9001;
     double endRange = 1.0;
     
     // Check whether the content must be encrypted before sending
-    if (mxSession.crypto && self.summary.isEncrypted) endRange = 0.9;
+    if (mxSession.crypto && [mxSession.crypto isRoomEncrypted:self.summary.roomId]) endRange = 0.9;
     
     // Use the uploader id as fake URL for this image data
     // The URL does not need to be valid as the MediaManager will get the data
@@ -1037,7 +1037,7 @@ NSInteger const kMXRoomAlreadyJoinedErrorCode = 9001;
     };
     
     // Add a local echo for this message during the sending process.
-    MXEventSentState initialSentState = (mxSession.crypto && self.summary.isEncrypted) ? MXEventSentStateEncrypting : MXEventSentStateUploading;
+    MXEventSentState initialSentState = (mxSession.crypto && [mxSession.crypto isRoomEncrypted:self.summary.roomId]) ? MXEventSentStateEncrypting : MXEventSentStateUploading;
     event = [self addLocalEchoForMessageContent:msgContent eventType:kMXEventTypeStringRoomMessage withState:initialSentState threadId:threadId];
     
     if (localEcho)
@@ -1051,7 +1051,7 @@ NSInteger const kMXRoomAlreadyJoinedErrorCode = 9001;
         MXStrongifyAndReturnIfNil(self);
 
         // Check whether the content must be encrypted before sending
-        if (self.mxSession.crypto && self.summary.isEncrypted)
+        if (self.mxSession.crypto && [self.mxSession.crypto isRoomEncrypted:self.summary.roomId])
         {
             // Add uploader observer to update the event state
             MXWeakify(self);
@@ -1306,7 +1306,7 @@ NSInteger const kMXRoomAlreadyJoinedErrorCode = 9001;
             msgContent[@"info"][@"h"] = @(size.height);
             msgContent[@"info"][@"duration"] = @((int)floor(durationInMs));
 
-            if (self.mxSession.crypto && self.summary.isEncrypted)
+            if (self.mxSession.crypto && [mxSession.crypto isRoomEncrypted:self.summary.roomId])
             {
                 [MXEncryptedAttachments encryptAttachment:thumbUploader data:videoThumbnailData success:^(MXEncryptedContentFile *result) {
 
@@ -1655,7 +1655,7 @@ NSInteger const kMXRoomAlreadyJoinedErrorCode = 9001;
     };
     
     // Add a local echo for this message during the sending process.
-    MXEventSentState initialSentState = (mxSession.crypto && self.summary.isEncrypted) ? MXEventSentStateEncrypting : MXEventSentStateUploading;
+    MXEventSentState initialSentState = (mxSession.crypto && [mxSession.crypto isRoomEncrypted:self.summary.roomId]) ? MXEventSentStateEncrypting : MXEventSentStateUploading;
     event = [self addLocalEchoForMessageContent:msgContent eventType:kMXEventTypeStringRoomMessage withState:initialSentState threadId:threadId];
     
     if (localEcho)
@@ -1666,7 +1666,7 @@ NSInteger const kMXRoomAlreadyJoinedErrorCode = 9001;
 
     roomOperation = [self preserveOperationOrder:event block:^{
 
-        if (self.mxSession.crypto && self.summary.isEncrypted)
+        if (self.mxSession.crypto && [mxSession.crypto isRoomEncrypted:self.summary.roomId])
         {
             // Register uploader observer
             MXWeakify(self);
@@ -3505,7 +3505,7 @@ NSInteger const kMXRoomAlreadyJoinedErrorCode = 9001;
 {
     MXCrypto *crypto = mxSession.crypto;
     
-    if (crypto && self.summary.isEncrypted)
+    if (crypto && [mxSession.crypto isRoomEncrypted:self.summary.roomId])
     {
         [self members:^(MXRoomMembers *roomMembers) {
             

--- a/changelog.d/5184.bugfix
+++ b/changelog.d/5184.bugfix
@@ -1,0 +1,1 @@
+Protect against encryption state loss


### PR DESCRIPTION
Add some defensive coding when deciding to send encrypted or not in the room.
The decision is based only in the crypto store state (existence of a valid algorithm), instead of the room state.
The crypto store is more stable, only updated with supported alg and never reverted.


### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request contains a changelog file in ./changelog.d. See https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog