### PR TITLE
Exclude all files and directories from iCloud backup

### DIFF
--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -731,6 +731,10 @@
 		9274AFE81EE580240009BEB6 /* MXCallKitAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = 9274AFE61EE580240009BEB6 /* MXCallKitAdapter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9274AFE91EE580240009BEB6 /* MXCallKitAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9274AFE71EE580240009BEB6 /* MXCallKitAdapter.m */; };
 		9CC8EFC1457B94FB58DFF1F7 /* libPods-MatrixSDK-MatrixSDK-macOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FA84A2BE7767F3645CAEC2AF /* libPods-MatrixSDK-MatrixSDK-macOS.a */; };
+		A780624E27B2CE74005780C0 /* FileManager+Backup.swift in Sources */ = {isa = PBXBuildFile; fileRef = A780624C27B2CE74005780C0 /* FileManager+Backup.swift */; };
+		A780624F27B2CE74005780C0 /* FileManager+Backup.swift in Sources */ = {isa = PBXBuildFile; fileRef = A780624C27B2CE74005780C0 /* FileManager+Backup.swift */; };
+		A780625027B2CE74005780C0 /* FileManager+AppGroupContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A780624D27B2CE74005780C0 /* FileManager+AppGroupContainer.swift */; };
+		A780625127B2CE74005780C0 /* FileManager+AppGroupContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A780624D27B2CE74005780C0 /* FileManager+AppGroupContainer.swift */; };
 		A816247C25F60C7700A46F05 /* MXDeviceListOperationsPoolUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A816247B25F60C7700A46F05 /* MXDeviceListOperationsPoolUnitTests.swift */; };
 		A816248525F60D0300A46F05 /* MXDeviceListOperationsPoolUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A816247B25F60C7700A46F05 /* MXDeviceListOperationsPoolUnitTests.swift */; };
 		B105CD9D261E0B70006EB204 /* MXSpaceChildrenSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = B105CD9C261E0B70006EB204 /* MXSpaceChildrenSummary.swift */; };
@@ -2299,6 +2303,8 @@
 		92634B811EF2E3C400DB9F60 /* MXCallKitConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXCallKitConfiguration.m; sourceTree = "<group>"; };
 		9274AFE61EE580240009BEB6 /* MXCallKitAdapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXCallKitAdapter.h; sourceTree = "<group>"; };
 		9274AFE71EE580240009BEB6 /* MXCallKitAdapter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXCallKitAdapter.m; sourceTree = "<group>"; };
+		A780624C27B2CE74005780C0 /* FileManager+Backup.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "FileManager+Backup.swift"; sourceTree = "<group>"; };
+		A780624D27B2CE74005780C0 /* FileManager+AppGroupContainer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "FileManager+AppGroupContainer.swift"; sourceTree = "<group>"; };
 		A816247B25F60C7700A46F05 /* MXDeviceListOperationsPoolUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXDeviceListOperationsPoolUnitTests.swift; sourceTree = "<group>"; };
 		B105CD9C261E0B70006EB204 /* MXSpaceChildrenSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXSpaceChildrenSummary.swift; sourceTree = "<group>"; };
 		B105CDD4261F54C8006EB204 /* MXSpaceChildContent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXSpaceChildContent.h; sourceTree = "<group>"; };
@@ -4647,6 +4653,8 @@
 				321CFDED225264C4004D31DF /* NSArray+MatrixSDK.m */,
 				EC11658B270F3ABF0089FA56 /* RLMRealm+MatrixSDK.h */,
 				EC11658C270F3ABF0089FA56 /* RLMRealm+MatrixSDK.m */,
+				A780624D27B2CE74005780C0 /* FileManager+AppGroupContainer.swift */,
+				A780624C27B2CE74005780C0 /* FileManager+Backup.swift */,
 			);
 			path = Categories;
 			sourceTree = "<group>";
@@ -5838,6 +5846,7 @@
 				32D2CC0323422462002BD8CA /* MX3PidAddSession.m in Sources */,
 				3283F7791EAF30F700C1688C /* MXBugReportRestClient.m in Sources */,
 				32B0E33B23A2989A0054FF1A /* MXEventReferenceChunk.m in Sources */,
+				A780625027B2CE74005780C0 /* FileManager+AppGroupContainer.swift in Sources */,
 				9274AFE91EE580240009BEB6 /* MXCallKitAdapter.m in Sources */,
 				3274538C23FD918800438328 /* MXKeyVerificationByToDeviceRequest.m in Sources */,
 				ECB6FA952683811800A941E4 /* MXiOSAudioOutputRouter.swift in Sources */,
@@ -6023,6 +6032,7 @@
 				C6F9358B1E5B3BE600FC34BF /* MXJSONModels.swift in Sources */,
 				EC8A539725B1BC77004E0802 /* MXCallReplacesEventContent.m in Sources */,
 				32FA10C21FA1C9EE00E54233 /* MXOutgoingRoomKeyRequestManager.m in Sources */,
+				A780624E27B2CE74005780C0 /* FileManager+Backup.swift in Sources */,
 				323547D42226D3F500F15F94 /* MXWellKnown.m in Sources */,
 				320DFDE519DD99B60068622A /* MXRestClient.m in Sources */,
 			);
@@ -6339,6 +6349,7 @@
 				EC1165B727107E330089FA56 /* MXStoreRoomListDataCounts.swift in Sources */,
 				B14EF2392397E90400758AF0 /* MXMediaManager.m in Sources */,
 				B14EF23A2397E90400758AF0 /* MXHTTPOperation.m in Sources */,
+				A780625127B2CE74005780C0 /* FileManager+AppGroupContainer.swift in Sources */,
 				B14EF23B2397E90400758AF0 /* MXKeyBackupData.m in Sources */,
 				B14EF23C2397E90400758AF0 /* MXJSONModels.m in Sources */,
 				EC8A538E25B1BC77004E0802 /* MXCallSessionDescription.m in Sources */,
@@ -6524,6 +6535,7 @@
 				B14EF2912397E90400758AF0 /* MXOutgoingRoomKeyRequestManager.m in Sources */,
 				B14EF2922397E90400758AF0 /* MXWellKnown.m in Sources */,
 				B1A026F926161EF5001AADFF /* MXSpaceChildSummaryResponse.m in Sources */,
+				A780624F27B2CE74005780C0 /* FileManager+Backup.swift in Sources */,
 				B14EF2932397E90400758AF0 /* MXRestClient.m in Sources */,
 				EC60EDD3265CFECC00B39A4E /* MXRoomSyncSummary.m in Sources */,
 			);

--- a/MatrixSDK/Background/Store/SyncResponseFileStore/MXSyncResponseFileStore.swift
+++ b/MatrixSDK/Background/Store/SyncResponseFileStore/MXSyncResponseFileStore.swift
@@ -50,8 +50,8 @@ public class MXSyncResponseFileStore: NSObject {
         }
         var cachePath: URL!
         
-        if let appGroupIdentifier = MXSDKOptions.sharedInstance().applicationGroupIdentifier {
-            cachePath = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroupIdentifier)
+        if let container = FileManager.default.applicationGroupContainerURL() {
+            cachePath = container
         } else {
             cachePath = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
         }
@@ -70,9 +70,7 @@ public class MXSyncResponseFileStore: NSObject {
         fileOperationQueue = DispatchQueue(label: "MXSyncResponseFileStore-" + MXTools.generateSecret())
 
         fileOperationQueue.async {
-            try? FileManager.default.createDirectory(at: syncResponsesFolderPath,
-                                                     withIntermediateDirectories: true,
-                                                     attributes: nil)
+            try? FileManager.default.createDirectoryExcludedFromBackup(at: syncResponsesFolderPath)
             
             // Clean the single cache file used for "v0"
             // TODO: Remove it at some point

--- a/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
+++ b/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
@@ -1751,12 +1751,10 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
 
 + (NSURL*)storeFolderURL
 {
-    // Check for a potential application group id.
-    NSString *applicationGroupIdentifier = [MXSDKOptions sharedInstance].applicationGroupIdentifier;
-    if (applicationGroupIdentifier)
+    // Check for a potential application group container
+    NSURL *sharedContainerURL = [[NSFileManager defaultManager] applicationGroupContainerURL];
+    if (sharedContainerURL)
     {
-        // Use the shared db file URL.
-        NSURL *sharedContainerURL = [[NSFileManager defaultManager] containerURLForSecurityApplicationGroupIdentifier:applicationGroupIdentifier];
         return [sharedContainerURL URLByAppendingPathComponent:kMXRealmCryptoStoreFolder];
     }
     else
@@ -1804,7 +1802,7 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
     if (![NSFileManager.defaultManager fileExistsAtPath:fileFolderURL.path])
     {
         MXLogDebug(@"[MXRealmCryptoStore] ensurePathExistenceForFileAtFileURL: Create full path hierarchy for %@", fileURL);
-        [[NSFileManager defaultManager] createDirectoryAtPath:fileFolderURL.path withIntermediateDirectories:YES attributes:nil error:nil];
+        [[NSFileManager defaultManager] createDirectoryExcludedFromBackupAtPath:fileFolderURL.path error:nil ];
     }
 }
 

--- a/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
+++ b/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
@@ -1802,7 +1802,7 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
     if (![NSFileManager.defaultManager fileExistsAtPath:fileFolderURL.path])
     {
         MXLogDebug(@"[MXRealmCryptoStore] ensurePathExistenceForFileAtFileURL: Create full path hierarchy for %@", fileURL);
-        [[NSFileManager defaultManager] createDirectoryExcludedFromBackupAtPath:fileFolderURL.path error:nil ];
+        [[NSFileManager defaultManager] createDirectoryExcludedFromBackupAtPath:fileFolderURL.path error:nil];
     }
 }
 

--- a/MatrixSDK/Data/RoomSummaryStore/CoreData/MXCoreDataRoomSummaryStore.swift
+++ b/MatrixSDK/Data/RoomSummaryStore/CoreData/MXCoreDataRoomSummaryStore.swift
@@ -46,13 +46,13 @@ public class MXCoreDataRoomSummaryStore: NSObject {
         }
         
         var cachePath: URL!
-        if let appGroupIdentifier = MXSDKOptions.sharedInstance().applicationGroupIdentifier {
-            cachePath = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroupIdentifier)
+        if let container = FileManager.default.applicationGroupContainerURL() {
+            cachePath = container
         } else {
             cachePath = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
         }
         let folderUrl = cachePath.appendingPathComponent(Constants.folderName).appendingPathComponent(userId)
-        try? FileManager.default.createDirectory(at: folderUrl, withIntermediateDirectories: true, attributes: nil)
+        try? FileManager.default.createDirectoryExcludedFromBackup(at: folderUrl)
         return folderUrl.appendingPathComponent(Constants.storeFileName)
     }()
     private static var managedObjectModel: NSManagedObjectModel = {

--- a/MatrixSDK/Data/RoomSummaryStore/File/MXFileRoomSummaryStore.m
+++ b/MatrixSDK/Data/RoomSummaryStore/File/MXFileRoomSummaryStore.m
@@ -54,10 +54,9 @@ static NSString *const kMXFileRoomSummaryStoreFolder = @"MXFileRoomSummaryStore"
     
     NSString *cachePath = nil;
     
-    NSString *applicationGroupIdentifier = [MXSDKOptions sharedInstance].applicationGroupIdentifier;
-    if (applicationGroupIdentifier)
+    NSURL *sharedContainerURL = [[NSFileManager defaultManager] applicationGroupContainerURL];
+    if (sharedContainerURL)
     {
-        NSURL *sharedContainerURL = [[NSFileManager defaultManager] containerURLForSecurityApplicationGroupIdentifier:applicationGroupIdentifier];
         cachePath = [sharedContainerURL path];
     }
     else
@@ -74,10 +73,7 @@ static NSString *const kMXFileRoomSummaryStoreFolder = @"MXFileRoomSummaryStore"
     NSString *folder = storePath;
     if (![NSFileManager.defaultManager fileExistsAtPath:folder])
     {
-        [[NSFileManager defaultManager] createDirectoryAtPath:folder
-                                  withIntermediateDirectories:YES
-                                                   attributes:nil
-                                                        error:nil];
+        [[NSFileManager defaultManager] createDirectoryExcludedFromBackupAtPath:folder error:nil];
     }
 }
 

--- a/MatrixSDK/Data/RoomSummaryStore/File/MXFileRoomSummaryStore.m
+++ b/MatrixSDK/Data/RoomSummaryStore/File/MXFileRoomSummaryStore.m
@@ -15,7 +15,6 @@
 //
 
 #import "MXFileRoomSummaryStore.h"
-#import "MXSDKOptions.h"
 #import "MXTools.h"
 #import "MatrixSDKSwiftHeader.h"
 

--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
@@ -407,10 +407,10 @@ static NSUInteger preloadOptions;
     [[NSFileManager defaultManager] removeItemAtPath:storePath error:&error];
 
     // And create folders back
-    [[NSFileManager defaultManager] createDirectoryAtPath:storePath withIntermediateDirectories:YES attributes:nil error:nil];
-    [[NSFileManager defaultManager] createDirectoryAtPath:storeRoomsPath withIntermediateDirectories:YES attributes:nil error:nil];
-    [[NSFileManager defaultManager] createDirectoryAtPath:storeUsersPath withIntermediateDirectories:YES attributes:nil error:nil];
-    [[NSFileManager defaultManager] createDirectoryAtPath:storeGroupsPath withIntermediateDirectories:YES attributes:nil error:nil];
+    [[NSFileManager defaultManager] createDirectoryExcludedFromBackupAtPath:storePath error:nil];
+    [[NSFileManager defaultManager] createDirectoryExcludedFromBackupAtPath:storeRoomsPath error:nil];
+    [[NSFileManager defaultManager] createDirectoryExcludedFromBackupAtPath:storeUsersPath error:nil];
+    [[NSFileManager defaultManager] createDirectoryExcludedFromBackupAtPath:storeGroupsPath error:nil];
     
     [roomSummaryStore removeAllSummaries];
 
@@ -966,10 +966,9 @@ static NSUInteger preloadOptions;
     
     NSString *cachePath = nil;
     
-    NSString *applicationGroupIdentifier = [MXSDKOptions sharedInstance].applicationGroupIdentifier;
-    if (applicationGroupIdentifier)
+    NSURL *sharedContainerURL = [[NSFileManager defaultManager] applicationGroupContainerURL];
+    if (sharedContainerURL)
     {
-        NSURL *sharedContainerURL = [[NSFileManager defaultManager] containerURLForSecurityApplicationGroupIdentifier:applicationGroupIdentifier];
         cachePath = [sharedContainerURL path];
     }
     else
@@ -1016,7 +1015,7 @@ static NSUInteger preloadOptions;
     NSString *roomFolder = [self folderForRoom:roomId forBackup:backup];
     if (![NSFileManager.defaultManager fileExistsAtPath:roomFolder])
     {
-        [[NSFileManager defaultManager] createDirectoryAtPath:roomFolder withIntermediateDirectories:YES attributes:nil error:nil];
+        [[NSFileManager defaultManager] createDirectoryExcludedFromBackupAtPath:roomFolder error:nil];
     }
 }
 
@@ -1100,7 +1099,7 @@ static NSUInteger preloadOptions;
             NSString *groupBackupFolder = [[storeBackupPath stringByAppendingPathComponent:backupEventStreamToken] stringByAppendingPathComponent:kMXFileStoreGroupsFolder];
             if (![NSFileManager.defaultManager fileExistsAtPath:groupBackupFolder])
             {
-                [[NSFileManager defaultManager] createDirectoryAtPath:groupBackupFolder withIntermediateDirectories:YES attributes:nil error:nil];
+                [[NSFileManager defaultManager] createDirectoryExcludedFromBackupAtPath:groupBackupFolder error:nil];
             }
             
             return [groupBackupFolder stringByAppendingPathComponent:groupId];
@@ -1447,7 +1446,7 @@ static NSUInteger preloadOptions;
                     // Make sure the backup folder exists
                     if (![NSFileManager.defaultManager fileExistsAtPath:self.storeBackupRoomsPath])
                     {
-                        [[NSFileManager defaultManager] createDirectoryAtPath:self.storeBackupRoomsPath withIntermediateDirectories:YES attributes:nil error:nil];
+                        [[NSFileManager defaultManager] createDirectoryExcludedFromBackupAtPath:self.storeBackupRoomsPath error:nil];
                     }
 
                     // Remove the room folder by trashing it into the backup folder
@@ -1602,7 +1601,7 @@ static NSUInteger preloadOptions;
                 NSString *storeBackupMetaDataPath = [self->storeBackupPath stringByAppendingPathComponent:self->backupEventStreamToken];
                 if (![NSFileManager.defaultManager fileExistsAtPath:storeBackupMetaDataPath])
                 {
-                    [[NSFileManager defaultManager] createDirectoryAtPath:storeBackupMetaDataPath withIntermediateDirectories:YES attributes:nil error:nil];
+                    [[NSFileManager defaultManager] createDirectoryExcludedFromBackupAtPath:storeBackupMetaDataPath error:nil];
                 }
                 
                 [[NSFileManager defaultManager] moveItemAtPath:file toPath:backupFile error:nil];
@@ -1655,7 +1654,7 @@ static NSUInteger preloadOptions;
                 NSString *storeBackupMetaDataPath = [self->storeBackupPath stringByAppendingPathComponent:self->backupEventStreamToken];
                 if (![NSFileManager.defaultManager fileExistsAtPath:storeBackupMetaDataPath])
                 {
-                    [[NSFileManager defaultManager] createDirectoryAtPath:storeBackupMetaDataPath withIntermediateDirectories:YES attributes:nil error:nil];
+                    [[NSFileManager defaultManager] createDirectoryExcludedFromBackupAtPath:storeBackupMetaDataPath error:nil];
                 }
 
                 [[NSFileManager defaultManager] moveItemAtPath:file toPath:backupFile error:nil];

--- a/MatrixSDK/Space/MXSpaceFileStore.swift
+++ b/MatrixSDK/Space/MXSpaceFileStore.swift
@@ -97,8 +97,8 @@ class MXSpaceFileStore: MXSpaceStore {
     private func setUpStoragePaths() {
         var _cacheUrl: URL?
         
-        if let applicationGroupIdentifier = MXSDKOptions.sharedInstance().applicationGroupIdentifier {
-            _cacheUrl = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: applicationGroupIdentifier)
+        if let container = FileManager.default.applicationGroupContainerURL() {
+            _cacheUrl = container
         } else {
             let cacheDirList = NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true)
             _cacheUrl = URL(fileURLWithPath: cacheDirList[0])
@@ -114,7 +114,7 @@ class MXSpaceFileStore: MXSpaceStore {
         var isDirectory: ObjCBool = false
         if !FileManager.default.fileExists(atPath: storeUrl.path, isDirectory: &isDirectory) {
             do {
-                try FileManager.default.createDirectory(at: storeUrl, withIntermediateDirectories: true, attributes: nil)
+                try FileManager.default.createDirectoryExcludedFromBackup(at: storeUrl)
                 self.storeUrl = storeUrl
             } catch {
                 MXLog.error("[MXSpaceStore] setUpStoragePaths was unable to create space storage folder: \(error)")

--- a/MatrixSDK/Utils/Categories/FileManager+AppGroupContainer.swift
+++ b/MatrixSDK/Utils/Categories/FileManager+AppGroupContainer.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+internal extension FileManager {
+    
+    /**
+     Get the url of the primary Matrix application group container.
+     */
+    @objc func applicationGroupContainerURL() -> URL? {
+        guard let appGroupId = MXSDKOptions.sharedInstance().applicationGroupIdentifier else {
+            return nil
+        }
+        return containerURL(forSecurityApplicationGroupIdentifier: appGroupId)
+    }
+}

--- a/MatrixSDK/Utils/Categories/FileManager+AppGroupContainer.swift
+++ b/MatrixSDK/Utils/Categories/FileManager+AppGroupContainer.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-internal extension FileManager {
+public extension FileManager {
     
     /**
      Get the url of the primary Matrix application group container.

--- a/MatrixSDK/Utils/Categories/FileManager+AppGroupContainer.swift
+++ b/MatrixSDK/Utils/Categories/FileManager+AppGroupContainer.swift
@@ -1,3 +1,19 @@
+//
+// Copyright 2022 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 import Foundation
 
 internal extension FileManager {

--- a/MatrixSDK/Utils/Categories/FileManager+Backup.swift
+++ b/MatrixSDK/Utils/Categories/FileManager+Backup.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+public extension FileManager {
+    /**
+     Create a directory at a url, including intermediate directories, which is excluded from iCloud / manual backups, no matter where it is located.
+     
+     Note: some directories are excluded automatically if they are nested within `<AppHome>/Library/Caches/` or `<AppHome>/tmp/`
+     see [details](https://developer.apple.com/documentation/foundation/optimizing_app_data_for_icloud_backup).
+     */
+    @objc func createDirectoryExcludedFromBackup(at url: URL) throws {
+        try createDirectory(at: url, withIntermediateDirectories: true, attributes: nil)
+        try excludeFromBackup(url: url)
+    }
+    
+    /**
+     Create a directory at a path, including intermediate directories, which is excluded from iCloud / manual backups, no matter where it is located.
+     
+     Note: some directories are excluded automatically if they are nested within `<AppHome>/Library/Caches/` or `<AppHome>/tmp/`
+     see [details](https://developer.apple.com/documentation/foundation/optimizing_app_data_for_icloud_backup).
+     */
+    @objc func createDirectoryExcludedFromBackup(atPath path: String) throws {
+        try createDirectoryExcludedFromBackup(at: URL(fileURLWithPath: path))
+    }
+    
+    /**
+     Exclude a given url from iCloud / manual backups, no matter where it is located.
+     
+     Note: some directories are excluded automatically if they are nested within `<AppHome>/Library/Caches/` or `<AppHome>/tmp/`
+     see [details](https://developer.apple.com/documentation/foundation/optimizing_app_data_for_icloud_backup).
+     */
+    @objc func excludeFromBackup(url: URL) throws {
+        try (url as NSURL).setResourceValue(true, forKey: .isExcludedFromBackupKey)
+    }
+    
+    /**
+     Exclude all user directories from iCloud / manual backups.
+     
+     User directories include `<AppHome>/Documents`, `<AppHome>/Library`, `<AppHome>/Library/Application Support` etc.
+     Some directories are excluded automatically if they are nested within `<AppHome>/Library/Caches/` or `<AppHome>/tmp/`
+     */
+    func excludeAllUserDirectoriesFromBackup() {
+        // Only `Documents` and `Library` directories need to be specified explicitly. Other directories are either excluded
+        // automatically (`tmp`, `Library/Caches`), or are nested within one of the excluded ones (e.g. `Library/Application Support`)
+        let urls = [
+            urls(for: .documentDirectory, in: .userDomainMask),
+            urls(for: .libraryDirectory, in: .userDomainMask)
+        ].flatMap { $0 }
+        
+        for url in urls {
+            do {
+                try excludeFromBackup(url: url)
+            } catch {
+                MXLog.debug("[FileManager+Backup]: Cannot exclude url from backup: \(error.localizedDescription)")
+            }
+        }
+    }
+    
+    /**
+     Exclude all files and directories inside a shared `AppGroup` container from iCloud / manual backups.
+     
+     Note: the current application will only exclude files / directories for which it has write permissions, typically those which it created.
+     Other files and directories will be unaffected.
+     */
+    func excludeAllAppGroupDirectoriesFromBackup() {
+        guard let container = applicationGroupContainerURL() else {
+            return
+        }
+        
+        // The `AppGroup` container cannot be modified directly, as it is potentially shared between multiple applications.
+        // Instead of that the individial files and directories without the `AppGroup` root can be excluded individually.
+        let urls: [URL]
+        do {
+            urls = try contentsOfDirectory(at: container, includingPropertiesForKeys: nil, options: [])
+        } catch {
+            MXLog.debug("[FileManager+Backup]: Cannot get contents of container: \(error.localizedDescription)")
+            return
+        }
+        
+        for url in urls where isWritableFile(atPath: url.path) {
+            do {
+                try excludeFromBackup(url: url)
+            } catch {
+                MXLog.debug("[FileManager+Backup]: Cannot exclude url from backup: \(error.localizedDescription)")
+            }
+        }
+    }
+}

--- a/MatrixSDK/Utils/Categories/FileManager+Backup.swift
+++ b/MatrixSDK/Utils/Categories/FileManager+Backup.swift
@@ -1,3 +1,19 @@
+//
+// Copyright 2022 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 import Foundation
 
 public extension FileManager {

--- a/MatrixSDK/Utils/Categories/FileManager+Backup.swift
+++ b/MatrixSDK/Utils/Categories/FileManager+Backup.swift
@@ -25,7 +25,7 @@ public extension FileManager {
      */
     @objc func createDirectoryExcludedFromBackup(at url: URL) throws {
         try createDirectory(at: url, withIntermediateDirectories: true, attributes: nil)
-        try excludeFromBackup(url: url)
+        try excludeItemFromBackup(at: url)
     }
     
     /**
@@ -44,7 +44,7 @@ public extension FileManager {
      Note: some directories are excluded automatically if they are nested within `<AppHome>/Library/Caches/` or `<AppHome>/tmp/`
      see [details](https://developer.apple.com/documentation/foundation/optimizing_app_data_for_icloud_backup).
      */
-    @objc func excludeFromBackup(url: URL) throws {
+    @objc func excludeItemFromBackup(at url: URL) throws {
         try (url as NSURL).setResourceValue(true, forKey: .isExcludedFromBackupKey)
     }
     
@@ -64,7 +64,7 @@ public extension FileManager {
         
         for url in urls {
             do {
-                try excludeFromBackup(url: url)
+                try excludeItemFromBackup(at: url)
             } catch {
                 MXLog.debug("[FileManager+Backup]: Cannot exclude url from backup: \(error.localizedDescription)")
             }
@@ -94,7 +94,7 @@ public extension FileManager {
         
         for url in urls where isWritableFile(atPath: url.path) {
             do {
-                try excludeFromBackup(url: url)
+                try excludeItemFromBackup(at: url)
             } catch {
                 MXLog.debug("[FileManager+Backup]: Cannot exclude url from backup: \(error.localizedDescription)")
             }

--- a/MatrixSDK/Utils/Categories/FileManager+Backup.swift
+++ b/MatrixSDK/Utils/Categories/FileManager+Backup.swift
@@ -66,7 +66,7 @@ public extension FileManager {
             do {
                 try excludeItemFromBackup(at: url)
             } catch {
-                MXLog.debug("[FileManager+Backup]: Cannot exclude url from backup: \(error.localizedDescription)")
+                MXLog.error("[FileManager+Backup]: Cannot exclude url from backup: \(error.localizedDescription)")
             }
         }
     }
@@ -88,7 +88,7 @@ public extension FileManager {
         do {
             urls = try contentsOfDirectory(at: container, includingPropertiesForKeys: nil, options: [])
         } catch {
-            MXLog.debug("[FileManager+Backup]: Cannot get contents of container: \(error.localizedDescription)")
+            MXLog.error("[FileManager+Backup]: Cannot get contents of container: \(error.localizedDescription)")
             return
         }
         
@@ -96,7 +96,7 @@ public extension FileManager {
             do {
                 try excludeItemFromBackup(at: url)
             } catch {
-                MXLog.debug("[FileManager+Backup]: Cannot exclude url from backup: \(error.localizedDescription)")
+                MXLog.error("[FileManager+Backup]: Cannot exclude url from backup: \(error.localizedDescription)")
             }
         }
     }

--- a/MatrixSDK/Utils/MXLogger.m
+++ b/MatrixSDK/Utils/MXLogger.m
@@ -18,6 +18,7 @@
 #import "MXLogger.h"
 
 #import "MatrixSDK.h"
+#import "MatrixSDKSwiftHeader.h"
 
 // stderr so it can be restored
 int stderrSave = 0;
@@ -302,10 +303,9 @@ static NSString* crashLogPath(void)
 {
     NSString *logsFolderPath = nil;
 
-    NSString *applicationGroupIdentifier = [MXSDKOptions sharedInstance].applicationGroupIdentifier;
-    if (applicationGroupIdentifier)
+    NSURL *sharedContainerURL = [[NSFileManager defaultManager] applicationGroupContainerURL];
+    if (sharedContainerURL)
     {
-        NSURL *sharedContainerURL = [[NSFileManager defaultManager] containerURLForSecurityApplicationGroupIdentifier:applicationGroupIdentifier];
         logsFolderPath = [sharedContainerURL path];
     }
     else

--- a/changelog.d/5498.change
+++ b/changelog.d/5498.change
@@ -1,0 +1,1 @@
+Exclude all files and directories from iCloud and iTunes backup


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-ios/issues/5498

As listed in [documentation](https://developer.apple.com/documentation/foundation/optimizing_app_data_for_icloud_backup), the iOS is automatically backing up a number of folders to iCloud / iTunes, including `<AppHome>/Documents/` and `<AppHome>/Library/Application Support/`. Additionally the Matrix SDK stores files in `AppGroup` containers (potentially shared between app and an extension), which are also automatically backed up to iCloud. These folders include data for rooms, spaces etc.

To opt-out of backups completely, each url needs to be explicitely marked with `isExcludedFromBackupKey` (this is applied recursively). I converted all `createDirectory` calls with a custom method, which automatically does this when creating a new directory.

This does not yet address smaller files (e.g. User Defaults preferences only created on save) or any future folders, which might be created without the backup exclusion. To solve for this second problem I added two functions `excludeAllUserDirectoriesFromBackup` and `excludeAllAppGroupDirectoriesFromBackup`, which need to be called by the main application (e.g. in `AppDelegate`) and exclude all top-level directories.

Arguably this second approach might make it redundant to explicitly specify backup choice when creating a new folder, however the blanker exclusion is only called at specific moments (e.g. app start), which may be before a particular folder is created. This would expose the folder to backups until the next app launch.