### PR TITLE
Replace NSParameterAssert with MXLogFailure and early return

### DIFF
--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -1928,7 +1928,12 @@ typedef void (^MXOnResumeDone)(void);
 
 - (void)handleBackgroundSyncCacheIfRequiredWithCompletion:(void (^)(void))completion
 {
-    NSParameterAssert(_state == MXSessionStateStoreDataReady || _state == MXSessionStatePaused);
+    BOOL isInValidState = _state == MXSessionStateStoreDataReady || _state == MXSessionStatePaused;
+    if (!isInValidState) {
+        MXLogFailure(@"[MXSession] state is not valid to handle background sync cache, investigate why the method was called");
+        completion();
+        return;
+    }
 
     if (!self.hasAnyBackgroundCachedSyncResponses)
     {


### PR DESCRIPTION
Replace `NSParameterAssert`, which is only cought in develop and not indicated in rageshakes, by `MXLogFailure` (which is also caught in debug mode, but adds logs to rageshakes) and an early exit from the method. This is to address an issue where inconsistent state (previously asserted by the `NSParameterAssert`) is nevertheless ignored by the method in production and potentially causing further inconsistencies.
