### PR TITLE
Threads: Stable Values

### DIFF
--- a/MatrixSDK/Data/Filters/MXRoomEventFilter.m
+++ b/MatrixSDK/Data/Filters/MXRoomEventFilter.m
@@ -22,8 +22,8 @@
 
 //  TODO: Replace when the MSC merged
 //  https://github.com/matrix-org/matrix-doc/pull/3440
-NSString *const kMXRoomEventFilterKeyRelatedByTypes = @"io.element.relation_types";
-NSString *const kMXRoomEventFilterKeyRelatedBySenders = @"io.element.relation_senders";
+NSString *const kMXRoomEventFilterKeyRelatedByTypes = @"related_by_rel_types";
+NSString *const kMXRoomEventFilterKeyRelatedBySenders = @"related_by_senders";
 
 @implementation MXRoomEventFilter
 

--- a/MatrixSDK/JSONModels/Event/Content/MXEventContentRelatesTo.m
+++ b/MatrixSDK/JSONModels/Event/Content/MXEventContentRelatesTo.m
@@ -19,7 +19,7 @@
 NSString *const kMXEventContentRelatesToKeyRelationType = @"rel_type";
 NSString *const kMXEventContentRelatesToKeyEventId = @"event_id";
 NSString *const kMXEventContentRelatesToKeyKey = @"key";
-NSString *const kMXEventContentRelatesToKeyIsReplyFallback = @"io.element.show_reply";
+NSString *const kMXEventContentRelatesToKeyIsReplyFallback = @"is_falling_back";
 NSString *const kMXEventContentRelatesToKeyInReplyTo = @"m.in_reply_to";
 
 @interface MXEventContentRelatesTo()

--- a/MatrixSDK/JSONModels/MXEvent.m
+++ b/MatrixSDK/JSONModels/MXEvent.m
@@ -117,7 +117,7 @@ NSString *const MXEventRelationTypeReplace           = @"m.replace";
 NSString *const kMXMessageContentKeyNewContent       = @"m.new_content";
 //  TODO: Replace when the MSC merged
 //  https://github.com/matrix-org/matrix-doc/pull/3440
-NSString *const MXEventRelationTypeThread            = @"io.element.thread";
+NSString *const MXEventRelationTypeThread            = @"m.thread";
 
 NSString *const kMXEventLocalEventIdPrefix           = @"kMXEventLocalId_";
 

--- a/MatrixSDK/JSONModels/MXMatrixVersions.m
+++ b/MatrixSDK/JSONModels/MXMatrixVersions.m
@@ -111,7 +111,8 @@ static NSString* const kJSONKeyMSC3440 = @"org.matrix.msc3440.stable";
 
 - (BOOL)supportsThreads
 {
-    return [self serverSupportsFeature:kJSONKeyMSC3440];
+    return [self serverSupportsVersion:MXMatrixClientServerAPIVersion.v1_3]
+        || [self serverSupportsFeature:kJSONKeyMSC3440];
 }
 
 #pragma mark - Private

--- a/MatrixSDK/JSONModels/MXMatrixVersions.m
+++ b/MatrixSDK/JSONModels/MXMatrixVersions.m
@@ -41,7 +41,7 @@ static NSString* const kJSONKeyVersions = @"versions";
 static NSString* const kJSONKeyUnstableFeatures = @"unstable_features";
 
 //  Unstable features
-static NSString* const kJSONKeyMSC3440 = @"org.matrix.msc3440";
+static NSString* const kJSONKeyMSC3440 = @"org.matrix.msc3440.stable";
 
 @interface MXMatrixVersions ()
 

--- a/changelog.d/5791.change
+++ b/changelog.d/5791.change
@@ -1,0 +1,1 @@
+Threads: Update all properties to stable values.


### PR DESCRIPTION
Fixes vector-im/element-ios#5791.

This will cause all thread events to move to the main timeline of a room. Will be based on `develop` after the PR merged.