### PR TITLE
Fix formatted_body content for unformatted events

### DIFF
--- a/MatrixSDK/Aggregations/MXAggregatedEditsUpdater.m
+++ b/MatrixSDK/Aggregations/MXAggregatedEditsUpdater.m
@@ -103,7 +103,7 @@
 
             // This enables editing replies that don't provide a fallback mx-reply body.
             compatibilityText = [NSString stringWithFormat:@"* %@", text];
-            if (formattedText)
+            if (formattedText.length > 0)
             {
                 compatibilityFormattedText = [NSString stringWithFormat:@"* %@", formattedText];
             }
@@ -112,7 +112,7 @@
     else
     {
         compatibilityText = [NSString stringWithFormat:@"* %@", text];
-        if (formattedText)
+        if (formattedText.length > 0)
         {
             compatibilityFormattedText = [NSString stringWithFormat:@"* %@", formattedText];
         }
@@ -134,7 +134,7 @@
 
     NSMutableDictionary *newContent = [NSMutableDictionary dictionaryWithDictionary:@{ kMXMessageTypeKey: messageType,
                                                                                        kMXMessageBodyKey: text }];
-    if (formattedText)
+    if (formattedText.length > 0)
     {
         [newContent addEntriesFromDictionary:@{
             @"formatted_body": formattedText,

--- a/MatrixSDK/Aggregations/MXAggregatedEditsUpdater.m
+++ b/MatrixSDK/Aggregations/MXAggregatedEditsUpdater.m
@@ -109,7 +109,10 @@
     else
     {
         compatibilityText = [NSString stringWithFormat:@"* %@", text];
-        compatibilityFormattedText = [NSString stringWithFormat:@"* %@", formattedText];
+        if (formattedText)
+        {
+            compatibilityFormattedText = [NSString stringWithFormat:@"* %@", formattedText];
+        }
     }
     
     NSMutableDictionary *content = [NSMutableDictionary new];

--- a/MatrixSDK/Aggregations/MXAggregatedEditsUpdater.m
+++ b/MatrixSDK/Aggregations/MXAggregatedEditsUpdater.m
@@ -103,7 +103,10 @@
 
             // This enables editing replies that don't provide a fallback mx-reply body.
             compatibilityText = [NSString stringWithFormat:@"* %@", text];
-            compatibilityFormattedText = [NSString stringWithFormat:@"* %@", formattedText];
+            if (formattedText)
+            {
+                compatibilityFormattedText = [NSString stringWithFormat:@"* %@", formattedText];
+            }
         }
     }
     else

--- a/changelog.d/6446.bugfix
+++ b/changelog.d/6446.bugfix
@@ -1,0 +1,1 @@
+Fix formatted_body content for unformatted events


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-ios/issues/6446

The formatted_body content is now properly omitted if there is no actual formatting within the message (same behaviour as Web).