### PR TITLE
API to ignore the sender of a room invite before the room is joined

### DIFF
--- a/MatrixSDK/Data/MXRoom.h
+++ b/MatrixSDK/Data/MXRoom.h
@@ -807,7 +807,7 @@ FOUNDATION_EXPORT NSInteger const kMXRoomInvalidInviteSenderErrorCode;
  @return a MXHTTPOperation instance.
  */
 - (MXHTTPOperation*)ignoreInviteSender:(void (^)(void))success
-                               failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
+                               failure:(void (^)(NSError *error))failure;
 
 /**
  Invite a user to this room.

--- a/MatrixSDK/Data/MXRoom.h
+++ b/MatrixSDK/Data/MXRoom.h
@@ -70,6 +70,11 @@ FOUNDATION_EXPORT NSString *const kMXRoomDidFlushDataNotification;
 FOUNDATION_EXPORT NSInteger const kMXRoomAlreadyJoinedErrorCode;
 
 /**
+ Error code when attempting to use a room invite sender which is invalid.
+ */
+FOUNDATION_EXPORT NSInteger const kMXRoomInvalidInviteSenderErrorCode;
+
+/**
  `MXRoom` is the class
  */
 @interface MXRoom : NSObject
@@ -791,6 +796,18 @@ FOUNDATION_EXPORT NSInteger const kMXRoomAlreadyJoinedErrorCode;
  */
 - (MXHTTPOperation*)leave:(void (^)(void))success
                   failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
+
+/**
+ Ignore the user who sent the invite to this room. This user is then added to the current
+ user's ignore list.
+ 
+ @param success A block object called when the operation is complete.
+ @param failure A block object called when the operation fails.
+
+ @return a MXHTTPOperation instance.
+ */
+- (MXHTTPOperation*)ignoreInviteSender:(void (^)(void))success
+                               failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
  Invite a user to this room.

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -44,6 +44,7 @@
 NSString *const kMXRoomDidFlushDataNotification = @"kMXRoomDidFlushDataNotification";
 NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotification";
 NSInteger const kMXRoomAlreadyJoinedErrorCode = 9001;
+NSInteger const kMXRoomInvalidInviteSenderErrorCode = 9002;
 
 @interface MXRoom ()
 {
@@ -1901,6 +1902,24 @@ NSInteger const kMXRoomAlreadyJoinedErrorCode = 9001;
                   failure:(void (^)(NSError *error))failure
 {
     return [mxSession leaveRoom:self.roomId success:success failure:failure];
+}
+
+- (MXHTTPOperation*)ignoreInviteSender:(void (^)(void))success
+                               failure:(void (^)(NSError *))failure {
+    MXHTTPOperation *operation = [[MXHTTPOperation alloc] init];
+    [self state:^(MXRoomState *roomState) {
+        MXRoomMember *myUser = [roomState.members memberWithUserId:self.mxSession.myUserId];
+        NSString *inviteSenderID = myUser.originalEvent.sender;
+        if (!inviteSenderID || [inviteSenderID isEqualToString:myUser.userId]) {
+            NSError *error = [NSError errorWithDomain:kMXNSErrorDomain code:kMXRoomInvalidInviteSenderErrorCode userInfo:nil];
+            failure(error);
+            return;
+        }
+        
+        MXHTTPOperation *operation2 = [self.mxSession ignoreUsers:@[inviteSenderID] success:success failure:failure];
+        [operation mutateTo:operation2];
+    }];
+    return operation;
 }
 
 - (MXHTTPOperation*)inviteUser:(NSString*)userId

--- a/changelog.d/5807.change
+++ b/changelog.d/5807.change
@@ -1,0 +1,1 @@
+Room: API to ignore the sender of a room invite before the room is joined


### PR DESCRIPTION
Relates to https://github.com/vector-im/element-ios/issues/5807