### PR TITLE
Update JitsiMeetSDK to 5.0.2.

### DIFF
--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -48,7 +48,7 @@ Pod::Spec.new do |s|
   end
 
   s.subspec 'JingleCallStack' do |ss|
-    ss.ios.deployment_target = "11.0"
+    ss.ios.deployment_target = "12.0"
     
     ss.source_files  = "MatrixSDKExtensions/VoIP/Jingle/**/*.{h,m}"
     

--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -60,11 +60,7 @@ Pod::Spec.new do |s|
     #ss.ios.dependency 'GoogleWebRTC', '~>1.1.21820'
     
     # Use WebRTC framework included in Jitsi Meet SDK
-    ss.ios.dependency 'JitsiMeetSDK', ' 3.10.2'
-
-    # JitsiMeetSDK has not yet binaries for arm64 simulator
-    ss.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-    ss.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+    ss.ios.dependency 'JitsiMeetSDK', '5.0.2'
   end
 
 end

--- a/changelog.d/6018.change
+++ b/changelog.d/6018.change
@@ -1,0 +1,1 @@
+Pods: Upgrade JitsiMeetSDK to 5.0.2 and re-enable building for ARM64 simulator.


### PR DESCRIPTION
Remove arm64 simulator exclusion.
Part of https://github.com/vector-im/element-ios/issues/6018