### PR TITLE
Increase CLIENT_TIMEOUT_MS for initial /sync

### DIFF
--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -85,7 +85,7 @@ NSString *const kMXSessionNoRoomTag = @"m.recent";  // Use the same value as mat
  Default timeouts used by the events streams.
  */
 #define SERVER_TIMEOUT_MS 30000
-#define CLIENT_TIMEOUT_MS 120000
+#define CLIENT_TIMEOUT_MS 240000
 
 /**
  Time before retrying in case of `MXSessionStateSyncError`.

--- a/changelog.d/1403.change
+++ b/changelog.d/1403.change
@@ -1,0 +1,1 @@
+Increase timeout for initial sync from 120 seconds to 240 seconds


### PR DESCRIPTION
Increase the client timeout, failed to do an initial sync for me on iOS simulator (1020 rooms) when using the SDK in a custom app.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request contains a changelog file in ./changelog.d. See https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
