### PR TITLE
Fixes vector-im/element-ios/issues/6187 - Prevent crashes on invalid …

### DIFF
--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -394,9 +394,17 @@ typedef void (^MXOnResumeDone)(void);
 
                 // Create myUser from the store
                 MXUser *myUser = [self.store userWithUserId:self->matrixRestClient.credentials.userId];
-
+                
                 // My user is a MXMyUser object
-                self->_myUser = (MXMyUser*)myUser;
+                if ([myUser isKindOfClass:[MXMyUser class]])
+                {
+                    self->_myUser = (MXMyUser *)myUser;
+                }
+                else
+                {
+                    self->_myUser = [[MXMyUser alloc] initWithUserId:self->matrixRestClient.credentials.userId];
+                }
+                
                 self->_myUser.mxSession = self;
                 
                 // Use the cached agreement to identity server terms.

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -402,7 +402,7 @@ typedef void (^MXOnResumeDone)(void);
                 }
                 else
                 {
-                    self->_myUser = [[MXMyUser alloc] initWithUserId:self->matrixRestClient.credentials.userId];
+                    self->_myUser = [[MXMyUser alloc] initWithUserId:myUser.userId andDisplayname:myUser.displayname andAvatarUrl:myUser.avatarUrl];
                 }
                 
                 self->_myUser.mxSession = self;

--- a/changelog.d/6187.bugfix
+++ b/changelog.d/6187.bugfix
@@ -1,0 +1,1 @@
+Fixed crashes on invalid casting of MXUser to MXMyUser causing unrecognized selectors on the mxSession property.


### PR DESCRIPTION
…casting of MXUser to MXMyUser causing unrecognized selectors on the mxSession property