### PR TITLE
Release 0.23.6

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## Changes in 0.23.6 (2022-05-19)
+
+No significant changes.
+
+
 ## Changes in 0.23.5 (2022-05-18)
 
 ✨ Features

--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "MatrixSDK"
-  s.version      = "0.23.5"
+  s.version      = "0.23.6"
   s.summary      = "The iOS SDK to build apps compatible with Matrix (https://www.matrix.org)"
 
   s.description  = <<-DESC

--- a/MatrixSDK/Crypto/Data/MXMegolmSessionData.m
+++ b/MatrixSDK/Crypto/Data/MXMegolmSessionData.m
@@ -16,6 +16,7 @@
 
 #import "MXMegolmSessionData.h"
 #import "MXSharedHistoryKeyService.h"
+#import "MXSDKOptions.h"
 
 @implementation MXMegolmSessionData
 
@@ -29,7 +30,10 @@
         MXJSONModelSetString(sessionData.roomId, JSONDictionary[@"room_id"]);
         MXJSONModelSetString(sessionData.sessionId, JSONDictionary[@"session_id"]);
         MXJSONModelSetString(sessionData.sessionKey, JSONDictionary[@"session_key"]);
-        MXJSONModelSetBoolean(sessionData.sharedHistory, JSONDictionary[kMXSharedHistoryKeyName]);
+        if (MXSDKOptions.sharedInstance.enableRoomSharedHistoryOnInvite)
+        {
+            MXJSONModelSetBoolean(sessionData.sharedHistory, JSONDictionary[kMXSharedHistoryKeyName]);
+        }
         MXJSONModelSetString(sessionData.algorithm, JSONDictionary[@"algorithm"]);
         MXJSONModelSetArray(sessionData.forwardingCurve25519KeyChain, JSONDictionary[@"forwarding_curve25519_key_chain"])
     }

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -1897,6 +1897,11 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 
 - (BOOL)isRoomSharingHistory:(NSString *)roomId
 {
+    if (!MXSDKOptions.sharedInstance.enableRoomSharedHistoryOnInvite)
+    {
+        return NO;
+    }
+    
     MXRoom *room = [self.mxSession roomWithRoomId:roomId];
     MXRoomHistoryVisibility visibility = room.summary.historyVisibility;
     return [visibility isEqualToString:kMXRoomHistoryVisibilityWorldReadable] || [visibility isEqualToString:kMXRoomHistoryVisibilityShared];

--- a/MatrixSDK/MatrixSDKVersion.m
+++ b/MatrixSDK/MatrixSDKVersion.m
@@ -16,4 +16,4 @@
 
 #import <Foundation/Foundation.h>
 
-NSString *const MatrixSDKVersion = @"0.23.5";
+NSString *const MatrixSDKVersion = @"0.23.6";

--- a/MatrixSDKTests/Crypto/Data/MXMegolmSessionDataUnitTests.swift
+++ b/MatrixSDKTests/Crypto/Data/MXMegolmSessionDataUnitTests.swift
@@ -19,6 +19,8 @@ import Foundation
 
 class MXMegolmSessionDataUnitTests: XCTestCase {
     func testCanInitWithJSONDictionary() {
+        MXSDKOptions.sharedInstance().enableRoomSharedHistoryOnInvite = true
+        
         let jsonDictionary: [String: Any] = [
             "sender_key": "A",
             "sender_claimed_keys": ["B": "C"],
@@ -40,6 +42,18 @@ class MXMegolmSessionDataUnitTests: XCTestCase {
         XCTAssertEqual(data?.sharedHistory, true)
         XCTAssertEqual(data?.algorithm, "G")
         XCTAssertEqual(data?.forwardingCurve25519KeyChain, ["H", "I"])
+    }
+    
+    func testIgnoreSharedHistoryIfFlagDisabled() {
+        MXSDKOptions.sharedInstance().enableRoomSharedHistoryOnInvite = false
+        let jsonDictionary: [String: Any] = [
+            "org.matrix.msc3061.shared_history": true,
+        ]
+        
+        let data = MXMegolmSessionData(fromJSON: jsonDictionary)
+        
+        XCTAssertNotNil(data)
+        XCTAssertEqual(data?.sharedHistory, false)
     }
     
     func testJsonDictionary() {

--- a/MatrixSDKTests/MXCryptoTests.m
+++ b/MatrixSDKTests/MXCryptoTests.m
@@ -3235,7 +3235,11 @@
             @[kMXRoomHistoryVisibilityWorldReadable, @(YES)]
         ];
         
-        // Visibility is set to shared by default
+        // Visibility is set to not shared by default
+        XCTAssertFalse([session.crypto isRoomSharingHistory:roomId]);
+        
+        // But can be enabled with a build flag
+        MXSDKOptions.sharedInstance.enableRoomSharedHistoryOnInvite = YES;
         XCTAssertTrue([session.crypto isRoomSharingHistory:roomId]);
         
         MXRoom *room = [session roomWithRoomId:roomId];


### PR DESCRIPTION
This PR prepares the release of MatrixSDK v0.23.6.

Notes:
- This PR targets `release/0.23.6/master`, which has been cut from `master`.
- It includes changes to the `Podfile`, but _not_ the corresponding changes to `Podfile.lock`, as `pod install` hasn't yet been run.
  This is because the `Podfile` targets future versions of dependencies yet to be released, so `pod install` wouldn't be able to find them yet.
- When the CI runs its checks, it will temporarily point to the pending release branches of those dependencies beforehand
- It is only during `release:finish` that `pod update` will be run -- updating the `Podfile.lock`
to use the now officially released dependencies -- before ultimately merging `release/0.23.6/master` into `master` to tag the release.

---

➡️  Once this PR is merged, you will need to first ensure that the products this one depends on are fully released,
   then run `bundle exec rake release:finish` to close this release.

💡 If you want to review _only_ the changes made since the release branch was cut from `develop`,
   you can [check those here](https://github.com/matrix-org/matrix-ios-sdk/compare/develop...release/0.23.6/release)
