### PR TITLE
Log errors with details in analytics

### DIFF
--- a/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
+++ b/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
@@ -408,7 +408,9 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
     [RLMRealm deleteFilesForConfiguration:config error:&error];
     if (error)
     {
-        MXLogError(@"[MXRealmCryptoStore] deleteStore: Error: %@", error);
+        MXLogErrorWithDetails(@"[MXRealmCryptoStore] deleteStore error", @{
+            @"error": error
+        });
         
         if (!readOnly)
         {
@@ -425,7 +427,9 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
             }
             else
             {
-                MXLogError(@"[MXRealmCryptoStore] deleteStore: Cannot open realm. Error: %@", error);
+                MXLogErrorWithDetails(@"[MXRealmCryptoStore] deleteStore: Cannot open realm.", @{
+                    @"error": error
+                });
             }
         }
     }
@@ -888,7 +892,9 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
         }
         else
         {
-            MXLogError(@"[MXRealmCryptoStore] performSessionOperationWithDevice. Error: olm session %@ not found", sessionId);
+            MXLogErrorWithDetails(@"[MXRealmCryptoStore] performSessionOperationWithDevice. Error: olm session not found", @{
+                @"sessionId": sessionId
+            });
             block(nil);
         }
     }];
@@ -1005,13 +1011,17 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
             }
             else
             {
-                MXLogError(@"[MXRealmCryptoStore] performSessionOperationWithGroupSessionWithId. Error: Cannot build MXOlmInboundGroupSession for megolm session %@", sessionId);
+                MXLogErrorWithDetails(@"[MXRealmCryptoStore] performSessionOperationWithGroupSessionWithId. Error: Cannot build MXOlmInboundGroupSession for megolm session", @{
+                    @"sessionId": sessionId
+                });
                 block(nil);
             }
         }
         else
         {
-            MXLogError(@"[MXRealmCryptoStore] performSessionOperationWithGroupSessionWithId. Error: megolm session %@ not found", sessionId);
+            MXLogErrorWithDetails(@"[MXRealmCryptoStore] performSessionOperationWithGroupSessionWithId. Error: megolm session not found", @{
+                @"sessionId": sessionId
+            });
             block(nil);
         }
     }];

--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
@@ -902,7 +902,11 @@ static NSUInteger preloadOptions;
                 }
                 @catch (NSException *exception)
                 {
-                    MXLogError(@"[MXFileStore] Warning: MXFileRoomStore file for room %@ has been corrupted. Exception: %@", roomId, exception);
+                    NSDictionary *logDetails = @{
+                        @"roomId": roomId ?: @"",
+                        @"exception": exception
+                    };
+                    MXLogErrorWithDetails(@"[MXFileStore] Warning: MXFileRoomStore file for room has been corrupted", logDetails);
                     [self logFiles];
                     [self deleteAllData];
                 }
@@ -941,7 +945,11 @@ static NSUInteger preloadOptions;
                 }
                 @catch (NSException *exception)
                 {
-                    MXLogError(@"[MXFileStore] Warning: MXFileRoomOutgoingMessagesStore file for room %@ has been corrupted. Exception: %@", roomId, exception);
+                    NSDictionary *logDetails = @{
+                        @"roomId": roomId ?: @"",
+                        @"exception": exception
+                    };
+                    MXLogErrorWithDetails(@"[MXFileStore] Warning: MXFileRoomOutgoingMessagesStore file for room as been corrupted", logDetails);
                     [self logFiles];
                     [self deleteAllData];
                 }
@@ -981,7 +989,11 @@ static NSUInteger preloadOptions;
                 }
                 @catch (NSException *exception)
                 {
-                    MXLogError(@"[MXFileStore] Warning: loadReceipts file for room %@ has been corrupted. Exception: %@", roomId, exception);
+                    NSDictionary *logDetails = @{
+                        @"roomId": roomId ?: @"",
+                        @"exception": exception
+                    };
+                    MXLogErrorWithDetails(@"[MXFileStore] Warning: loadReceipts file for room as been corrupted", logDetails);
                     
                     // We used to reset the store and force a full initial sync but this makes the app
                     // start very slowly.

--- a/MatrixSDK/Utils/MXLog.h
+++ b/MatrixSDK/Utils/MXLog.h
@@ -33,7 +33,11 @@
 }
 
 #define MXLogError(message, ...) { \
-    [MXLogObjcWrapper logError:[NSString stringWithFormat: message, ##__VA_ARGS__] file:@__FILE__ function:[NSString stringWithFormat:@"%s", __FUNCTION__] line:__LINE__]; \
+    [MXLogObjcWrapper logError:[NSString stringWithFormat: message, ##__VA_ARGS__] details:nil file:@__FILE__ function:[NSString stringWithFormat:@"%s", __FUNCTION__] line:__LINE__]; \
+}
+
+#define MXLogErrorWithDetails(message, dictionary) { \
+    [MXLogObjcWrapper logError:message details:dictionary file:@__FILE__ function:[NSString stringWithFormat:@"%s", __FUNCTION__] line:__LINE__]; \
 }
 
 #define MXLogFailure(message, ...) { \

--- a/MatrixSDK/Utils/MXLog.swift
+++ b/MatrixSDK/Utils/MXLog.swift
@@ -112,10 +112,13 @@ private var logger: SwiftyBeaver.Type = {
                              details: @autoclosure () -> [String: Any]? = nil,
                              _ file: String = #file, _ function: String = #function, line: Int = #line, context: Any? = nil) {
         logger.error(formattedMessage(message(), details: details()), file, function, line: line, context: context)
+        
+        #if !DEBUG
         if let details = details() {
             // Tracking errors via analytics as an experiment (provided user consent), but only if details explicitly specified
             MXSDKOptions.sharedInstance().analyticsDelegate?.trackNonFatalIssue("\(message())", details: details)
         }
+        #endif
     }
     
     @available(swift, obsoleted: 5.4)
@@ -127,6 +130,7 @@ private var logger: SwiftyBeaver.Type = {
                                details: @autoclosure () -> [String: Any]? = nil,
                                _ file: String = #file, _ function: String = #function, line: Int = #line, context: Any? = nil) {
         logger.error(formattedMessage(message(), details: details()), file, function, line: line, context: context)
+        
         #if DEBUG
         assertionFailure("\(message())")
         #else

--- a/MatrixSDK/Utils/MXLog.swift
+++ b/MatrixSDK/Utils/MXLog.swift
@@ -108,20 +108,25 @@ private var logger: SwiftyBeaver.Type = {
         logger.warning(message, file, function, line: line)
     }
     
-    public static func error(_ message: @autoclosure () -> Any, _
-                                file: String = #file, _ function: String = #function, line: Int = #line, context: Any? = nil) {
-        logger.error(message(), file, function, line: line, context: context)
+    public static func error(_ message: @autoclosure () -> Any,
+                             details: @autoclosure () -> [String: Any]? = nil,
+                             _ file: String = #file, _ function: String = #function, line: Int = #line, context: Any? = nil) {
+        logger.error(formattedMessage(message(), details: details()), file, function, line: line, context: context)
+        if let details = details() {
+            // Tracking errors via analytics as an experiment (provided user consent), but only if details explicitly specified
+            MXSDKOptions.sharedInstance().analyticsDelegate?.trackNonFatalIssue("\(message())", details: details)
+        }
     }
     
     @available(swift, obsoleted: 5.4)
-    @objc public static func logError(_ message: String, file: String, function: String, line: Int) {
-        logger.error(message, file, function, line: line)
+    @objc public static func logError(_ message: String, details: [String: Any]? = nil, file: String, function: String, line: Int) {
+        error(message, details: details, context: nil)
     }
     
     public static func failure(_ message: @autoclosure () -> Any,
                                details: @autoclosure () -> [String: Any]? = nil,
                                _ file: String = #file, _ function: String = #function, line: Int = #line, context: Any? = nil) {
-        logger.error(message(), file, function, line: line, context: context)
+        logger.error(formattedMessage(message(), details: details()), file, function, line: line, context: context)
         #if DEBUG
         assertionFailure("\(message())")
         #else
@@ -130,13 +135,8 @@ private var logger: SwiftyBeaver.Type = {
     }
     
     @available(swift, obsoleted: 5.4)
-    @objc public static func logFailure(_ message: String, details: [String: Any]? = nil,  file: String, function: String, line: Int) {
-        logger.error(message, file, function, line: line)
-        #if DEBUG
-        assertionFailure(message)
-        #else
-        MXSDKOptions.sharedInstance().analyticsDelegate?.trackNonFatalIssue(message, details: details)
-        #endif
+    @objc public static func logFailure(_ message: String, details: [String: Any]? = nil, file: String, function: String, line: Int) {
+        failure(message, details: details, file, function, line: line, context: nil)
     }
     
     // MARK: - Private
@@ -181,5 +181,12 @@ private var logger: SwiftyBeaver.Type = {
         
         logger.removeAllDestinations()
         logger.addDestination(consoleDestination)
+    }
+    
+    fileprivate static func formattedMessage(_ message: Any, details: [String: Any]? = nil) -> String {
+        guard let details = details else {
+            return "\(message)"
+        }
+        return "\(message) - \(details)"
     }
 }

--- a/MatrixSDK/Utils/MXLogObjcWrapper.h
+++ b/MatrixSDK/Utils/MXLogObjcWrapper.h
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (void)logWarning:(NSString *)message file:(NSString *)file function:(NSString *)function line:(NSUInteger)line;
 
-+ (void)logError:(NSString *)message file:(NSString *)file function:(NSString *)function line:(NSUInteger)line;
++ (void)logError:(NSString *)message details:(nullable NSDictionary<NSString *, id> *)details file:(NSString *)file function:(NSString *)function line:(NSUInteger)line;
 
 + (void)logFailure:(NSString *)message details:(nullable NSDictionary<NSString *, id> *)details file:(NSString *)file function:(NSString *)function line:(NSUInteger)line;
 

--- a/MatrixSDK/Utils/MXLogObjcWrapper.m
+++ b/MatrixSDK/Utils/MXLogObjcWrapper.m
@@ -39,9 +39,9 @@
     [MXLog logWarning:message file:file function:function line:line];
 }
 
-+ (void)logError:(NSString *)message file:(NSString *)file function:(NSString *)function line:(NSUInteger)line
++ (void)logError:(NSString *)message details:(nullable NSDictionary<NSString *, id> *)details file:(NSString *)file function:(NSString *)function line:(NSUInteger)line
 {
-    [MXLog logError:message file:file function:function line:line];
+    [MXLog logError:message details:details file:file function:function line:line];
 }
 
 + (void)logFailure:(NSString *)message details:(nullable NSDictionary<NSString *, id> *)details file:(NSString *)file function:(NSString *)function line:(NSUInteger)line

--- a/changelog.d/pr-1517.misc
+++ b/changelog.d/pr-1517.misc
@@ -1,0 +1,1 @@
+Analytics: Log errors with details in analytics


### PR DESCRIPTION
Enabling analytics tracking for `MXLog.error`, where previously only `MXLog.failure` where tracked. To limit the amount of noise that would result from tracking errors with variables in the string we are only tracking those errors that manually specify a separate `details` dictionary. This will be changed in the future to either log all errors by default or convert them all to detail-based events