### PR TITLE
Subclass MXCrypto to enable work-in-progress Rust sdk

### DIFF
--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -1791,6 +1791,8 @@
 		ED44F01528180EAB00452A5D /* MXSharedHistoryKeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED44F01328180EAB00452A5D /* MXSharedHistoryKeyManager.swift */; };
 		ED44F01A28180F4000452A5D /* MXSharedHistoryKeyManagerUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED44F01728180F1C00452A5D /* MXSharedHistoryKeyManagerUnitTests.swift */; };
 		ED44F01B28180F4000452A5D /* MXSharedHistoryKeyManagerUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED44F01728180F1C00452A5D /* MXSharedHistoryKeyManagerUnitTests.swift */; };
+		ED47CB6D28523995004FD755 /* MXCryptoV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED47CB6C28523995004FD755 /* MXCryptoV2.swift */; };
+		ED47CB6E28523995004FD755 /* MXCryptoV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED47CB6C28523995004FD755 /* MXCryptoV2.swift */; };
 		ED51943928462D130006EEC6 /* MXRoomStateUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED51943828462D130006EEC6 /* MXRoomStateUnitTests.swift */; };
 		ED51943A28462D130006EEC6 /* MXRoomStateUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED51943828462D130006EEC6 /* MXRoomStateUnitTests.swift */; };
 		ED51943C284630090006EEC6 /* MXRestClientStub.m in Sources */ = {isa = PBXBuildFile; fileRef = ED51943B284630090006EEC6 /* MXRestClientStub.m */; };
@@ -2808,6 +2810,7 @@
 		ED44F01028180BCC00452A5D /* MXSharedHistoryKeyRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXSharedHistoryKeyRequest.swift; sourceTree = "<group>"; };
 		ED44F01328180EAB00452A5D /* MXSharedHistoryKeyManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXSharedHistoryKeyManager.swift; sourceTree = "<group>"; };
 		ED44F01728180F1C00452A5D /* MXSharedHistoryKeyManagerUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXSharedHistoryKeyManagerUnitTests.swift; sourceTree = "<group>"; };
+		ED47CB6C28523995004FD755 /* MXCryptoV2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXCryptoV2.swift; sourceTree = "<group>"; };
 		ED51943828462D130006EEC6 /* MXRoomStateUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXRoomStateUnitTests.swift; sourceTree = "<group>"; };
 		ED51943B284630090006EEC6 /* MXRestClientStub.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXRestClientStub.m; sourceTree = "<group>"; };
 		ED51943E284630100006EEC6 /* MXRestClientStub.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXRestClientStub.h; sourceTree = "<group>"; };
@@ -3151,6 +3154,7 @@
 				3252DCAB224BE59E0032264F /* Verification */,
 				322A51B41D9AB15900C8536D /* MXCrypto.h */,
 				322A51B51D9AB15900C8536D /* MXCrypto.m */,
+				ED47CB6C28523995004FD755 /* MXCryptoV2.swift */,
 				325D1C251DFECE0D0070B8BF /* MXCrypto_Private.h */,
 				322A51C51D9BBD3C00C8536D /* MXOlmDevice.h */,
 				322A51C61D9BBD3C00C8536D /* MXOlmDevice.m */,
@@ -6188,6 +6192,7 @@
 				B105CDD8261F54C8006EB204 /* MXSpaceChildContent.m in Sources */,
 				327E9ABD2284521C00A98BC1 /* MXEventUnsignedData.m in Sources */,
 				32AF9286240EA2430008A0FD /* MXSecretShareRequest.m in Sources */,
+				ED47CB6D28523995004FD755 /* MXCryptoV2.swift in Sources */,
 				32A1513A1DAD292400400192 /* MXMegolmEncryption.m in Sources */,
 				EC60EDFE265CFFD200B39A4E /* MXInvitedGroupSync.m in Sources */,
 				8EC5110C256822B400EC4E5B /* MXTaggedEvents.m in Sources */,
@@ -6747,6 +6752,7 @@
 				B14EF2062397E90400758AF0 /* MXGroup.m in Sources */,
 				B14EF2072397E90400758AF0 /* MXAutoDiscovery.m in Sources */,
 				3297913123AA126500F7BB9B /* MXKeyVerificationStatusResolver.m in Sources */,
+				ED47CB6E28523995004FD755 /* MXCryptoV2.swift in Sources */,
 				B14EF2082397E90400758AF0 /* MX3PidAddManager.m in Sources */,
 				ECD2899026EB3B3400F268CF /* MXRoomListData.swift in Sources */,
 				B14EF2092397E90400758AF0 /* MXCallKitConfiguration.m in Sources */,
@@ -7237,6 +7243,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				OTHER_SWIFT_FLAGS = "-D DEBUG";
 				SDKROOT = "";
 				SWIFT_SWIFT3_OBJC_INFERENCE = On;
 				SWIFT_VERSION = 5.0;

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -144,7 +144,16 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     __block MXCrypto *crypto;
 
 #ifdef MX_CRYPTO
-
+    
+    #if DEBUG
+    // If running non-production build AND build flag enabled,
+    // switch to work-in-progress Rust implementation of crypto.
+    if (MXSDKOptions.sharedInstance.enableCryptoV2)
+    {
+        return [[MXCryptoV2 alloc] init];
+    }
+    #endif
+    
     dispatch_queue_t cryptoQueue = [MXCrypto dispatchQueueForUser:mxSession.matrixRestClient.credentials.userId];
     dispatch_sync(cryptoQueue, ^{
 
@@ -161,6 +170,16 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 + (void)checkCryptoWithMatrixSession:(MXSession*)mxSession complete:(void (^)(MXCrypto *crypto))complete
 {
 #ifdef MX_CRYPTO
+    
+    #if DEBUG
+    // If running non-production build AND build flag enabled,
+    // switch to work-in-progress Rust implementation of crypto.
+    if (MXSDKOptions.sharedInstance.enableCryptoV2)
+    {
+        complete([[MXCryptoV2 alloc] init]);
+        return;
+    }
+    #endif
 
     MXLogDebug(@"[MXCrypto] checkCryptoWithMatrixSession for %@", mxSession.matrixRestClient.credentials.userId);
 

--- a/MatrixSDK/Crypto/MXCryptoV2.swift
+++ b/MatrixSDK/Crypto/MXCryptoV2.swift
@@ -1,0 +1,329 @@
+//
+//  MXCryptoV2.swift
+//  MatrixSDK
+//
+//  Created by Element on 11/05/2022.
+//
+
+import Foundation
+
+#if DEBUG
+
+/**
+ A work-in-progress subclass of `MXCrypto` which uses [matrix-rust-sdk](https://github.com/matrix-org/matrix-rust-sdk/tree/main/crates/matrix-sdk-crypto)
+ under the hood.
+ 
+ This subclass serves as a skeleton to enable itterative implementation of matrix-rust-sdk without affecting existing
+ production code. It is a subclass because `MXCrypto` does not define a reusable protocol, and to define one would require
+ further risky refactors across the application.
+ 
+ Another benefit of using a subclass and overriding every method with new implementation is that existing integration tests
+ for crypto-related functionality can still run (and eventually pass) without any changes.
+ */
+@objcMembers
+public class MXCryptoV2: MXCrypto {
+    
+    public override var deviceCurve25519Key: String! {
+        warnNotImplemented()
+        return nil
+    }
+    
+    public override var deviceEd25519Key: String! {
+        warnNotImplemented()
+        return nil
+    }
+    
+    public override var olmVersion: String! {
+        warnNotImplemented()
+        return nil
+    }
+    
+    public override var backup: MXKeyBackup! {
+        warnNotImplemented()
+        return nil
+    }
+    
+    public override var keyVerificationManager: MXKeyVerificationManager! {
+        warnNotImplemented()
+        return nil
+    }
+    
+    public override var recoveryService: MXRecoveryService! {
+        warnNotImplemented()
+        return nil
+    }
+    
+    public override var secretStorage: MXSecretStorage! {
+        warnNotImplemented()
+        return nil
+    }
+    
+    public override var secretShareManager: MXSecretShareManager! {
+        warnNotImplemented()
+        return nil
+    }
+    
+    public override var crossSigning: MXCrossSigning! {
+        warnNotImplemented()
+        return nil
+    }
+    
+    public override class func createCrypto(withMatrixSession mxSession: MXSession!) -> MXCrypto! {
+        warnNotImplemented()
+        return nil
+    }
+    
+    public override class func check(withMatrixSession mxSession: MXSession!, complete: ((MXCrypto?) -> Void)!) {
+        warnNotImplemented()
+    }
+    
+    public override class func rehydrateExportedOlmDevice(_ exportedOlmDevice: MXExportedOlmDevice!, with credentials: MXCredentials!, complete: ((Bool) -> Void)!) {
+        warnNotImplemented()
+    }
+    
+    public override func start(_ onComplete: (() -> Void)!, failure: ((Error?) -> Void)!) {
+        onComplete?()
+        warnNotImplemented()
+    }
+    
+    public override func close(_ deleteStore: Bool) {
+        warnNotImplemented()
+    }
+    
+    public override func encryptEventContent(_ eventContent: [AnyHashable : Any]!, withType eventType: String!, in room: MXRoom!, success: (([AnyHashable : Any]?, String?) -> Void)!, failure: ((Error?) -> Void)!) -> MXHTTPOperation! {
+        warnNotImplemented()
+        return nil
+    }
+    
+    public override func hasKeys(toDecryptEvent event: MXEvent!, onComplete: ((Bool) -> Void)!) {
+        warnNotImplemented()
+    }
+    
+    public override func decryptEvent(_ event: MXEvent!, inTimeline timeline: String!) -> MXEventDecryptionResult! {
+        warnNotImplemented()
+        return nil
+    }
+    
+    public override func decryptEvents(_ events: [MXEvent]!, inTimeline timeline: String!, onComplete: (([MXEventDecryptionResult]?) -> Void)!) {
+        warnNotImplemented()
+    }
+    
+    public override func ensureEncryption(inRoom roomId: String!, success: (() -> Void)!, failure: ((Error?) -> Void)!) -> MXHTTPOperation! {
+        warnNotImplemented()
+        return nil
+    }
+    
+    public override func discardOutboundGroupSessionForRoom(withRoomId roomId: String!, onComplete: (() -> Void)!) {
+        warnNotImplemented()
+    }
+    
+    public override func handleDeviceListsChanges(_ deviceLists: MXDeviceListResponse!) {
+        // Not implemented, will be handled by Rust
+        warnNotImplemented(ignore: true)
+    }
+    
+    public override func handleDeviceOneTimeKeysCount(_ deviceOneTimeKeysCount: [String : NSNumber]!) {
+        // Not implemented, will be handled by Rust
+        warnNotImplemented(ignore: true)
+    }
+    
+    public override func handleDeviceUnusedFallbackKeys(_ deviceUnusedFallbackKeys: [String]!) {
+        // Not implemented, will be handled by Rust
+        warnNotImplemented(ignore: true)
+    }
+    
+    public override func handleRoomKeyEvent(_ event: MXEvent!, onComplete: (() -> Void)!) {
+        // Not implemented, will be handled by Rust
+        warnNotImplemented(ignore: true)
+    }
+    
+    public override func onSyncCompleted(_ oldSyncToken: String!, nextSyncToken: String!, catchingUp: Bool) {
+        warnNotImplemented()
+    }
+    
+    public override func eventDeviceInfo(_ event: MXEvent!) -> MXDeviceInfo! {
+        warnNotImplemented()
+        return nil
+    }
+    
+    public override func setDeviceVerification(_ verificationStatus: MXDeviceVerification, forDevice deviceId: String!, ofUser userId: String!, success: (() -> Void)!, failure: ((Error?) -> Void)!) {
+        warnNotImplemented()
+    }
+    
+    public override func setDevicesKnown(_ devices: MXUsersDevicesMap<MXDeviceInfo>!, complete: (() -> Void)!) {
+        warnNotImplemented()
+    }
+    
+    public override func setUserVerification(_ verificationStatus: Bool, forUser userId: String!, success: (() -> Void)!, failure: ((Error?) -> Void)!) {
+        warnNotImplemented()
+    }
+    
+    public override func trustLevel(forUser userId: String!) -> MXUserTrustLevel! {
+        warnNotImplemented()
+        return nil
+    }
+    
+    public override func deviceTrustLevel(forDevice deviceId: String!, ofUser userId: String!) -> MXDeviceTrustLevel! {
+        warnNotImplemented()
+        return nil
+    }
+    
+    public override func trustLevelSummary(forUserIds userIds: [String]!, success: ((MXUsersTrustLevelSummary?) -> Void)!, failure: ((Error?) -> Void)!) {
+        warnNotImplemented()
+    }
+    
+    public override func trustLevelSummary(forUserIds userIds: [String]!, onComplete: ((MXUsersTrustLevelSummary?) -> Void)!) {
+        warnNotImplemented()
+    }
+    
+    public override func downloadKeys(_ userIds: [String]!, forceDownload: Bool, success: ((MXUsersDevicesMap<MXDeviceInfo>?, [String : MXCrossSigningInfo]?) -> Void)!, failure: ((Error?) -> Void)!) -> MXHTTPOperation! {
+        warnNotImplemented()
+        return nil
+    }
+    
+    public override func crossSigningKeys(forUser userId: String!) -> MXCrossSigningInfo! {
+        warnNotImplemented()
+        return nil
+    }
+    
+    public override func devices(forUser userId: String!) -> [String : MXDeviceInfo]! {
+        warnNotImplemented()
+        return nil
+    }
+    
+    public override func device(withDeviceId deviceId: String!, ofUser userId: String!) -> MXDeviceInfo! {
+        warnNotImplemented()
+        return nil
+    }
+    
+    public override func resetReplayAttackCheck(inTimeline timeline: String!) {
+        warnNotImplemented()
+    }
+    
+    public override func resetDeviceKeys() {
+        warnNotImplemented()
+    }
+    
+    public override func deleteStore(_ onComplete: (() -> Void)!) {
+        warnNotImplemented()
+    }
+    
+    public override func requestAllPrivateKeys() {
+        warnNotImplemented()
+    }
+    
+    public override func exportRoomKeys(_ success: (([[AnyHashable : Any]]?) -> Void)!, failure: ((Error?) -> Void)!) {
+        warnNotImplemented()
+    }
+    
+    public override func exportRoomKeys(withPassword password: String!, success: ((Data?) -> Void)!, failure: ((Error?) -> Void)!) {
+        warnNotImplemented()
+    }
+    
+    public override func importRoomKeys(_ keys: [[AnyHashable : Any]]!, success: ((UInt, UInt) -> Void)!, failure: ((Error?) -> Void)!) {
+        warnNotImplemented()
+    }
+    
+    public override func importRoomKeys(_ keyFile: Data!, withPassword password: String!, success: ((UInt, UInt) -> Void)!, failure: ((Error?) -> Void)!) {
+        warnNotImplemented()
+    }
+    
+    public override func pendingKeyRequests(_ onComplete: ((MXUsersDevicesMap<NSArray>?) -> Void)!) {
+        // Not implemented, will be handled by Rust
+        warnNotImplemented(ignore: true)
+    }
+    
+    public override func accept(_ keyRequest: MXIncomingRoomKeyRequest!, success: (() -> Void)!, failure: ((Error?) -> Void)!) {
+        warnNotImplemented()
+    }
+    
+    public override func acceptAllPendingKeyRequests(fromUser userId: String!, andDevice deviceId: String!, onComplete: (() -> Void)!) {
+        warnNotImplemented()
+    }
+    
+    public override func ignore(_ keyRequest: MXIncomingRoomKeyRequest!, onComplete: (() -> Void)!) {
+        warnNotImplemented()
+    }
+    
+    public override func ignoreAllPendingKeyRequests(fromUser userId: String!, andDevice deviceId: String!, onComplete: (() -> Void)!) {
+        warnNotImplemented()
+    }
+    
+    public override func setOutgoingKeyRequestsEnabled(_ enabled: Bool, onComplete: (() -> Void)!) {
+        warnNotImplemented()
+    }
+    
+    public override func isOutgoingKeyRequestsEnabled() -> Bool {
+        warnNotImplemented()
+        return false
+    }
+    
+    public override var enableOutgoingKeyRequestsOnceSelfVerificationDone: Bool {
+        get {
+            warnNotImplemented()
+            return false
+        }
+        set {
+            warnNotImplemented()
+        }
+    }
+    
+    public override func reRequestRoomKey(for event: MXEvent!) {
+        warnNotImplemented()
+    }
+    
+    public override var warnOnUnknowDevices: Bool {
+        get {
+            warnNotImplemented()
+            return false
+        }
+        set {
+            warnNotImplemented()
+        }
+    }
+    
+    public override var globalBlacklistUnverifiedDevices: Bool {
+        get {
+            warnNotImplemented()
+            return false
+        }
+        set {
+            warnNotImplemented()
+        }
+    }
+    
+    public override func isBlacklistUnverifiedDevices(inRoom roomId: String!) -> Bool {
+        warnNotImplemented()
+        return false
+    }
+    
+    public override func isRoomEncrypted(_ roomId: String!) -> Bool {
+        warnNotImplemented()
+        return false
+    }
+    
+    public override func isRoomSharingHistory(_ roomId: String!) -> Bool {
+        warnNotImplemented()
+        return false
+    }
+    
+    public override func setBlacklistUnverifiedDevicesInRoom(_ roomId: String!, blacklist: Bool) {
+        warnNotImplemented()
+    }
+    
+    // MARK: - Private
+    
+    /**
+     Convenience function which logs methods that are being called by the application,
+     but are not yet implemented via the Rust component.
+     */
+    private static func warnNotImplemented(ignore: Bool = false, _ function: String = #function) {
+        MXLog.debug("[MXCryptoV2] function `\(function)` not implemented, ignored: \(ignore)")
+    }
+    
+    private func warnNotImplemented(ignore: Bool = false, _ function: String = #function) {
+        Self.warnNotImplemented(ignore: ignore, function)
+    }
+}
+
+#endif

--- a/MatrixSDK/Crypto/MXCryptoV2.swift
+++ b/MatrixSDK/Crypto/MXCryptoV2.swift
@@ -9,17 +9,16 @@ import Foundation
 
 #if DEBUG
 
-/**
- A work-in-progress subclass of `MXCrypto` which uses [matrix-rust-sdk](https://github.com/matrix-org/matrix-rust-sdk/tree/main/crates/matrix-sdk-crypto)
- under the hood.
- 
- This subclass serves as a skeleton to enable itterative implementation of matrix-rust-sdk without affecting existing
- production code. It is a subclass because `MXCrypto` does not define a reusable protocol, and to define one would require
- further risky refactors across the application.
- 
- Another benefit of using a subclass and overriding every method with new implementation is that existing integration tests
- for crypto-related functionality can still run (and eventually pass) without any changes.
- */
+
+ /// A work-in-progress subclass of `MXCrypto` which uses [matrix-rust-sdk](https://github.com/matrix-org/matrix-rust-sdk/tree/main/crates/matrix-sdk-crypto)
+/// under the hood.
+///
+/// This subclass serves as a skeleton to enable itterative implementation of matrix-rust-sdk without affecting existing
+/// production code. It is a subclass because `MXCrypto` does not define a reusable protocol, and to define one would require
+/// further risky refactors across the application.
+///
+/// Another benefit of using a subclass and overriding every method with new implementation is that existing integration tests
+/// for crypto-related functionality can still run (and eventually pass) without any changes.
 @objcMembers
 public class MXCryptoV2: MXCrypto {
     
@@ -313,10 +312,9 @@ public class MXCryptoV2: MXCrypto {
     
     // MARK: - Private
     
-    /**
-     Convenience function which logs methods that are being called by the application,
-     but are not yet implemented via the Rust component.
-     */
+    
+    /// Convenience function which logs methods that are being called by the application,
+    /// but are not yet implemented via the Rust component.
     private static func warnNotImplemented(ignore: Bool = false, _ function: String = #function) {
         MXLog.debug("[MXCryptoV2] function `\(function)` not implemented, ignored: \(ignore)")
     }

--- a/MatrixSDK/Crypto/MXCryptoV2.swift
+++ b/MatrixSDK/Crypto/MXCryptoV2.swift
@@ -13,7 +13,7 @@ import Foundation
  /// A work-in-progress subclass of `MXCrypto` which uses [matrix-rust-sdk](https://github.com/matrix-org/matrix-rust-sdk/tree/main/crates/matrix-sdk-crypto)
 /// under the hood.
 ///
-/// This subclass serves as a skeleton to enable itterative implementation of matrix-rust-sdk without affecting existing
+/// This subclass serves as a skeleton to enable iterative implementation of matrix-rust-sdk without affecting existing
 /// production code. It is a subclass because `MXCrypto` does not define a reusable protocol, and to define one would require
 /// further risky refactors across the application.
 ///

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -3643,7 +3643,7 @@ NSInteger const kMXRoomInvalidInviteSenderErrorCode = 9002;
     if (!crypto)
     {
 #ifdef MX_CRYPTO
-        MXLogFailure(@"[MXRoom] checkEncryptionState: Crypto module is not present");
+        MXLogError(@"[MXRoom] checkEncryptionState: Crypto module is not present");
 #endif
         return;
     }
@@ -3659,7 +3659,7 @@ NSInteger const kMXRoomInvalidInviteSenderErrorCode = 9002;
     {
         if (self.summary.isEncrypted)
         {
-            MXLogFailure(@"[MXRoom] checkEncryptionState: Crypto and state store do not match");
+            MXLogError(@"[MXRoom] checkEncryptionState: Crypto and state store do not match");
         }
         else
         {

--- a/MatrixSDK/MXSDKOptions.h
+++ b/MatrixSDK/MXSDKOptions.h
@@ -200,9 +200,21 @@ NS_ASSUME_NONNULL_BEGIN
  Enable sharing of session keys for an immediate historical context (e.g. last 10-20 messages)
  when inviting a new user to a room with shared history.
  
- @remark YES by default.
+ @remark NO by default.
  */
 @property (nonatomic) BOOL enableRoomSharedHistoryOnInvite;
+
+#if DEBUG
+
+/**
+ Enable Crypto module V2, a work-in-progress and NOT production-ready implementation
+ of [matrix-rust-sdk](https://github.com/matrix-org/matrix-rust-sdk/tree/main/crates/matrix-sdk-crypto).
+ 
+ @remark NO by default.
+ */
+@property (nonatomic) BOOL enableCryptoV2;
+
+#endif
 
 @end
 

--- a/MatrixSDK/MXSDKOptions.m
+++ b/MatrixSDK/MXSDKOptions.m
@@ -54,6 +54,10 @@ static MXSDKOptions *sharedOnceInstance = nil;
         _authEnableRefreshTokens = NO;
         _enableThreads = NO;
         _enableRoomSharedHistoryOnInvite = NO;
+        
+        #if DEBUG
+        _enableCryptoV2 = NO;
+        #endif
     }
     
     return self;

--- a/MatrixSDKTests/TestPlans/CryptoTests.xctestplan
+++ b/MatrixSDKTests/TestPlans/CryptoTests.xctestplan
@@ -71,7 +71,6 @@
         "MXCryptoTests\/testMXDeviceListDidUpdateUsersDevicesNotification",
         "MXCryptoTests\/testMXSDKOptionsEnableCryptoWhenOpeningMXSession",
         "MXCryptoTests\/testMXSessionEventWithEventId",
-        "MXCryptoTests\/testMultipleDownloadKeys",
         "MXCryptoTests\/testReplayAttack",
         "MXCryptoTests\/testReplayAttackForEventEdits",
         "MXCryptoTests\/testRestoreOlmOutboundKey",

--- a/changelog.d/pr-1496.misc
+++ b/changelog.d/pr-1496.misc
@@ -1,0 +1,1 @@
+Crypto: Subclass MXCrypto to enable work-in-progress Rust sdk


### PR DESCRIPTION
To avoid long-running feature branch when implementing [Matrix Rust SDK](https://github.com/matrix-org/matrix-rust-sdk/tree/main/crates/matrix-sdk-crypto) aka Element-R, I'd like to start merging small changes into `develop` that are well isolated and cannot be shipped to production by accident. In particular all newly added code is hidden both behind a build flag as well as behind `DEBUG` compiler macro, so the new code cannot be accidentally used and shipped to production builds.

This particular PR sets up the skeleton for new rust-based implementation by overriding `MXCrypto` and all of its methods. This has both benefits and risks:
- no need to do any risky refactor across the rest of the application (for example by definining shared protocol)
- existing integration tests can still run unaltered, and validate that future Rust implementation works as expected
- potential risk: compiler does not ensure that each `MXCrypto`'s method is overriden, so if new public API was added to `MXCrypto`, this would not be automatically picked up by `MXCryptoV2`. This is a small risk, as the code is not meant for production yet, and when productionizing, more safety measures will be put in place.

Finally note this PR does not yet add any actual Rust library, merely sets the stage up.