### PR TITLE
Return room identifier and known servers when resolving alias

### DIFF
--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -1721,6 +1721,10 @@
 		ECF29BDF264195320053E6D6 /* MXAssertedIdentityModel.h in Headers */ = {isa = PBXBuildFile; fileRef = ECF29BDD264195320053E6D6 /* MXAssertedIdentityModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		ECF29BE52641953C0053E6D6 /* MXAssertedIdentityModel.m in Sources */ = {isa = PBXBuildFile; fileRef = ECF29BE42641953C0053E6D6 /* MXAssertedIdentityModel.m */; };
 		ECF29BE62641953C0053E6D6 /* MXAssertedIdentityModel.m in Sources */ = {isa = PBXBuildFile; fileRef = ECF29BE42641953C0053E6D6 /* MXAssertedIdentityModel.m */; };
+		ED88999127F2065D00718486 /* MXRoomAliasResolution.h in Headers */ = {isa = PBXBuildFile; fileRef = ED88998F27F2065C00718486 /* MXRoomAliasResolution.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		ED88999227F2065D00718486 /* MXRoomAliasResolution.h in Headers */ = {isa = PBXBuildFile; fileRef = ED88998F27F2065C00718486 /* MXRoomAliasResolution.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		ED88999327F2065D00718486 /* MXRoomAliasResolution.m in Sources */ = {isa = PBXBuildFile; fileRef = ED88999027F2065D00718486 /* MXRoomAliasResolution.m */; };
+		ED88999427F2065D00718486 /* MXRoomAliasResolution.m in Sources */ = {isa = PBXBuildFile; fileRef = ED88999027F2065D00718486 /* MXRoomAliasResolution.m */; };
 		ED8943D427E34762000FC39C /* MXMemoryRoomStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED8943D327E34762000FC39C /* MXMemoryRoomStoreTests.swift */; };
 		ED8943D527E34762000FC39C /* MXMemoryRoomStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED8943D327E34762000FC39C /* MXMemoryRoomStoreTests.swift */; };
 		EDB4209227DF77390036AF39 /* MXEventsEnumeratorOnArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB4209027DF77310036AF39 /* MXEventsEnumeratorOnArrayTests.swift */; };
@@ -2693,6 +2697,8 @@
 		ECF29BDD264195320053E6D6 /* MXAssertedIdentityModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXAssertedIdentityModel.h; sourceTree = "<group>"; };
 		ECF29BE42641953C0053E6D6 /* MXAssertedIdentityModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXAssertedIdentityModel.m; sourceTree = "<group>"; };
 		ED2F344856EFFCA383E37B22 /* Pods-SDK-MatrixSDK.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SDK-MatrixSDK.release.xcconfig"; path = "Target Support Files/Pods-SDK-MatrixSDK/Pods-SDK-MatrixSDK.release.xcconfig"; sourceTree = "<group>"; };
+		ED88998F27F2065C00718486 /* MXRoomAliasResolution.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXRoomAliasResolution.h; sourceTree = "<group>"; };
+		ED88999027F2065D00718486 /* MXRoomAliasResolution.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXRoomAliasResolution.m; sourceTree = "<group>"; };
 		ED8943D327E34762000FC39C /* MXMemoryRoomStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXMemoryRoomStoreTests.swift; sourceTree = "<group>"; };
 		EDB4209027DF77310036AF39 /* MXEventsEnumeratorOnArrayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXEventsEnumeratorOnArrayTests.swift; sourceTree = "<group>"; };
 		EDB4209427DF822B0036AF39 /* MXEventsByTypesEnumeratorOnArrayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXEventsByTypesEnumeratorOnArrayTests.swift; sourceTree = "<group>"; };
@@ -3504,6 +3510,8 @@
 				3281E8B619E42DFE00976E1A /* MXJSONModels.m */,
 				323E0C591A306D7A00A31D73 /* MXEvent.h */,
 				323E0C5A1A306D7A00A31D73 /* MXEvent.m */,
+				ED88998F27F2065C00718486 /* MXRoomAliasResolution.h */,
+				ED88999027F2065D00718486 /* MXRoomAliasResolution.m */,
 				B17982F02119E4A0001FD722 /* MXRoomPowerLevels.h */,
 				B17982F42119E4A2001FD722 /* MXRoomPowerLevels.m */,
 				B17982F12119E4A0001FD722 /* MXRoomTombStoneContent.h */,
@@ -4957,6 +4965,7 @@
 				EC8A538B25B1BC77004E0802 /* MXCallCandidate.h in Headers */,
 				F03EF5041DF01596009DF592 /* MXLRUCache.h in Headers */,
 				EC8A539D25B1BC77004E0802 /* MXCallCandidatesEventContent.h in Headers */,
+				ED88999127F2065D00718486 /* MXRoomAliasResolution.h in Headers */,
 				18B22A7027707CDD00482170 /* MXEventContentLocation.h in Headers */,
 				EC60EDC6265CFEA800B39A4E /* MXRoomSyncUnreadNotifications.h in Headers */,
 				329FB1791A0A74B100A5E88E /* MXTools.h in Headers */,
@@ -5509,6 +5518,7 @@
 				B14EF3542397E90400758AF0 /* MXLoginPolicy.h in Headers */,
 				B19A30CF24042F0800FB6F35 /* MXSelfVerifyingMasterKeyTrustedQRCodeData.h in Headers */,
 				B14EF3552397E90400758AF0 /* MXCryptoTools.h in Headers */,
+				ED88999227F2065D00718486 /* MXRoomAliasResolution.h in Headers */,
 				B14EF3562397E90400758AF0 /* MXGroup.h in Headers */,
 				B14EF3572397E90400758AF0 /* MX3PidAddSession.h in Headers */,
 				B14EF3582397E90400758AF0 /* MXUser.h in Headers */,
@@ -6071,6 +6081,7 @@
 				325AF3E324897D9400EF937D /* MXSecretRecoveryResult.m in Sources */,
 				F03EF5091DF071D5009DF592 /* MXEncryptedAttachments.m in Sources */,
 				ECE3DF842707370000FB4C96 /* MXRoomListDataPaginationOptions.swift in Sources */,
+				ED88999327F2065D00718486 /* MXRoomAliasResolution.m in Sources */,
 				324DD2C1246D658500377005 /* MXHkdfSha256.m in Sources */,
 				EC60ED73265CFCA500B39A4E /* MXToDeviceSyncResponse.m in Sources */,
 				3274538623FD69D600438328 /* MXKeyVerificationRequestByToDeviceJSONModel.m in Sources */,
@@ -6593,6 +6604,7 @@
 				B14EF2532397E90400758AF0 /* MXPushRuleSenderNotificationPermissionConditionChecker.m in Sources */,
 				324AAC752399140D00380A66 /* MXKeyVerificationAccept.m in Sources */,
 				B14EF2542397E90400758AF0 /* MXReceiptData.m in Sources */,
+				ED88999427F2065D00718486 /* MXRoomAliasResolution.m in Sources */,
 				32B0E34223A378320054FF1A /* MXEventReference.m in Sources */,
 				B105CD9E261E0B70006EB204 /* MXSpaceChildrenSummary.swift in Sources */,
 				B14EF2552397E90400758AF0 /* MXWellKnownBaseConfig.m in Sources */,

--- a/MatrixSDK/Contrib/Swift/MXRestClient.swift
+++ b/MatrixSDK/Contrib/Swift/MXRestClient.swift
@@ -1665,17 +1665,17 @@ public extension MXRestClient {
     }
     
     /**
-     Get the room ID corresponding to this room alias
-     
+     Resolve given room alias to a room identifier and a list of servers aware of this identifier
+
      - parameters:
         - roomAlias: the alias of the room to look for.
         - completion: A block object called when the operation completes.
-        - response: Provides the the ID of the room on success.
-     
+        - response: Provides a resolution object containing the room ID and a list of servers
+
      - returns: a `MXHTTPOperation` instance.
      */
-    @nonobjc @discardableResult func roomId(forRoomAlias roomAlias: String, completion: @escaping (_ response: MXResponse<String>) -> Void) -> MXHTTPOperation {
-        return __roomID(forRoomAlias: roomAlias, success: currySuccess(completion), failure: curryFailure(completion))
+    @nonobjc @discardableResult func resolveRoomAlias(_ roomAlias: String, completion: @escaping (_ response: MXResponse<MXRoomAliasResolution>) -> Void) -> MXHTTPOperation {
+        return __resolveRoomAlias(roomAlias, success: currySuccess(completion), failure: curryFailure(completion))
     }
     
     // Mark: - Media Repository API

--- a/MatrixSDK/JSONModels/MXRoomAliasResolution.h
+++ b/MatrixSDK/JSONModels/MXRoomAliasResolution.h
@@ -1,0 +1,31 @@
+//
+//  MXRoomAliasResolution.h
+//  Pods
+//
+//  Created by Element on 28/03/2022.
+//
+
+#ifndef MXRoomAliasResolution_h
+#define MXRoomAliasResolution_h
+
+#import "MXJSONModel.h"
+
+/**
+ The result of a server resolving a room alias via /directory/room/ endpoint
+ into a cannonical identifier with servers that are aware of this identifier.
+ */
+@interface MXRoomAliasResolution : MXJSONModel
+
+/**
+ Resolved room identifier that matches a given alias
+ */
+@property (nonatomic, strong) NSString *roomId;
+
+/**
+ A list of servers that are aware of the room identifier.
+ */
+@property (nonatomic, strong) NSArray<NSString *> *servers;
+
+@end
+
+#endif /* MXRoomAliasResolution_h */

--- a/MatrixSDK/JSONModels/MXRoomAliasResolution.m
+++ b/MatrixSDK/JSONModels/MXRoomAliasResolution.m
@@ -1,0 +1,21 @@
+//
+//  MXRoomAliasResolution.m
+//  MatrixSDK
+//
+//  Created by Element on 28/03/2022.
+//
+
+#import <Foundation/Foundation.h>
+#import "MXRoomAliasResolution.h"
+
+@implementation MXRoomAliasResolution
+
++ (instancetype)modelFromJSON:(NSDictionary *)JSONDictionary
+{
+    MXRoomAliasResolution *resolution = [[MXRoomAliasResolution alloc] init];
+    MXJSONModelSetString(resolution.roomId, JSONDictionary[@"room_id"]);
+    MXJSONModelSetArray(resolution.servers, JSONDictionary[@"servers"])
+    return resolution;
+}
+
+@end

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -44,6 +44,7 @@
 #import "MXURLPreview.h"
 #import "MXTaggedEvents.h"
 #import "MXCredentials.h"
+#import "MXRoomAliasResolution.h"
 
 @class MXThirdpartyProtocolsResponse;
 @class MXThirdPartyUsersResponse;
@@ -2010,18 +2011,19 @@ NS_REFINED_FOR_SWIFT;
                                 failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**
- Get the room ID corresponding to this room alias
+ Resolve given room alias to a room identifier and a list of servers aware of this identifier
 
  @param roomAlias the alias of the room to look for.
 
- @param success A block object called when the operation succeeds. It provides the ID of the room.
+ @param success A block object called when the operation succeeds.
+                It provides a resolution object containing room ID and a list of servers
  @param failure A block object called when the operation fails.
 
  @return a MXHTTPOperation instance.
  */
-- (MXHTTPOperation*)roomIDForRoomAlias:(NSString*)roomAlias
-                               success:(void (^)(NSString *roomId))success
-                               failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
+- (MXHTTPOperation*)resolveRoomAlias:(NSString *)roomAlias
+                             success:(void (^)(MXRoomAliasResolution *resolution))success
+                             failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 
 #pragma mark - Third party Lookup API

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -4029,9 +4029,9 @@ andUnauthenticatedHandler: (MXRestClientUnauthenticatedHandler)unauthenticatedHa
                                  }];
 }
 
-- (MXHTTPOperation*)roomIDForRoomAlias:(NSString*)roomAlias
-                               success:(void (^)(NSString *roomId))success
-                               failure:(void (^)(NSError *error))failure
+- (MXHTTPOperation *)resolveRoomAlias:(NSString *)roomAlias
+                              success:(void (^)(MXRoomAliasResolution *))success
+                              failure:(void (^)(NSError *))failure
 {
     // Note: characters in a room alias need to be escaped in the URL
     NSString *path = [NSString stringWithFormat:@"%@/directory/room/%@",
@@ -4047,11 +4047,11 @@ andUnauthenticatedHandler: (MXRestClientUnauthenticatedHandler)unauthenticatedHa
 
                                      if (success)
                                      {
-                                         __block NSString *roomId;
+                                         __block MXRoomAliasResolution *resolution;
                                          [self dispatchProcessing:^{
-                                             MXJSONModelSetString(roomId, JSONResponse[@"room_id"]);
+                                             resolution = [MXRoomAliasResolution modelFromJSON:JSONResponse];
                                          } andCompletion:^{
-                                             success(roomId);
+                                             success(resolution);
                                          }];
                                      }
                                  }

--- a/MatrixSDK/Space/MXRoomAliasAvailabilityChecker.swift
+++ b/MatrixSDK/Space/MXRoomAliasAvailabilityChecker.swift
@@ -54,7 +54,7 @@ public class MXRoomAliasAvailabilityChecker {
             return nil
         }
         
-        return session.matrixRestClient.roomId(forRoomAlias: fullAlias) { response in
+        return session.matrixRestClient.resolveRoomAlias(fullAlias) { response in
             if response.isSuccess {
                 completion(.notAvailable)
             } else if let error = response.error, let response = MXHTTPOperation.urlResponse(fromError: error), response.statusCode == 404 {

--- a/MatrixSDKTests/MXRestClientTests.m
+++ b/MatrixSDKTests/MXRestClientTests.m
@@ -383,6 +383,8 @@
                     XCTAssertNotNil(resolution);
                     XCTAssertNotEqual(resolution.roomId.length, 0);
                     XCTAssertEqualObjects(resolution.roomId, roomId, @"Mapping from room alias to room ID is wrong");
+                    XCTAssertNotEqual(resolution.servers.count, 0);
+                    XCTAssertNotEqual(resolution.servers[0].length, 0);
                     
                     // Test with a valid alias which already exists
                     [bobRestClient2 addRoomAlias:roomId alias:correctAlias success:^{

--- a/MatrixSDKTests/MXRestClientTests.m
+++ b/MatrixSDKTests/MXRestClientTests.m
@@ -22,6 +22,7 @@
 #import "MatrixSDKTestsData.h"
 #import "MXRoomMember.h"
 #import "MXKey.h"
+#import "MXRoomAliasResolution.h"
 #import "MXThirdpartyProtocolsResponse.h"
 
 // Do not bother with retain cycles warnings in tests
@@ -377,11 +378,11 @@
             // Test with a valid alias
             [bobRestClient2 addRoomAlias:roomId alias:correctAlias success:^{
                 
-                [bobRestClient2 roomIDForRoomAlias:correctAlias success:^(NSString *roomId2) {
+                [bobRestClient2 resolveRoomAlias:correctAlias success:^(MXRoomAliasResolution *resolution) {
                     
-                    XCTAssertNotNil(roomId2);
-                    XCTAssertNotEqual(roomId2.length, 0);
-                    XCTAssertEqualObjects(roomId2, roomId, @"Mapping from room alias to room ID is wrong");
+                    XCTAssertNotNil(resolution);
+                    XCTAssertNotEqual(resolution.roomId.length, 0);
+                    XCTAssertEqualObjects(resolution.roomId, roomId, @"Mapping from room alias to room ID is wrong");
                     
                     // Test with a valid alias which already exists
                     [bobRestClient2 addRoomAlias:roomId alias:correctAlias success:^{
@@ -427,7 +428,7 @@
             [bobRestClient2 removeRoomAlias:roomAlias success:^{
                 
                 // Check whether it has been removed correctly
-                [bobRestClient2 roomIDForRoomAlias:roomAlias success:^(NSString *roomId2) {
+                [bobRestClient2 resolveRoomAlias:roomAlias success:^(MXRoomAliasResolution *resolution) {
                     
                     XCTFail(@"The request should not succeed");
                     [expectation fulfill];
@@ -1226,25 +1227,6 @@
         }];
     }];
 }
-
-// Disabled as it seems that the registration method we use in tests now uses the
-// local part of the user id as the default displayname
-//- (void)testUserNilDisplayName
-//{
-//    [self.matrixSDKTestsData doMXRestClientTestWithBob:self readyToTest:^(MXRestClient *bobRestClient, XCTestExpectation *expectation) {
-//
-//        [bobRestClient displayNameForUser:nil success:^(NSString *displayname) {
-//
-//            XCTAssertNil(displayname, @"mxBob has no displayname defined");
-//            [expectation fulfill];
-//
-//        } failure:^(NSError *error) {
-//            XCTFail(@"The request should not fail - NSError: %@", error);
-//            [expectation fulfill];
-//        }];
-//
-//    }];
-//}
 
 - (void)testUserAvatarUrl
 {

--- a/changelog.d/4858.change
+++ b/changelog.d/4858.change
@@ -1,0 +1,1 @@
+Room: Return room identifier and known servers when resolving alias


### PR DESCRIPTION
Relates to https://github.com/vector-im/element-ios/issues/4858

The [directory/room/<room_alias>](https://spec.matrix.org/v1.2/client-server-api/#get_matrixclientv3directoryroomroomalias) endpoint used to convert room alias to a room identifier returns a list of servers that are aware of the room. In the existing SDK implementation this list of servers is never stored (we only grab the identifier), meaning that if we later want to join this room from another home server, it is no longer possible without the knowledge of the servers.

To solve this on the SDK side, store both `room_id` as well as list of `servers` in a new `MXRoomAliasResolution` object which can be fetched via `resolveRoomAlias` endpoint, replacing the simpler `roomIdForAlias`