### PR TITLE
Shared history flag in crypto module

### DIFF
--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -1897,6 +1897,11 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 
 - (BOOL)isRoomSharingHistory:(NSString *)roomId
 {
+    if (!MXSDKOptions.sharedInstance.enableRoomSharedHistoryOnInvite)
+    {
+        return NO;
+    }
+    
     MXRoom *room = [self.mxSession roomWithRoomId:roomId];
     MXRoomHistoryVisibility visibility = room.summary.historyVisibility;
     return [visibility isEqualToString:kMXRoomHistoryVisibilityWorldReadable] || [visibility isEqualToString:kMXRoomHistoryVisibilityShared];

--- a/MatrixSDKTests/MXCryptoTests.m
+++ b/MatrixSDKTests/MXCryptoTests.m
@@ -3235,7 +3235,11 @@
             @[kMXRoomHistoryVisibilityWorldReadable, @(YES)]
         ];
         
-        // Visibility is set to shared by default
+        // Visibility is set to not shared by default
+        XCTAssertFalse([session.crypto isRoomSharingHistory:roomId]);
+        
+        // But can be enabled with a build flag
+        MXSDKOptions.sharedInstance.enableRoomSharedHistoryOnInvite = YES;
         XCTAssertTrue([session.crypto isRoomSharingHistory:roomId]);
         
         MXRoom *room = [session roomWithRoomId:roomId];


### PR DESCRIPTION
Crypto module should internally respect build flag when deciding if a room has shared history or not.