### PR TITLE
Distinguish between original and edit message when preventing replay attacks

### DIFF
--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -5509,9 +5509,9 @@
 			buildConfigurationList = 32C6F94019DD814400EA4E9C /* Build configuration list for PBXNativeTarget "MatrixSDK-iOS" */;
 			buildPhases = (
 				385E87177134AE6EBD88F314 /* [CP] Check Pods Manifest.lock */,
+				32C6F92A19DD814400EA4E9C /* Headers */,
 				32C6F92819DD814400EA4E9C /* Sources */,
 				32C6F92919DD814400EA4E9C /* Frameworks */,
-				32C6F92A19DD814400EA4E9C /* Headers */,
 				32C6F92B19DD814400EA4E9C /* Resources */,
 				323B2ADA1BCD47F000B11F34 /* CopyFiles */,
 			);
@@ -5548,9 +5548,9 @@
 			buildConfigurationList = B14EF3682397E90400758AF0 /* Build configuration list for PBXNativeTarget "MatrixSDK-macOS" */;
 			buildPhases = (
 				C9A686A24B8547C17FE45FC5 /* [CP] Check Pods Manifest.lock */,
+				B14EF2962397E90400758AF0 /* Headers */,
 				B14EF1C92397E90400758AF0 /* Sources */,
 				B14EF2942397E90400758AF0 /* Frameworks */,
-				B14EF2962397E90400758AF0 /* Headers */,
 				B14EF3662397E90400758AF0 /* Resources */,
 				B14EF3672397E90400758AF0 /* CopyFiles */,
 			);

--- a/MatrixSDK/Background/MXBackgroundSyncService.swift
+++ b/MatrixSDK/Background/MXBackgroundSyncService.swift
@@ -407,7 +407,7 @@ public enum MXBackgroundSyncServiceError: Error {
                     throw MXBackgroundSyncServiceError.unknown
             }
             
-            let olmResult = try olmDevice.decryptGroupMessage(ciphertext, roomId: event.roomId, inTimeline: nil, sessionId: sessionId, senderKey: senderKey)
+            let olmResult = try olmDevice.decryptGroupMessage(ciphertext, isEditEvent: event.isEdit(), roomId: event.roomId, inTimeline: nil, sessionId: sessionId, senderKey: senderKey)
             
             let decryptionResult = MXEventDecryptionResult()
             decryptionResult.clearEvent = olmResult.payload

--- a/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmDecryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmDecryption.m
@@ -99,7 +99,13 @@
     }
 
     NSError *olmError;
-    MXDecryptionResult *olmResult = [olmDevice decryptGroupMessage:ciphertext roomId:event.roomId inTimeline:timeline sessionId:sessionId senderKey:senderKey error:&olmError];
+    MXDecryptionResult *olmResult = [olmDevice decryptGroupMessage:ciphertext
+                                                       isEditEvent:event.isEditEvent
+                                                            roomId:event.roomId
+                                                        inTimeline:timeline
+                                                         sessionId:sessionId
+                                                         senderKey:senderKey
+                                                             error:&olmError];
 
     result = [MXEventDecryptionResult new];
     if (olmResult)

--- a/MatrixSDK/Crypto/MXOlmDevice.h
+++ b/MatrixSDK/Crypto/MXOlmDevice.h
@@ -252,6 +252,9 @@ Determine if an incoming messages is a prekey message matching an existing sessi
  Decrypt a received message with an inbound group session.
  
  @param body the base64-encoded body of the encrypted message.
+ @param isEditEvent whether the event has an edit relationship to another event.
+                    This is used when detecting a replay attack as a way to
+                    distinguish an edit of a message from the original edited message.
  @param roomId the room in which the message was received.
  @param timeline the id of the timeline where the event is decrypted. It is used
                  to prevent replay attack.
@@ -261,7 +264,9 @@ Determine if an incoming messages is a prekey message matching an existing sessi
 
  @return the decrypting result. Nil if the sessionId is unknown.
  */
-- (MXDecryptionResult*)decryptGroupMessage:(NSString*)body roomId:(NSString*)roomId
+- (MXDecryptionResult*)decryptGroupMessage:(NSString*)body
+                               isEditEvent:(BOOL)isEditEvent
+                                    roomId:(NSString*)roomId
                                 inTimeline:(NSString*)timeline
                                  sessionId:(NSString*)sessionId senderKey:(NSString*)senderKey
                                      error:(NSError** )error;

--- a/MatrixSDK/Crypto/MXOlmDevice.m
+++ b/MatrixSDK/Crypto/MXOlmDevice.m
@@ -432,9 +432,12 @@
     return sessions;
 }
 
-- (MXDecryptionResult *)decryptGroupMessage:(NSString *)body roomId:(NSString *)roomId
+- (MXDecryptionResult *)decryptGroupMessage:(NSString *)body
+                                isEditEvent:(BOOL)isEditEvent
+                                     roomId:(NSString *)roomId
                                  inTimeline:(NSString *)timeline
-                                  sessionId:(NSString *)sessionId senderKey:(NSString *)senderKey
+                                  sessionId:(NSString *)sessionId
+                                  senderKey:(NSString *)senderKey
                                       error:(NSError *__autoreleasing *)error
 {
     __block NSUInteger messageIndex;
@@ -471,7 +474,7 @@
                 inboundGroupSessionMessageIndexes[timeline] = [NSMutableDictionary dictionary];
             }
             
-            NSString *messageIndexKey = [NSString stringWithFormat:@"%@|%@|%tu", senderKey, sessionId, messageIndex];
+            NSString *messageIndexKey = [NSString stringWithFormat:@"%@|%@|%tu|%d", senderKey, sessionId, messageIndex, isEditEvent];
             if (inboundGroupSessionMessageIndexes[timeline][messageIndexKey])
             {
                 MXLogDebug(@"[MXOlmDevice] decryptGroupMessage: Warning: Possible replay attack %@", messageIndexKey);

--- a/changelog.d/5835.bugfix
+++ b/changelog.d/5835.bugfix
@@ -1,0 +1,1 @@
+Crypto: Distinguish between original and edit message when preventing replay attacks


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-ios/issues/5835

This solution is not perfect and bloats the `decrypt` API even further, but is the most straightforward way to fix the issue where an edit event is first decrypted and then the original event with the same content (because it has been aggregated) is being decrypted and fails, resulting in the message being dropped from the timeline.

In this solution we use the `isEditEvent` flag as yet another component of `messageIndexKey` to determine whether this is likely a replay attack or not.