### PR TITLE
Reload room state if detected empty

### DIFF
--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -1791,6 +1791,10 @@
 		ED44F01528180EAB00452A5D /* MXSharedHistoryKeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED44F01328180EAB00452A5D /* MXSharedHistoryKeyManager.swift */; };
 		ED44F01A28180F4000452A5D /* MXSharedHistoryKeyManagerUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED44F01728180F1C00452A5D /* MXSharedHistoryKeyManagerUnitTests.swift */; };
 		ED44F01B28180F4000452A5D /* MXSharedHistoryKeyManagerUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED44F01728180F1C00452A5D /* MXSharedHistoryKeyManagerUnitTests.swift */; };
+		ED51943928462D130006EEC6 /* MXRoomStateUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED51943828462D130006EEC6 /* MXRoomStateUnitTests.swift */; };
+		ED51943A28462D130006EEC6 /* MXRoomStateUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED51943828462D130006EEC6 /* MXRoomStateUnitTests.swift */; };
+		ED51943C284630090006EEC6 /* MXRestClientStub.m in Sources */ = {isa = PBXBuildFile; fileRef = ED51943B284630090006EEC6 /* MXRestClientStub.m */; };
+		ED51943D284630090006EEC6 /* MXRestClientStub.m in Sources */ = {isa = PBXBuildFile; fileRef = ED51943B284630090006EEC6 /* MXRestClientStub.m */; };
 		ED5AE8C52816C8CF00105072 /* MXCoreDataRoomSummaryStore.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = ED5AE8C22816C8CF00105072 /* MXCoreDataRoomSummaryStore.xcdatamodeld */; };
 		ED5AE8C62816C8CF00105072 /* MXCoreDataRoomSummaryStore.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = ED5AE8C22816C8CF00105072 /* MXCoreDataRoomSummaryStore.xcdatamodeld */; };
 		ED5C95CE2833E85600843D82 /* MXOlmDeviceUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED5C95CD2833E85600843D82 /* MXOlmDeviceUnitTests.swift */; };
@@ -2804,6 +2808,9 @@
 		ED44F01028180BCC00452A5D /* MXSharedHistoryKeyRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXSharedHistoryKeyRequest.swift; sourceTree = "<group>"; };
 		ED44F01328180EAB00452A5D /* MXSharedHistoryKeyManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXSharedHistoryKeyManager.swift; sourceTree = "<group>"; };
 		ED44F01728180F1C00452A5D /* MXSharedHistoryKeyManagerUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXSharedHistoryKeyManagerUnitTests.swift; sourceTree = "<group>"; };
+		ED51943828462D130006EEC6 /* MXRoomStateUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXRoomStateUnitTests.swift; sourceTree = "<group>"; };
+		ED51943B284630090006EEC6 /* MXRestClientStub.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXRestClientStub.m; sourceTree = "<group>"; };
+		ED51943E284630100006EEC6 /* MXRestClientStub.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXRestClientStub.h; sourceTree = "<group>"; };
 		ED5AE8C32816C8CF00105072 /* MXRoomSummaryCoreDataStore2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = MXRoomSummaryCoreDataStore2.xcdatamodel; sourceTree = "<group>"; };
 		ED5AE8C42816C8CF00105072 /* MXRoomSummaryCoreDataStore.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = MXRoomSummaryCoreDataStore.xcdatamodel; sourceTree = "<group>"; };
 		ED5C95CD2833E85600843D82 /* MXOlmDeviceUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXOlmDeviceUnitTests.swift; sourceTree = "<group>"; };
@@ -3679,6 +3686,8 @@
 				329571971B024D2B00ABB3BA /* MXMockCallStackCall.h */,
 				329571981B024D2B00ABB3BA /* MXMockCallStackCall.m */,
 				ECE3DFA7270CF69500FB4C96 /* MockRoomSummary.swift */,
+				ED51943E284630100006EEC6 /* MXRestClientStub.h */,
+				ED51943B284630090006EEC6 /* MXRestClientStub.m */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -3981,6 +3990,7 @@
 				3281E8A119E2DE4300976E1A /* MXSessionTests.m */,
 				32A27D1E19EC335300BAFADE /* MXRoomTests.m */,
 				3265CB3A1A151C3800E24B2F /* MXRoomStateTests.m */,
+				ED51943828462D130006EEC6 /* MXRoomStateUnitTests.swift */,
 				3246BDC41A1A0789000A7D62 /* MXRoomStateDynamicTests.m */,
 				328DDEC01A07E57E008C7DC8 /* MXJSONModelTests.m */,
 				329FB17B1A0A963700A5E88E /* MXRoomMemberTests.m */,
@@ -6488,6 +6498,7 @@
 				32B477822638133C00EA5800 /* MXFilterUnitTests.m in Sources */,
 				322985CF26FBAE7B001890BC /* TestObserver.swift in Sources */,
 				32DC15D71A8DFF0D006F9AD3 /* MXNotificationCenterTests.m in Sources */,
+				ED51943928462D130006EEC6 /* MXRoomStateUnitTests.swift in Sources */,
 				329571991B024D2B00ABB3BA /* MXMockCallStack.m in Sources */,
 				EDB4209227DF77390036AF39 /* MXEventsEnumeratorOnArrayTests.swift in Sources */,
 				3281E8A819E41A2000976E1A /* MatrixSDKTestsData.m in Sources */,
@@ -6572,6 +6583,7 @@
 				322985CB26FAF898001890BC /* MXSession.swift in Sources */,
 				EC131B192779D8D500712964 /* MXThreadEventTimelineUnitTests.swift in Sources */,
 				B135067427EB201E00BD3276 /* MXLocationServiceTests.swift in Sources */,
+				ED51943C284630090006EEC6 /* MXRestClientStub.m in Sources */,
 				18C26C4F273C0EB300805154 /* MXPollAggregatorTests.swift in Sources */,
 				ED35652F281153480002BF6A /* MXMegolmSessionDataUnitTests.swift in Sources */,
 				32EEA83F2603CA140041425B /* MXRestClientExtensionsTests.m in Sources */,
@@ -7046,6 +7058,7 @@
 				B1E09A392397FD7D0057C069 /* MXMyUserTests.m in Sources */,
 				322985D026FBAE7B001890BC /* TestObserver.swift in Sources */,
 				B1E09A202397FCE90057C069 /* MXCryptoBackupTests.m in Sources */,
+				ED51943A28462D130006EEC6 /* MXRoomStateUnitTests.swift in Sources */,
 				B1E09A3B2397FD820057C069 /* MXStoreNoStoreTests.m in Sources */,
 				EDB4209327DF77390036AF39 /* MXEventsEnumeratorOnArrayTests.swift in Sources */,
 				32B4778E2638133D00EA5800 /* MXFilterUnitTests.m in Sources */,
@@ -7130,6 +7143,7 @@
 				322985CC26FAF898001890BC /* MXSession.swift in Sources */,
 				EC131B1A2779D8D500712964 /* MXThreadEventTimelineUnitTests.swift in Sources */,
 				B135067527EB201E00BD3276 /* MXLocationServiceTests.swift in Sources */,
+				ED51943D284630090006EEC6 /* MXRestClientStub.m in Sources */,
 				18C26C50273C0EB400805154 /* MXPollAggregatorTests.swift in Sources */,
 				ED356530281153480002BF6A /* MXMegolmSessionDataUnitTests.swift in Sources */,
 				32C78BA8256D227D008130B1 /* MXCryptoMigrationTests.m in Sources */,

--- a/MatrixSDK/Data/MXRoomState.m
+++ b/MatrixSDK/Data/MXRoomState.m
@@ -112,13 +112,34 @@
                matrixSession:(MXSession *)matrixSession
                   onComplete:(void (^)(MXRoomState *roomState))onComplete
 {
+    NSString *loadEventId = [NSUUID UUID].UUIDString;
+    MXLogDebug(@"[MXRoomState] loadRoomStateFromStore(%@): Loading state for room %@", loadEventId, roomId)
+    
     MXRoomState *roomState = [[MXRoomState alloc] initWithRoomId:roomId andMatrixSession:matrixSession andDirection:YES];
     if (roomState)
     {
         [store stateOfRoom:roomId success:^(NSArray<MXEvent *> * _Nonnull stateEvents) {
-            [roomState handleStateEvents:stateEvents];
+            if (!stateEvents.count) {
+                MXLogWarning(@"[MXRoomState] loadRoomStateFromStore(%@): No state events stored, loading from api", loadEventId);
+                
+                [matrixSession.matrixRestClient stateOfRoom:roomId success:^(NSArray *JSONData) {
+                    NSArray<MXEvent *> *events = [MXEvent modelsFromJSON:JSONData];
+                    MXLogDebug(@"[MXRoomState] loadRoomStateFromStore(%@): Loaded %lu events from api", loadEventId, events.count);
+                    
+                    [roomState handleStateEvents:events];
+                    onComplete(roomState);
+                } failure:^(NSError *error) {
+                    MXLogError(@"[MXRoomState] loadRoomStateFromStore(%@): Failed to load any events from api", loadEventId);
+                    
+                    onComplete(roomState);
+                }];
+            } else {
+                MXLogDebug(@"[MXRoomState] loadRoomStateFromStore(%@): Initializing with %lu state events", loadEventId, stateEvents.count);
+                
+                [roomState handleStateEvents:stateEvents];
+                onComplete(roomState);
+            }
 
-            onComplete(roomState);
         } failure:nil];
     }
 }

--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
@@ -2251,9 +2251,8 @@ static NSUInteger preloadOptions;
         }
         
         id object = [NSKeyedUnarchiver unarchivedObjectOfClasses:classes fromData:data error:&error];
-        if (object)
+        if (object && !error)
         {
-            MXLogDebug(@"[MXFileStore] Loaded object from class");
             return object;
         }
         else
@@ -2297,9 +2296,8 @@ static NSUInteger preloadOptions;
         
         // Seems to be an implementation detaul
         id object = [unarchiver decodeTopLevelObjectForKey:NSKeyedArchiveRootObjectKey error:&error];
-        if (object)
+        if (object && !error)
         {
-            MXLogDebug(@"[MXFileStore] Loaded object from class");
             return object;
         }
         else

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -1444,7 +1444,7 @@ NS_REFINED_FOR_SWIFT;
  @return a MXHTTPOperation instance.
  */
 - (MXHTTPOperation*)stateOfRoom:(NSString*)roomId
-                        success:(void (^)(NSDictionary *JSONData))success
+                        success:(void (^)(NSArray *JSONData))success
                         failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
 /**

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -2780,7 +2780,7 @@ andUnauthenticatedHandler: (MXRestClientUnauthenticatedHandler)unauthenticatedHa
 }
 
 - (MXHTTPOperation*)stateOfRoom:(NSString*)roomId
-                        success:(void (^)(NSDictionary *JSONData))success
+                        success:(void (^)(NSArray *JSONData))success
                         failure:(void (^)(NSError *error))failure
 {
     NSString *path = [NSString stringWithFormat:@"%@/rooms/%@/state", apiPathPrefix, roomId];
@@ -2789,7 +2789,7 @@ andUnauthenticatedHandler: (MXRestClientUnauthenticatedHandler)unauthenticatedHa
     return [httpClient requestWithMethod:@"GET"
                                     path:path
                               parameters:nil
-                                 success:^(NSDictionary *JSONResponse) {
+                                 success:^(id JSONResponse) {
                                      MXStrongifyAndReturnIfNil(self);
 
                                      if (success)

--- a/MatrixSDK/Utils/MXHTTPClient.m
+++ b/MatrixSDK/Utils/MXHTTPClient.m
@@ -349,7 +349,7 @@ static NSUInteger requestCount = 0;
             });
         }
         
-    } downloadProgress:nil completionHandler:^(NSURLResponse * _Nonnull theResponse, NSDictionary *JSONResponse, NSError * _Nullable error) {
+    } downloadProgress:nil completionHandler:^(NSURLResponse * _Nonnull theResponse, id JSONResponse, NSError * _Nullable error) {
         NSHTTPURLResponse *response = (NSHTTPURLResponse*)theResponse;
         mxHTTPOperation.httpResponse = response;
 

--- a/MatrixSDKTests/MXRestClientTests.m
+++ b/MatrixSDKTests/MXRestClientTests.m
@@ -822,16 +822,13 @@
 {
     [self.matrixSDKTestsData doMXRestClientTestWithBobAndARoomWithMessages:self readyToTest:^(MXRestClient *bobRestClient, NSString *roomId, XCTestExpectation *expectation) {
         
-        [bobRestClient stateOfRoom:roomId success:^(NSDictionary *JSONData) {
+        [bobRestClient stateOfRoom:roomId success:^(NSArray *JSONData) {
             
             XCTAssertNotNil(JSONData);
-            
-            XCTAssert([JSONData isKindOfClass:[NSArray class]]);
-            NSArray *states = (NSArray*)JSONData;
-            XCTAssertGreaterThan(states.count, 0);
+            XCTAssertGreaterThan(JSONData.count, 0);
             
             // Check that all provided events are state events
-            for (NSDictionary *eventDict in states)
+            for (NSDictionary *eventDict in JSONData)
             {
                 MXEvent *event = [MXEvent modelFromJSON:eventDict];
                 

--- a/MatrixSDKTests/MXRoomStateUnitTests.swift
+++ b/MatrixSDKTests/MXRoomStateUnitTests.swift
@@ -1,0 +1,109 @@
+// 
+// Copyright 2022 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+@testable import MatrixSDK
+
+class MXRoomStateUnitTests: XCTestCase {
+    class StoreStub: MXNoStore {
+        var stubbedStatePerRoom = [String: [MXEvent]]()
+        
+        func stateEventsCount(for roomId: String) -> Int {
+            return stubbedStatePerRoom[roomId]?.count ?? 0
+        }
+        
+        override func state(ofRoom roomId: String, success: @escaping ([MXEvent]) -> Void, failure: ((Error) -> Void)? = nil) {
+            success(stubbedStatePerRoom[roomId] ?? [])
+        }
+        
+        override func storeState(forRoom roomId: String, stateEvents: [MXEvent]) {
+            stubbedStatePerRoom[roomId] = stateEvents
+        }
+    }
+    
+    var roomId = "abc"
+    var store: StoreStub!
+    var restClient: MXRestClientStub!
+    var session: MXSession!
+    
+    override func setUp() {
+        super.setUp()
+        
+        store = StoreStub()
+        restClient = MXRestClientStub(credentials: MXCredentials(homeServer: "www", userId: "@user:domain", accessToken: nil))
+        session = MXSession(matrixRestClient: restClient)
+        session.setStore(store, completion: { _ in })
+    }
+    
+    func testLoadRoomStateFromStore_loadsOnlyFromStore_ifStoreNotEmpty() {
+        let storeEvents = [
+            buildStateEventJSON(id: "1")
+        ]
+        let apiEvents = [
+            buildStateEventJSON(id: "1"),
+            buildStateEventJSON(id: "2"),
+            buildStateEventJSON(id: "3")
+        ]
+        
+        // Store has 1 event whereas API has 3
+        store.stubbedStatePerRoom[roomId] = MXEvent.models(fromJSON: storeEvents) as? [MXEvent]
+        restClient.stubbedStatePerRoom = [roomId: apiEvents]
+
+        let exp = expectation(description: "roomState")
+        MXRoomState.load(from: store, withRoomId: roomId, matrixSession: session) { state in
+        
+            // We expect only the one state event already stored and nothing from the API
+            XCTAssertEqual(state?.stateEvents.count, 1)
+            XCTAssertEqual(self.store.stateEventsCount(for: self.roomId), 1)
+            
+            exp.fulfill()
+            self.session.close()
+        }
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+    
+    func testLoadRoomStateFromStore_loadsFromAPI_ifStoreEmpty() {
+        let events = [
+            buildStateEventJSON(id: "1"),
+            buildStateEventJSON(id: "2")
+        ]
+        
+        // Store has no state, but API is set to return two events
+        store.stubbedStatePerRoom[roomId] = []
+        restClient.stubbedStatePerRoom = [roomId: events]
+
+        let exp = expectation(description: "roomState")
+        MXRoomState.load(from: store, withRoomId: roomId, matrixSession: session) { state in
+        
+            // We expect to now have 2 events which are also saved into store
+            XCTAssertEqual(state?.stateEvents.count, 2)
+            XCTAssertEqual(self.store.stateEventsCount(for: self.roomId), 2)
+            
+            exp.fulfill()
+            self.session.close()
+        }
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+    
+    // MARK: - Helpers
+    
+    func buildStateEventJSON(id: String) -> [String: Any] {
+        return [
+            "event_id": id,
+            "type": "m.room.state",
+        ]
+    }
+}

--- a/MatrixSDKTests/Mocks/MXRestClientStub.h
+++ b/MatrixSDKTests/Mocks/MXRestClientStub.h
@@ -1,5 +1,5 @@
 // 
-// Copyright 2020 The Matrix.org Foundation C.I.C
+// Copyright 2022 The Matrix.org Foundation C.I.C
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,16 +14,21 @@
 // limitations under the License.
 //
 
-#ifndef MatrixSDKTests_Bridging_Header_h
-#define MatrixSDKTests_Bridging_Header_h
+#ifndef MXRestClientStub_h
+#define MXRestClientStub_h
 
-#import "MatrixSDKTestsData.h"
-#import "MatrixSDKTestsE2EData.h"
-#import "MXDeviceListOperationsPool.h"
-#import "MXBackgroundTask.h"
-#import "MXUIKitBackgroundModeHandler.h"
-#import "MXApplicationProtocol.h"
-#import "MXCrypto_Private.h"
-#import "MXRestClientStub.h"
+#import "MXRestClient.h"
 
-#endif /* MatrixSDKTests_Bridging_Header_h */
+/**
+ Stubbed version of MXRestClient which can be used in unit tests without making any actual API calls
+ */
+@interface MXRestClientStub : MXRestClient
+
+/**
+ Stubbed data that will be returned when calling `stateOfRoom` instead of making HTTP requests
+ */
+@property (nonatomic, strong) NSDictionary<NSString *, NSArray <NSDictionary *>*> *stubbedStatePerRoom;
+
+@end
+
+#endif /* MXRestClientStub_h */

--- a/MatrixSDKTests/Mocks/MXRestClientStub.m
+++ b/MatrixSDKTests/Mocks/MXRestClientStub.m
@@ -1,5 +1,5 @@
 // 
-// Copyright 2020 The Matrix.org Foundation C.I.C
+// Copyright 2022 The Matrix.org Foundation C.I.C
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,16 +14,15 @@
 // limitations under the License.
 //
 
-#ifndef MatrixSDKTests_Bridging_Header_h
-#define MatrixSDKTests_Bridging_Header_h
-
-#import "MatrixSDKTestsData.h"
-#import "MatrixSDKTestsE2EData.h"
-#import "MXDeviceListOperationsPool.h"
-#import "MXBackgroundTask.h"
-#import "MXUIKitBackgroundModeHandler.h"
-#import "MXApplicationProtocol.h"
-#import "MXCrypto_Private.h"
+#import <Foundation/Foundation.h>
 #import "MXRestClientStub.h"
 
-#endif /* MatrixSDKTests_Bridging_Header_h */
+@implementation MXRestClientStub
+
+- (MXHTTPOperation *)stateOfRoom:(NSString *)roomId success:(void (^)(NSArray *))success failure:(void (^)(NSError *))failure
+{
+    success(self.stubbedStatePerRoom[roomId]);
+    return [[MXHTTPOperation alloc] init];
+}
+
+@end

--- a/MatrixSDKTests/TestPlans/UnitTests.xctestplan
+++ b/MatrixSDKTests/TestPlans/UnitTests.xctestplan
@@ -60,6 +60,7 @@
         "MXQRCodeDataUnitTests",
         "MXReplyEventParserUnitTests",
         "MXResponseUnitTests",
+        "MXRoomStateUnitTests",
         "MXSharedHistoryKeyManagerUnitTests",
         "MXStoreRoomListDataManagerUnitTests",
         "MXSyncResponseUnitTests",


### PR DESCRIPTION
Aims to solve state loss reported (among others) in:
- https://github.com/matrix-org/element-ios-rageshakes/issues/18865
- https://github.com/matrix-org/element-ios-rageshakes/issues/18751
- https://github.com/matrix-org/element-ios-rageshakes/issues/18740

# Problem

After [previously](https://github.com/matrix-org/matrix-ios-sdk/pull/1478) adding some extra logs, the following is likely a reason for state corruption:

1. Some rooms report having no `state` file present on disk. This should be the case only when there is no user logged in, or when we are clearning cache / initial syncing. After clearing of the cache all rooms should be restored to their full glory, but based on the logs this does not actually happen. The issue has been reported on particularly large accounts, so the assumption is that during the very long initial sync (minutes), some room state fails to be loaded, either due to some implementation bug, or because the app is killed etc
2. When the state file is missing, `MXRoomState` will load 0 state events from disk and later write 0 state events to disk. At this point `MXFileStore` has a file but no state in it. Note that the user may not see any issue at this point, because data is also loaded from `MXRoomSummary` which is managed by Core Data, and is only updated when new state events arrive. In other words, even if state file is missing, the room may be still correctly showing a name at this point.
3. As time goes on, new state events arrive to the device and are correctly stored on disk, but the previously missing state is never recovered. Additionally, only now will `MXRoomSummary` be updated, and valid name be replaced with "X & Y others", because there is indeed no state with name present. 

In short, the root cause is missing state file at t0, which only because apparent in the form of "X and Y others" name at t1, when new state events have arrived (minutes, hours or days later).

# Solution
Ideally we would want to identify and resolve the issue where state file is never recreated after clearing of cache, initial sync or log in. This is however still too complex, as the bug may be in `MXSession` managing sync data, or `MXFileStore` suffering from a race condition, or any other issue.

Instead we will monitor when a state file is missing during the loading of `MXRoomState`, and if no state events are returned from the store, we will trigger a (previously unused) HTTP request to fetch the entire room state and persist it on disk. When this happens, and new state events are returned from the API, name of the room will be automatically correct, because it is updated on any new state events.