### PR TITLE
Add assertion failure macros

### DIFF
--- a/MatrixSDK/Data/RoomList/CoreData/MXCoreDataRoomListDataFetcher.swift
+++ b/MatrixSDK/Data/RoomList/CoreData/MXCoreDataRoomListDataFetcher.swift
@@ -29,7 +29,6 @@ internal class MXCoreDataRoomListDataFetcher: NSObject, MXRoomListDataFetcher {
     
     private let multicastDelegate: MXMulticastDelegate<MXRoomListDataFetcherDelegate> = MXMulticastDelegate()
     
-    private weak var session: MXSession?
     internal let fetchOptions: MXRoomListDataFetchOptions
     private lazy var dataUpdateThrottler: MXThrottler = {
         return MXThrottler(minimumDelay: 0.1, queue: .main)
@@ -114,10 +113,8 @@ internal class MXCoreDataRoomListDataFetcher: NSObject, MXRoomListDataFetcher {
         return result
     }
     
-    internal init(session: MXSession?,
-                  fetchOptions: MXRoomListDataFetchOptions,
+    internal init(fetchOptions: MXRoomListDataFetchOptions,
                   store: MXRoomSummaryCoreDataContextableStore) {
-        self.session = session
         self.fetchOptions = fetchOptions
         self.store = store
         super.init()

--- a/MatrixSDK/Data/RoomList/CoreData/MXCoreDataRoomListDataManager.swift
+++ b/MatrixSDK/Data/RoomList/CoreData/MXCoreDataRoomListDataManager.swift
@@ -36,8 +36,8 @@ public class MXCoreDataRoomListDataManager: NSObject, MXRoomListDataManager {
                                                   session: session,
                                                   spaceService: spaceService)
         }
-        guard let session = session, let store = session.store else {
-            fatalError("[MXCoreDataRoomListDataManager] No session or no store")
+        guard let store = session?.store else {
+            fatalError("[MXCoreDataRoomListDataManager] No session store")
         }
         guard let coreDataStore = store.roomSummaryStore as? MXRoomSummaryCoreDataContextableStore else {
             fatalError("[MXCoreDataRoomListDataManager] Session.store.roomSummaryStore is not CoreDataContextable")
@@ -46,8 +46,7 @@ public class MXCoreDataRoomListDataManager: NSObject, MXRoomListDataManager {
         assert(coreDataStore.mainManagedObjectContext.concurrencyType == .mainQueueConcurrencyType,
                "[MXCoreDataRoomListDataManager] Managed object context must have mainQueueConcurrencyType")
         
-        return MXCoreDataRoomListDataFetcher(session: session,
-                                             fetchOptions: options,
+        return MXCoreDataRoomListDataFetcher(fetchOptions: options,
                                              store: coreDataStore)
     }
 }

--- a/MatrixSDK/Utils/MXLog.h
+++ b/MatrixSDK/Utils/MXLog.h
@@ -35,3 +35,7 @@
 #define MXLogError(message, ...) { \
     [MXLogObjcWrapper logError:[NSString stringWithFormat: message, ##__VA_ARGS__] file:@__FILE__ function:[NSString stringWithFormat:@"%s", __FUNCTION__] line:__LINE__]; \
 }
+
+#define MXLogFailure(message, ...) { \
+    [MXLogObjcWrapper logFailure:[NSString stringWithFormat: message, ##__VA_ARGS__] file:@__FILE__ function:[NSString stringWithFormat:@"%s", __FUNCTION__] line:__LINE__]; \
+}

--- a/MatrixSDK/Utils/MXLog.swift
+++ b/MatrixSDK/Utils/MXLog.swift
@@ -118,6 +118,22 @@ private var logger: SwiftyBeaver.Type = {
         logger.error(message, file, function, line: line)
     }
     
+    public static func failure(_ message: @autoclosure () -> Any, _
+                                file: String = #file, _ function: String = #function, line: Int = #line, context: Any? = nil) {
+        logger.error(message(), file, function, line: line, context: context)
+        #if DEBUG
+        assertionFailure("\(message())")
+        #endif
+    }
+    
+    @available(swift, obsoleted: 5.4)
+    @objc public static func logFailure(_ message: String, file: String, function: String, line: Int) {
+        logger.error(message, file, function, line: line)
+        #if DEBUG
+        assertionFailure(message)
+        #endif
+    }
+    
     // MARK: - Private
     
     fileprivate static func configureLogger(_ logger: SwiftyBeaver.Type, withConfiguration configuration: MXLogConfiguration) {

--- a/MatrixSDK/Utils/MXLogObjcWrapper.h
+++ b/MatrixSDK/Utils/MXLogObjcWrapper.h
@@ -33,6 +33,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (void)logError:(NSString *)message file:(NSString *)file function:(NSString *)function line:(NSUInteger)line;
 
++ (void)logFailure:(NSString *)message file:(NSString *)file function:(NSString *)function line:(NSUInteger)line;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/MatrixSDK/Utils/MXLogObjcWrapper.m
+++ b/MatrixSDK/Utils/MXLogObjcWrapper.m
@@ -44,4 +44,9 @@
     [MXLog logError:message file:file function:function line:line];
 }
 
++ (void)logFailure:(NSString *)message file:(NSString *)file function:(NSString *)function line:(NSUInteger)line
+{
+    [MXLog logFailure:message file:file function:function line:line];
+}
+
 @end

--- a/MatrixSDKTests/MXCoreDataRoomListDataManagerUnitTests.swift
+++ b/MatrixSDKTests/MXCoreDataRoomListDataManagerUnitTests.swift
@@ -187,8 +187,7 @@ class MXCoreDataRoomListDataManagerUnitTests: XCTestCase {
             store.storeSummary(summary)
         }
         
-        let fetcher = MXCoreDataRoomListDataFetcher(session: nil,
-                                                    fetchOptions: basicFetchOptions,
+        let fetcher = MXCoreDataRoomListDataFetcher(fetchOptions: basicFetchOptions,
                                                     store: store)
         return fetcher
     }


### PR DESCRIPTION
Add macros and `MXLog` methods to log assertions that "crash" the app in DEBUG mode. This is a useful tool during development: wherease merely logging to console is easy to miss, an assertion forces the developer to debug a given issue whilst the context is still in place.