### PR TITLE
Fixes vector-im/element-ios/issues/6227 - Prevent invalid room names …

### DIFF
--- a/MatrixSDK/Data/MXRoomSummaryUpdater.m
+++ b/MatrixSDK/Data/MXRoomSummaryUpdater.m
@@ -507,8 +507,11 @@
             }
             default:
             {
-                NSString *memberName = [self memberNameFromRoomState:roomState withIdentifier:memberIdentifiers.firstObject];
-                displayName = [_roomNameStringLocalizer moreThanTwoMembers:memberName count:@(memberCount - 2)];
+                if (memberCount > 2)
+                {
+                    NSString *memberName = [self memberNameFromRoomState:roomState withIdentifier:memberIdentifiers.firstObject];
+                    displayName = [_roomNameStringLocalizer moreThanTwoMembers:memberName count:@(memberCount - 2)];
+                }
                 break;
             }
         }

--- a/changelog.d/6227.bugfix
+++ b/changelog.d/6227.bugfix
@@ -1,0 +1,1 @@
+Prevent invalid room names on member count underflows.


### PR DESCRIPTION
…on member count underflows.