### PR TITLE
Change `sharedHistory` flag to unstable variant

### DIFF
--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -1787,6 +1787,10 @@
 		EDB4209627DF822B0036AF39 /* MXEventsByTypesEnumeratorOnArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB4209427DF822B0036AF39 /* MXEventsByTypesEnumeratorOnArrayTests.swift */; };
 		EDB4209927DF842F0036AF39 /* MXEventFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB4209827DF842F0036AF39 /* MXEventFixtures.swift */; };
 		EDB4209A27DF842F0036AF39 /* MXEventFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB4209827DF842F0036AF39 /* MXEventFixtures.swift */; };
+		EDBCF336281A8ABD00ED5044 /* MXSharedHistoryKeyService.h in Headers */ = {isa = PBXBuildFile; fileRef = EDBCF335281A8AB900ED5044 /* MXSharedHistoryKeyService.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EDBCF337281A8ABE00ED5044 /* MXSharedHistoryKeyService.h in Headers */ = {isa = PBXBuildFile; fileRef = EDBCF335281A8AB900ED5044 /* MXSharedHistoryKeyService.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EDBCF339281A8D3D00ED5044 /* MXSharedHistoryKeyService.m in Sources */ = {isa = PBXBuildFile; fileRef = EDBCF338281A8D3D00ED5044 /* MXSharedHistoryKeyService.m */; };
+		EDBCF33A281A8D3D00ED5044 /* MXSharedHistoryKeyService.m in Sources */ = {isa = PBXBuildFile; fileRef = EDBCF338281A8D3D00ED5044 /* MXSharedHistoryKeyService.m */; };
 		EDF4678727E3331D00435913 /* EventsEnumeratorDataSourceStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF4678627E3331D00435913 /* EventsEnumeratorDataSourceStub.swift */; };
 		EDF4678827E3331D00435913 /* EventsEnumeratorDataSourceStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF4678627E3331D00435913 /* EventsEnumeratorDataSourceStub.swift */; };
 		F0173EAC1FCF0E8900B5F6A3 /* MXGroup.h in Headers */ = {isa = PBXBuildFile; fileRef = F0173EAA1FCF0E8800B5F6A3 /* MXGroup.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -2785,6 +2789,8 @@
 		EDB4209027DF77310036AF39 /* MXEventsEnumeratorOnArrayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXEventsEnumeratorOnArrayTests.swift; sourceTree = "<group>"; };
 		EDB4209427DF822B0036AF39 /* MXEventsByTypesEnumeratorOnArrayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXEventsByTypesEnumeratorOnArrayTests.swift; sourceTree = "<group>"; };
 		EDB4209827DF842F0036AF39 /* MXEventFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXEventFixtures.swift; sourceTree = "<group>"; };
+		EDBCF335281A8AB900ED5044 /* MXSharedHistoryKeyService.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXSharedHistoryKeyService.h; sourceTree = "<group>"; };
+		EDBCF338281A8D3D00ED5044 /* MXSharedHistoryKeyService.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXSharedHistoryKeyService.m; sourceTree = "<group>"; };
 		EDC74874AB2D86EFEE912B04 /* Pods-MatrixSDK-MatrixSDK-macOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MatrixSDK-MatrixSDK-macOS.debug.xcconfig"; path = "Target Support Files/Pods-MatrixSDK-MatrixSDK-macOS/Pods-MatrixSDK-MatrixSDK-macOS.debug.xcconfig"; sourceTree = "<group>"; };
 		EDF4678627E3331D00435913 /* EventsEnumeratorDataSourceStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsEnumeratorDataSourceStub.swift; sourceTree = "<group>"; };
 		F0173EAA1FCF0E8800B5F6A3 /* MXGroup.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXGroup.h; sourceTree = "<group>"; };
@@ -4123,6 +4129,8 @@
 				32A30B161FB4813400C8309E /* MXIncomingRoomKeyRequestManager.h */,
 				32A30B171FB4813400C8309E /* MXIncomingRoomKeyRequestManager.m */,
 				ED44F01328180EAB00452A5D /* MXSharedHistoryKeyManager.swift */,
+				EDBCF335281A8AB900ED5044 /* MXSharedHistoryKeyService.h */,
+				EDBCF338281A8D3D00ED5044 /* MXSharedHistoryKeyService.m */,
 			);
 			path = KeySharing;
 			sourceTree = "<group>";
@@ -5171,6 +5179,7 @@
 				324DD2A6246AE81300377005 /* MXSecretStorageKeyContent.h in Headers */,
 				EC60ED8F265CFD3B00B39A4E /* MXRoomSync.h in Headers */,
 				ECD2899E26EB570B00F268CF /* MXRoomSummaryStore.h in Headers */,
+				EDBCF336281A8ABD00ED5044 /* MXSharedHistoryKeyService.h in Headers */,
 				EC8A53C325B1BC77004E0802 /* MXCallInviteEventContent.h in Headers */,
 				3281E8B919E42DFE00976E1A /* MXJSONModels.h in Headers */,
 				3A108AA225810FE5005EEBE9 /* MXRawDataKey.h in Headers */,
@@ -5675,6 +5684,7 @@
 				B14EF3432397E90400758AF0 /* MXRoomEventTimeline.h in Headers */,
 				B14EF3442397E90400758AF0 /* NSArray+MatrixSDK.h in Headers */,
 				B165B81225C3307E003CF7F7 /* MXLoginSSOIdentityProviderBrand.h in Headers */,
+				EDBCF337281A8ABE00ED5044 /* MXSharedHistoryKeyService.h in Headers */,
 				324DD2C6246E638B00377005 /* MXAesHmacSha2.h in Headers */,
 				B14EF3452397E90400758AF0 /* MXReplyEventParser.h in Headers */,
 				323F878E25553D84009E9E67 /* MXTaskProfile.h in Headers */,
@@ -6083,6 +6093,7 @@
 				66836AB727CFA17200515780 /* MXEventStreamService.swift in Sources */,
 				B11BD44922CB56790064D8B0 /* MXReplyEventParser.m in Sources */,
 				EC0B941127184E8A00B4D440 /* MXRoomSummaryMO.swift in Sources */,
+				EDBCF339281A8D3D00ED5044 /* MXSharedHistoryKeyService.m in Sources */,
 				EC0B941327184E8A00B4D440 /* MXRoomMembersCountMO.swift in Sources */,
 				323360701A403A0D0071A488 /* MXFileStore.m in Sources */,
 				B1136967230C1E8600E2B2FA /* MXIdentityService.swift in Sources */,
@@ -6629,6 +6640,7 @@
 				66836AB827CFA17200515780 /* MXEventStreamService.swift in Sources */,
 				3A59A4A025A7A16F00DDA1FC /* MXOlmOutboundGroupSession.m in Sources */,
 				EC0B941227184E8A00B4D440 /* MXRoomSummaryMO.swift in Sources */,
+				EDBCF33A281A8D3D00ED5044 /* MXSharedHistoryKeyService.m in Sources */,
 				EC0B941427184E8A00B4D440 /* MXRoomMembersCountMO.swift in Sources */,
 				B14EF1F92397E90400758AF0 /* MXReactionRelation.m in Sources */,
 				B19A30BB2404268600FB6F35 /* MXQRCodeData.m in Sources */,

--- a/MatrixSDK/Background/MXBackgroundSyncService.swift
+++ b/MatrixSDK/Background/MXBackgroundSyncService.swift
@@ -579,6 +579,7 @@ public enum MXBackgroundSyncServiceError: Error {
             return
         }
         
+        let sharedHistory = (content[kMXSharedHistoryKeyName] as? Bool) ?? isRoomSharingHistory(roomId: roomId)
         olmDevice.addInboundGroupSession(sessionId,
                                          sessionKey: sessionKey,
                                          roomId: roomId,
@@ -586,7 +587,7 @@ public enum MXBackgroundSyncServiceError: Error {
                                          forwardingCurve25519KeyChain: forwardingKeyChain,
                                          keysClaimed: keysClaimed,
                                          exportFormat: exportFormat,
-                                         sharedHistory: isRoomSharingHistory(roomId: roomId))
+                                         sharedHistory: sharedHistory)
     }
     
     private func isRoomSharingHistory(roomId: String) -> Bool {

--- a/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmDecryption.h
+++ b/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmDecryption.h
@@ -21,8 +21,7 @@
 #ifdef MX_CRYPTO
 
 #import "MXDecrypting.h"
-
-@protocol MXSharedHistoryKeyService;
+#import "MXSharedHistoryKeyService.h"
 
 @interface MXMegolmDecryption : NSObject <MXDecrypting, MXSharedHistoryKeyService>
 

--- a/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmDecryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmDecryption.m
@@ -533,12 +533,13 @@
 
 #pragma mark - MXSharedHistoryKeyStore
 
-
-- (BOOL)hasSharedHistoryForSessionId:(NSString *)sessionId senderKey:(NSString *)senderKey
+- (BOOL)hasSharedHistoryForRoomId:(NSString *)roomId
+                        sessionId:(NSString *)sessionId
+                        senderKey:(NSString *)senderKey
 {
     MXOlmInboundGroupSession *session = [crypto.store inboundGroupSessionWithId:sessionId
                                                                    andSenderKey:senderKey];
-    return session.sharedHistory;
+    return session.sharedHistory && [session.roomId isEqualToString:roomId];
 }
 
 - (void)shareKeysForRequest:(MXSharedHistoryKeyRequest *)request

--- a/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmEncryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmEncryption.m
@@ -28,6 +28,7 @@
 #import "MXTools.h"
 #import "MXOutboundSessionInfo.h"
 #import <OLMKit/OLMKit.h>
+#import "MXSharedHistoryKeyService.h"
 
 
 @interface MXMegolmEncryption ()
@@ -354,6 +355,7 @@
 {
     NSString *sessionKey = session.session.sessionKey;
     NSUInteger chainIndex = session.session.messageIndex;
+    BOOL sharedHistory = [self isSessionSharingHistory:session];
 
     NSDictionary *payload = @{
                               @"type": kMXEventTypeStringRoomKey,
@@ -362,7 +364,8 @@
                                       @"room_id": roomId,
                                       @"session_id": session.sessionId,
                                       @"session_key": sessionKey,
-                                      @"chain_index": @(chainIndex)
+                                      @"chain_index": @(chainIndex),
+                                      kMXSharedHistoryKeyName: @(sharedHistory)
                                       }
                               };
 

--- a/MatrixSDK/Crypto/Data/MXMegolmSessionData.m
+++ b/MatrixSDK/Crypto/Data/MXMegolmSessionData.m
@@ -15,6 +15,7 @@
  */
 
 #import "MXMegolmSessionData.h"
+#import "MXSharedHistoryKeyService.h"
 
 @implementation MXMegolmSessionData
 
@@ -28,7 +29,7 @@
         MXJSONModelSetString(sessionData.roomId, JSONDictionary[@"room_id"]);
         MXJSONModelSetString(sessionData.sessionId, JSONDictionary[@"session_id"]);
         MXJSONModelSetString(sessionData.sessionKey, JSONDictionary[@"session_key"]);
-        MXJSONModelSetBoolean(sessionData.sharedHistory, JSONDictionary[@"shared_history"]);
+        MXJSONModelSetBoolean(sessionData.sharedHistory, JSONDictionary[kMXSharedHistoryKeyName]);
         MXJSONModelSetString(sessionData.algorithm, JSONDictionary[@"algorithm"]);
         MXJSONModelSetArray(sessionData.forwardingCurve25519KeyChain, JSONDictionary[@"forwarding_curve25519_key_chain"])
     }
@@ -44,7 +45,7 @@
       @"room_id": _roomId,
       @"session_id": _sessionId,
       @"session_key":_sessionKey,
-      @"shared_history": @(_sharedHistory),
+      kMXSharedHistoryKeyName: @(_sharedHistory),
       @"algorithm": _algorithm,
       @"forwarding_curve25519_key_chain": _forwardingCurve25519KeyChain ? _forwardingCurve25519KeyChain : @[]
       };

--- a/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.m
+++ b/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.m
@@ -29,6 +29,7 @@
 #import "MXKeyProvider.h"
 #import "MXRawDataKey.h"
 #import "MXCrossSigning_Private.h"
+#import "MXSharedHistoryKeyService.h"
 
 #pragma mark - Constants definitions
 
@@ -1612,7 +1613,7 @@ NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
                                         @"sender_claimed_keys": sessionData.senderClaimedKeys,
                                         @"forwarding_curve25519_key_chain": sessionData.forwardingCurve25519KeyChain ?  sessionData.forwardingCurve25519KeyChain : @[],
                                         @"session_key": sessionData.sessionKey,
-                                        @"shared_history": @(sessionData.sharedHistory)
+                                        kMXSharedHistoryKeyName: @(sessionData.sharedHistory)
                                         };
     OLMPkMessage *encryptedSessionBackupData = [_backupKey encryptMessage:[MXTools serialiseJSONObject:sessionBackupData] error:nil];
     if (![self checkOLMPkMessage:encryptedSessionBackupData])

--- a/MatrixSDK/Crypto/KeySharing/MXSharedHistoryKeyManager.swift
+++ b/MatrixSDK/Crypto/KeySharing/MXSharedHistoryKeyManager.swift
@@ -16,13 +16,6 @@
 
 import Foundation
 
-/// Object managing the session keys and responsible for executing key share requests
-@objc
-public protocol MXSharedHistoryKeyService {
-    func hasSharedHistory(sessionId: String, senderKey: String) -> Bool
-    func shareKeys(request: MXSharedHistoryKeyRequest, success: (() -> Void)?, failure: ((NSError?) -> Void)?)
-}
-
 /// Manager responsible for sharing keys of messages in a room with an invited user
 ///
 /// The intent of sharing keys with different users on invite is to allow them to see any immediate
@@ -79,7 +72,7 @@ public class MXSharedHistoryKeyManager: NSObject {
                 senderKey: session.senderKey
             )
             
-            service.shareKeys(request: request) {
+            service.shareKeys(for: request) {
                 // Success does not trigger any further action / user notification, so we only log the outcome
                 MXLog.debug("[MXSharedHistoryRoomKeyRequestManager] Shared key successfully")
             } failure: {
@@ -109,7 +102,7 @@ public class MXSharedHistoryKeyManager: NSObject {
             return nil
         }
         
-        guard service.hasSharedHistory(sessionId: sessionId, senderKey: senderKey) else {
+        guard service.hasSharedHistory(forSessionId: sessionId, senderKey: senderKey) else {
             MXLog.debug("[MXSharedHistoryRoomKeyRequestManager] Skipping keys for message without shared history")
             return nil
         }

--- a/MatrixSDK/Crypto/KeySharing/MXSharedHistoryKeyService.h
+++ b/MatrixSDK/Crypto/KeySharing/MXSharedHistoryKeyService.h
@@ -32,8 +32,9 @@ FOUNDATION_EXPORT NSString *const kMXSharedHistoryKeyName;
 /**
  Check whether key for a given session (sessionId + senderKey) exists
  */
-- (BOOL)hasSharedHistoryForSessionId:(NSString *)sessionId
-                           senderKey:(NSString *)senderKey;
+- (BOOL)hasSharedHistoryForRoomId:(NSString *)roomId
+                        sessionId:(NSString *)sessionId
+                        senderKey:(NSString *)senderKey;
 
 /**
  Share keys for a given request, containing userId, list of devices and session to share

--- a/MatrixSDK/Crypto/KeySharing/MXSharedHistoryKeyService.h
+++ b/MatrixSDK/Crypto/KeySharing/MXSharedHistoryKeyService.h
@@ -1,0 +1,47 @@
+// 
+// Copyright 2022 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#ifndef MXSharedHistoryKeyService_h
+#define MXSharedHistoryKeyService_h
+
+/**
+ Name of the field for `sharedHistory` flag when sharing, exporting or backing up keys
+ */
+FOUNDATION_EXPORT NSString *const kMXSharedHistoryKeyName;
+
+@class MXSharedHistoryKeyRequest;
+
+/**
+ Object managing the session keys and responsible for executing key share requests
+ */
+@protocol MXSharedHistoryKeyService <NSObject>
+
+/**
+ Check whether key for a given session (sessionId + senderKey) exists
+ */
+- (BOOL)hasSharedHistoryForSessionId:(NSString *)sessionId
+                           senderKey:(NSString *)senderKey;
+
+/**
+ Share keys for a given request, containing userId, list of devices and session to share
+ */
+- (void)shareKeysForRequest:(MXSharedHistoryKeyRequest *)request
+                    success:(void(^)(void))success
+                    failure:(void(^)(NSError *))failure;
+
+@end
+
+#endif /* MXSharedHistoryKeyService_h */

--- a/MatrixSDK/Crypto/KeySharing/MXSharedHistoryKeyService.m
+++ b/MatrixSDK/Crypto/KeySharing/MXSharedHistoryKeyService.m
@@ -1,0 +1,19 @@
+// 
+// Copyright 2022 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+NSString *const kMXSharedHistoryKeyName = @"org.matrix.msc3061.shared_history";

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -52,6 +52,7 @@
 #import "MXDeviceListResponse.h"
 
 #import "MatrixSDKSwiftHeader.h"
+#import "MXSharedHistoryKeyService.h"
 /**
  The store to use for crypto.
  */
@@ -2506,7 +2507,8 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
                          @"session_id": sessionId,
                          @"session_key": key[@"key"],
                          @"chain_index": key[@"chain_index"],
-                         @"forwarding_curve25519_key_chain": key[@"forwarding_curve25519_key_chain"]
+                         @"forwarding_curve25519_key_chain": key[@"forwarding_curve25519_key_chain"],
+                         kMXSharedHistoryKeyName: key[@"shared_history"]
                          }
                  };
     }

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -125,7 +125,9 @@ NSInteger const kMXRoomInvalidInviteSenderErrorCode = 9002;
         if (mxSession.crypto)
         {
             MXMegolmDecryption *decryption = [[MXMegolmDecryption alloc] initWithCrypto:mxSession.crypto];
-            sharedHistoryKeyManager = [[MXSharedHistoryKeyManager alloc] initWithCrypto:mxSession.crypto service:decryption];
+            sharedHistoryKeyManager = [[MXSharedHistoryKeyManager alloc] initWithRoomId:roomId
+                                                                                 crypto:mxSession.crypto
+                                                                                service:decryption];
         }
 
         if (store)

--- a/MatrixSDK/MatrixSDK.h
+++ b/MatrixSDK/MatrixSDK.h
@@ -162,6 +162,7 @@ FOUNDATION_EXPORT NSString *MatrixSDKVersion;
 #import "MXOlmDecryption.h"
 #import "MXCachedSyncResponse.h"
 #import "MXBackgroundCryptoStore.h"
+#import "MXSharedHistoryKeyService.h"
 
 //  Sync response models
 #import "MXSyncResponse.h"

--- a/MatrixSDKTests/Crypto/Data/MXMegolmSessionDataUnitTests.swift
+++ b/MatrixSDKTests/Crypto/Data/MXMegolmSessionDataUnitTests.swift
@@ -25,7 +25,7 @@ class MXMegolmSessionDataUnitTests: XCTestCase {
             "room_id": "D",
             "session_id": "E",
             "session_key": "F",
-            "shared_history": true,
+            "org.matrix.msc3061.shared_history": true,
             "algorithm": "G",
             "forwarding_curve25519_key_chain": ["H", "I"]
         ]
@@ -61,7 +61,7 @@ class MXMegolmSessionDataUnitTests: XCTestCase {
             "room_id": "D",
             "session_id": "E",
             "session_key": "F",
-            "shared_history": true,
+            "org.matrix.msc3061.shared_history": true,
             "algorithm": "G",
             "forwarding_curve25519_key_chain": ["H", "I"]
         ])

--- a/MatrixSDKTests/Crypto/KeySharing/MXSharedHistoryKeyManagerUnitTests.swift
+++ b/MatrixSDKTests/Crypto/KeySharing/MXSharedHistoryKeyManagerUnitTests.swift
@@ -28,9 +28,9 @@ class MXSharedHistoryKeyManagerUnitTests: XCTestCase {
         }
     }
     
-    class SpyService: MXSharedHistoryKeyService {
+    class SpyService: NSObject, MXSharedHistoryKeyService {
         var sharedHistory: Set<String>?
-        func hasSharedHistory(sessionId: String, senderKey: String) -> Bool {
+        func hasSharedHistory(forSessionId sessionId: String!, senderKey: String!) -> Bool {
             guard let sharedHistory = sharedHistory else {
                 return true
             }
@@ -38,7 +38,7 @@ class MXSharedHistoryKeyManagerUnitTests: XCTestCase {
         }
         
         var requests = [MXSharedHistoryKeyRequest]()
-        func shareKeys(request: MXSharedHistoryKeyRequest, success: (() -> Void)?, failure: ((NSError?) -> Void)?) {
+        func shareKeys(for request: MXSharedHistoryKeyRequest!, success: (() -> Void)!, failure: ((Error?) -> Void)!) {
             requests.append(request)
             success?()
         }

--- a/MatrixSDKTests/Crypto/KeySharing/MXSharedHistoryKeyManagerUnitTests.swift
+++ b/MatrixSDKTests/Crypto/KeySharing/MXSharedHistoryKeyManagerUnitTests.swift
@@ -29,12 +29,20 @@ class MXSharedHistoryKeyManagerUnitTests: XCTestCase {
     }
     
     class SpyService: NSObject, MXSharedHistoryKeyService {
-        var sharedHistory: Set<String>?
-        func hasSharedHistory(forSessionId sessionId: String!, senderKey: String!) -> Bool {
+        struct SessionStub: Hashable {
+            let roomId: String
+            let sessionId: String
+            let senderKey: String
+        }
+        
+        var sharedHistory: Set<SessionStub>?
+        func hasSharedHistory(forRoomId roomId: String!, sessionId: String!, senderKey: String!) -> Bool {
             guard let sharedHistory = sharedHistory else {
                 return true
             }
-            return sharedHistory.contains(sessionId)
+            
+            let session = SessionStub(roomId: roomId, sessionId: sessionId, senderKey: senderKey)
+            return sharedHistory.contains(session)
         }
         
         var requests = [MXSharedHistoryKeyRequest]()
@@ -76,7 +84,6 @@ class MXSharedHistoryKeyManagerUnitTests: XCTestCase {
         crypto.devices.setObject(MXDeviceInfo(deviceId: "1"), forUser: "user1", andDevice: "1")
         
         service = SpyService()
-        manager = MXSharedHistoryKeyManager(crypto: crypto, service: service)
     }
     
     private func makeEvent(
@@ -84,7 +91,7 @@ class MXSharedHistoryKeyManagerUnitTests: XCTestCase {
         senderKey: String = "456"
     ) -> MXEvent {
         MXEvent(fromJSON: [
-            "room_id": "123",
+            "room_id": "ABC",
             "type": kMXEventTypeStringRoomEncrypted,
             "content": [
                 "session_id": sessionId,
@@ -93,13 +100,35 @@ class MXSharedHistoryKeyManagerUnitTests: XCTestCase {
         ])
     }
     
+    private func makeInboundSession(
+        roomId: String = "ABC",
+        sessionId: String = "123",
+        senderKey: String = "456"
+    ) -> SpyService.SessionStub {
+        return .init(roomId: roomId, sessionId: sessionId, senderKey: senderKey)
+    }
+    
+    private func shareKeys(
+        userId: String = "user1",
+        roomId: String = "ABC",
+        enumerator: MXEventsEnumerator? = nil,
+        limit: Int = .max
+    ) {
+        manager = MXSharedHistoryKeyManager(roomId: roomId, crypto: crypto, service: service)
+        manager.shareMessageKeys(
+            withUserId: userId,
+            messageEnumerator: enumerator ?? self.enumerator,
+            limit: limit
+        )
+    }
+    
     func testDoesNotCreateRequestIfNoKnownDevices() {
         enumerator.messages = [
             makeEvent(sessionId: "A", senderKey: "B")
         ]
         crypto.devices = MXUsersDevicesMap<MXDeviceInfo>()
         
-        manager.shareMessageKeys(withUserId: "user1", messageEnumerator: enumerator, limit: .max)
+        shareKeys()
         
         XCTAssertEqual(service.requests.count, 0)
     }
@@ -112,7 +141,7 @@ class MXSharedHistoryKeyManagerUnitTests: XCTestCase {
         crypto.devices.setObject(MXDeviceInfo(deviceId: "2"), forUser: "user1", andDevice: "2")
         crypto.devices.setObject(MXDeviceInfo(deviceId: "3"), forUser: "user2", andDevice: "3")
         
-        manager.shareMessageKeys(withUserId: "user1", messageEnumerator: enumerator, limit: .max)
+        shareKeys()
         
         XCTAssertEqual(service.requests.count, 1)
         XCTAssertEqual(
@@ -123,7 +152,7 @@ class MXSharedHistoryKeyManagerUnitTests: XCTestCase {
                     MXDeviceInfo(deviceId: "1"),
                     MXDeviceInfo(deviceId: "2")
                 ],
-                roomId: "123",
+                roomId: "ABC",
                 sessionId: "A",
                 senderKey: "B"
             )
@@ -141,7 +170,7 @@ class MXSharedHistoryKeyManagerUnitTests: XCTestCase {
             makeEvent(sessionId: "3", senderKey: "B"),
         ]
         
-        manager.shareMessageKeys(withUserId: "user1", messageEnumerator: enumerator, limit: .max)
+        shareKeys()
         
         let identifiers = service.requests.map { [$0.sessionId, $0.senderKey] }
         XCTAssertEqual(service.requests.count, 5)
@@ -161,7 +190,7 @@ class MXSharedHistoryKeyManagerUnitTests: XCTestCase {
             makeEvent(sessionId: "1"),
         ]
         
-        manager.shareMessageKeys(withUserId: "user1", messageEnumerator: enumerator, limit: 3)
+        shareKeys(limit: 3)
         
         let identifiers = service.requests.map { $0.sessionId }
         XCTAssertEqual(service.requests.count, 3)
@@ -177,16 +206,43 @@ class MXSharedHistoryKeyManagerUnitTests: XCTestCase {
             makeEvent(sessionId: "5"),
         ]
         service.sharedHistory = [
-            "1",
-            "2",
-            "4",
+            makeInboundSession(sessionId: "1"),
+            makeInboundSession(sessionId: "2"),
+            makeInboundSession(sessionId: "4"),
         ]
         
-        manager.shareMessageKeys(withUserId: "user1", messageEnumerator: enumerator, limit: .max)
+        shareKeys()
         
         let identifiers = service.requests.map { $0.sessionId }
         XCTAssertEqual(service.requests.count, 3)
         XCTAssertEqual(Set(identifiers), ["1", "2", "4"])
+    }
+    
+    func testIgnoresEventsWithMismatchedRoomId() {
+        enumerator.messages = [
+            makeEvent(sessionId: "1"),
+            makeEvent(sessionId: "2"),
+            makeEvent(sessionId: "3"),
+        ]
+        service.sharedHistory = [
+            makeInboundSession(
+                roomId: "XYZ",
+                sessionId: "1"
+            ),
+            makeInboundSession(
+                roomId: "ABC",
+                sessionId: "2"
+            ),
+            makeInboundSession(
+                roomId: "XYZ",
+                sessionId: "3"
+            ),
+        ]
+        
+        shareKeys(roomId: "ABC")
+        
+        XCTAssertEqual(service.requests.count, 1)
+        XCTAssertEqual(service.requests.first?.sessionId, "2")
     }
 }
 

--- a/MatrixSDKTests/MXCryptoShareTests.m
+++ b/MatrixSDKTests/MXCryptoShareTests.m
@@ -704,7 +704,7 @@
                                     [aliceSession1.crypto setDeviceVerification:MXDeviceVerified forDevice:aliceSession2.myDeviceId ofUser:aliceSession1.myUserId success:^{
                                         [aliceSession2.crypto setDeviceVerification:MXDeviceVerified forDevice:aliceSession1.myDeviceId ofUser:aliceSession1.myUserId success:^{
                                             
-                                            // Alice2 pagingates in the room to get the keys forwarded to her
+                                            // Alice2 paginates in the room to get the keys forwarded to her
                                             MXRoom *roomFromAlice2POV = [aliceSession2 roomWithRoomId:roomId];
                                             [roomFromAlice2POV liveTimeline:^(id<MXEventTimeline> liveTimeline) {
                                                 [liveTimeline resetPagination];

--- a/MatrixSDKTests/MatrixSDKTestsE2EData.h
+++ b/MatrixSDKTests/MatrixSDKTestsE2EData.h
@@ -86,6 +86,12 @@
                  withPassword:(NSString*)password
                    onComplete:(void (^)(MXSession *newSession))onComplete;
 
+- (void)loginUserOnANewDevice:(XCTestCase*)testCase
+                  credentials:(MXCredentials*)credentials
+                 withPassword:(NSString*)password
+                        store:(id<MXStore>)store
+                   onComplete:(void (^)(MXSession *newSession))onComplete;
+
 
 #pragma mark - Cross-signing
 


### PR DESCRIPTION
Resolves https://github.com/vector-im/element-ios/issues/4947 which is an implementation of https://github.com/matrix-org/matrix-doc/pull/3061

Handle several edge cases when key sharing:

- use unstable parameter name of `shared_history` when exporting and importing keys. This makes it compatible with the existing web implementation (e.g. backup keys on the web and restore on iOS => preserve `sharedHistory` flag)
- add integration tests for key sharing across several devices
- ensure that keys are only shared if the roomId of the session matches the room a user is invited into