### PR TITLE
taking a video call does not always default to loudspeaker

### DIFF
--- a/MatrixSDK/VoIP/MXiOSAudioOutputRouter.swift
+++ b/MatrixSDK/VoIP/MXiOSAudioOutputRouter.swift
@@ -232,14 +232,7 @@ public class MXiOSAudioOutputRouter: NSObject {
 fileprivate extension AVAudioSession {
     
     var outputRoutes: [MXiOSAudioOutputRoute] {
-        let oldCategory = category
-        try? setCategory(.multiRoute)
-        
-        let result = currentRoute.outputs.map({ MXiOSAudioOutputRoute(withPort: $0) })
-        
-        try? setCategory(oldCategory)
-        
-        return result
+        return currentRoute.outputs.map({ MXiOSAudioOutputRoute(withPort: $0) })
     }
     
 }

--- a/changelog.d/5368.bugfix
+++ b/changelog.d/5368.bugfix
@@ -1,0 +1,1 @@
+MXiOSAudioOutputRouter: fixed issue that prevents the system to properly switch from built-in to bluetooth output.


### PR DESCRIPTION
Resolves https://github.com/vector-im/element-ios/issues/5368

- MXiOSAudioOutputRouter: fixed issue that prevents the system to properly switch from built-in to bluetooth output.