### PR TITLE
Fix e2ee regression introduced by #1358

### DIFF
--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -488,7 +488,13 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
                 {
                     // If the crypto has been enabled after the initialSync (the global one or the one for this room),
                     // the algorithm has not been initialised yet. So, do it now from room state information
-                    algorithm = [self->_store algorithmForRoom:room.roomId];
+                    algorithm = roomState.encryptionAlgorithm;
+                    if (!algorithm)
+                    {
+                        algorithm = [self->_store algorithmForRoom:room.roomId];
+                        MXLogWarning(@"[MXCrypto] encryptEventContent: roomState.encryptionAlgorithm is nil for room %@. Try to use algorithm in the crypto store: %@", room.roomId, algorithm);
+                    }
+                    
                     if (algorithm)
                     {
                         [self setEncryptionInRoom:room.roomId withMembers:userIds algorithm:algorithm inhibitDeviceQuery:NO];

--- a/MatrixSDK/Data/MXRoomSummary.m
+++ b/MatrixSDK/Data/MXRoomSummary.m
@@ -545,6 +545,13 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
 
 - (void)setIsEncrypted:(BOOL)isEncrypted
 {
+    // This should never happen
+    if (_isEncrypted && !isEncrypted)
+    {
+        MXLogError(@"[MXRoomSummary] setIsEncrypted: Attempt to reset isEncrypted for room %@. Ignote it. Call stack: %@", self.roomId, [NSThread callStackSymbols]);
+        return;
+    }
+    
     _isEncrypted = isEncrypted;
     
     if (_isEncrypted && [MXSDKOptions sharedInstance].computeE2ERoomSummaryTrust)

--- a/MatrixSDKTests/MXCryptoTests.m
+++ b/MatrixSDKTests/MXCryptoTests.m
@@ -3129,6 +3129,8 @@
 }
 
 // Check MXRoom.checkEncryptionState can autofix the disabling of E2E encryption
+// For dev purpose, it is interesting to comment https://github.com/matrix-org/matrix-ios-sdk/blob/610db96cf8e470770f92d6afc40bc4332b240da4/MatrixSDK/Data/MXRoomSummary.m#L552
+//
 // - Alice is in an encrypted room
 // - Try to corrupt summary.isEncrypted
 // - Send a message

--- a/MatrixSDKTests/MXCryptoTests.m
+++ b/MatrixSDKTests/MXCryptoTests.m
@@ -3128,6 +3128,49 @@
     }];
 }
 
+// Check MXRoom.checkEncryptionState can autofix the disabling of E2E encryption
+// - Alice is in an encrypted room
+// - Try to corrupt summary.isEncrypted
+// - Send a message
+// -> The message must be e2e encrypted
+- (void)testBadSummaryIsEncryptedState
+{
+    // - Alice is in an encrypted room
+    [matrixSDKTestsE2EData doE2ETestWithAliceInARoom:self readyToTest:^(MXSession *aliceSession, NSString *roomId, XCTestExpectation *expectation) {
+        
+        NSString *message = @"Hello myself!";
+        
+        MXRoom *roomFromAlicePOV = [aliceSession roomWithRoomId:roomId];
+        
+        XCTAssert(roomFromAlicePOV.summary.isEncrypted);
+        
+        // - Try to corrupt summary.isEncrypted
+        roomFromAlicePOV.summary.isEncrypted = NO;
+        [roomFromAlicePOV.summary save:YES];
+        
+        // - Send a message
+        // Add some delay because there are some dispatch_asyncs in the crypto code
+        // This is a hole but a matter of few ms. This should be fine for real life
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.1 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+            [roomFromAlicePOV sendTextMessage:message threadId:nil success:nil failure:^(NSError *error) {
+                XCTFail(@"Cannot set up intial test conditions - error: %@", error);
+                [expectation fulfill];
+            }];
+        });
+        
+        /// -> The message must be e2e encrypted
+        [roomFromAlicePOV liveTimeline:^(id<MXEventTimeline> liveTimeline) {
+            
+            [liveTimeline listenToEventsOfTypes:@[kMXEventTypeStringRoomMessage] onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
+                
+                XCTAssertEqual(0, [self checkEncryptedEvent:event roomId:roomId clearMessage:message senderSession:aliceSession]);
+                
+                [expectation fulfill];
+            }];
+        }];
+    }];
+}
+
 @end
 
 #pragma clang diagnostic pop

--- a/changelog.d/5564.bugfix
+++ b/changelog.d/5564.bugfix
@@ -1,0 +1,1 @@
+Fix e2ee regression introduced by #1358


### PR DESCRIPTION
Closes https://github.com/vector-im/element-ios/issues/5564.

The source of truth for the encryption of a room is back to `MXRoomSummary.isEncrypted`, which is a rollback of #1358.
The additional change of this PR is that on every send, there is a check if this value is aligned with the one in the crypto store.
There is also some error logs if something tries to reset `MXRoomSummary.isEncrypted`.
