### PR TITLE
Release 0.22.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## Changes in 0.22.3 (2022-02-24)
+
+🐛 Bugfixes
+
+- Thread Safety: Replace all objc_sync_enter/exit methods with recursive locks. ([#5675](https://github.com/vector-im/element-ios/issues/5675))
+
+
 ## Changes in 0.22.2 (2022-02-22)
 
 🙌 Improvements

--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "MatrixSDK"
-  s.version      = "0.22.2"
+  s.version      = "0.22.3"
   s.summary      = "The iOS SDK to build apps compatible with Matrix (https://www.matrix.org)"
 
   s.description  = <<-DESC

--- a/MatrixSDK/Data/EventTimeline/Thread/MXThreadEventTimeline.swift
+++ b/MatrixSDK/Data/EventTimeline/Thread/MXThreadEventTimeline.swift
@@ -55,6 +55,7 @@ public class MXThreadEventTimeline: NSObject, MXEventTimeline {
     
     /// The current pending request
     private var currentHttpOperation: MXHTTPOperation?
+    private let lockListeners = NSRecursiveLock()
     
     private lazy var threadEventFilter: MXRoomEventFilter = {
         let filter = MXRoomEventFilter()
@@ -439,9 +440,9 @@ public class MXThreadEventTimeline: NSObject, MXEventTimeline {
     
     /// Thread safe access to listeners array
     private func synchronizeListeners(_ block: () -> Void) {
-        objc_sync_enter(listeners)
+        lockListeners.lock()
+        defer { lockListeners.unlock() }
         block()
-        objc_sync_exit(listeners)
     }
     
     private func fixRoomId(inEvents events: [MXEvent]) {

--- a/MatrixSDK/MatrixSDKVersion.m
+++ b/MatrixSDK/MatrixSDKVersion.m
@@ -16,4 +16,4 @@
 
 #import <Foundation/Foundation.h>
 
-NSString *const MatrixSDKVersion = @"0.22.2";
+NSString *const MatrixSDKVersion = @"0.22.3";

--- a/MatrixSDK/Threads/MXThreadingService.swift
+++ b/MatrixSDK/Threads/MXThreadingService.swift
@@ -46,6 +46,7 @@ public class MXThreadingService: NSObject {
     
     private weak var session: MXSession?
     
+    private let lockThreads = NSRecursiveLock()
     private var threads: [String: MXThread] = [:]
     private let multicastDelegate: MXMulticastDelegate<MXThreadingServiceDelegate> = MXMulticastDelegate()
     
@@ -110,10 +111,9 @@ public class MXThreadingService: NSObject {
     /// - Parameter identifier: identifier of a thread
     /// - Returns: thread instance if found, nil otherwise
     public func thread(withId identifier: String) -> MXThread? {
-        objc_sync_enter(threads)
-        let result = threads[identifier]
-        objc_sync_exit(threads)
-        return result
+        lockThreads.lock()
+        defer { lockThreads.unlock() }
+        return threads[identifier]
     }
     
     public func createTempThread(withId identifier: String, roomId: String) -> MXThread {
@@ -308,9 +308,9 @@ public class MXThreadingService: NSObject {
     }
     
     private func saveThread(_ thread: MXThread) {
-        objc_sync_enter(threads)
+        lockThreads.lock()
+        defer { lockThreads.unlock() }
         threads[thread.id] = thread
-        objc_sync_exit(threads)
     }
     
     //  MARK: - Delegate

--- a/MatrixSDK/Utils/MXMulticastDelegate.swift
+++ b/MatrixSDK/Utils/MXMulticastDelegate.swift
@@ -22,6 +22,7 @@ public class MXMulticastDelegate <T: AnyObject> {
     /// Weakly referenced delegates
     private let delegates: NSHashTable<T> = NSHashTable.weakObjects()
     private let dispatchQueue: DispatchQueue
+    private let lockDelegates = NSRecursiveLock()
     
     /// Initializer
     /// - Parameter dispatchQueue: Queue to invoke delegate methods
@@ -70,9 +71,9 @@ public class MXMulticastDelegate <T: AnyObject> {
     
     /// Thread safe access to delegates array
     private func synchronizeDelegates(_ block: () -> Void) {
-        objc_sync_enter(delegates)
+        lockDelegates.lock()
+        defer { lockDelegates.unlock() }
         block()
-        objc_sync_exit(delegates)
     }
     
     deinit {

--- a/changelog.d/5675.bugfix
+++ b/changelog.d/5675.bugfix
@@ -1,1 +1,0 @@
-Thread Safety: Replace all objc_sync_enter/exit methods with recursive locks.

--- a/changelog.d/5675.bugfix
+++ b/changelog.d/5675.bugfix
@@ -1,0 +1,1 @@
+Thread Safety: Replace all objc_sync_enter/exit methods with recursive locks.


### PR DESCRIPTION
This PR prepares the release of MatrixSDK v0.22.3.

Notes:
- This PR targets `release/0.22.3/master`, which has been cut from `master`.
- It includes changes to the `Podfile`, but _not_ the corresponding changes to `Podfile.lock`, as `pod install` hasn't yet been run.
  This is because the `Podfile` targets future versions of dependencies yet to be released, so `pod install` wouldn't be able to find them yet.
- When the CI runs its checks, it will temporarily point to the pending release branches of those dependencies beforehand
- It is only during `release:finish` that `pod update` will be run -- updating the `Podfile.lock`
to use the now officially released dependencies -- before ultimately merging `release/0.22.3/master` into `master` to tag the release.

---

➡️  Once this PR is merged, you will need to first ensure that the products this one depends on are fully released,
   then run `bundle exec rake release:finish` to close this release.

💡 If you want to review _only_ the changes made since the release branch was cut from `develop`,
   you can [check those here](https://github.com/matrix-org/matrix-ios-sdk/compare/develop...release/0.22.3/release)
