### PR TITLE
Add `logoutDevices` parameter to `MXRestClient.changePassword` api

### DIFF
--- a/MatrixSDK/Contrib/Swift/MXRestClient.swift
+++ b/MatrixSDK/Contrib/Swift/MXRestClient.swift
@@ -288,13 +288,14 @@ public extension MXRestClient {
      - parameters:
          - old: the current password to update.
          - new: the new password.
+         - logoutDevices flag to log out all devices
          - completion: A block object called when the operation completes
          - response: indicates whether the operation succeeded or not.
      
      - returns: a `MXHTTPOperation` instance.
      */
-    @nonobjc @discardableResult func changePassword(from old: String, to new: String, completion: @escaping (_ response: MXResponse<Void>) -> Void) -> MXHTTPOperation {
-        return __changePassword(old, with: new, success: currySuccess(completion), failure: curryFailure(completion))
+    @nonobjc @discardableResult func changePassword(from old: String, to new: String, logoutDevices: Bool, completion: @escaping (_ response: MXResponse<Void>) -> Void) -> MXHTTPOperation {
+        return __changePassword(old, with: new, logoutDevices: logoutDevices, success: currySuccess(completion), failure: curryFailure(completion))
     }
     
     

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -515,12 +515,15 @@ NS_REFINED_FOR_SWIFT;
 
  @param oldPassword the current password to update.
  @param newPassword the new password.
+ @param logoutDevices flag to logout from all devices.
  @param success A block object called when the operation succeeds.
  @param failure A block object called when the operation fails.
 
  @return a MXHTTPOperation instance.
  */
-- (MXHTTPOperation*)changePassword:(NSString*)oldPassword with:(NSString*)newPassword
+- (MXHTTPOperation*)changePassword:(NSString*)oldPassword
+                              with:(NSString*)newPassword
+                     logoutDevices:(BOOL)logoutDevices
                            success:(void (^)(void))success
                            failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -924,7 +924,9 @@ andUnauthenticatedHandler: (MXRestClientUnauthenticatedHandler)unauthenticatedHa
                                  }];
 }
 
-- (MXHTTPOperation*)changePassword:(NSString*)oldPassword with:(NSString*)newPassword
+- (MXHTTPOperation*)changePassword:(NSString*)oldPassword
+                              with:(NSString*)newPassword
+                     logoutDevices:(BOOL)logoutDevices
                            success:(void (^)(void))success
                            failure:(void (^)(NSError *error))failure
 {
@@ -943,7 +945,8 @@ andUnauthenticatedHandler: (MXRestClientUnauthenticatedHandler)unauthenticatedHa
                                              @"user": self.credentials.userId,
                                              @"password": oldPassword,
                                            },
-                                 @"new_password": newPassword
+                                 @"new_password": newPassword,
+                                 @"logout_devices": @(logoutDevices)
                                  };
 
     MXWeakify(self);

--- a/changelog.d/6175.api
+++ b/changelog.d/6175.api
@@ -1,0 +1,1 @@
+MXRestClient: Add `logoutDevices` parameter to `changePassword` method.


### PR DESCRIPTION
Part of vector-im/element-ios#6175