### PR TITLE
Revert Realm schema

### DIFF
--- a/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
+++ b/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
@@ -32,7 +32,7 @@
 #import "MXBackgroundModeHandler.h"
 #import "RLMRealm+MatrixSDK.h"
 
-NSUInteger const kMXRealmCryptoStoreVersion = 18;
+NSUInteger const kMXRealmCryptoStoreVersion = 17;
 
 static NSString *const kMXRealmCryptoStoreFolder = @"MXRealmCryptoStore";
 
@@ -114,7 +114,6 @@ RLM_ARRAY_TYPE(MXRealmOlmSession)
 @interface MXRealmOlmInboundGroupSession : RLMObject
 @property NSString *sessionId;
 @property NSString *senderKey;
-@property NSString *roomId;
 @property NSData *olmInboundGroupSessionData;
 
 // A primary key is required to update `backedUp`.
@@ -123,8 +122,6 @@ RLM_ARRAY_TYPE(MXRealmOlmSession)
 
 // Indicate if the key has been backed up to the homeserver
 @property BOOL backedUp;
-
-@property BOOL sharedHistory;
 
 @end
 
@@ -954,10 +951,8 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
                 realmSession = [[MXRealmOlmInboundGroupSession alloc] initWithValue:@{
                     @"sessionId": session.session.sessionIdentifier,
                     @"senderKey": session.senderKey,
-                    @"roomId": session.roomId,
                     @"sessionIdSenderKey": sessionIdSenderKey,
                     @"olmInboundGroupSessionData": [NSKeyedArchiver archivedDataWithRootObject:session],
-                    @"sharedHistory": @(session.sharedHistory)
                 }];
                 
                 [realm addObject:realmSession];
@@ -2155,8 +2150,6 @@ static BOOL shouldCompactOnLaunch = YES;
                         newObject[@"cryptoVersion"] = @(MXCryptoVersion2);
                     }
                 }];
-            case 17:
-                MXLogDebug(@"[MXRealmCryptoStore] Migration from schema #17 -> #18: Automatically adding MXRealmOlmInboundGroupSession.roomId and MXRealmOlmInboundGroupSession.sharedHistory");
         }
     }
     


### PR DESCRIPTION
I have [merged](https://github.com/matrix-org/matrix-ios-sdk/pull/1444/files) a change 2 days ago which adds two new fields to a Realm entity, namely `sharedHistory` and `roomId`. These were meant as fields to enable querying sessions for all shared keys per room.

Since then we have decided to share keys based on last X messages, meaning that we can query directy by sessionId and senderKey, and previously added `roomId` and `sharedHistory` are not necessary on the Realm entity (they are still stored in the nested serialized data in the realm entity). This PR removes them before the next release of the iOS app.