### PR TITLE
BackgroundStore: Avoid clearing file store when event stream token is missing

### DIFF
--- a/MatrixSDK/Background/MXBackgroundStore.swift
+++ b/MatrixSDK/Background/MXBackgroundStore.swift
@@ -39,8 +39,8 @@ class MXBackgroundStore: NSObject, MXStore {
     init(withCredentials credentials: MXCredentials) {
         fileStore = MXFileStore(credentials: credentials)
         storeService = MXStoreService(store: fileStore, credentials: credentials)
-        //  load real eventStreamToken
-        fileStore.loadMetaData()
+        //  load real eventStreamToken without enabling clear data
+        fileStore.loadMetaData(false)
     }
     
     //  Return real eventStreamToken, to be able to launch a meaningful background sync

--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.h
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.h
@@ -166,9 +166,16 @@ typedef NS_OPTIONS(NSInteger, MXFileStorePreloadOptions)
 #pragma mark - Sync API (Do not use them on the main thread)
 
 /**
- Load metadata for the store. Sets eventStreamToken.
+ Calls `loadMetaData:` with `enableClearData` as YES.
  */
 - (void)loadMetaData;
+
+/**
+ Load metadata for the store. Sets eventStreamToken.
+
+ @param enableClearData flag to enable clearing data in case of eventStreamToken is missing.
+ */
+- (void)loadMetaData:(BOOL)enableClearData;
 
 /**
  Get the room store for a given room.

--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
@@ -1597,11 +1597,18 @@ static NSUInteger preloadOptions;
 #pragma mark - MXFileStore metadata
 - (void)loadMetaData
 {
+    [self loadMetaData:YES];
+}
+
+- (void)loadMetaData:(BOOL)enableClearData
+{
+    MXLogDebug(@"[MXFileStore] loadMetaData: enableClearData: %@", enableClearData ? @"YES" : @"NO");
+
     NSString *metaDataFile = [storePath stringByAppendingPathComponent:kMXFileStoreMedaDataFile];
     
     @try
     {
-        metaData = [NSKeyedUnarchiver unarchiveObjectWithFile:metaDataFile];
+        metaData = [self loadRootObjectWithoutSecureCodingFromFile:metaDataFile];
     }
     @catch (NSException *exception)
     {
@@ -1623,7 +1630,10 @@ static NSUInteger preloadOptions;
     {
         MXLogDebug(@"[MXFileStore] loadMetaData: event stream token is missing");
         [self logFiles];
-        [self deleteAllData];
+        if (enableClearData)
+        {
+            [self deleteAllData];
+        }
     }
 }
 
@@ -1665,7 +1675,7 @@ static NSUInteger preloadOptions;
             self->backupEventStreamToken = self->metaData.eventStreamToken;
 
             // Store new data
-            [NSKeyedArchiver archiveRootObject:self->metaData toFile:file];
+            [self saveObject:self->metaData toFile:file];
 
 #if DEBUG
             MXLogDebug(@"[MXFileStore commit] lasted %.0fms for metadata", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);

--- a/changelog.d/5924.bugfix
+++ b/changelog.d/5924.bugfix
@@ -1,0 +1,1 @@
+MXBackgroundStore: Avoid clearing file store if event stream token is missing.


### PR DESCRIPTION
Fixes another case for vector-im/element-ios#5924