### PR TITLE
Mark MXTools.generateTransactionId as non-null.

### DIFF
--- a/MatrixSDK/Utils/MXTools.h
+++ b/MatrixSDK/Utils/MXTools.h
@@ -63,7 +63,7 @@
 
  @return the transaction id.
  */
-+ (NSString*)generateTransactionId;
++ (NSString* _Nonnull)generateTransactionId;
 
 /**
  Removing new line characters from NSString.

--- a/MatrixSDK/Utils/MXTools.m
+++ b/MatrixSDK/Utils/MXTools.m
@@ -523,7 +523,7 @@ NSCharacterSet *uriComponentCharset;
     return [[NSProcessInfo processInfo] globallyUniqueString];
 }
 
-+ (NSString *)generateTransactionId
++ (NSString * _Nonnull)generateTransactionId
 {
     return [NSString stringWithFormat:@"m%u.%tu", arc4random_uniform(INT32_MAX), transactionIdCount++];
 }

--- a/changelog.d/pr-1477.api
+++ b/changelog.d/pr-1477.api
@@ -1,0 +1,1 @@
+MXTools: generateTransactionId no longer returns an optional in Swift. 


### PR DESCRIPTION
Small tweak to `MXTools` so it no longer returns an optional when calling `generateTransactionId`