### PR TITLE
Fix room state for peeking

### DIFF
--- a/MatrixSDK/Data/MXRoomState.m
+++ b/MatrixSDK/Data/MXRoomState.m
@@ -562,7 +562,11 @@
     // Update store with new room state when all state event have been processed
     if (_isLive && [mxSession.store respondsToSelector:@selector(storeStateForRoom:stateEvents:)])
     {
-        [mxSession.store storeStateForRoom:_roomId stateEvents:self.stateEvents];
+        MXRoom *currentRoom = [mxSession roomWithRoomId:_roomId];
+        // Check if the room membership is different from Unknown.
+        if (currentRoom.summary.membership != MXMembershipUnknown) {
+            [mxSession.store storeStateForRoom:_roomId stateEvents:self.stateEvents];
+        }
     }
 }
 


### PR DESCRIPTION
During a bug investigation, we found that the FileStore may be corrupted with peeking feature (when previewing a room), but not joining the room after previewing it.

In result, we had a « ghost » room in the room list, with some content, but not all the content of this room (ie: no room summary, but messages were visible, and we can pickup the previous messages when scrolling), instead of having nothing.

So I added a condition on Unknown membership rooms to avoid to add them to the file store.