### PR TITLE
MXSDKOptions: Remove threads option

### DIFF
--- a/MatrixSDK/MXSDKOptions.h
+++ b/MatrixSDK/MXSDKOptions.h
@@ -189,13 +189,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, assign) BOOL authEnableRefreshTokens;
 
-/**
- Enable threading module and thread-specific replies to events.
-
- @remark NO by default.
- */
-@property (nonatomic) BOOL enableThreads;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/MatrixSDK/MXSDKOptions.m
+++ b/MatrixSDK/MXSDKOptions.m
@@ -52,7 +52,6 @@ static MXSDKOptions *sharedOnceInstance = nil;
         self.roomListDataManagerClass = [MXCoreDataRoomListDataManager class];
         _clientPermalinkBaseUrl = nil;
         _authEnableRefreshTokens = NO;
-        _enableThreads = NO;
     }
     
     return self;

--- a/MatrixSDK/Threads/MXThreadingService.swift
+++ b/MatrixSDK/Threads/MXThreadingService.swift
@@ -96,11 +96,6 @@ public class MXThreadingService: NSObject {
     ///   - direction: direction of the event
     ///   - completion: Completion block containing the flag indicating that the event is handled
     public func handleEvent(_ event: MXEvent, direction: MXTimelineDirection, completion: ((Bool) -> Void)?) {
-        guard MXSDKOptions.sharedInstance().enableThreads else {
-            //  threads disabled in the SDK
-            completion?(false)
-            return
-        }
         guard let session = session else {
             //  session closed
             completion?(false)

--- a/changelog.d/5799.change
+++ b/changelog.d/5799.change
@@ -1,0 +1,1 @@
+MXSDKOptions: Remove `enableThreads` options, which is true by default now.


### PR DESCRIPTION
Removes `enableThreads` option from `MXSDKOptions`, which is true by default now.

Part of vector-im/element-ios#5799