### PR TITLE
Accept key backups as usable if they're signed with the master cross-signing key

### DIFF
--- a/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.m
+++ b/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.m
@@ -1139,18 +1139,18 @@ static Class DefaultAlgorithmClass;
     for (NSString *keyId in mySigs)
     {
         // XXX: is this how we're supposed to get the device id?
-        NSString *deviceId;
+        NSString *deviceIdOrCrossSigningKey;
         NSArray<NSString *> *components = [keyId componentsSeparatedByString:@":"];
         if (components.count == 2)
         {
-            deviceId = components[1];
+            deviceIdOrCrossSigningKey = components[1];
         }
 
-        if (deviceId)
+        if (deviceIdOrCrossSigningKey)
         {
             BOOL valid = NO;
 
-            MXDeviceInfo *device = [self->crypto.deviceList storedDevice:myUserId deviceId:deviceId];
+            MXDeviceInfo *device = [self->crypto.deviceList storedDevice:myUserId deviceId:deviceIdOrCrossSigningKey];
             if (device)
             {
                 NSError *error;
@@ -1162,15 +1162,15 @@ static Class DefaultAlgorithmClass;
                 }
                 
                 MXKeyBackupVersionTrustSignature *signature = [MXKeyBackupVersionTrustSignature new];
-                signature.deviceId = deviceId;
+                signature.deviceId = device.deviceId;
                 signature.device = device;
                 signature.valid = valid;
                 [signatures addObject:signature];
             }
-            else if ([deviceId isEqualToString:crypto.crossSigning.myUserCrossSigningKeys.masterKeys.keys])
+            else if ([deviceIdOrCrossSigningKey isEqualToString:crypto.crossSigning.myUserCrossSigningKeys.masterKeys.keys])
             {
                 NSError *error;
-                BOOL valid = [crypto.crossSigning.crossSigningTools pkVerifyObject:authData.JSONDictionary userId:myUserId publicKey:deviceId error:&error];
+                BOOL valid = [crypto.crossSigning.crossSigningTools pkVerifyObject:authData.JSONDictionary userId:myUserId publicKey:deviceIdOrCrossSigningKey error:&error];
                 
                 if (!valid)
                 {
@@ -1182,13 +1182,13 @@ static Class DefaultAlgorithmClass;
                 }
 
                 MXKeyBackupVersionTrustSignature *signature = [MXKeyBackupVersionTrustSignature new];
-                signature.keys = deviceId;
+                signature.keys = deviceIdOrCrossSigningKey;
                 signature.valid = valid;
                 [signatures addObject:signature];
             }
             else
             {
-                MXLogDebug(@"[MXKeyBackup] trustForKeyBackupVersion: Signature with unknown key %@", deviceId);
+                MXLogDebug(@"[MXKeyBackup] trustForKeyBackupVersion: Signature with unknown key %@", deviceIdOrCrossSigningKey);
             }
         }
     }

--- a/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.m
+++ b/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.m
@@ -1167,24 +1167,28 @@ static Class DefaultAlgorithmClass;
                 signature.valid = valid;
                 [signatures addObject:signature];
             }
-            else // Try interpreting it as the MSK public key
+            else if ([deviceId isEqualToString:crypto.crossSigning.myUserCrossSigningKeys.masterKeys.keys])
             {
                 NSError *error;
                 BOOL valid = [crypto.crossSigning.crossSigningTools pkVerifyObject:authData.JSONDictionary userId:myUserId publicKey:deviceId error:&error];
                 
                 if (!valid)
                 {
-                    MXLogDebug(@"[MXKeyBackup] trustForKeyBackupVersion: Signature with unknown key %@", deviceId);
+                    MXLogDebug(@"[MXKeyBackup] trustForKeyBackupVersion: Signature with cross-signing master key is invalid");
                 }
                 else
                 {
                     keyBackupVersionTrust.usable = YES;
-
-                    MXKeyBackupVersionTrustSignature *signature = [MXKeyBackupVersionTrustSignature new];
-                    signature.keys = deviceId;
-                    signature.valid = valid;
-                    [signatures addObject:signature];
                 }
+
+                MXKeyBackupVersionTrustSignature *signature = [MXKeyBackupVersionTrustSignature new];
+                signature.keys = deviceId;
+                signature.valid = valid;
+                [signatures addObject:signature];
+            }
+            else
+            {
+                MXLogDebug(@"[MXKeyBackup] trustForKeyBackupVersion: Signature with unknown key %@", deviceId);
             }
         }
     }

--- a/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.m
+++ b/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.m
@@ -1178,6 +1178,8 @@ static Class DefaultAlgorithmClass;
                 }
                 else
                 {
+                    keyBackupVersionTrust.usable = YES;
+
                     MXKeyBackupVersionTrustSignature *signature = [MXKeyBackupVersionTrustSignature new];
                     signature.keys = deviceId;
                     signature.valid = valid;

--- a/changelog.d/pr-1492.bugfix
+++ b/changelog.d/pr-1492.bugfix
@@ -1,0 +1,1 @@
+Accept key backups as usable if they're signed with the master cross-signing key. Contributed by Brad @ Beeper


### PR DESCRIPTION
Accept key backups if they're signed by the master cross-signing key.

Used matrix-js-sdk as a reference which accepts it as usable if either the signing device is verified or it's the cross-signing key. https://github.com/matrix-org/matrix-js-sdk/blob/develop/src/crypto/backup.ts#L426-L433

Signed-off-by: Brad Murray <brad@beeper.com>

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request contains a changelog file in ./changelog.d. See https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
