### PR TITLE
Do not pause MXSession if a sync request is cancelled

### DIFF
--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -1544,18 +1544,7 @@ typedef void (^MXOnResumeDone)(void);
         int32_t code = (int32_t)error.code;
 
         if ([error.domain isEqualToString:NSURLErrorDomain]
-            && code == kCFURLErrorCancelled)
-        {
-            MXLogDebug(@"[MXSession] The connection has been cancelled in state: %@", [MXTools readableSessionState:_state]);
-
-            // This happens when the SDK cannot make any more requests because the app is in background
-            // and the background task is expired or going to expire.
-            // The app should have paused the SDK before but it did not. So, pause the SDK ourselves.
-            MXLogDebug(@"[MXSession] -> Go to pause");
-            [self pause];
-        }
-        else if ([error.domain isEqualToString:NSURLErrorDomain]
-                 && code == kCFURLErrorTimedOut && serverTimeout == 0)
+            && code == kCFURLErrorTimedOut && serverTimeout == 0)
         {
             MXLogError(@"[MXSession] The connection has been timeout.");
             // The reconnection attempt failed on timeout: there is no data to retrieve from server

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -1544,7 +1544,15 @@ typedef void (^MXOnResumeDone)(void);
         int32_t code = (int32_t)error.code;
 
         if ([error.domain isEqualToString:NSURLErrorDomain]
-            && code == kCFURLErrorTimedOut && serverTimeout == 0)
+            && code == kCFURLErrorCancelled)
+        {
+            // Individual requests sometimes get correctly cancelled (e.g. the screen which initiated it is deallocated),
+            // and such cancellation should not alter the session in any way, nor re-trigger the sync (as with other error types).
+            // It is still useful to log the cancellation though.
+            MXLogDebug(@"[MXSession] A single request has been cancelled in state: %@", [MXTools readableSessionState:_state]);
+        }
+        else if ([error.domain isEqualToString:NSURLErrorDomain]
+                 && code == kCFURLErrorTimedOut && serverTimeout == 0)
         {
             MXLogError(@"[MXSession] The connection has been timeout.");
             // The reconnection attempt failed on timeout: there is no data to retrieve from server

--- a/changelog.d/5509.bugfix
+++ b/changelog.d/5509.bugfix
@@ -1,0 +1,1 @@
+MXSession: Do not pause the session if a sync fails due to cancellation.


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-ios/issues/5509

A sync request could be cancelled whilst the app is in foreground (e.g. a screen that triggers the sync is deallocated), but this cancellation should not be pausing `MXSession`. Other types of failure correctly re-trigger the sync after some timeout.