### PR TITLE
Include ID server access token in 3pid invites.

### DIFF
--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -1412,7 +1412,7 @@ andUnauthenticatedHandler: (MXRestClientUnauthenticatedHandler)unauthenticatedHa
                                                success:(void (^)(NSDictionary *updatedParameters))success
                                                failure:(void (^)(NSError *error))failure
 {
-    MXHTTPOperation *operation = [self useIdentityAccessToken:^(NSString * _Nullable accessToken) {
+    MXHTTPOperation *operation = [self getIdentityAccessTokenIfNecessary:^(NSString * _Nullable accessToken) {
         if (accessToken)
         {
             NSMutableDictionary *updatedParameters = [NSMutableDictionary dictionaryWithDictionary:parameters];
@@ -1435,8 +1435,7 @@ andUnauthenticatedHandler: (MXRestClientUnauthenticatedHandler)unauthenticatedHa
                                                     success:(void (^)(NSArray<NSDictionary *> *updatedArray))success
                                                     failure:(void (^)(NSError *error))failure
 {
-    MXHTTPOperation *operation = [self useIdentityAccessToken:^(NSString * _Nullable accessToken) {
-                
+    MXHTTPOperation *operation = [self getIdentityAccessTokenIfNecessary:^(NSString * _Nullable accessToken) {
         if (accessToken)
         {
             NSMutableArray *updatedArray = [NSMutableArray arrayWithCapacity:invite3PIDArray.count];
@@ -1466,8 +1465,8 @@ andUnauthenticatedHandler: (MXRestClientUnauthenticatedHandler)unauthenticatedHa
  @param success A block called when the access token was retrieved, or when no access token is required.
  @param failure A block called when an error occurs.
  */
-- (MXHTTPOperation*)useIdentityAccessToken:(void (^)(NSString * _Nullable accessToken))success
-                                   failure:(void (^)(NSError *error))failure
+- (MXHTTPOperation*)getIdentityAccessTokenIfNecessary:(void (^)(NSString * _Nullable accessToken))success
+                                              failure:(void (^)(NSError *error))failure
 {
     MXHTTPOperation *operation;
 

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -66,6 +66,11 @@ NSString *const kMXAccountDataTypeAcceptedTermsKey = @"accepted";
 NSString *const kMX3PIDMediumEmail  = @"email";
 NSString *const kMX3PIDMediumMSISDN = @"msisdn";
 
+// Room creation dictionary key for third party id invites.
+NSString *const kMXInvite3PIDKey = @"invite_3pid";
+// Third party id invite key for access token.
+NSString *const kMX3PIDAccessTokenKey = @"id_access_token";
+
 /**
  MXRestClient error domain
  */
@@ -1407,9 +1412,68 @@ andUnauthenticatedHandler: (MXRestClientUnauthenticatedHandler)unauthenticatedHa
                                                success:(void (^)(NSDictionary *updatedParameters))success
                                                failure:(void (^)(NSError *error))failure
 {
+    MXHTTPOperation *operation = [self useIdentityAccessToken:^(NSString * _Nullable accessToken) {
+        if (accessToken)
+        {
+            NSMutableDictionary *updatedParameters = [NSMutableDictionary dictionaryWithDictionary:parameters];
+            updatedParameters[kMX3PIDAccessTokenKey] = accessToken;
+            
+            success(updatedParameters);
+        }
+        else
+        {
+            success(parameters);
+        }
+        
+    } failure:failure];
+
+    return operation;
+}
+
+// Add the "id_access_token" parameter to all invites if the HS requires it.
+- (MXHTTPOperation*)addIdentityAccessTokenToInvite3PIDArray:(NSArray<NSDictionary *> *)invite3PIDArray
+                                                    success:(void (^)(NSArray<NSDictionary *> *updatedArray))success
+                                                    failure:(void (^)(NSError *error))failure
+{
+    MXHTTPOperation *operation = [self useIdentityAccessToken:^(NSString * _Nullable accessToken) {
+                
+        if (accessToken)
+        {
+            NSMutableArray *updatedArray = [NSMutableArray arrayWithCapacity:invite3PIDArray.count];
+            for (NSDictionary *invite in invite3PIDArray)
+            {
+                NSMutableDictionary *updatedInvite = [NSMutableDictionary dictionaryWithDictionary:invite];
+                updatedInvite[kMX3PIDAccessTokenKey] = accessToken;
+                
+                [updatedArray addObject:updatedInvite];
+            }
+            
+            success(updatedArray);
+        }
+        else
+        {
+            success(invite3PIDArray);
+        }
+        
+    } failure:failure];
+    
+    return operation;
+}
+
+/**
+ Gets the identity access token from the handler if available and the HS requires it.
+ 
+ @param success A block called when the access token was retrieved, or when no access token is required.
+ @param failure A block called when an error occurs.
+ */
+- (MXHTTPOperation*)useIdentityAccessToken:(void (^)(NSString * _Nullable accessToken))success
+                                   failure:(void (^)(NSError *error))failure
+{
     MXHTTPOperation *operation;
 
+    MXWeakify(self);
     operation = [self supportedMatrixVersions:^(MXMatrixVersions *matrixVersions) {
+        MXStrongifyAndReturnIfNil(self);
 
         MXHTTPOperation *operation2;
         if (matrixVersions.doesServerAcceptIdentityAccessToken)
@@ -1419,13 +1483,10 @@ andUnauthenticatedHandler: (MXRestClientUnauthenticatedHandler)unauthenticatedHa
                 MXWeakify(self);
                 operation2 = self.identityServerAccessTokenHandler(^(NSString *accessToken) {
                     MXStrongifyAndReturnIfNil(self);
-
+                    
                     if (accessToken)
                     {
-                        NSMutableDictionary *updatedParameters = [NSMutableDictionary dictionaryWithDictionary:parameters];
-                        updatedParameters[@"id_access_token"] = accessToken;
-
-                        success(updatedParameters);
+                        success(accessToken);
                     }
                     else
                     {
@@ -1433,7 +1494,7 @@ andUnauthenticatedHandler: (MXRestClientUnauthenticatedHandler)unauthenticatedHa
                         NSError *error = [NSError errorWithDomain:kMXRestClientErrorDomain code:MXRestClientErrorMissingIdentityServerAccessToken userInfo:nil];
                         [self dispatchFailure:error inBlock:failure];
                     }
-
+                    
                 }, ^(NSError *error) {
                     failure(error);
                 });
@@ -1447,7 +1508,7 @@ andUnauthenticatedHandler: (MXRestClientUnauthenticatedHandler)unauthenticatedHa
         }
         else
         {
-            success(parameters);
+            success(nil);
         }
         
         [operation mutateTo:operation2];
@@ -2523,7 +2584,7 @@ andUnauthenticatedHandler: (MXRestClientUnauthenticatedHandler)unauthenticatedHa
     operation = [self addIdentityAccessTokenToParameters:parameters success:^(NSDictionary *updatedParameters) {
         MXStrongifyAndReturnIfNil(self);
 
-        MXHTTPOperation *operation2 = [self inviteByThreePidToRoom:roomId parameters:parameters success:success failure:failure];
+        MXHTTPOperation *operation2 = [self inviteByThreePidToRoom:roomId parameters:updatedParameters success:success failure:failure];
         
         [operation mutateTo:operation2];
 
@@ -2655,7 +2716,26 @@ andUnauthenticatedHandler: (MXRestClientUnauthenticatedHandler)unauthenticatedHa
                                      success:(void (^)(MXCreateRoomResponse *response))success
                                      failure:(void (^)(NSError *error))failure
 {
-    return [self createRoom:parameters.JSONDictionary success:success failure:failure];
+    MXHTTPOperation *operation;
+    
+    NSMutableDictionary *jsonDictionary = [NSMutableDictionary dictionaryWithDictionary:parameters.JSONDictionary];
+    NSArray<NSDictionary *> *invite3PIDArray = jsonDictionary[kMXInvite3PIDKey];
+    if (invite3PIDArray && invite3PIDArray.count)
+    {
+        MXWeakify(self);
+        operation = [self addIdentityAccessTokenToInvite3PIDArray:invite3PIDArray success:^(NSArray<NSDictionary *> *updatedArray) {
+            MXStrongifyAndReturnIfNil(self);
+            
+            jsonDictionary[kMXInvite3PIDKey] = updatedArray;
+            MXHTTPOperation *operation2 = [self createRoom:jsonDictionary success:success failure:failure];
+            [operation mutateTo:operation2];
+            
+        } failure:failure];
+    } else {
+        operation = [self createRoom:jsonDictionary success:success failure:failure];
+    }
+
+    return operation;
 }
 
 - (MXHTTPOperation*)createRoom:(NSDictionary*)parameters

--- a/changelog.d/6385.change
+++ b/changelog.d/6385.change
@@ -1,0 +1,1 @@
+Include ID server access token when making a 3pid invite (and creating a room).


### PR DESCRIPTION
Most of the changes in this PR are for invites as part of room creation. Sending an ordinary invite had all the right logic, but also a bug.

I did consider adding the access token field to `MX3PIDInvite` however given the homeserver could say it isn't needed, this didn't seem great with the json dictionary property checking for a specific number of fields.

Fixes https://github.com/vector-im/element-ios/issues/6385 