### PR TITLE
Paginated events always show the most recent edit

### DIFF
--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -1717,12 +1717,16 @@
 		ECF29BDF264195320053E6D6 /* MXAssertedIdentityModel.h in Headers */ = {isa = PBXBuildFile; fileRef = ECF29BDD264195320053E6D6 /* MXAssertedIdentityModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		ECF29BE52641953C0053E6D6 /* MXAssertedIdentityModel.m in Sources */ = {isa = PBXBuildFile; fileRef = ECF29BE42641953C0053E6D6 /* MXAssertedIdentityModel.m */; };
 		ECF29BE62641953C0053E6D6 /* MXAssertedIdentityModel.m in Sources */ = {isa = PBXBuildFile; fileRef = ECF29BE42641953C0053E6D6 /* MXAssertedIdentityModel.m */; };
+		ED8943D427E34762000FC39C /* MXMemoryRoomStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED8943D327E34762000FC39C /* MXMemoryRoomStoreTests.swift */; };
+		ED8943D527E34762000FC39C /* MXMemoryRoomStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED8943D327E34762000FC39C /* MXMemoryRoomStoreTests.swift */; };
 		EDB4209227DF77390036AF39 /* MXEventsEnumeratorOnArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB4209027DF77310036AF39 /* MXEventsEnumeratorOnArrayTests.swift */; };
 		EDB4209327DF77390036AF39 /* MXEventsEnumeratorOnArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB4209027DF77310036AF39 /* MXEventsEnumeratorOnArrayTests.swift */; };
 		EDB4209527DF822B0036AF39 /* MXEventsByTypesEnumeratorOnArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB4209427DF822B0036AF39 /* MXEventsByTypesEnumeratorOnArrayTests.swift */; };
 		EDB4209627DF822B0036AF39 /* MXEventsByTypesEnumeratorOnArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB4209427DF822B0036AF39 /* MXEventsByTypesEnumeratorOnArrayTests.swift */; };
 		EDB4209927DF842F0036AF39 /* MXEventFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB4209827DF842F0036AF39 /* MXEventFixtures.swift */; };
 		EDB4209A27DF842F0036AF39 /* MXEventFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB4209827DF842F0036AF39 /* MXEventFixtures.swift */; };
+		EDF4678727E3331D00435913 /* EventsEnumeratorDataSourceStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF4678627E3331D00435913 /* EventsEnumeratorDataSourceStub.swift */; };
+		EDF4678827E3331D00435913 /* EventsEnumeratorDataSourceStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF4678627E3331D00435913 /* EventsEnumeratorDataSourceStub.swift */; };
 		F0173EAC1FCF0E8900B5F6A3 /* MXGroup.h in Headers */ = {isa = PBXBuildFile; fileRef = F0173EAA1FCF0E8800B5F6A3 /* MXGroup.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F0173EAD1FCF0E8900B5F6A3 /* MXGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = F0173EAB1FCF0E8900B5F6A3 /* MXGroup.m */; };
 		F03EF4FE1DF014D9009DF592 /* MXMediaLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F03EF4FA1DF014D9009DF592 /* MXMediaLoader.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -2683,10 +2687,12 @@
 		ECF29BDD264195320053E6D6 /* MXAssertedIdentityModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXAssertedIdentityModel.h; sourceTree = "<group>"; };
 		ECF29BE42641953C0053E6D6 /* MXAssertedIdentityModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXAssertedIdentityModel.m; sourceTree = "<group>"; };
 		ED2F344856EFFCA383E37B22 /* Pods-SDK-MatrixSDK.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SDK-MatrixSDK.release.xcconfig"; path = "Target Support Files/Pods-SDK-MatrixSDK/Pods-SDK-MatrixSDK.release.xcconfig"; sourceTree = "<group>"; };
+		ED8943D327E34762000FC39C /* MXMemoryRoomStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXMemoryRoomStoreTests.swift; sourceTree = "<group>"; };
 		EDB4209027DF77310036AF39 /* MXEventsEnumeratorOnArrayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXEventsEnumeratorOnArrayTests.swift; sourceTree = "<group>"; };
 		EDB4209427DF822B0036AF39 /* MXEventsByTypesEnumeratorOnArrayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXEventsByTypesEnumeratorOnArrayTests.swift; sourceTree = "<group>"; };
 		EDB4209827DF842F0036AF39 /* MXEventFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXEventFixtures.swift; sourceTree = "<group>"; };
 		EDC74874AB2D86EFEE912B04 /* Pods-MatrixSDK-MatrixSDK-macOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MatrixSDK-MatrixSDK-macOS.debug.xcconfig"; path = "Target Support Files/Pods-MatrixSDK-MatrixSDK-macOS/Pods-MatrixSDK-MatrixSDK-macOS.debug.xcconfig"; sourceTree = "<group>"; };
+		EDF4678627E3331D00435913 /* EventsEnumeratorDataSourceStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsEnumeratorDataSourceStub.swift; sourceTree = "<group>"; };
 		F0173EAA1FCF0E8800B5F6A3 /* MXGroup.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXGroup.h; sourceTree = "<group>"; };
 		F0173EAB1FCF0E8900B5F6A3 /* MXGroup.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXGroup.m; sourceTree = "<group>"; };
 		F03EF4FA1DF014D9009DF592 /* MXMediaLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXMediaLoader.h; sourceTree = "<group>"; };
@@ -4720,9 +4726,26 @@
 			path = Common;
 			sourceTree = "<group>";
 		};
+		ED8943D127E3474A000FC39C /* Store */ = {
+			isa = PBXGroup;
+			children = (
+				ED8943D227E34755000FC39C /* MXMemoryStore */,
+			);
+			path = Store;
+			sourceTree = "<group>";
+		};
+		ED8943D227E34755000FC39C /* MXMemoryStore */ = {
+			isa = PBXGroup;
+			children = (
+				ED8943D327E34762000FC39C /* MXMemoryRoomStoreTests.swift */,
+			);
+			path = MXMemoryStore;
+			sourceTree = "<group>";
+		};
 		EDB4208E27DF76C60036AF39 /* Data */ = {
 			isa = PBXGroup;
 			children = (
+				ED8943D127E3474A000FC39C /* Store */,
 				EDB4208F27DF77230036AF39 /* EventsEnumerator */,
 			);
 			path = Data;
@@ -4731,6 +4754,7 @@
 		EDB4208F27DF77230036AF39 /* EventsEnumerator */ = {
 			isa = PBXGroup;
 			children = (
+				EDF4678627E3331D00435913 /* EventsEnumeratorDataSourceStub.swift */,
 				EDB4209027DF77310036AF39 /* MXEventsEnumeratorOnArrayTests.swift */,
 				EDB4209427DF822B0036AF39 /* MXEventsByTypesEnumeratorOnArrayTests.swift */,
 			);
@@ -6228,6 +6252,7 @@
 				3A7B8D0E267FCF7200D9DD96 /* MXDehydrationTests.m in Sources */,
 				3281E8A019E2CC1200976E1A /* MXHTTPClientTests.m in Sources */,
 				321809B919EEBF3000377451 /* MXEventTests.m in Sources */,
+				EDF4678727E3331D00435913 /* EventsEnumeratorDataSourceStub.swift in Sources */,
 				EC746C59274E61EF002AD24C /* MXThreadingServiceTests.swift in Sources */,
 				32A31BC120D3F4C4005916C7 /* MXFilterTests.m in Sources */,
 				32B477842638133C00EA5800 /* MXAggregatedReferenceUnitTests.m in Sources */,
@@ -6243,6 +6268,7 @@
 				327137241A24BDDE00DB6757 /* MXUserTests.m in Sources */,
 				32B0E3E723A3864C0054FF1A /* MXEventReferenceUnitTests.swift in Sources */,
 				32720DA2222EB5650086FFF5 /* MXAutoDiscoveryTests.m in Sources */,
+				ED8943D427E34762000FC39C /* MXMemoryRoomStoreTests.swift in Sources */,
 				327E37B91A977810007F026F /* MXLoggerUnitTests.m in Sources */,
 				18937E7C273A5AE500902626 /* MXPollRelationTests.m in Sources */,
 				32792BE12296C64200F4FC9D /* MXAggregatedEditsTests.m in Sources */,
@@ -6746,6 +6772,7 @@
 				32D5D16423E400A600E3E37C /* MXRoomSummaryTrustTests.m in Sources */,
 				B1E09A1B2397FCE90057C069 /* MXAggregatedReactionTests.m in Sources */,
 				B1E09A3F2397FD820057C069 /* MXNotificationCenterTests.m in Sources */,
+				EDF4678827E3331D00435913 /* EventsEnumeratorDataSourceStub.swift in Sources */,
 				EC746C5A274E61EF002AD24C /* MXThreadingServiceTests.swift in Sources */,
 				B1E09A222397FCE90057C069 /* MXRoomSummaryTests.m in Sources */,
 				B1E09A3A2397FD820057C069 /* MXStoreTests.m in Sources */,
@@ -6761,6 +6788,7 @@
 				B1F939F626289F2600D0E525 /* MXSpaceChildContentTests.swift in Sources */,
 				B1E09A412397FD820057C069 /* MXAccountDataTests.m in Sources */,
 				B1E09A2D2397FD750057C069 /* MXRestClientNoAuthAPITests.m in Sources */,
+				ED8943D527E34762000FC39C /* MXMemoryRoomStoreTests.swift in Sources */,
 				B1E09A332397FD750057C069 /* MXRoomStateTests.m in Sources */,
 				18937E7D273A5AE500902626 /* MXPollRelationTests.m in Sources */,
 				B1E09A352397FD7D0057C069 /* MXEventTests.m in Sources */,

--- a/MatrixSDK/Background/MXBackgroundStore.swift
+++ b/MatrixSDK/Background/MXBackgroundStore.swift
@@ -165,11 +165,11 @@ class MXBackgroundStore: NSObject, MXStore {
     }
     
     func messagesEnumerator(forRoom roomId: String) -> MXEventsEnumerator {
-        return MXEventsEnumeratorOnArray(messages: [])
+        return MXEventsEnumeratorOnArray(eventIds: [], dataSource: nil)
     }
     
     func messagesEnumerator(forRoom roomId: String, withTypeIn types: [Any]?) -> MXEventsEnumerator {
-        return MXEventsEnumeratorOnArray(messages: [])
+        return MXEventsEnumeratorOnArray(eventIds: [], dataSource: nil)
     }
     
     func relations(forEvent eventId: String, inRoom roomId: String, relationType: String) -> [MXEvent] {

--- a/MatrixSDK/Data/EventsEnumerator/MXEventsByTypesEnumeratorOnArray.h
+++ b/MatrixSDK/Data/EventsEnumerator/MXEventsByTypesEnumeratorOnArray.h
@@ -18,20 +18,25 @@
 #import <Foundation/Foundation.h>
 
 #import "MXEventsEnumerator.h"
+#import "MXEventsEnumeratorOnArray.h"
 
 /**
- Generic events enumerator on an array of events with a filter on events types.
+ Generic events enumerator on an array of event identifiers with a filter on events types.
  */
 @interface MXEventsByTypesEnumeratorOnArray : NSObject <MXEventsEnumerator>
 
 /**
- Construct an enumerator based on a events array.
+ Construct an enumerator based on an array of event identifiers.
 
  @param messages the list of messages to enumerate on.
  @param types an array of event types strings to use as a filter filter.
+ @param dataSource object responsible for translating an event identifier into
+                   the most recent version of the event.
 
  @return the newly created instance.
  */
-- (instancetype)initWithMessages:(NSArray<MXEvent*> *)messages andTypesIn:(NSArray*)types;
+- (instancetype)initWithEventIds:(NSArray<NSString *> *)eventIds
+                      andTypesIn:(NSArray*)types
+                      dataSource:(id<MXEventsEnumeratorDataSource>)dataSource;
 
 @end

--- a/MatrixSDK/Data/EventsEnumerator/MXEventsByTypesEnumeratorOnArray.m
+++ b/MatrixSDK/Data/EventsEnumerator/MXEventsByTypesEnumeratorOnArray.m
@@ -34,13 +34,15 @@
 
 @implementation MXEventsByTypesEnumeratorOnArray
 
-- (instancetype)initWithMessages:(NSArray<MXEvent *> *)messages andTypesIn:(NSArray *)theTypes
+- (instancetype)initWithEventIds:(NSArray<NSString *> *)eventIds
+                      andTypesIn:(NSArray*)theTypes
+                      dataSource:(id<MXEventsEnumeratorDataSource>)dataSource
 {
     self = [super init];
     if (self)
     {
         types = theTypes;
-        allMessagesEnumerator = [[MXEventsEnumeratorOnArray alloc] initWithMessages:messages];
+        allMessagesEnumerator = [[MXEventsEnumeratorOnArray alloc] initWithEventIds:eventIds dataSource:dataSource];
     }
 
     return self;

--- a/MatrixSDK/Data/EventsEnumerator/MXEventsEnumerator.h
+++ b/MatrixSDK/Data/EventsEnumerator/MXEventsEnumerator.h
@@ -17,13 +17,13 @@
 #import "MXEvent.h"
 
 /**
- The `MXStoreEventsEnumerator` protocol defines an interface that must be implemented 
+ The `MXEventsEnumerator` protocol defines an interface that must be implemented
  in order to iterate on a list of events.
  
  This interface is used in the MXStore to manage the results of requests on the store
  database.
 
- The `MXStoreEventsEnumerator` implementation must start the iteration on the most recent
+ The `MXEventsEnumerator` implementation must start the iteration on the most recent
  events of the list.
  */
 @protocol MXEventsEnumerator <NSObject>

--- a/MatrixSDK/Data/EventsEnumerator/MXEventsEnumeratorOnArray.h
+++ b/MatrixSDK/Data/EventsEnumerator/MXEventsEnumeratorOnArray.h
@@ -19,16 +19,30 @@
 #import "MXEventsEnumerator.h"
 
 /**
- Generic events enumerator on an array of events.
+ Data source which provides the most up-to-date event to an enumerator
+ based on the event identifier.
+ */
+@protocol MXEventsEnumeratorDataSource
+- (MXEvent *)eventWithEventId:(NSString *)eventId;
+@end
+
+/**
+ Generic events enumerator on an array of event identifiers that are
+ translated to events on demand.
  */
 @interface MXEventsEnumeratorOnArray : NSObject <MXEventsEnumerator>
 
 /**
- Construct an enumerator based on a events array.
+ Construct an enumerator based on an array of event identifiers.
+
+ @param eventIds the list of event identifiers to enumerate.
+                 The order is chronological where the first item is the oldest event
+ @param dataSource object responsible for translating an event identifier into
+                   the most recent version of the event.
  
- @param messages the list of messages to enumerate.
  @return the newly created instance.
  */
-- (instancetype)initWithMessages:(NSArray<MXEvent*> *)messages;
+- (instancetype)initWithEventIds:(NSArray<NSString *> *)eventIds
+                      dataSource:(id<MXEventsEnumeratorDataSource>)dataSource;
 
 @end

--- a/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryRoomStore.m
+++ b/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryRoomStore.m
@@ -20,7 +20,7 @@
 #import "MXEventsEnumeratorOnArray.h"
 #import "MXEventsByTypesEnumeratorOnArray.h"
 
-@interface MXMemoryRoomStore ()
+@interface MXMemoryRoomStore () <MXEventsEnumeratorDataSource>
 {
 }
 
@@ -85,14 +85,23 @@
     [messagesByEventIds removeAllObjects];
 }
 
+- (NSArray <NSString *>*)allEventIds
+{
+    NSMutableArray *eventIds = [[NSMutableArray alloc] initWithCapacity:messages.count];
+    for (MXEvent *event in messages) {
+        [eventIds addObject:event.eventId];
+    }
+    return eventIds.copy;
+}
+
 - (id<MXEventsEnumerator>)messagesEnumerator
 {
-    return [[MXEventsEnumeratorOnArray alloc] initWithMessages:messages];
+    return [[MXEventsEnumeratorOnArray alloc] initWithEventIds:[self allEventIds] dataSource:self];
 }
 
 - (id<MXEventsEnumerator>)enumeratorForMessagesWithTypeIn:(NSArray*)types
 {
-    return [[MXEventsByTypesEnumeratorOnArray alloc] initWithMessages:messages andTypesIn:types];
+    return [[MXEventsByTypesEnumeratorOnArray alloc] initWithEventIds:[self allEventIds] andTypesIn:types dataSource:self];
 }
 
 - (NSArray<MXEvent*>*)eventsAfter:(NSString *)eventId threadId:(NSString *)threadId except:(NSString *)userId withTypeIn:(NSSet<MXEventTypeString>*)types

--- a/MatrixSDK/Data/Store/MXNoStore/MXNoStore.m
+++ b/MatrixSDK/Data/Store/MXNoStore/MXNoStore.m
@@ -20,7 +20,7 @@
 #import "MXEventsEnumeratorOnArray.h"
 #import "MXVoidRoomSummaryStore.h"
 
-@interface MXNoStore ()
+@interface MXNoStore () <MXEventsEnumeratorDataSource>
 {
     // key: roomId, value: the pagination token
     NSMutableDictionary<NSString*, NSString*> *paginationTokens;
@@ -239,7 +239,7 @@
     // of MXNoStore is to not store messages so that all paginations are made
     // via requests to the homeserver.
     // So, return an empty enumerator.
-    return [[MXEventsEnumeratorOnArray alloc] initWithMessages:@[]];
+    return [[MXEventsEnumeratorOnArray alloc] initWithEventIds:@[] dataSource:nil];
 }
 
 - (id<MXEventsEnumerator>)messagesEnumeratorForRoom:(NSString *)roomId withTypeIn:(NSArray *)types
@@ -247,7 +247,11 @@
     // [MXStore messagesEnumeratorForRoom: withTypeIn: ignoreMemberProfileChanges:] is used
     // to get the last message of the room which must not be nil.
     // So return an enumerator with the last message we have without caring of its type.
-    return [[MXEventsEnumeratorOnArray alloc] initWithMessages:@[lastMessages[roomId]]];
+    MXEvent *event = lastMessages[roomId];
+    if (event) {
+        return [[MXEventsEnumeratorOnArray alloc] initWithEventIds:@[event.eventId] dataSource:self];
+    }
+    return [[MXEventsEnumeratorOnArray alloc] initWithEventIds:@[] dataSource:nil];
 }
 
 - (NSArray<MXEvent *> *)relationsForEvent:(NSString *)eventId inRoom:(NSString *)roomId relationType:(NSString *)relationType
@@ -460,6 +464,18 @@
     [partialTextMessages removeAllObjects];
     [users removeAllObjects];
     [groups removeAllObjects];
+}
+
+#pragma mark - MXEventsEnumeratorDataSource
+
+- (MXEvent *)eventWithEventId:(NSString *)eventId
+{
+    for (MXEvent *event in lastMessages.allValues) {
+        if ([event.eventId isEqualToString:eventId]) {
+            return event;
+        }
+    }
+    return nil;
 }
 
 @end

--- a/MatrixSDKTests/Data/EventsEnumerator/EventsEnumeratorDataSourceStub.swift
+++ b/MatrixSDKTests/Data/EventsEnumerator/EventsEnumeratorDataSourceStub.swift
@@ -1,0 +1,39 @@
+// 
+// Copyright 2022 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+class EventsEnumeratorDataSourceStub: MXEventsEnumeratorDataSource {
+    let eventIds: [String]
+    var eventsById: [String: MXEvent]
+    
+    init(events: [MXEvent]) {
+        eventIds = events.map(\.eventId)
+        eventsById = events.reduce(into: [String: MXEvent]()) { dict, item in
+            dict[item.eventId] = item
+        }
+    }
+    
+    func update(events: [MXEvent]) {
+        eventsById = events.reduce(into: [String: MXEvent]()) { dict, item in
+            dict[item.eventId] = item
+        }
+    }
+    
+    func event(withEventId eventId: String!) -> MXEvent? {
+        return eventsById[eventId]
+    }
+}

--- a/MatrixSDKTests/Data/EventsEnumerator/MXEventsByTypesEnumeratorOnArrayTests.swift
+++ b/MatrixSDKTests/Data/EventsEnumerator/MXEventsByTypesEnumeratorOnArrayTests.swift
@@ -25,7 +25,7 @@ class MXEventsByTypesEnumeratorOnArrayTests: XCTestCase {
     
     func test_nextBatchHasAllMessages() {
         let events = (1...100).map(MXEvent.fixture)
-        let enumerator = MXEventsByTypesEnumeratorOnArray(messages: events, andTypesIn: nil)!
+        let enumerator = makeEnumerator(events: events)
         
         let batch = enumerator.nextBatch(100)
         
@@ -34,7 +34,7 @@ class MXEventsByTypesEnumeratorOnArrayTests: XCTestCase {
     
     func test_nextBatchReturnsPortionOfMessages() {
         let events = (1...30).map(MXEvent.fixture)
-        let enumerator = MXEventsByTypesEnumeratorOnArray(messages: events, andTypesIn: nil)!
+        let enumerator = makeEnumerator(events: events)
         
         let batch = enumerator.nextBatch(10)
         
@@ -44,13 +44,20 @@ class MXEventsByTypesEnumeratorOnArrayTests: XCTestCase {
     
     func test_secondBatchReturnsCorrectSlice() {
         let events = (1...40).map(MXEvent.fixture)
-        let enumerator = MXEventsByTypesEnumeratorOnArray(messages: events, andTypesIn: nil)!
+        let enumerator = makeEnumerator(events: events)
         
         let _ = enumerator.nextBatch(8)
         let batch = enumerator.nextBatch(8)
         
         XCTAssertEqual(batch.count, 8)
         XCTAssertEqual(batch, Array(events[24..<32]).reversed())
+    }
+    
+    // Helpers
+    
+    private func makeEnumerator(events: [MXEvent]) -> MXEventsByTypesEnumeratorOnArray {
+        let dataSource = EventsEnumeratorDataSourceStub(events: events)
+        return MXEventsByTypesEnumeratorOnArray(eventIds: events.map(\.eventId), andTypesIn: nil, dataSource: dataSource)!
     }
 }
 

--- a/MatrixSDKTests/Data/Store/MXMemoryStore/MXMemoryRoomStoreTests.swift
+++ b/MatrixSDKTests/Data/Store/MXMemoryStore/MXMemoryRoomStoreTests.swift
@@ -1,0 +1,77 @@
+// 
+// Copyright 2022 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+class MXMemoryRoomStoreTests: XCTestCase {
+    func test_messagesEnumeratorForRoom_containsCorrectEvents() {
+        let events = (1...50).map(MXEvent.fixture)
+        let store = MXMemoryRoomStore()
+        events.forEach {
+            store.store($0, direction: .forwards)
+        }
+        
+        let enumerator = store.messagesEnumerator
+        let batch = enumerator?.nextEventsBatch(100, threadId: nil)
+        
+        XCTAssertEqual(batch, events)
+    }
+    
+    func test_messagesEnumeratorForRoom_returnsMostRecentEvents() {
+        let event = MXEvent.fixture(id: 1)
+        let store = MXMemoryRoomStore()
+        store.store(event, direction: .forwards)
+        
+        let updated = MXEvent.fixture(id: 1)
+        updated.wireContent = ["isEdited": true]
+        
+        let enumerator = store.messagesEnumerator
+        store.replace(updated)
+        
+        let nextEvent = enumerator?.nextEvent
+        
+        XCTAssertEqual(nextEvent, updated)
+    }
+    
+    func test_messagesEnumeratorForRoomByType_containsCorrectEvents() {
+        let events = (1...50).map(MXEvent.fixture)
+        let store = MXMemoryRoomStore()
+        events.forEach {
+            store.store($0, direction: .forwards)
+        }
+        
+        let enumerator = store.enumeratorForMessagesWithType(in: nil)
+        let batch = enumerator?.nextEventsBatch(100, threadId: nil)
+        
+        XCTAssertEqual(batch, events.reversed())
+    }
+    
+    func test_messagesEnumeratorForRoomByType_returnsMostRecentEvents() {
+        let event = MXEvent.fixture(id: 1)
+        let store = MXMemoryRoomStore()
+        store.store(event, direction: .forwards)
+        
+        let updated = MXEvent.fixture(id: 1)
+        updated.wireContent = ["isEdited": true]
+        
+        let enumerator = store.enumeratorForMessagesWithType(in: nil)
+        store.replace(updated)
+        
+        let nextEvent = enumerator?.nextEvent
+        
+        XCTAssertEqual(nextEvent, updated)
+    }
+}

--- a/changelog.d/5848.bugfix
+++ b/changelog.d/5848.bugfix
@@ -1,0 +1,1 @@
+Timeline: Paginated events always show the most recent edit


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-ios/issues/5848

The previous implementation of event enumerator used in the timeline would copy the messages from a store (memory or file) and itterate through this list. If however an event got edited, it would only update the version in store and not its equivalent in the enumerator, meaning that once the pagination fetched the edited event, it would grab the original unedited event.

As the root cause of this issue is multiple sources of truth, the solution is to move closer to a single source of truth: the enumerator is only given an initial list of event identifiers and a data source. When the time comes to grab a list of events, the enumerator will request the most recent versions of the events from the data source, ensuring that any changes made between init and the batching are still propagated to the timeline.