### PR TITLE
`MXRoomEventFilter`: New property names for relation types and senders

### DIFF
--- a/MatrixSDK/Data/EventTimeline/Thread/MXThreadEventTimeline.swift
+++ b/MatrixSDK/Data/EventTimeline/Thread/MXThreadEventTimeline.swift
@@ -59,7 +59,7 @@ public class MXThreadEventTimeline: NSObject, MXEventTimeline {
     
     private lazy var threadEventFilter: MXRoomEventFilter = {
         let filter = MXRoomEventFilter()
-        filter.relationTypes = [MXEventRelationTypeThread]
+        filter.relatedByTypes = [MXEventRelationTypeThread]
         return filter
     }()
     

--- a/MatrixSDK/Data/Filters/MXRoomEventFilter.h
+++ b/MatrixSDK/Data/Filters/MXRoomEventFilter.h
@@ -66,14 +66,16 @@
 @property (nonatomic) NSArray<NSString*> *notSenders;
 
 /**
- A list of relation types which must be bundled with the event to include it. If this list is absent then no filtering is done on relation types.
+ A list of relation types to include. An event `A` is included in the filter only if there exists another event `B`,
+ which relates to `A` with a relation type included in the list.
+ If this list is absent then no filtering is done on relation types.
  */
-@property (nonatomic) NSArray<NSString*> *relationTypes;
+@property (nonatomic) NSArray<NSString*> *relatedByTypes;
 
 /**
- A list of senders of relations
+ A list of senders to include. An event `A` is included in the filter only if there exists another event `B` which relates to `A` and has a `sender` included in the list.
  */
-@property (nonatomic) NSArray<NSString*> *relationSenders;
+@property (nonatomic) NSArray<NSString*> *relatedBySenders;
 
 /**
  The maximum number of events to return.

--- a/MatrixSDK/Data/Filters/MXRoomEventFilter.h
+++ b/MatrixSDK/Data/Filters/MXRoomEventFilter.h
@@ -73,7 +73,7 @@
 @property (nonatomic) NSArray<NSString*> *relatedByTypes;
 
 /**
- A list of senders to include. An event `A` is included in the filter only if there exists another event `B` which relates to `A` and has a `sender` included in the list.
+ A list of senders to include. An event `A` is included in the filter only if there exists another event `B` which relates to `A` and `sender` of `A` is included in the list.
  */
 @property (nonatomic) NSArray<NSString*> *relatedBySenders;
 

--- a/MatrixSDK/Data/Filters/MXRoomEventFilter.m
+++ b/MatrixSDK/Data/Filters/MXRoomEventFilter.m
@@ -22,8 +22,8 @@
 
 //  TODO: Replace when the MSC merged
 //  https://github.com/matrix-org/matrix-doc/pull/3440
-NSString *const kMXRoomEventFilterKeyRelationTypes = @"io.element.relation_types";
-NSString *const kMXRoomEventFilterKeyRelationSenders = @"io.element.relation_senders";
+NSString *const kMXRoomEventFilterKeyRelatedByTypes = @"io.element.relation_types";
+NSString *const kMXRoomEventFilterKeyRelatedBySenders = @"io.element.relation_senders";
 
 @implementation MXRoomEventFilter
 
@@ -143,27 +143,27 @@ NSString *const kMXRoomEventFilterKeyRelationSenders = @"io.element.relation_sen
     return lazyLoadMembers;
 }
 
-- (void)setRelationTypes:(NSArray<NSString *> *)relationTypes
+- (void)setRelatedByTypes:(NSArray<NSString *> *)relatedByTypes
 {
-    dictionary[kMXRoomEventFilterKeyRelationTypes] = relationTypes;
+    dictionary[kMXRoomEventFilterKeyRelatedByTypes] = relatedByTypes;
 }
 
-- (NSArray<NSString *> *)relationTypes
+- (NSArray<NSString *> *)relatedByTypes
 {
     NSArray<NSString *> *result;
-    MXJSONModelSetArray(result, dictionary[kMXRoomEventFilterKeyRelationTypes]);
+    MXJSONModelSetArray(result, dictionary[kMXRoomEventFilterKeyRelatedByTypes]);
     return result;
 }
 
-- (void)setRelationSenders:(NSArray<NSString *> *)relationSenders
+- (void)setRelatedBySenders:(NSArray<NSString *> *)relatedBySenders
 {
-    dictionary[kMXRoomEventFilterKeyRelationSenders] = relationSenders;
+    dictionary[kMXRoomEventFilterKeyRelatedBySenders] = relatedBySenders;
 }
 
-- (NSArray<NSString *> *)relationSenders
+- (NSArray<NSString *> *)relatedBySenders
 {
     NSArray<NSString *> *result;
-    MXJSONModelSetArray(result, dictionary[kMXRoomEventFilterKeyRelationSenders]);
+    MXJSONModelSetArray(result, dictionary[kMXRoomEventFilterKeyRelatedBySenders]);
     return result;
 }
 

--- a/MatrixSDK/Threads/MXThreadingService.swift
+++ b/MatrixSDK/Threads/MXThreadingService.swift
@@ -150,9 +150,9 @@ public class MXThreadingService: NSObject {
         if session.homeserverCapabilities?.threads?.isEnabled == true {
             //  homeserver supports threads
             let filter = MXRoomEventFilter()
-            filter.relationTypes = [MXEventRelationTypeThread]
+            filter.relatedByTypes = [MXEventRelationTypeThread]
             if onlyParticipated {
-                filter.relationSenders = [session.myUserId]
+                filter.relatedBySenders = [session.myUserId]
             }
             return session.matrixRestClient.messages(forRoom: roomId,
                                                      from: "",

--- a/changelog.d/5705.change
+++ b/changelog.d/5705.change
@@ -1,0 +1,1 @@
+MXRoomEventFilter: Update property names for relation types and senders.


### PR DESCRIPTION
Fix vector-im/element-ios#5705

This is just updating some property names right now, to be more aligned with stable values, which i'll update later in another PR.