### PR TITLE
Remove unwanted parts from replies new_content body/formatted_body

### DIFF
--- a/MatrixSDK/Aggregations/MXAggregatedEditsUpdater.m
+++ b/MatrixSDK/Aggregations/MXAggregatedEditsUpdater.m
@@ -101,7 +101,7 @@
         {
             MXLogDebug(@"[MXAggregations] replaceTextMessageEvent: Fail to parse reply event: %@", event.eventId);
 
-            // This enables edition of replies that don't provide a fallback mx-reply body.
+            // This enables editing replies that don't provide a fallback mx-reply body.
             compatibilityText = [NSString stringWithFormat:@"* %@", text];
             compatibilityFormattedText = [NSString stringWithFormat:@"* %@", formattedText];
         }

--- a/changelog.d/3517.bugfix
+++ b/changelog.d/3517.bugfix
@@ -1,0 +1,1 @@
+Remove unwanted parts from replies new_content body/formatted_body


### PR DESCRIPTION
This fixes an issue mentioned in https://github.com/vector-im/element-ios/issues/3517 
It removes body parts that shouldn't be added to the **new_content** body/formatted_body but only to the compatibility body/formatted_body. 

It also enables the ability to edit replies that have lost their mx-reply fallback (preserving the same behaviour as it already has: clients that handle rich replies will display everything properly, clients that don't will only be able to display the reply body)

Here's a screenshot of EleWeb displaying edited reply from an iOS client before and after this update. 

<img width="650" alt="image" src="https://user-images.githubusercontent.com/80891108/171445312-43219326-c37a-46ea-a224-4c1236b9fe35.png">