### PR TITLE
Disable nightly tests as they time out.

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,8 +1,8 @@
 name: Nightly checks
 
 on:
-  schedule:
-    - cron:  '0 3 * * 1-5'
+  # schedule:
+  #   - cron:  '0 3 * * 1-5'
 
   workflow_dispatch:
 

--- a/changelog.d/pr-1523.build
+++ b/changelog.d/pr-1523.build
@@ -1,0 +1,1 @@
+Disable nightly tests for now as they're always timing out.


### PR DESCRIPTION
Disables the nightly tests for now as they're always timing out. The `workflow_dispatch` trigger is left so we can always run them manually whilst testing changes to fix them.
