### PR TITLE
Fix room state membersCount not being set in time

### DIFF
--- a/MatrixSDK/Data/MXRoomState.m
+++ b/MatrixSDK/Data/MXRoomState.m
@@ -77,7 +77,9 @@
         
         stateEvents = [NSMutableDictionary dictionary];
         _members = [[MXRoomMembers alloc] initWithRoomState:self andMatrixSession:mxSession];
-        _membersCount = [MXRoomMembersCount new];
+        _membersCount = [[MXRoomMembersCount alloc] initWithMembers:_members.members.count
+                                                             joined:_members.joinedMembers.count
+                                                            invited:[_members membersWithMembership:MXMembershipInvite].count];
         roomAliases = [NSMutableDictionary dictionary];
         thirdPartyInvites = [NSMutableDictionary dictionary];
         membersWithThirdPartyInviteTokenCache = [NSMutableDictionary dictionary];

--- a/changelog.d/4949.bugfix
+++ b/changelog.d/4949.bugfix
@@ -1,0 +1,1 @@
+Room: fix crash on members count not being always properly set


### PR DESCRIPTION
Should fix https://github.com/vector-im/element-ios/issues/4949

I'm not 100% sure it's okay to init the object this way (or at this moment rather), but this [new] call seems to be the only way to have a memberCounts object with non-initialized properties