### PR TITLE
Track non-fatal issues via analytics

### DIFF
--- a/MatrixSDK/Utils/MXAnalyticsDelegate.h
+++ b/MatrixSDK/Utils/MXAnalyticsDelegate.h
@@ -115,6 +115,17 @@ NS_ASSUME_NONNULL_BEGIN
                            isReply:(BOOL)isReply
                       startsThread:(BOOL)startsThread;
 
+#pragma mark - Health metrics
+
+/**
+ Report a non-fatal issue, i.e. an internal error that did not result in a crash
+ 
+ @param issue the description of the issue that occured
+ @param details a dictionary of additional context-dependent details about the issue
+ */
+- (void)trackNonFatalIssue:(NSString *)issue
+                   details:(nullable NSDictionary <NSString *, id> *)details;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/MatrixSDK/Utils/MXLog.h
+++ b/MatrixSDK/Utils/MXLog.h
@@ -37,5 +37,9 @@
 }
 
 #define MXLogFailure(message, ...) { \
-    [MXLogObjcWrapper logFailure:[NSString stringWithFormat: message, ##__VA_ARGS__] file:@__FILE__ function:[NSString stringWithFormat:@"%s", __FUNCTION__] line:__LINE__]; \
+    [MXLogObjcWrapper logFailure:[NSString stringWithFormat: message, ##__VA_ARGS__] details:nil file:@__FILE__ function:[NSString stringWithFormat:@"%s", __FUNCTION__] line:__LINE__]; \
+}
+
+#define MXLogFailureWithDetails(message, dictionary) { \
+    [MXLogObjcWrapper logFailure:message details:dictionary file:@__FILE__ function:[NSString stringWithFormat:@"%s", __FUNCTION__] line:__LINE__]; \
 }

--- a/MatrixSDK/Utils/MXLog.swift
+++ b/MatrixSDK/Utils/MXLog.swift
@@ -118,19 +118,24 @@ private var logger: SwiftyBeaver.Type = {
         logger.error(message, file, function, line: line)
     }
     
-    public static func failure(_ message: @autoclosure () -> Any, _
-                                file: String = #file, _ function: String = #function, line: Int = #line, context: Any? = nil) {
+    public static func failure(_ message: @autoclosure () -> Any,
+                               details: @autoclosure () -> [String: Any]? = nil,
+                               _ file: String = #file, _ function: String = #function, line: Int = #line, context: Any? = nil) {
         logger.error(message(), file, function, line: line, context: context)
         #if DEBUG
         assertionFailure("\(message())")
+        #else
+        MXSDKOptions.sharedInstance().analyticsDelegate?.trackNonFatalIssue("\(message())", details: details())
         #endif
     }
     
     @available(swift, obsoleted: 5.4)
-    @objc public static func logFailure(_ message: String, file: String, function: String, line: Int) {
+    @objc public static func logFailure(_ message: String, details: [String: Any]? = nil,  file: String, function: String, line: Int) {
         logger.error(message, file, function, line: line)
         #if DEBUG
         assertionFailure(message)
+        #else
+        MXSDKOptions.sharedInstance().analyticsDelegate?.trackNonFatalIssue(message, details: details)
         #endif
     }
     

--- a/MatrixSDK/Utils/MXLogObjcWrapper.h
+++ b/MatrixSDK/Utils/MXLogObjcWrapper.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (void)logError:(NSString *)message file:(NSString *)file function:(NSString *)function line:(NSUInteger)line;
 
-+ (void)logFailure:(NSString *)message file:(NSString *)file function:(NSString *)function line:(NSUInteger)line;
++ (void)logFailure:(NSString *)message details:(nullable NSDictionary<NSString *, id> *)details file:(NSString *)file function:(NSString *)function line:(NSUInteger)line;
 
 @end
 

--- a/MatrixSDK/Utils/MXLogObjcWrapper.m
+++ b/MatrixSDK/Utils/MXLogObjcWrapper.m
@@ -44,9 +44,9 @@
     [MXLog logError:message file:file function:function line:line];
 }
 
-+ (void)logFailure:(NSString *)message file:(NSString *)file function:(NSString *)function line:(NSUInteger)line
++ (void)logFailure:(NSString *)message details:(nullable NSDictionary<NSString *, id> *)details file:(NSString *)file function:(NSString *)function line:(NSUInteger)line
 {
-    [MXLog logFailure:message file:file function:function line:line];
+    [MXLog logFailure:message details:details file:file function:function line:line];
 }
 
 @end


### PR DESCRIPTION
Use existing `MXAnalyticsDelegate` to track any non-fatal issues, i.e. anything logged via `MXLog.failure` or `MXLogFailure`.

The SDK itself is not responsible for tracking the issues, it merely sends relevant information via delegate. If a client does not set the delegate, or the user has not consenting to sending crash and analytics data, no issues will be tracked.