### PR TITLE
Log when filters cannot be saved or loaded

### DIFF
--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
@@ -1652,13 +1652,15 @@ static NSUInteger preloadOptions;
 #pragma mark - Matrix filters
 - (void)loadFilters
 {
+    MXLogDebug(@"[MXFileStore] Loading filters");
     NSString *file = [storePath stringByAppendingPathComponent:kMXFileStoreFiltersFile];
-    filters = [NSKeyedUnarchiver unarchiveObjectWithFile:file];
+    filters = [self loadObjectOfClasses:[NSSet setWithArray:@[NSDictionary.class, NSString.class]] fromFile:file];
 
     if (!filters)
     {
         // This is used as flag to indicate it has been mounted from the file
         filters = [NSMutableDictionary dictionary];
+        MXLogDebug(@"[MXFileStore] No filters loaded, creating empty dictionary");
     }
 }
 
@@ -1690,7 +1692,8 @@ static NSUInteger preloadOptions;
             }
 
             // Store new data
-            [NSKeyedArchiver archiveRootObject:self->filters toFile:file];
+            MXLogDebug(@"[MXFileStore] Saving filters");
+            [self saveObject:self->filters toFile:file];
         });
     }
 }
@@ -2171,6 +2174,65 @@ static NSUInteger preloadOptions;
 
 
 #pragma mark - Tools
+
+- (void)saveObject:(id)object toFile:(NSString *)file
+{
+    if (@available(iOS 11.0, *))
+    {
+        NSError *error;
+        NSData *data = [NSKeyedArchiver archivedDataWithRootObject:object requiringSecureCoding:NO error:&error];
+        if (error)
+        {
+            MXLogDebug(@"[MXFileStore] Failed archiving root object with error: '%@'", error.localizedDescription);
+            return;
+        }
+        
+        BOOL success = [data writeToFile:file options:0 error:&error];
+        if (success)
+        {
+            MXLogDebug(@"[MXFileStore] Saved data successfully");
+        }
+        else
+        {
+            MXLogDebug(@"[MXFileStore] Failed saving data with error: '%@'", error.localizedDescription);
+        }
+    }
+    else
+    {
+        [NSKeyedArchiver archiveRootObject:object toFile:file];
+    }
+}
+
+- (id)loadObjectOfClasses:(NSSet<Class> *)classes fromFile:(NSString *)file
+{
+    if (@available(iOS 11.0, *))
+    {
+        NSData *data = [NSData dataWithContentsOfFile:file];
+        if (!data)
+        {
+            MXLogDebug(@"[MXFileStore] No data to load at file %@", file);
+            return nil;
+        }
+        
+        NSError *error;
+        id object = [NSKeyedUnarchiver unarchivedObjectOfClasses:classes fromData:data error:&error];
+        if (object)
+        {
+            MXLogDebug(@"[MXFileStore] Loaded object from class");
+            return object;
+        }
+        else
+        {
+            MXLogDebug(@"[MXFileStore] Failed loading object from class with error: '%@'", error.localizedDescription);
+            return nil;
+        }
+    }
+    else
+    {
+        return [NSKeyedUnarchiver unarchiveObjectWithFile:file];
+    }
+}
+
 /**
  List recursevely files in a folder
  

--- a/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryStore.m
+++ b/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryStore.m
@@ -429,6 +429,11 @@
     filters[filterId] = filter.jsonString;
 }
 
+- (NSArray<NSString *> *)allFilterIds
+{
+    return filters.allKeys;
+}
+
 - (void)filterWithFilterId:(nonnull NSString*)filterId
                    success:(nonnull void (^)(MXFilterJSONModel * _Nullable filter))success
                    failure:(nullable void (^)(NSError * _Nullable error))failure

--- a/MatrixSDK/Data/Store/MXNoStore/MXNoStore.m
+++ b/MatrixSDK/Data/Store/MXNoStore/MXNoStore.m
@@ -348,6 +348,11 @@
 {
 }
 
+- (NSArray<NSString *> *)allFilterIds
+{
+    return @[];
+}
+
 - (void)filterWithFilterId:(nonnull NSString*)filterId
                    success:(nonnull void (^)(MXFilterJSONModel * _Nullable filter))success
                    failure:(nullable void (^)(NSError * _Nullable error))failure

--- a/MatrixSDK/Data/Store/MXStore.h
+++ b/MatrixSDK/Data/Store/MXStore.h
@@ -522,6 +522,11 @@
 - (void)storeFilter:(nonnull MXFilterJSONModel*)filter withFilterId:(nonnull NSString*)filterId;
 
 /**
+ Retrieve a list of all stored filter ids.
+ */
+- (nonnull NSArray <NSString *> *)allFilterIds;
+
+/**
  Retrieve a filter with a given id.
 
  @param filterId the id of the filter.

--- a/MatrixSDKTests/MXFilterTests.m
+++ b/MatrixSDKTests/MXFilterTests.m
@@ -175,6 +175,7 @@
 
                         XCTAssertNotNil(filter2);
                         XCTAssertEqualObjects(filter, filter2);
+                        XCTAssertEqualObjects(fileStore.allFilterIds, @[syncFilterId]);
 
                         [expectation fulfill];
 

--- a/changelog.d/5873.bugfix
+++ b/changelog.d/5873.bugfix
@@ -1,0 +1,1 @@
+MXFileStore: Log when filters cannot be saved or loaded


### PR DESCRIPTION
Partially resolves https://github.com/vector-im/element-ios/issues/5873, client-side change https://github.com/vector-im/element-ios/pull/5882

When investigating why the app triggers an initial sync twice I found that at the point of the second sync the app does not have any filters stored on local disk. Technically this qualifies as "filter ID is different from last sync" because it cannot be matched to anything in store, which triggers a complete cache wipe and trigger of another sync.

I could not determine from the rageshakes why the filters were missing, the options are really a failure to save or a failure to load. We do not currently log errors with either. To improve this I swaped `NSKeyUnarchiver/Archiver` APIs to the newer ones (iOS11+) which report back an error. Using this API we can get richer logs when something goes wrong.