### PR TITLE
Disable default key sharing for history

### DIFF
--- a/MatrixSDK/MXSDKOptions.m
+++ b/MatrixSDK/MXSDKOptions.m
@@ -53,7 +53,7 @@ static MXSDKOptions *sharedOnceInstance = nil;
         _clientPermalinkBaseUrl = nil;
         _authEnableRefreshTokens = NO;
         _enableThreads = NO;
-        _enableRoomSharedHistoryOnInvite = YES;
+        _enableRoomSharedHistoryOnInvite = NO;
     }
     
     return self;

--- a/MatrixSDKTests/MXCryptoShareTests.m
+++ b/MatrixSDKTests/MXCryptoShareTests.m
@@ -600,6 +600,7 @@
             [expectation fulfill];
         };
         
+        [MXSDKOptions sharedInstance].enableRoomSharedHistoryOnInvite = YES;
         [MXSDKOptions sharedInstance].enableCryptoWhenStartingMXSession = YES;
         [matrixSDKTestsData doMXSessionTestWithBob:nil
                                        readyToTest:^(MXSession *bobSession, XCTestExpectation *expectation2)
@@ -677,6 +678,7 @@
             [expectation fulfill];
         };
         
+        [MXSDKOptions sharedInstance].enableRoomSharedHistoryOnInvite = YES;
         [MXSDKOptions sharedInstance].enableCryptoWhenStartingMXSession = YES;
         [matrixSDKTestsData doMXSessionTestWithBob:nil
                                        readyToTest:^(MXSession *bobSession, XCTestExpectation *expectation2)


### PR DESCRIPTION
The feature is not quite ready to be released yet, so disabling it by default for the upcoming release