### PR TITLE
Fixes for Background Sync Cache Processing

### DIFF
--- a/MatrixSDK/Background/Store/MXSyncResponseStore.swift
+++ b/MatrixSDK/Background/Store/MXSyncResponseStore.swift
@@ -31,6 +31,7 @@ public enum MXSyncResponseStoreError: Error {
     func syncResponseSize(withId id: String) -> Int
     func updateSyncResponse(withId id: String, syncResponse: MXCachedSyncResponse)
     func deleteSyncResponse(withId id: String)
+    func deleteSyncResponses(withIds ids: [String])
     
     /// All ids of valid stored sync responses.
     /// Sync responses are stored in chunks to save RAM when processing it

--- a/MatrixSDK/Background/Store/SyncResponseFileStore/MXSyncResponseFileStore.swift
+++ b/MatrixSDK/Background/Store/SyncResponseFileStore/MXSyncResponseFileStore.swift
@@ -183,6 +183,13 @@ public class MXSyncResponseFileStore: NSObject {
         metadata.outdatedSyncResponseIds.removeAll(where: { $0 == id })
         saveMetaData(metadata)
     }
+
+    private func deleteSyncResponseIds(ids: [String]) {
+        var metadata = readMetaData()
+        metadata.syncResponseIds.removeAll(where: { ids.contains($0) })
+        metadata.outdatedSyncResponseIds.removeAll(where: { ids.contains($0) })
+        saveMetaData(metadata)
+    }
 }
 
 //  MARK: - MXSyncResponseStore
@@ -218,6 +225,13 @@ extension MXSyncResponseFileStore: MXSyncResponseStore {
     public func deleteSyncResponse(withId id: String) {
         saveSyncResponse(path: syncResponsePath(withId: id), syncResponse: nil)
         deleteSyncResponseId(id: id)
+    }
+
+    public func deleteSyncResponses(withIds ids: [String]) {
+        for id in ids {
+            saveSyncResponse(path: syncResponsePath(withId: id), syncResponse: nil)
+        }
+        deleteSyncResponseIds(ids: ids)
     }
     
     public var syncResponseIds: [String] {

--- a/MatrixSDK/Background/Store/SyncResponseFileStore/MXSyncResponseFileStore.swift
+++ b/MatrixSDK/Background/Store/SyncResponseFileStore/MXSyncResponseFileStore.swift
@@ -178,10 +178,7 @@ public class MXSyncResponseFileStore: NSObject {
     }
     
     private func deleteSyncResponseId(id: String) {
-        var metadata = readMetaData()
-        metadata.syncResponseIds.removeAll(where: { $0 == id })
-        metadata.outdatedSyncResponseIds.removeAll(where: { $0 == id })
-        saveMetaData(metadata)
+        deleteSyncResponseIds(ids: [id])
     }
 
     private func deleteSyncResponseIds(ids: [String]) {

--- a/MatrixSDK/Data/EventTimeline/Room/MXRoomEventTimeline.m
+++ b/MatrixSDK/Data/EventTimeline/Room/MXRoomEventTimeline.m
@@ -792,7 +792,7 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
 
         // Retrieve the event from the HS to check whether the redacted event is a state event or not
         MXWeakify(self);
-        httpOperation = [room.mxSession.matrixRestClient eventWithEventId:redactionEvent.redacts inRoom:room.roomId success:^(MXEvent *event) {
+        httpOperation = [room.mxSession eventWithEventId:redactionEvent.redacts inRoom:room.roomId success:^(MXEvent *event) {
             MXStrongifyAndReturnIfNil(self);
 
             if (event.isState)
@@ -822,7 +822,7 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
 
             self->httpOperation = nil;
 
-            MXLogDebug(@"[MXRoomEventTimeline] handleRedaction: failed to retrieved the redacted event");
+            MXLogError(@"[MXRoomEventTimeline] handleRedaction: failed to retrieve the redacted event: %@", error);
         }];
     }
 }

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -2713,7 +2713,9 @@ NSInteger const kMXRoomAlreadyJoinedErrorCode = 9001;
         {
             [self.summary resetLastMessage:nil failure:nil commit:YES];
         }
-    } failure:nil];
+    } failure:^(NSError *error) {
+        MXLogError(@"[MXRoom] removeAllOutgoingMessages: event fetch failed: %@", error);
+    }];
 }
 
 - (void)removeOutgoingMessage:(NSString*)outgoingMessageEventId

--- a/MatrixSDK/Data/MXRoomSummary.m
+++ b/MatrixSDK/Data/MXRoomSummary.m
@@ -500,7 +500,9 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
                                      success:^(MXEvent *event) {
                 MXEvent *editedEvent = [event editedEventFromReplacementEvent:replaceEvent];
                 [self handleEvent:editedEvent];
-            } failure:nil];
+            } failure:^(NSError *error) {
+                MXLogError(@"[MXRoomSummary] registerEventEditsListener: event fetch failed: %@", error);
+            }];
         }
     }];
 }

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -927,18 +927,35 @@ typedef void (^MXOnResumeDone)(void);
 
 - (BOOL)isPauseable
 {
-    return _state == MXSessionStateSyncInProgress
-        || _state == MXSessionStateRunning
-        || _state == MXSessionStateBackgroundSyncInProgress
-        || _state == MXSessionStatePauseRequested;
+    switch (_state)
+    {
+        case MXSessionStateSyncInProgress:
+        case MXSessionStateRunning:
+        case MXSessionStateBackgroundSyncInProgress:
+        case MXSessionStatePauseRequested:
+        case MXSessionStateSyncError:
+        case MXSessionStateHomeserverNotReachable:
+            return YES;
+        default:
+            return NO;
+    }
 }
 
 - (BOOL)isResumable
 {
-    return !eventStreamRequest ||
-        (_state == MXSessionStateBackgroundSyncInProgress
-        || _state == MXSessionStatePauseRequested
-        || _state == MXSessionStatePaused);
+    if (!eventStreamRequest)
+    {
+        return YES;
+    }
+    switch (_state)
+    {
+        case MXSessionStateBackgroundSyncInProgress:
+        case MXSessionStatePauseRequested:
+        case MXSessionStatePaused:
+            return YES;
+        default:
+            return NO;
+    }
 }
 
 - (MXAggregations *)aggregations

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -1990,13 +1990,24 @@ typedef void (^MXOnResumeDone)(void);
         
         //  revert to old state
         [self setState:oldState];
-        
-        if (completion)
-        {
-            completion();
-        }
-        
+
         taskCompleted();
+
+        if (self.hasAnyBackgroundCachedSyncResponses)
+        {
+            //  if there are new sync responses, also process them
+            [self handleBackgroundSyncCacheIfRequiredWithCompletion:completion];
+        }
+        else
+        {
+            //  trigger delete all data here, just to clean up resources
+            [syncResponseStore deleteData];
+
+            if (completion)
+            {
+                completion();
+            }
+        }
     }];
 }
 

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -522,6 +522,7 @@ typedef void (^MXOnResumeDone)(void);
                                     dispatch_group_leave(dispatchGroup);
                                 }
                             } failure:^(NSError *error) {
+                                MXLogError(@"[MXSession] handleSyncResponse: event fetch failed: %@", error);
                                 dispatch_group_leave(dispatchGroup);
                             }];
                         }
@@ -3092,6 +3093,7 @@ typedef void (^MXOnResumeDone)(void);
                 }
                 
             } failure:^(NSError *error) {
+                MXLogError(@"[MXSession] fixRoomsSummariesLastMessage: event fetch failed: %@", error);
                 dispatch_group_leave(dispatchGroup);
             }];
         }
@@ -4615,7 +4617,9 @@ typedef void (^MXOnResumeDone)(void);
             {
                 [summary resetLastMessage:nil failure:nil commit:YES];
             }
-        } failure:nil];
+        } failure:^(NSError *error) {
+            MXLogError(@"[MXSession] onDidDecryptEvent: event fetch failed: %@", error);
+        }];
     }
 }
 

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -2908,10 +2908,7 @@ typedef void (^MXOnResumeDone)(void);
         if (failure)
         {
             MXError *error = [[MXError alloc] initWithErrorCode:kMXErrCodeStringNotFound
-                                                          error:@"Could not find event (null)"
-                                                       userInfo:@{
-                                                           NSLocalizedDescriptionKey: @"Request failed: not found (404)"
-                                                       }];
+                                                          error:@"Could not find event (null)"];
             dispatch_async(dispatch_get_main_queue(), ^{
                 failure(error.createNSError);
             });

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -2938,6 +2938,7 @@ typedef void (^MXOnResumeDone)(void);
 {
     if (eventId == nil)
     {
+        MXLogError(@"[MXSession] eventWithEventId called with no eventId. Call stack: %@", [NSThread callStackSymbols]);
         if (failure)
         {
             MXError *error = [[MXError alloc] initWithErrorCode:kMXErrCodeStringNotFound

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -2902,6 +2902,21 @@ typedef void (^MXOnResumeDone)(void);
                              success:(void (^)(MXEvent *event))success
                              failure:(void (^)(NSError *error))failure
 {
+    if (eventId == nil)
+    {
+        if (failure)
+        {
+            MXError *error = [[MXError alloc] initWithErrorCode:kMXErrCodeStringNotFound
+                                                          error:@"Could not find event (null)"
+                                                       userInfo:@{
+                                                           NSLocalizedDescriptionKey: @"Request failed: not found (404)"
+                                                       }];
+            dispatch_async(dispatch_get_main_queue(), ^{
+                failure(error.createNSError);
+            });
+        }
+        return nil;
+    }
     MXHTTPOperation *operation;
 
     void (^decryptIfNeeded)(MXEvent *event) = ^(MXEvent *event) {

--- a/MatrixSDK/Utils/MXServerNotices.m
+++ b/MatrixSDK/Utils/MXServerNotices.m
@@ -181,7 +181,7 @@ NSUInteger const kMXServerNoticesMaxPinnedNoticesPerRoom = 2;
 
                 } failure:^(NSError *error) {
 
-                    MXLogDebug(@"[MXServerNotices] Failed to get pinned event %@. Continue anyway", pinnedEventId);
+                    MXLogError(@"[MXServerNotices] Failed to get pinned event %@ with error: %@. Continue anyway", pinnedEventId, error);
                     dispatch_group_leave(group);
                 }];
             }

--- a/changelog.d/5426.change
+++ b/changelog.d/5426.change
@@ -1,0 +1,1 @@
+MXSession: Avoid event/null requests and reprocess bg sync cache if received when processing.


### PR DESCRIPTION
Makes a couple of things:
- Avoids `event/(null)` requests and immediately fails them.
- Adds some error logs around `event/(null)` requests.
- Avoids session state back and forth when there is no cached sync responses.
- Adds another bg sync cache processing round in the session if new data received when processing an old one.

Part of vector-im/element-ios#5426