### PR TITLE
Mark MXRestClient init as required for mocking.

### DIFF
--- a/MatrixSDK/Contrib/Swift/MXRestClient.swift
+++ b/MatrixSDK/Contrib/Swift/MXRestClient.swift
@@ -75,7 +75,7 @@ public extension MXRestClient {
      
      - returns: a `MXRestClient` instance.
      */
-    @nonobjc convenience init(homeServer: URL, unrecognizedCertificateHandler handler: MXHTTPClientOnUnrecognizedCertificate?) {
+    @nonobjc required convenience init(homeServer: URL, unrecognizedCertificateHandler handler: MXHTTPClientOnUnrecognizedCertificate?) {
         self.init(__homeServer: homeServer.absoluteString, andOnUnrecognizedCertificateBlock: handler)
     }
     

--- a/changelog.d/6179.api
+++ b/changelog.d/6179.api
@@ -1,0 +1,1 @@
+Mark MXRestClient init as `required` for mocking.


### PR DESCRIPTION
In order to add a protocol that includes the client's `init`, this PR marks it as `required`. Part of 
https://github.com/vector-im/element-ios/issues/6179