### PR TITLE
DevX: Add Codecov

### DIFF
--- a/.github/workflows/ci-unit-tests.yml
+++ b/.github/workflows/ci-unit-tests.yml
@@ -56,3 +56,6 @@ jobs:
         with:
           name: MatrixSDK-macOS.xcresult
           path: build/test/MatrixSDK-macOS.xcresult/
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@ source "https://rubygems.org"
 gem "fastlane"
 gem "cocoapods", '~>1.11.2'
 gem "xcode-install"
+gem "slather"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,6 +34,7 @@ GEM
       aws-eventstream (~> 1, >= 1.0.2)
     babosa (1.0.4)
     claide (1.0.3)
+    clamp (1.3.2)
     cocoapods (1.11.2)
       addressable (~> 2.8)
       claide (>= 1.0.2, < 2.0)
@@ -205,6 +206,7 @@ GEM
     memoist (0.16.2)
     mini_magick (4.11.0)
     mini_mime (1.1.1)
+    mini_portile2 (2.8.0)
     minitest (5.14.4)
     molinillo (0.8.0)
     multi_json (1.15.0)
@@ -213,10 +215,14 @@ GEM
     nap (1.1.0)
     naturally (2.2.1)
     netrc (0.11.0)
+    nokogiri (1.13.6)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
     optparse (0.1.1)
     os (1.1.1)
     plist (3.6.0)
     public_suffix (4.0.6)
+    racc (1.6.0)
     rake (13.0.6)
     representable (3.1.1)
       declarative (< 0.1.0)
@@ -237,6 +243,12 @@ GEM
     simctl (1.6.8)
       CFPropertyList
       naturally
+    slather (2.7.2)
+      CFPropertyList (>= 2.2, < 4)
+      activesupport
+      clamp (~> 1.3)
+      nokogiri (~> 1.12)
+      xcodeproj (~> 1.21)
     terminal-notifier (2.0.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
@@ -278,6 +290,7 @@ PLATFORMS
 DEPENDENCIES
   cocoapods (~> 1.11.2)
   fastlane
+  slather
   xcode-install
 
 BUNDLED WITH

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,5 @@
+.. image:: https://codecov.io/gh/matrix-org/matrix-ios-sdk/branch/develop/graph/badge.svg?token=2c9mzJoVpu:target: https://codecov.io/gh/matrix-org/matrix-ios-sdk
+
 Matrix iOS SDK
 ==============
 

--- a/changelog.d/6306.build
+++ b/changelog.d/6306.build
@@ -1,0 +1,1 @@
+Add Codecov for unit tests coverage.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,16 @@
+coverage:
+  status:
+    project:
+      default:
+        # Commits pushed to master should not make the overall
+        # project coverage decrease by more than 1%:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        # Be tolerant on slight code coverage diff on PRs to limit
+        # noisy red coverage status on github PRs.
+        # Note: The coverage stats are still uploaded
+        # to codecov so that PR reviewers can see uncovered lines
+        target: auto
+        threshold: 1%

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -89,6 +89,13 @@ platform :ios do
       output_directory: "./build/test",
       open_report: !is_ci?
     )
+
+    slather(
+      cobertura_xml: true,
+      output_directory: "./build/test",
+      workspace: "MatrixSDK.xcworkspace",
+      scheme: "MatrixSDK-macOS",
+    )
   end
 
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -94,6 +94,7 @@ platform :ios do
       cobertura_xml: true,
       output_directory: "./build/test",
       workspace: "MatrixSDK.xcworkspace",
+      proj: "MatrixSDK.xcodeproj",
       scheme: "MatrixSDK-macOS",
     )
   end


### PR DESCRIPTION
Part of vector-im/element-ios#6306

Used the same config file with https://github.com/vector-im/element-x-ios/blob/develop/codecov.yml, as i've no shining ideas to append atm.

If i'm correct Codecov will be able to comment on subsequent PRs after the base coverage is detected when this is merged. We should be able to see the difference also at https://app.codecov.io/gh/matrix-org/matrix-ios-sdk/pulls