### PR TITLE
Detect multiple valid SSSS keys

### DIFF
--- a/MatrixSDK/Crypto/Recovery/MXRecoveryService.m
+++ b/MatrixSDK/Crypto/Recovery/MXRecoveryService.m
@@ -87,7 +87,7 @@ NSString *const MXRecoveryServiceErrorDomain = @"org.matrix.sdk.recoveryService"
     MXSecretStorageKeyContent *keyContent = [_secretStorage keyWithKeyId:self.recoveryId];
     if (!keyContent)
     {
-        // No recovery at all
+        MXLogError(@"[MXRecoveryService] usePassphrase: no recovery key exists");
         return NO;
     }
     
@@ -190,6 +190,7 @@ NSString *const MXRecoveryServiceErrorDomain = @"org.matrix.sdk.recoveryService"
     MXSecretStorageKeyContent *keyContent = [_secretStorage keyWithKeyId:self.recoveryId];
     if (!keyContent)
     {
+        MXLogError(@"[MXRecoveryService] checkPrivateKey: no recovery key exists");
         complete(NO);
         return;
     }

--- a/MatrixSDK/Crypto/SecretStorage/MXSecretStorage.h
+++ b/MatrixSDK/Crypto/SecretStorage/MXSecretStorage.h
@@ -140,6 +140,11 @@ typedef NS_ENUM(NSUInteger, MXSecretStorageErrorCode)
  */
 - (nullable MXSecretStorageKeyContent *)defaultKey;
 
+/**
+ Count all non-empty SSSS keys in user's account_data
+ */
+- (NSInteger)numberOfValidKeys;
+
 
 #pragma mark - Secret storage
 

--- a/MatrixSDK/Data/MXAccountData.h
+++ b/MatrixSDK/Data/MXAccountData.h
@@ -62,6 +62,13 @@
 - (NSDictionary *)accountDataForEventType:(NSString*)eventType;
 
 /**
+ Get all account data events
+ 
+ @return dictionary of the user account_data events, keyed by event type
+ */
+- (NSDictionary <NSString *, id>*)allAccountDataEvents;
+
+/**
  The account data as sent by the homeserver /sync response.
  */
 @property (nonatomic, readonly) NSDictionary<NSString *, id> *accountData;

--- a/MatrixSDK/Data/MXAccountData.m
+++ b/MatrixSDK/Data/MXAccountData.m
@@ -71,6 +71,11 @@
     return accountDataDict[eventType];
 }
 
+- (NSDictionary<NSString *,id> *)allAccountDataEvents
+{
+    return accountDataDict.copy;
+}
+
 - (NSDictionary<NSString *, id> *)accountData
 {
     // Rebuild the dictionary as sent by the homeserver

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -1858,6 +1858,7 @@ typedef void (^MXOnResumeDone)(void);
             }
         }
 
+        [self validateAccountData];
         self.store.userAccountData = _accountData.accountData;
         
         // Trigger a global notification for the account data update
@@ -1867,6 +1868,20 @@ typedef void (^MXOnResumeDone)(void);
                                                                 object:self
                                                               userInfo:nil];
         }
+    }
+}
+
+/**
+ Private method to validate local account data and report any potential state corruption
+ */
+- (void)validateAccountData
+{
+    // Detecting an issue where more than one valid SSSS key is present on the client
+    // https://github.com/vector-im/element-ios/issues/4569
+    NSInteger keysCount = self.crypto.secretStorage.numberOfValidKeys;
+    if (keysCount > 1)
+    {
+        MXLogError(@"[MXSession] validateAccountData: Detected %ld valid SSSS keys, should only have one at most", keysCount)
     }
 }
 

--- a/MatrixSDKTests/TestPlans/CryptoTests.xctestplan
+++ b/MatrixSDKTests/TestPlans/CryptoTests.xctestplan
@@ -29,6 +29,7 @@
   "testTargets" : [
     {
       "selectedTests" : [
+        "MXCryptoSecretStorageTests",
         "MXCryptoShareTests\/testShareHistoryKeysWithInvitedUser",
         "MXCryptoShareTests\/testSharedHistoryPreservedWhenForwardingKeys",
         "MXCryptoTests\/testAliceAndBlockedBob",

--- a/changelog.d/4569.misc
+++ b/changelog.d/4569.misc
@@ -1,0 +1,1 @@
+Secret Storage: Detect multiple valid SSSS keys


### PR DESCRIPTION
Resolves https://github.com/vector-im/element-ios/issues/4569

An issue has been reported aprox a year ago with multiple valid SSSS keys and the iOS picking up the wrong one when authenticating (i.e. asking only for passkey, not passphrase). The issue has not been reported since then and could not be reproduced, so it isn't obvious whether it still occurs.

Based on the [initial report](https://github.com/vector-im/element-ios/issues/4569) the iOS did have a valid SSSS key and `m.secret_storage.default_key` was correctly pointing to it (otherwise the authentication would not ask for passphrase instead of passkey), but the client had reportedly more than one valid key. This means that the client has either failed to re-point `m.secret_storage.default_key` to the more recent key, or failed to delete / invalidate the previous key. Note that SSSS keys are never fully deleted, but remain in the local / server database, albeit with nil-ed content.

As it isn't possible to reproduce this issue, I decided to add some extra logs to help with detecting this issue in the future. Namely assuming that at most one valid SSSS key should be present at any given point (client can also have zero keys), the client will log an error if it detects more than one.