### PR TITLE
Release 0.22.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## Changes in 0.22.4 (2022-02-25)
+
+🙌 Improvements
+
+- MXThreadingService: Add thread creation delegate method. ([#5694](https://github.com/vector-im/element-ios/issues/5694))
+
+
 ## Changes in 0.22.3 (2022-02-24)
 
 🐛 Bugfixes

--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "MatrixSDK"
-  s.version      = "0.22.3"
+  s.version      = "0.22.4"
   s.summary      = "The iOS SDK to build apps compatible with Matrix (https://www.matrix.org)"
 
   s.description  = <<-DESC

--- a/MatrixSDK/Data/EventTimeline/Room/MXRoomEventTimeline.m
+++ b/MatrixSDK/Data/EventTimeline/Room/MXRoomEventTimeline.m
@@ -290,7 +290,7 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
     [self paginateFromStore:numItems direction:direction onComplete:^(NSArray<MXEvent *> *eventsFromStore) {
         MXStrongifyAndReturnIfNil(self);
         
-        NSUInteger remainingNumItems = numItems;
+        NSInteger remainingNumItems = numItems;
         NSUInteger eventsFromStoreCount = eventsFromStore.count;
 
         if (direction == MXTimelineDirectionBackwards)

--- a/MatrixSDK/Data/EventTimeline/Thread/MXThreadEventTimeline.swift
+++ b/MatrixSDK/Data/EventTimeline/Thread/MXThreadEventTimeline.swift
@@ -216,8 +216,8 @@ public class MXThreadEventTimeline: NSObject, MXEventTimeline {
         paginateFromStore(numberOfItems: numItems, direction: direction) { [weak self] eventsFromStore in
             guard let self = self else { return }
             
-            var remainingNumItems = numItems
-            let eventsFromStoreCount = UInt(eventsFromStore.count)
+            var remainingNumItems = Int(numItems)
+            let eventsFromStoreCount = eventsFromStore.count
             
             if direction == .backwards {
                 // messagesFromStore are in chronological order
@@ -237,7 +237,7 @@ public class MXThreadEventTimeline: NSObject, MXEventTimeline {
                     return
                 }
                 
-                if remainingNumItems <= 0 && self.hasReachedHomeServerBackwardsPaginationEnd {
+                if remainingNumItems <= 0 || self.hasReachedHomeServerBackwardsPaginationEnd {
                     DispatchQueue.main.async {
                         // Nothing more to do
                         MXLog.debug("[MXThreadEventTimeline][\(self.timelineId)] paginate: is done from the store")
@@ -276,7 +276,7 @@ public class MXThreadEventTimeline: NSObject, MXEventTimeline {
                                                             eventType: nil,
                                                             from: paginationToken,
                                                             direction: direction,
-                                                            limit: remainingNumItems,
+                                                            limit: UInt(remainingNumItems),
                                                             completion: { [weak self] response in
                                                                 guard let self = self else { return }
                                                                 switch response {

--- a/MatrixSDK/MatrixSDKVersion.m
+++ b/MatrixSDK/MatrixSDKVersion.m
@@ -16,4 +16,4 @@
 
 #import <Foundation/Foundation.h>
 
-NSString *const MatrixSDKVersion = @"0.22.3";
+NSString *const MatrixSDKVersion = @"0.22.4";

--- a/MatrixSDKTests/MXThreadingServiceTests.swift
+++ b/MatrixSDKTests/MXThreadingServiceTests.swift
@@ -79,27 +79,22 @@ class MXThreadingServiceTests: XCTestCase {
                     initialRoom.sendTextMessage("Thread message", threadId: threadId, localEcho: &localEcho) { response2 in
                         switch response2 {
                         case .success(let eventId):
-                            var observer: NSObjectProtocol?
-                            observer = NotificationCenter.default.addObserver(forName: MXThreadingService.newThreadCreated,
-                                                                              object: nil,
-                                                                              queue: .main) { notification in
-                                if let observer = observer {
-                                    NotificationCenter.default.removeObserver(observer)
-                                }
+                            threadingService.addDelegate(MockThreadingServiceDelegate(withNewThreadBlock: { _ in
+                                threadingService.removeAllDelegates()
                                 guard let thread = threadingService.thread(withId: threadId) else {
                                     XCTFail("Thread must be created")
                                     expectation.fulfill()
                                     return
                                 }
-                                
+
                                 XCTAssertEqual(thread.id, threadId, "Thread must have the correct id")
                                 XCTAssertEqual(thread.roomId, initialRoom.roomId, "Thread must have the correct room id")
                                 XCTAssertEqual(thread.lastMessage?.eventId, eventId, "Thread last message must have the correct event id")
                                 XCTAssertNotNil(thread.rootMessage, "Thread must have the root event")
                                 XCTAssertEqual(thread.numberOfReplies, 1, "Thread must have only 1 reply")
-                                
+
                                 expectation.fulfill()
-                            }
+                            }))
                         case .failure(let error):
                             XCTFail("Failed to setup test conditions: \(error)")
                             expectation.fulfill()
@@ -151,13 +146,8 @@ class MXThreadingServiceTests: XCTestCase {
                                                 localEcho: &localEcho) { response2 in
                         switch response2 {
                         case .success:
-                            var observer: NSObjectProtocol?
-                            observer = NotificationCenter.default.addObserver(forName: MXThreadingService.newThreadCreated,
-                                                                              object: nil,
-                                                                              queue: .main) { notification in
-                                if let observer = observer {
-                                    NotificationCenter.default.removeObserver(observer)
-                                }
+                            threadingService.addDelegate(MockThreadingServiceDelegate(withNewThreadBlock: { _ in
+                                threadingService.removeAllDelegates()
                                 guard let thread = threadingService.thread(withId: threadId) else {
                                     XCTFail("Thread must be created")
                                     expectation.fulfill()
@@ -189,7 +179,7 @@ class MXThreadingServiceTests: XCTestCase {
                                         expectation.fulfill()
                                     }
                                 }
-                            }
+                            }))
                         case .failure(let error):
                             XCTFail("Failed to setup test conditions: \(error)")
                             expectation.fulfill()
@@ -237,13 +227,8 @@ class MXThreadingServiceTests: XCTestCase {
                     initialRoom.sendTextMessage("Thread message", threadId: threadId, localEcho: &localEcho) { response2 in
                         switch response2 {
                         case .success(let lastEventId):
-                            var observer: NSObjectProtocol?
-                            observer = NotificationCenter.default.addObserver(forName: MXThreadingService.newThreadCreated,
-                                                                              object: nil,
-                                                                              queue: .main) { notification in
-                                if let observer = observer {
-                                    NotificationCenter.default.removeObserver(observer)
-                                }
+                            threadingService.addDelegate(MockThreadingServiceDelegate(withNewThreadBlock: { _ in
+                                threadingService.removeAllDelegates()
                                 guard let thread = threadingService.thread(withId: threadId),
                                       let lastMessage = thread.lastMessage else {
                                     XCTFail("Thread must be created with a last message")
@@ -269,14 +254,15 @@ class MXThreadingServiceTests: XCTestCase {
                                             }
                                             
                                             XCTAssertEqual(replyEvent.threadId, threadId, "Reply must also be in the thread")
-                                            
-                                            guard let relatesTo = replyEvent.content[kMXEventRelationRelatesToKey] as? [String: Any],
-                                                  let inReplyTo = relatesTo["m.in_reply_to"] as? [String: String] else {
-                                                XCTFail("Reply event must have a reply-to dictionary in the content")
-                                                expectation.fulfill()
-                                                return
-                                            }
-                                            XCTAssertEqual(inReplyTo["event_id"], lastEventId, "Reply must point to the last message event")
+
+                                            XCTAssertEqual(replyEvent.relatesTo?.inReplyTo?.eventId, lastEventId, "Reply must point to the last message event")
+//                                            guard let relatesTo = replyEvent.content[kMXEventRelationRelatesToKey] as? [String: Any],
+//                                                  let inReplyTo = relatesTo["m.in_reply_to"] as? [String: Any] else {
+//                                                XCTFail("Reply event must have a reply-to dictionary in the content")
+//                                                expectation.fulfill()
+//                                                return
+//                                            }
+//                                            XCTAssertEqual(inReplyTo["event_id"] as? String, lastEventId, "Reply must point to the last message event")
                                             
                                             expectation.fulfill()
                                         }
@@ -285,7 +271,7 @@ class MXThreadingServiceTests: XCTestCase {
                                         expectation.fulfill()
                                     }
                                 }
-                            }
+                            }))
                         case .failure(let error):
                             XCTFail("Failed to setup test conditions: \(error)")
                             expectation.fulfill()
@@ -335,13 +321,8 @@ class MXThreadingServiceTests: XCTestCase {
                     initialRoom.sendTextMessage("Thread message", threadId: threadId, localEcho: &localEcho) { response2 in
                         switch response2 {
                         case .success(let eventId):
-                            var observer: NSObjectProtocol?
-                            observer = NotificationCenter.default.addObserver(forName: MXThreadingService.newThreadCreated,
-                                                                              object: nil,
-                                                                              queue: .main) { notification in
-                                if let observer = observer {
-                                    NotificationCenter.default.removeObserver(observer)
-                                }
+                            threadingService.addDelegate(MockThreadingServiceDelegate(withNewThreadBlock: { _ in
+                                threadingService.removeAllDelegates()
                                 threadingService.allThreads(inRoom: initialRoom.roomId) { response in
                                     switch response {
                                     case .success(let threads):
@@ -362,7 +343,7 @@ class MXThreadingServiceTests: XCTestCase {
                                     }
                                     expectation.fulfill()
                                 }
-                            }
+                            }))
                         case .failure(let error):
                             XCTFail("Failed to setup test conditions: \(error)")
                             expectation.fulfill()
@@ -417,13 +398,8 @@ class MXThreadingServiceTests: XCTestCase {
                     initialRoom.sendTextMessage("Thread message 1", threadId: threadId1, localEcho: &localEcho) { response2 in
                         switch response2 {
                         case .success:
-                            var observer: NSObjectProtocol?
-                            observer = NotificationCenter.default.addObserver(forName: MXThreadingService.newThreadCreated,
-                                                                              object: nil,
-                                                                              queue: .main) { notification in
-                                if let observer = observer {
-                                    NotificationCenter.default.removeObserver(observer)
-                                }
+                            threadingService.addDelegate(MockThreadingServiceDelegate(withNewThreadBlock: { _ in
+                                threadingService.removeAllDelegates()
                                 
                                 initialRoom.sendTextMessage("Root message 2",
                                                             threadId: nil,
@@ -439,40 +415,35 @@ class MXThreadingServiceTests: XCTestCase {
                                         initialRoom.sendTextMessage("Thread message 2", threadId: threadId2, localEcho: &localEcho) { response2 in
                                             switch response2 {
                                             case .success:
-                                                var observer: NSObjectProtocol?
-                                                observer = NotificationCenter.default.addObserver(forName: MXThreadingService.newThreadCreated,
-                                                                                                  object: nil,
-                                                                                                  queue: .main) { notification in
-                                                    if let observer = observer {
-                                                        NotificationCenter.default.removeObserver(observer)
+                                                threadingService.addDelegate(MockThreadingServiceDelegate(withNewThreadBlock: { _ in
+                                                    threadingService.removeAllDelegates()
 
-                                                        threadingService.allThreads(inRoom: initialRoom.roomId) { response in
-                                                            switch response {
-                                                            case .success(let threads):
-                                                                XCTAssertEqual(threads.count, 2, "Must have 2 threads")
-                                                                XCTAssertEqual(threads.first?.id, threadId2, "Latest thread must be in the first position")
-                                                                XCTAssertEqual(threads.last?.id, threadId1, "Older thread must be in the last position")
+                                                    threadingService.allThreads(inRoom: initialRoom.roomId) { response in
+                                                        switch response {
+                                                        case .success(let threads):
+                                                            XCTAssertEqual(threads.count, 2, "Must have 2 threads")
+                                                            XCTAssertEqual(threads.first?.id, threadId2, "Latest thread must be in the first position")
+                                                            XCTAssertEqual(threads.last?.id, threadId1, "Older thread must be in the last position")
 
-                                                                threadingService.allThreads(inRoom: initialRoom.roomId, onlyParticipated: true) { response2 in
-                                                                    switch response2 {
-                                                                    case .success(let participatedThreads):
-                                                                        XCTAssertEqual(participatedThreads.count, 2, "Must have 2 participated threads")
-                                                                        XCTAssertEqual(participatedThreads.first?.id, threadId2, "Latest thread must be in the first position")
-                                                                        XCTAssertEqual(participatedThreads.last?.id, threadId1, "Older thread must be in the last position")
-                                                                        
-                                                                        expectation.fulfill()
-                                                                    case .failure(let error):
-                                                                        XCTFail("Failed to setup test conditions: \(error)")
-                                                                        expectation.fulfill()
-                                                                    }
+                                                            threadingService.allThreads(inRoom: initialRoom.roomId, onlyParticipated: true) { response2 in
+                                                                switch response2 {
+                                                                case .success(let participatedThreads):
+                                                                    XCTAssertEqual(participatedThreads.count, 2, "Must have 2 participated threads")
+                                                                    XCTAssertEqual(participatedThreads.first?.id, threadId2, "Latest thread must be in the first position")
+                                                                    XCTAssertEqual(participatedThreads.last?.id, threadId1, "Older thread must be in the last position")
+
+                                                                    expectation.fulfill()
+                                                                case .failure(let error):
+                                                                    XCTFail("Failed to setup test conditions: \(error)")
+                                                                    expectation.fulfill()
                                                                 }
-                                                            case .failure(let error):
-                                                                XCTFail("Failed to setup test conditions: \(error)")
-                                                                expectation.fulfill()
                                                             }
+                                                        case .failure(let error):
+                                                            XCTFail("Failed to setup test conditions: \(error)")
+                                                            expectation.fulfill()
                                                         }
                                                     }
-                                                }
+                                                }))
                                             case .failure(let error):
                                                 XCTFail("Failed to setup test conditions: \(error)")
                                                 expectation.fulfill()
@@ -485,7 +456,7 @@ class MXThreadingServiceTests: XCTestCase {
                                 }
                                 
                                 expectation.fulfill()
-                            }
+                            }))
                         case .failure(let error):
                             XCTFail("Failed to setup test conditions: \(error)")
                             expectation.fulfill()
@@ -498,4 +469,23 @@ class MXThreadingServiceTests: XCTestCase {
             }
         }
     }
+}
+
+private class MockThreadingServiceDelegate: MXThreadingServiceDelegate {
+
+    private let newThreadBlock: ((MXThread) -> Void)
+    private static var instance: MockThreadingServiceDelegate?
+
+    init(withNewThreadBlock newThreadBlock: @escaping (MXThread) -> Void) {
+        self.newThreadBlock = newThreadBlock
+        //  do not allow this to be deallocated
+        Self.instance = self
+    }
+
+    func threadingService(_ service: MXThreadingService,
+                          didCreateNewThread thread: MXThread,
+                          direction: MXTimelineDirection) {
+        newThreadBlock(thread)
+    }
+
 }

--- a/changelog.d/5694.change
+++ b/changelog.d/5694.change
@@ -1,0 +1,1 @@
+MXThreadingService: Add thread creation delegate method.

--- a/changelog.d/5694.change
+++ b/changelog.d/5694.change
@@ -1,1 +1,0 @@
-MXThreadingService: Add thread creation delegate method.


### PR DESCRIPTION
This PR prepares the release of MatrixSDK v0.22.4.

Notes:
- This PR targets `release/0.22.4/master`, which has been cut from `master`.
- It includes changes to the `Podfile`, but _not_ the corresponding changes to `Podfile.lock`, as `pod install` hasn't yet been run.
  This is because the `Podfile` targets future versions of dependencies yet to be released, so `pod install` wouldn't be able to find them yet.
- When the CI runs its checks, it will temporarily point to the pending release branches of those dependencies beforehand
- It is only during `release:finish` that `pod update` will be run -- updating the `Podfile.lock`
to use the now officially released dependencies -- before ultimately merging `release/0.22.4/master` into `master` to tag the release.

---

➡️  Once this PR is merged, you will need to first ensure that the products this one depends on are fully released,
   then run `bundle exec rake release:finish` to close this release.

💡 If you want to review _only_ the changes made since the release branch was cut from `develop`,
   you can [check those here](https://github.com/matrix-org/matrix-ios-sdk/compare/develop...release/0.22.4/release)
