### PR TITLE
Notify other devices of verification acceptance

### DIFF
--- a/MatrixSDK/Crypto/Verification/Data/MXTransactionCancelCode.h
+++ b/MatrixSDK/Crypto/Verification/Data/MXTransactionCancelCode.h
@@ -71,6 +71,9 @@ NS_ASSUME_NONNULL_BEGIN
 // The QR code is invalid
 + (instancetype)qrCodeInvalid;
 
+// Verification request accepted by another device
++ (instancetype)accepted;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/MatrixSDK/Crypto/Verification/Data/MXTransactionCancelCode.m
+++ b/MatrixSDK/Crypto/Verification/Data/MXTransactionCancelCode.m
@@ -87,4 +87,9 @@
     return [[MXTransactionCancelCode alloc] initWithValue:@"m.qr_code.invalid" humanReadable:@"Invalid QR code"];
 }
 
++ (instancetype)accepted
+{
+    return [[MXTransactionCancelCode alloc] initWithValue:@"m.accepted" humanReadable:@"Verification request accepted by another device"];
+}
+
 @end

--- a/MatrixSDK/Crypto/Verification/MXKeyVerificationManager.h
+++ b/MatrixSDK/Crypto/Verification/MXKeyVerificationManager.h
@@ -203,6 +203,13 @@ FOUNDATION_EXPORT NSString *const MXKeyVerificationManagerNotificationTransactio
  */
 - (void)removeQRCodeTransactionWithTransactionId:(NSString*)transactionId;
 
+
+- (void)notifyOthersOfAcceptanceWithTransactionId:(NSString*)transactionId
+                               acceptedUserId:(NSString*)acceptedUserId
+                             acceptedDeviceId:(NSString*)acceptedDeviceId
+                                      success:(void(^)(void))success
+                                      failure:(void(^)(NSError *error))failure;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/MatrixSDK/Crypto/Verification/MXKeyVerificationManager.m
+++ b/MatrixSDK/Crypto/Verification/MXKeyVerificationManager.m
@@ -687,6 +687,25 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
     return operation;
 }
 
+- (void)notifyOthersOfAcceptanceWithTransactionId:(NSString*)transactionId
+                               acceptedUserId:(NSString*)acceptedUserId
+                             acceptedDeviceId:(NSString*)acceptedDeviceId
+                                      success:(void(^)(void))success
+                                      failure:(void(^)(NSError *error))failure
+{
+    [self otherDeviceIdsOfUser:acceptedUserId success:^(NSArray<NSString *> *deviceIds) {
+        NSMutableArray *nonChosenDevices = [deviceIds mutableCopy];
+        [nonChosenDevices removeObject:acceptedDeviceId];
+        
+        MXKeyVerificationCancel *cancel = [MXKeyVerificationCancel new];
+        MXTransactionCancelCode *cancelCode = MXTransactionCancelCode.accepted;
+        cancel.transactionId = transactionId;
+        cancel.code = cancelCode.value;
+        cancel.reason = cancelCode.humanReadable;
+        [self sendToDevices:acceptedUserId deviceIds:nonChosenDevices eventType:kMXEventTypeStringKeyVerificationCancel content:cancel.JSONDictionary success:success failure:failure];
+    } failure:failure];
+}
+
 - (void)cancelVerificationRequest:(MXKeyVerificationRequest*)request
                           success:(void(^)(void))success
                           failure:(void(^)(NSError *error))failure

--- a/MatrixSDK/Crypto/Verification/Requests/MXKeyVerificationRequest.m
+++ b/MatrixSDK/Crypto/Verification/Requests/MXKeyVerificationRequest.m
@@ -197,6 +197,11 @@ NSString * const MXKeyVerificationRequestDidChangeNotification = @"MXKeyVerifica
     {
         [self updateState:MXKeyVerificationRequestStateReady notifiy:YES];
     }
+    [self.manager notifyOthersOfAcceptanceWithTransactionId:self.requestId acceptedUserId:self.otherUser acceptedDeviceId: self.otherDevice success:^{
+        MXLogDebug(@"[MXKeyVerificationRequest] handleReady notified others of acceptance");
+    } failure:^(NSError * _Nonnull error) {
+        MXLogError(@"[MXKeyVerificationRequest] handleReady failed notify others of acceptance");
+    }];
 }
 
 - (void)handleCancel:(MXKeyVerificationCancel *)cancelContent


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-ios/issues/4470

When a client receives a verification request acceptance it needs to notify other devices that it was accepted so they can dismiss their requests.


### Todo
- [ ] check if the same issue exists on android and fix. https://github.com/vector-im/element-android/issues/5724