### PR TITLE
Fix MXRoom retain cycles.

### DIFF
--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -546,6 +546,7 @@ NSInteger const kMXRoomInvalidInviteSenderErrorCode = 9002;
 
     MXWeakify(self);
     void(^onSuccess)(NSString *) = ^(NSString *eventId) {
+        MXStrongifyAndReturnIfNil(self);
         
         if (event)
         {
@@ -559,7 +560,6 @@ NSInteger const kMXRoomInvalidInviteSenderErrorCode = 9002;
             // Update stored echo.
             // We keep this event here as local echo to handle correctly outgoing messages from multiple devices.
             // The echo will be removed when the corresponding event will come through the server sync.
-            MXStrongifyAndReturnIfNil(self);
             [self updateOutgoingMessage:localEventId withOutgoingMessage:event];
         }
 
@@ -568,11 +568,11 @@ NSInteger const kMXRoomInvalidInviteSenderErrorCode = 9002;
             success(eventId);
         }
 
-        MXStrongifyAndReturnIfNil(self);
         [self handleNextOperationAfter:roomOperation];
     };
 
     void(^onFailure)(NSError *) = ^(NSError *error) {
+        MXStrongifyAndReturnIfNil(self);
         
         if (event)
         {
@@ -581,7 +581,6 @@ NSInteger const kMXRoomInvalidInviteSenderErrorCode = 9002;
             event.sentState = MXEventSentStateFailed;
 
             // Update the stored echo.
-            MXStrongifyAndReturnIfNil(self);
             [self updateOutgoingMessage:event.eventId withOutgoingMessage:event];
         }
 
@@ -590,7 +589,6 @@ NSInteger const kMXRoomInvalidInviteSenderErrorCode = 9002;
             failure(error);
         }
 
-        MXStrongifyAndReturnIfNil(self);
         [self handleNextOperationAfter:roomOperation];
     };
     
@@ -1039,13 +1037,13 @@ NSInteger const kMXRoomInvalidInviteSenderErrorCode = 9002;
 
     MXWeakify(self);
     void(^onSuccess)(NSString *) = ^(NSString *eventId) {
+        MXStrongifyAndReturnIfNil(self);
 
         if (success)
         {
             success(eventId);
         }
 
-        MXStrongifyAndReturnIfNil(self);
         [self handleNextOperationAfter:roomOperation];
     };
 

--- a/MatrixSDK/Data/MXRoomAccountDataUpdater.m
+++ b/MatrixSDK/Data/MXRoomAccountDataUpdater.m
@@ -28,7 +28,9 @@
 
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        updaterPerSession = [[NSMapTable alloc] init];
+        updaterPerSession = [[NSMapTable alloc] initWithKeyOptions:NSPointerFunctionsWeakMemory
+                                                      valueOptions:NSPointerFunctionsWeakMemory
+                                                          capacity:1];
     });
 
     MXRoomAccountDataUpdater *updater = [updaterPerSession objectForKey:mxSession];

--- a/MatrixSDK/Data/MXRoomSummaryUpdater.m
+++ b/MatrixSDK/Data/MXRoomSummaryUpdater.m
@@ -44,7 +44,9 @@
 
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        updaterPerSession = [[NSMapTable alloc] init];
+        updaterPerSession = [[NSMapTable alloc] initWithKeyOptions:NSPointerFunctionsWeakMemory
+                                                      valueOptions:NSPointerFunctionsWeakMemory
+                                                          capacity:1];
     });
 
     MXRoomSummaryUpdater *updater = [updaterPerSession objectForKey:mxSession];

--- a/MatrixSDK/MXSession.h
+++ b/MatrixSDK/MXSession.h
@@ -1084,12 +1084,16 @@ typedef void (^MXOnBackgroundSyncFail)(NSError *error);
 /**
  Delegate for updating room summaries.
  By default, it is the one returned by [MXRoomSummaryUpdater roomSummaryUpdaterForSession:].
+ 
+ This property is strong as the only other reference to the delegate is a weak ref in the updaterPerSession table.
  */
 @property id<MXRoomSummaryUpdating> roomSummaryUpdateDelegate;
 
 /**
  Delegate for updating room account data.
  By default, it is the one returned by [MXRoomAccountDataUpdater roomAccountDataUpdaterForSession:].
+ 
+ This property is strong as the only other reference to the delegate is a weak ref in the updaterPerSession table.
  */
 @property id<MXRoomAccountDataUpdating> roomAccountDataUpdateDelegate;
 

--- a/changelog.d/5805.bugfix
+++ b/changelog.d/5805.bugfix
@@ -1,0 +1,1 @@
+MXRoom: Fix retain cycles, in particular between MXRoomOperation and its block.


### PR DESCRIPTION
As part of https://github.com/vector-im/element-ios/issues/5805 this fixes some memory issues discovered.

In particular `MXRoomOperation`'s block would often have a strong reference to the operation that owned it, causing them to hang around even after being removed from the `orderedOperations` array.

Additionally, `MXRoomAccountDataUpdater` and `MXRoomSummaryUpdater` now use weak map tables to avoid strong references that hold on to `MXRoom` instances forever.