### PR TITLE
Move  `handleRoomKeyEvent` logic back to `MXSession`.

### DIFF
--- a/MatrixSDK/Crypto/MXCrypto.h
+++ b/MatrixSDK/Crypto/MXCrypto.h
@@ -264,12 +264,12 @@ extern NSString *const MXDeviceListDidUpdateUsersDevicesNotification;
 - (void)handleDeviceUnusedFallbackKeys:(NSArray<NSString *> *)deviceUnusedFallbackKeys;
 
 /**
- Handle toDevice event
+ Handle a room key event.
  
- @param event the `toDevice` event.
+ @param event the room key event.
  @param onComplete the block called when the operation completes.
  */
-- (void)handleToDeviceEvent:(MXEvent*)event onComplete:(void (^)(void))onComplete;
+- (void)handleRoomKeyEvent:(MXEvent*)event onComplete:(void (^)(void))onComplete;
 
 /**
  Handle the completion of a /sync.

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -818,24 +818,6 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 #endif
 }
 
-- (void)handleToDeviceEvent:(MXEvent *)event onComplete:(void (^)(void))onComplete
-{
-    switch (event.eventType)
-    {
-        case MXEventTypeRoomKey:
-        {
-            [self handleRoomKeyEvent:event onComplete:onComplete];
-            break;
-        }
-            
-        default:
-            onComplete();
-            break;
-    }
-    [self.mxSession.eventStreamService dispatchOnLiveToDeviceWithEvent:event];
-}
-
-
 - (void)handleRoomKeyEvent:(MXEvent*)event onComplete:(void (^)(void))onComplete
 {
     // Use decryptionQueue as synchronisation because decryptions require room keys

--- a/MatrixSDK/EventStream/MXEventStreamService.swift
+++ b/MatrixSDK/EventStream/MXEventStreamService.swift
@@ -38,7 +38,7 @@ import Foundation
     }
 
     public func dispatchOnLiveToDevice(event: MXEvent) {
-            multicastDelegate.invoke({ listener in listener.onLiveToDeviceEvent(event: event)})
+        multicastDelegate.invoke({ listener in listener.onLiveToDeviceEvent(event: event)})
     }
 }
 

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -1885,8 +1885,19 @@ typedef void (^MXOnResumeDone)(void);
         onComplete();
     };
     
-    
-    [_crypto handleToDeviceEvent:event onComplete:onHandleToDeviceEventDone];
+    switch (event.eventType)
+    {
+        case MXEventTypeRoomKey:
+        {
+            [_crypto handleRoomKeyEvent:event onComplete:onHandleToDeviceEventDone];
+            break;
+        }
+
+        default:
+            onHandleToDeviceEventDone();
+            break;
+    }
+    [_eventStreamService dispatchOnLiveToDeviceWithEvent:event];
 }
 
 /**

--- a/MatrixSDKTests/MXCryptoTests.m
+++ b/MatrixSDKTests/MXCryptoTests.m
@@ -1893,7 +1893,7 @@
                 newContent[@"session_key"] = sessionInfo.session.sessionKey;
                 toDeviceEvent.clearEvent.wireContent = newContent;
 
-                [bobSession.crypto handleToDeviceEvent:toDeviceEvent onComplete:^{}];
+                [bobSession.crypto handleRoomKeyEvent:toDeviceEvent onComplete:^{}];
 
                 // We still must be able to decrypt the event
                 // ie, the implementation must have ignored the new room key with the advanced outbound group
@@ -1963,7 +1963,7 @@
                     }];
                     
                     // Reinject the m.room_key event. This mimics a room_key event that arrives after message events.
-                    [bobSession.crypto handleToDeviceEvent:toDeviceEvent onComplete:^{}];
+                    [bobSession.crypto handleRoomKeyEvent:toDeviceEvent onComplete:^{}];
                 }];
             }];
         }];

--- a/MatrixSDKTests/MXRoomSummaryTests.m
+++ b/MatrixSDKTests/MXRoomSummaryTests.m
@@ -1398,7 +1398,7 @@ NSString *uisiString = @"The sender's device has not sent us the keys for this m
                         // Attempt a new decryption
                         [bobSession decryptEvents:@[event] inTimeline:nil onComplete:^(NSArray<MXEvent *> *failedEvents) {
                             // Reinject the m.room_key event. This mimics a room_key event that arrives after message events.
-                            [bobSession.crypto handleToDeviceEvent:toDeviceEvent onComplete:^{}];
+                            [bobSession.crypto handleRoomKeyEvent:toDeviceEvent onComplete:^{}];
                         }];
 
                         break;

--- a/changelog.d/5938.bugfix
+++ b/changelog.d/5938.bugfix
@@ -1,0 +1,1 @@
+Move `handleRoomKeyEvent` logic back to `MXSession`.


### PR DESCRIPTION
Accompanies https://github.com/vector-im/element-ios/pull/5945