### PR TITLE
Core Data Fix Parameterized Fetch Requests

### DIFF
--- a/MatrixSDK/Data/RoomList/CoreData/MXCoreDataRoomListDataFetcher.swift
+++ b/MatrixSDK/Data/RoomList/CoreData/MXCoreDataRoomListDataFetcher.swift
@@ -444,10 +444,10 @@ private class RoomSummaryForTotalCounts: NSObject, MXRoomSummaryProtocol {
     /// Initializer with a dictionary obtained by a fetch request, with result type `.dictionaryResultType`. Only parses some properties.
     /// - Parameter dictionary: Dictionary object representing an `MXRoomSummaryMO` instance
     init(withDictionary dictionary: [String: Any]) {
-        dataTypes = MXRoomSummaryDataTypes(rawValue: dictionary[kPropertyNameDataTypesInt] as? Int ?? 0)
-        sentStatus = MXRoomSummarySentStatus(rawValue: dictionary[kPropertyNameSentStatusInt] as? UInt ?? 0) ?? .ok
-        notificationCount = dictionary[kPropertyNameNotificationCount] as? UInt ?? 0
-        highlightCount = dictionary[kPropertyNameHighlightCount] as? UInt ?? 0
+        dataTypes = MXRoomSummaryDataTypes(rawValue: Int(dictionary[kPropertyNameDataTypesInt] as? Int64 ?? 0))
+        sentStatus = MXRoomSummarySentStatus(rawValue: UInt(dictionary[kPropertyNameSentStatusInt] as? Int16 ?? 0)) ?? .ok
+        notificationCount = UInt(dictionary[kPropertyNameNotificationCount] as? Int16 ?? 0)
+        highlightCount = UInt(dictionary[kPropertyNameHighlightCount] as? Int16 ?? 0)
         super.init()
     }
 

--- a/MatrixSDK/Data/RoomList/CoreData/MXCoreDataRoomListDataFetcher.swift
+++ b/MatrixSDK/Data/RoomList/CoreData/MXCoreDataRoomListDataFetcher.swift
@@ -99,6 +99,7 @@ internal class MXCoreDataRoomListDataFetcher: NSObject, MXRoomListDataFetcher {
             properties.append(property)
         }
         request.propertiesToFetch = properties
+        //  when specific properties set, use dictionary result type for issues seen mostly on iOS 12 devices
         request.resultType = .dictionaryResultType
         var result: MXRoomListDataCounts? = nil
         do {

--- a/MatrixSDK/Data/RoomList/CoreData/MXCoreDataRoomListDataFetcher.swift
+++ b/MatrixSDK/Data/RoomList/CoreData/MXCoreDataRoomListDataFetcher.swift
@@ -17,6 +17,11 @@
 import Foundation
 import CoreData
 
+private let kPropertyNameDataTypesInt: String = "s_dataTypesInt"
+private let kPropertyNameSentStatusInt: String = "s_sentStatusInt"
+private let kPropertyNameNotificationCount: String = "s_notificationCount"
+private let kPropertyNameHighlightCount: String = "s_highlightCount"
+
 internal typealias MXRoomSummaryCoreDataContextableStore = MXRoomSummaryStore & CoreDataContextable
 
 @objcMembers
@@ -77,13 +82,13 @@ internal class MXCoreDataRoomListDataFetcher: NSObject, MXRoomListDataFetcher {
         guard fetchOptions.paginationOptions != .none else {
             return nil
         }
-        let request = MXRoomSummaryMO.typedFetchRequest()
+        let request = MXRoomSummaryMO.genericFetchRequest()
         request.predicate = filterPredicate(for: filterOptions)
         let propertyNames: [String] = [
-            "s_dataTypesInt",
-            "s_sentStatusInt",
-            "s_notificationCount",
-            "s_highlightCount"
+            kPropertyNameDataTypesInt,
+            kPropertyNameSentStatusInt,
+            kPropertyNameNotificationCount,
+            kPropertyNameHighlightCount
         ]
         var properties: [NSPropertyDescription] = []
         
@@ -94,14 +99,18 @@ internal class MXCoreDataRoomListDataFetcher: NSObject, MXRoomListDataFetcher {
             properties.append(property)
         }
         request.propertiesToFetch = properties
+        request.resultType = .dictionaryResultType
+        var result: MXRoomListDataCounts? = nil
         do {
-            let summaries = try store.mainManagedObjectContext.fetch(request)
-            return MXStoreRoomListDataCounts(withRooms: summaries,
-                                             total: nil)
+            if let dictionaries = try store.mainManagedObjectContext.fetch(request) as? [[String: Any]] {
+                let summaries = dictionaries.map { RoomSummaryForTotalCounts(withDictionary: $0) }
+                result = MXStoreRoomListDataCounts(withRooms: summaries,
+                                                   total: nil)
+            }
         } catch let error {
             MXLog.error("[MXCoreDataRoomListDataFetcher] failed to calculate total counts: \(error)")
-            return nil
         }
+        return result
     }
     
     internal init(session: MXSession?,
@@ -379,4 +388,71 @@ extension MXCoreDataRoomListDataFetcher: NSFetchedResultsControllerDelegate {
         }
     }
     
+}
+
+//  MARK: - RoomSummaryForTotalCounts
+
+/// Room summary implementation specific to total counts calculation.
+private class RoomSummaryForTotalCounts: NSObject, MXRoomSummaryProtocol {
+
+    var roomId: String = ""
+    var roomTypeString: String?
+    var roomType: MXRoomType = .room
+    var avatar: String?
+    var displayname: String?
+    var topic: String?
+    var creatorUserId: String = ""
+    var aliases: [String] = []
+    var joinRule: String? = kMXRoomJoinRuleInvite
+    var membership: MXMembership = .unknown
+    var membershipTransitionState: MXMembershipTransitionState = .unknown
+    var membersCount: MXRoomMembersCount = MXRoomMembersCount(members: 0, joined: 0, invited: 0)
+    var isConferenceUserRoom: Bool = false
+    var hiddenFromUser: Bool = false
+    var storedHash: UInt = 0
+    var lastMessage: MXRoomLastMessage?
+    var isEncrypted: Bool = false
+    var trust: MXUsersTrustLevelSummary?
+    var localUnreadEventCount: UInt = 0
+    var notificationCount: UInt
+    var highlightCount: UInt
+    var hasAnyUnread: Bool {
+        return localUnreadEventCount > 0
+    }
+    var hasAnyNotification: Bool {
+        return notificationCount > 0
+    }
+    var hasAnyHighlight: Bool {
+        return highlightCount > 0
+    }
+    var isDirect: Bool {
+        return isTyped(.direct)
+    }
+    var directUserId: String?
+    var others: [String: NSCoding]?
+    var favoriteTagOrder: String?
+    var dataTypes: MXRoomSummaryDataTypes
+
+    func isTyped(_ types: MXRoomSummaryDataTypes) -> Bool {
+        return (dataTypes.rawValue & types.rawValue) != 0
+    }
+
+    var sentStatus: MXRoomSummarySentStatus
+    var spaceChildInfo: MXSpaceChildInfo?
+    var parentSpaceIds: Set<String> = []
+
+    /// Initializer with a dictionary obtained by a fetch request, with result type `.dictionaryResultType`. Only parses some properties.
+    /// - Parameter dictionary: Dictionary object representing an `MXRoomSummaryMO` instance
+    init(withDictionary dictionary: [String: Any]) {
+        dataTypes = MXRoomSummaryDataTypes(rawValue: dictionary[kPropertyNameDataTypesInt] as? Int ?? 0)
+        sentStatus = MXRoomSummarySentStatus(rawValue: dictionary[kPropertyNameSentStatusInt] as? UInt ?? 0) ?? .ok
+        notificationCount = dictionary[kPropertyNameNotificationCount] as? UInt ?? 0
+        highlightCount = dictionary[kPropertyNameHighlightCount] as? UInt ?? 0
+        super.init()
+    }
+
+    override var description: String {
+        return "<RoomSummaryForTotalCounts: \(roomId) \(String(describing: displayname))>"
+    }
+
 }

--- a/MatrixSDK/Data/RoomSummaryStore/CoreData/MXCoreDataRoomSummaryStore.swift
+++ b/MatrixSDK/Data/RoomSummaryStore/CoreData/MXCoreDataRoomSummaryStore.swift
@@ -99,8 +99,6 @@ public class MXCoreDataRoomSummaryStore: NSObject {
         let request = MXRoomSummaryMO.typedFetchRequest()
         request.includesSubentities = false
         request.includesPropertyValues = false
-        //  fetch nothing
-        request.propertiesToFetch = []
         request.resultType = .countResultType
         var result = 0
         moc.performAndWait {
@@ -119,16 +117,18 @@ public class MXCoreDataRoomSummaryStore: NSObject {
         guard let property = MXRoomSummaryMO.entity().propertiesByName[propertyName] else {
             fatalError("[MXCoreDataRoomSummaryStore] Couldn't find \(propertyName) on entity \(String(describing: MXRoomSummaryMO.self)), probably property name changed")
         }
-        let request = MXRoomSummaryMO.typedFetchRequest()
+        let request = MXRoomSummaryMO.genericFetchRequest()
         request.includesSubentities = false
         //  only fetch room identifiers
         request.propertiesToFetch = [property]
+        request.resultType = .dictionaryResultType
         var result: [String] = []
         moc.performAndWait {
             do {
-                let results = try moc.fetch(request)
-                //  do not attempt to access other properties from the results
-                result = results.map({ $0.s_identifier })
+                if let dictionaries = try moc.fetch(request) as? [[String: Any]] {
+                    //  other properties than 'propertyName' won't exist in the dictionary
+                    result = dictionaries.compactMap({ $0[propertyName] as? String })
+                }
             } catch {
                 MXLog.error("[MXCoreDataRoomSummaryStore] fetchRoomIds failed: \(error)")
             }

--- a/MatrixSDK/Data/RoomSummaryStore/CoreData/MXCoreDataRoomSummaryStore.swift
+++ b/MatrixSDK/Data/RoomSummaryStore/CoreData/MXCoreDataRoomSummaryStore.swift
@@ -121,6 +121,7 @@ public class MXCoreDataRoomSummaryStore: NSObject {
         request.includesSubentities = false
         //  only fetch room identifiers
         request.propertiesToFetch = [property]
+        //  when specific properties set, use dictionary result type for issues seen mostly on iOS 12 devices
         request.resultType = .dictionaryResultType
         var result: [String] = []
         moc.performAndWait {

--- a/MatrixSDK/Data/RoomSummaryStore/CoreData/Models/MXRoomSummaryMO.swift
+++ b/MatrixSDK/Data/RoomSummaryStore/CoreData/Models/MXRoomSummaryMO.swift
@@ -21,7 +21,15 @@ internal let StringArrayDelimiter: String = ";"
 
 @objc(MXRoomSummaryMO)
 public class MXRoomSummaryMO: NSManagedObject {
-    
+
+    /// Fetch request to be used with any kind of result type
+    /// - Returns: NSFetchRequest instance with an abstract result type
+    internal static func genericFetchRequest() -> NSFetchRequest<NSFetchRequestResult> {
+        return NSFetchRequest<NSFetchRequestResult>(entityName: entityName)
+    }
+
+    /// Fetch request to be used with object result type
+    /// - Returns: NSFetchRequest instance with `MXRoomSummaryMO` result type
     internal static func typedFetchRequest() -> NSFetchRequest<MXRoomSummaryMO> {
         return NSFetchRequest<MXRoomSummaryMO>(entityName: entityName)
     }

--- a/changelog.d/5519.bugfix
+++ b/changelog.d/5519.bugfix
@@ -1,0 +1,1 @@
+CoreData: Fix fetch requests fetching only specific properties.


### PR DESCRIPTION
Fix vector-im/element-ios#5519

> This property can be set with [managedObjectResultType](https://developer.apple.com/documentation/coredata/nsfetchrequestresulttype/1506452-managedobjectresulttype) and thereby implement a partial faulting (whereby only some of the properties are populated) of the returned objects, as well as the [dictionaryResultType](https://developer.apple.com/documentation/coredata/nsfetchrequestresulttype/1506237-dictionaryresulttype) to define what properties are included in the resulting [NSDictionary](https://developer.apple.com/documentation/foundation/nsdictionary).

Documentation for `NSFetchRequest.propertiesToFetch` says above, but `managedObjectResultType` it doesn't work properly on some devices, seems mostly on iOS 12.

Will also fix https://github.com/vector-im/element-ios/issues/5528