### PR TITLE
Do not commit to file store after typing a single character

### DIFF
--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -370,10 +370,6 @@ NSInteger const kMXRoomInvalidInviteSenderErrorCode = 9002;
 - (void)setPartialTextMessage:(NSString *)partialTextMessage
 {
     [mxSession.store storePartialTextMessageForRoom:self.roomId partialTextMessage:partialTextMessage];
-    if ([mxSession.store respondsToSelector:@selector(commit)])
-    {
-        [mxSession.store commit];
-    }
 }
 
 - (NSString *)partialTextMessage

--- a/changelog.d/5906.bugfix
+++ b/changelog.d/5906.bugfix
@@ -1,0 +1,1 @@
+Room: Do not commit to file store after typing a single character


### PR DESCRIPTION
Relates to https://github.com/vector-im/element-ios/issues/5906

For some reason we are writing to disk on every character typed when composing a message, i.e. we are writing multiple types per second for something that is quite ephemeral. For instance if the app crashed whilst a message was being typed, at most a few sentences would be lost. It does not seem necessary to commit on every single character typed and it will improve the typing performance a bit if we dont.