### PR TITLE
Add extra logs when saving and loading room state

### DIFF
--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
@@ -2271,7 +2271,7 @@ static NSUInteger preloadOptions;
         NSKeyedUnarchiver *unarchiver = [[NSKeyedUnarchiver alloc] initForReadingFromData:data error:&error];
         if (error && !unarchiver)
         {
-            MXLogFailure(@"[MXFileStore] Cannot create unarchiver with error: '%@", error.debugDescription);
+            MXLogFailure(@"[MXFileStore] Cannot create unarchiver with error: '%@'", error.debugDescription);
             return nil;
         }
         unarchiver.requiresSecureCoding = NO;

--- a/changelog.d/pr-1478.misc
+++ b/changelog.d/pr-1478.misc
@@ -1,0 +1,1 @@
+MXFileStore: Add extra logs when saving and loading room state


### PR DESCRIPTION
Relates to repeatedly reported issues:
- https://github.com/matrix-org/element-ios-rageshakes/issues/18751
- https://github.com/matrix-org/element-ios-rageshakes/issues/18740

This does not fix the state corruption issue but uses newer KeyedUnarchiver/Archiver API which provides errors when something fails. Additionally add logs when we arent able to load state or the number of state events we are persisting.