### PR TITLE
Fix retain cycles in MXEventListener & MXRoomSummary

### DIFF
--- a/MatrixSDK/Data/MXEventListener.h
+++ b/MatrixSDK/Data/MXEventListener.h
@@ -51,7 +51,7 @@ typedef void (^MXOnEvent)(MXEvent *event, MXTimelineDirection direction, id _Nul
  */
 - (void)notify:(MXEvent*)event direction:(MXTimelineDirection)direction andCustomObject:(nullable id)customObject;
 
-@property (nonatomic, readonly) id sender;
+@property (nonatomic, weak, readonly) id sender;
 @property (nonatomic, nullable, readonly) NSArray<MXEventTypeString>* eventTypes;
 @property (nonatomic, readonly) MXOnEvent listenerBlock;
 

--- a/MatrixSDK/Data/MXRoomSummary.m
+++ b/MatrixSDK/Data/MXRoomSummary.m
@@ -374,7 +374,9 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
     
     // Process every message received by back pagination
     __block BOOL lastMessageUpdated = NO;
+    MXWeakify(timeline);
     [timeline listenToEvents:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *eventState) {
+        MXStrongifyAndReturnIfNil(timeline);
         if (direction == MXTimelineDirectionBackwards
             && !lastMessageUpdated)
         {

--- a/changelog.d/5058.bugfix
+++ b/changelog.d/5058.bugfix
@@ -1,0 +1,1 @@
+MXEventListener/MXRoomSummary: Fix retain cycles


### PR DESCRIPTION
This is the second part of a fix for a triple-leak involving `MXKRoomDataSource`, `MXRoomEventTimeline` and `MXEventListener`. The first part can be found in vector-im/element-ios#5923.

There are two issues here:

1. When listening for events on `timeline`, `MXRoomSummary` strongly captures the latter in its own event handler block.
2. The `sender` property on `MXEventListener` is strong and, in all cases I was able to locate, the listener is stored in an array on the object that is passed in as `sender`, creating a retain cycle.

I haven't found concrete steps to reproduce the leak (and the memory graph debugger is also not 100% reliable) but the cycle frequently shows after having entered, left and posted in rooms a few times.

![Screenshot 2022-03-27 at 20 31 21](https://user-images.githubusercontent.com/1137962/160296813-d737a5bf-68a4-4808-90dc-697797b4d650.png)
![Screenshot 2022-03-27 at 20 30 12](https://user-images.githubusercontent.com/1137962/160296817-7b9e4557-4445-46ae-bc8a-1971ad3e9426.png)

Relates to: vector-im/element-ios#5058

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request contains a changelog file in ./changelog.d. See https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
