### PR TITLE
Outgoing SAS User Verification Flow

### DIFF
--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -1851,6 +1851,20 @@
 		ED7019E12886C26D00FC31B9 /* MXCryptoRequestsUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED2DD11B286C4F3E00F06731 /* MXCryptoRequestsUnitTests.swift */; };
 		ED7019E22886C28900FC31B9 /* MXCryptoProtocolStubs.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED8F1D332885ADE200F897E7 /* MXCryptoProtocolStubs.swift */; };
 		ED7019E32886C29400FC31B9 /* Device+Stub.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED8F1D312885AC5700F897E7 /* Device+Stub.swift */; };
+		ED7019E52886C32900FC31B9 /* MXSASTransactionV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7019E42886C32900FC31B9 /* MXSASTransactionV2.swift */; };
+		ED7019E62886C32900FC31B9 /* MXSASTransactionV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7019E42886C32900FC31B9 /* MXSASTransactionV2.swift */; };
+		ED7019E82886C33100FC31B9 /* MXKeyVerificationRequestV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7019E72886C33100FC31B9 /* MXKeyVerificationRequestV2.swift */; };
+		ED7019E92886C33100FC31B9 /* MXKeyVerificationRequestV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7019E72886C33100FC31B9 /* MXKeyVerificationRequestV2.swift */; };
+		ED7019EB2886C33A00FC31B9 /* MXKeyVerificationManagerV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7019EA2886C33A00FC31B9 /* MXKeyVerificationManagerV2.swift */; };
+		ED7019EC2886C33A00FC31B9 /* MXKeyVerificationManagerV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7019EA2886C33A00FC31B9 /* MXKeyVerificationManagerV2.swift */; };
+		ED7019F52886CA6C00FC31B9 /* MXKeyVerificationRequestV2UnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7019EF2886CA6C00FC31B9 /* MXKeyVerificationRequestV2UnitTests.swift */; };
+		ED7019F62886CA6C00FC31B9 /* MXKeyVerificationRequestV2UnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7019EF2886CA6C00FC31B9 /* MXKeyVerificationRequestV2UnitTests.swift */; };
+		ED7019F72886CA6C00FC31B9 /* VerificationRequest+Stub.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7019F02886CA6C00FC31B9 /* VerificationRequest+Stub.swift */; };
+		ED7019F82886CA6C00FC31B9 /* VerificationRequest+Stub.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7019F02886CA6C00FC31B9 /* VerificationRequest+Stub.swift */; };
+		ED7019F92886CA6C00FC31B9 /* Sas+Stub.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7019F32886CA6C00FC31B9 /* Sas+Stub.swift */; };
+		ED7019FA2886CA6C00FC31B9 /* Sas+Stub.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7019F32886CA6C00FC31B9 /* Sas+Stub.swift */; };
+		ED7019FB2886CA6C00FC31B9 /* MXSASTransactionV2UnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7019F42886CA6C00FC31B9 /* MXSASTransactionV2UnitTests.swift */; };
+		ED7019FC2886CA6C00FC31B9 /* MXSASTransactionV2UnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7019F42886CA6C00FC31B9 /* MXSASTransactionV2UnitTests.swift */; };
 		ED88999127F2065D00718486 /* MXRoomAliasResolution.h in Headers */ = {isa = PBXBuildFile; fileRef = ED88998F27F2065C00718486 /* MXRoomAliasResolution.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		ED88999227F2065D00718486 /* MXRoomAliasResolution.h in Headers */ = {isa = PBXBuildFile; fileRef = ED88998F27F2065C00718486 /* MXRoomAliasResolution.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		ED88999327F2065D00718486 /* MXRoomAliasResolution.m in Sources */ = {isa = PBXBuildFile; fileRef = ED88999027F2065D00718486 /* MXRoomAliasResolution.m */; };
@@ -2916,6 +2930,13 @@
 		ED5AE8C32816C8CF00105072 /* MXRoomSummaryCoreDataStore2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = MXRoomSummaryCoreDataStore2.xcdatamodel; sourceTree = "<group>"; };
 		ED5AE8C42816C8CF00105072 /* MXRoomSummaryCoreDataStore.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = MXRoomSummaryCoreDataStore.xcdatamodel; sourceTree = "<group>"; };
 		ED5C95CD2833E85600843D82 /* MXOlmDeviceUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXOlmDeviceUnitTests.swift; sourceTree = "<group>"; };
+		ED7019E42886C32900FC31B9 /* MXSASTransactionV2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXSASTransactionV2.swift; sourceTree = "<group>"; };
+		ED7019E72886C33100FC31B9 /* MXKeyVerificationRequestV2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXKeyVerificationRequestV2.swift; sourceTree = "<group>"; };
+		ED7019EA2886C33A00FC31B9 /* MXKeyVerificationManagerV2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXKeyVerificationManagerV2.swift; sourceTree = "<group>"; };
+		ED7019EF2886CA6C00FC31B9 /* MXKeyVerificationRequestV2UnitTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXKeyVerificationRequestV2UnitTests.swift; sourceTree = "<group>"; };
+		ED7019F02886CA6C00FC31B9 /* VerificationRequest+Stub.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "VerificationRequest+Stub.swift"; sourceTree = "<group>"; };
+		ED7019F32886CA6C00FC31B9 /* Sas+Stub.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Sas+Stub.swift"; sourceTree = "<group>"; };
+		ED7019F42886CA6C00FC31B9 /* MXSASTransactionV2UnitTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXSASTransactionV2UnitTests.swift; sourceTree = "<group>"; };
 		ED88998F27F2065C00718486 /* MXRoomAliasResolution.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXRoomAliasResolution.h; sourceTree = "<group>"; };
 		ED88999027F2065D00718486 /* MXRoomAliasResolution.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXRoomAliasResolution.m; sourceTree = "<group>"; };
 		ED8943D327E34762000FC39C /* MXMemoryRoomStoreUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXMemoryRoomStoreUnitTests.swift; sourceTree = "<group>"; };
@@ -3063,6 +3084,7 @@
 				320B3938239FD15E00BE2C06 /* MXKeyVerificationRequest.h */,
 				320B393E239FD48400BE2C06 /* MXKeyVerificationRequest_Private.h */,
 				320B3939239FD15E00BE2C06 /* MXKeyVerificationRequest.m */,
+				ED7019E72886C33100FC31B9 /* MXKeyVerificationRequestV2.swift */,
 				320B3932239FA56900BE2C06 /* MXKeyVerificationByDMRequest.h */,
 				320B3933239FA56900BE2C06 /* MXKeyVerificationByDMRequest.m */,
 				3274538823FD918800438328 /* MXKeyVerificationByToDeviceRequest.h */,
@@ -3451,6 +3473,7 @@
 				3252DCAC224BE5D40032264F /* MXKeyVerificationManager.h */,
 				3252DCAD224BE5D40032264F /* MXKeyVerificationManager.m */,
 				3252DCCF224D25810032264F /* MXKeyVerificationManager_Private.h */,
+				ED7019EA2886C33A00FC31B9 /* MXKeyVerificationManagerV2.swift */,
 			);
 			path = Verification;
 			sourceTree = "<group>";
@@ -3528,6 +3551,7 @@
 				321CFDE422525A49004D31DF /* MXSASTransaction.h */,
 				321CFDF022549C39004D31DF /* MXSASTransaction_Private.h */,
 				321CFDE522525A49004D31DF /* MXSASTransaction.m */,
+				ED7019E42886C32900FC31B9 /* MXSASTransactionV2.swift */,
 				321CFDE822525DED004D31DF /* MXIncomingSASTransaction.h */,
 				B1DDC9D52418098200D208E3 /* MXIncomingSASTransaction_Private.h */,
 				321CFDE922525DEE004D31DF /* MXIncomingSASTransaction.m */,
@@ -5106,6 +5130,7 @@
 				ED35652A281150230002BF6A /* Data */,
 				ED21F67B28104BA1002FF83D /* Algorithms */,
 				ED2DD11A286C4F3100F06731 /* CryptoMachine */,
+				ED7019ED2886CA6C00FC31B9 /* Verification */,
 				ED5C95CD2833E85600843D82 /* MXOlmDeviceUnitTests.swift */,
 			);
 			path = Crypto;
@@ -5164,6 +5189,41 @@
 				ED44F01728180F1C00452A5D /* MXSharedHistoryKeyManagerUnitTests.swift */,
 			);
 			path = KeySharing;
+			sourceTree = "<group>";
+		};
+		ED7019ED2886CA6C00FC31B9 /* Verification */ = {
+			isa = PBXGroup;
+			children = (
+				ED7019EE2886CA6C00FC31B9 /* Requests */,
+				ED7019F12886CA6C00FC31B9 /* Transactions */,
+			);
+			path = Verification;
+			sourceTree = "<group>";
+		};
+		ED7019EE2886CA6C00FC31B9 /* Requests */ = {
+			isa = PBXGroup;
+			children = (
+				ED7019EF2886CA6C00FC31B9 /* MXKeyVerificationRequestV2UnitTests.swift */,
+				ED7019F02886CA6C00FC31B9 /* VerificationRequest+Stub.swift */,
+			);
+			path = Requests;
+			sourceTree = "<group>";
+		};
+		ED7019F12886CA6C00FC31B9 /* Transactions */ = {
+			isa = PBXGroup;
+			children = (
+				ED7019F22886CA6C00FC31B9 /* SAS */,
+			);
+			path = Transactions;
+			sourceTree = "<group>";
+		};
+		ED7019F22886CA6C00FC31B9 /* SAS */ = {
+			isa = PBXGroup;
+			children = (
+				ED7019F32886CA6C00FC31B9 /* Sas+Stub.swift */,
+				ED7019F42886CA6C00FC31B9 /* MXSASTransactionV2UnitTests.swift */,
+			);
+			path = SAS;
 			sourceTree = "<group>";
 		};
 		ED8943D127E3474A000FC39C /* Store */ = {
@@ -6480,6 +6540,7 @@
 				3281E8B819E42DFE00976E1A /* MXJSONModel.m in Sources */,
 				32AF929924115D8B0008A0FD /* MXPendingSecretShareRequest.m in Sources */,
 				327E9AE22285497100A98BC1 /* MXEventContentRelatesTo.m in Sources */,
+				ED7019EB2886C33A00FC31B9 /* MXKeyVerificationManagerV2.swift in Sources */,
 				32A1514B1DAF7C0C00400192 /* MXUsersDevicesMap.m in Sources */,
 				328BCB3421947BE200A976D3 /* MXKeyBackupVersionTrust.m in Sources */,
 				324AAC72239913AD00380A66 /* MXKeyVerificationRequestByDMJSONModel.m in Sources */,
@@ -6590,6 +6651,7 @@
 				3281E8BA19E42DFE00976E1A /* MXJSONModels.m in Sources */,
 				3245A7531AF7B2930001D8A7 /* MXCallManager.m in Sources */,
 				32E226A71D06AC9F00E6CA54 /* MXPeekingRoom.m in Sources */,
+				ED7019E82886C33100FC31B9 /* MXKeyVerificationRequestV2.swift in Sources */,
 				320F7D2C260A8E3B00EF8608 /* MXSyncResponseStoreMetaDataModel.swift in Sources */,
 				021AFBA72179E91900742B2C /* MXEncryptedContentFile.m in Sources */,
 				3220094619EFBF30008DE41D /* MXSessionEventListener.m in Sources */,
@@ -6721,6 +6783,7 @@
 				B19A30C22404268600FB6F35 /* MXVerifyingAnotherUserQRCodeData.m in Sources */,
 				EC8A53BD25B1BC77004E0802 /* MXCallRejectEventContent.m in Sources */,
 				ECCA02BE27348FE300B6F34F /* MXThread.swift in Sources */,
+				ED7019E52886C32900FC31B9 /* MXSASTransactionV2.swift in Sources */,
 				EC1848C72686174E00865E16 /* MXiOSAudioOutputRouteType.swift in Sources */,
 				3220093919EFA4C9008DE41D /* MXEventListener.m in Sources */,
 				EC5C562A27A36EDB0014CBE9 /* MXInReplyTo.m in Sources */,
@@ -6795,6 +6858,7 @@
 				EDF1B6932876CD8600BBBCEE /* MXTaskQueueUnitTests.swift in Sources */,
 				32684CB821085F770046D2F9 /* MXLazyLoadingTests.m in Sources */,
 				18121F75273E6D2400B68ADF /* MXPollBuilderTests.swift in Sources */,
+				ED7019F72886CA6C00FC31B9 /* VerificationRequest+Stub.swift in Sources */,
 				B14EECEE2578FE3F00448735 /* MXAuthenticationSessionUnitTests.swift in Sources */,
 				ED2DD11D286C4F4400F06731 /* MXCryptoRequestsUnitTests.swift in Sources */,
 				32832B5D1BCC048300241108 /* MXStoreMemoryStoreTests.m in Sources */,
@@ -6829,6 +6893,7 @@
 				B19A30D82404335D00FB6F35 /* MXQRCodeDataUnitTests.m in Sources */,
 				32B477852638133C00EA5800 /* MXAggregatedEditsUnitTests.m in Sources */,
 				ECB6FA8E267CFF4300A941E4 /* MXCredentialsUnitTests.swift in Sources */,
+				ED7019F52886CA6C00FC31B9 /* MXKeyVerificationRequestV2UnitTests.swift in Sources */,
 				3A108E6725826F52005EEBE9 /* MXKeyProviderUnitTests.m in Sources */,
 				3A858DE8275511A4006322C1 /* MXRoomAliasAvailabilityCheckerResultTests.swift in Sources */,
 				EC116593270FB6970089FA56 /* MXBackgroundTaskUnitTests.swift in Sources */,
@@ -6857,6 +6922,7 @@
 				3281E8A219E2DE4300976E1A /* MXSessionTests.m in Sources */,
 				327137241A24BDDE00DB6757 /* MXUserTests.m in Sources */,
 				EC40386728A279220067D5B8 /* MXKeyBackupUnitTests.swift in Sources */,
+				ED7019FB2886CA6C00FC31B9 /* MXSASTransactionV2UnitTests.swift in Sources */,
 				32B0E3E723A3864C0054FF1A /* MXEventReferenceUnitTests.swift in Sources */,
 				32720DA2222EB5650086FFF5 /* MXAutoDiscoveryTests.m in Sources */,
 				ED8943D427E34762000FC39C /* MXMemoryRoomStoreUnitTests.swift in Sources */,
@@ -6872,6 +6938,7 @@
 				32D8CAC219DEE6ED002AF8A0 /* MXRestClientNoAuthAPITests.m in Sources */,
 				32FCAB4D19E578860049C555 /* MXRestClientTests.m in Sources */,
 				32C78BA7256D227D008130B1 /* MXCryptoMigrationTests.m in Sources */,
+				ED7019F92886CA6C00FC31B9 /* Sas+Stub.swift in Sources */,
 				ED21F68528104DA2002FF83D /* MXMegolmEncryptionTests.swift in Sources */,
 				ED44F01A28180F4000452A5D /* MXSharedHistoryKeyManagerUnitTests.swift in Sources */,
 				322985CB26FAF898001890BC /* MXSession.swift in Sources */,
@@ -7070,6 +7137,7 @@
 				B14EF2152397E90400758AF0 /* MXRoom.swift in Sources */,
 				B14EF2162397E90400758AF0 /* MXOlmSession.m in Sources */,
 				EC8A53A425B1BC77004E0802 /* MXCallEventContent.m in Sources */,
+				ED7019EC2886C33A00FC31B9 /* MXKeyVerificationManagerV2.swift in Sources */,
 				B14EF2172397E90400758AF0 /* MXMegolmDecryption.m in Sources */,
 				3A23A740256D322C00B9D00F /* MXAes.m in Sources */,
 				B14EF2182397E90400758AF0 /* MXEmojiRepresentation.m in Sources */,
@@ -7180,6 +7248,7 @@
 				B14EF2472397E90400758AF0 /* MXContentScanEncryptedBody.m in Sources */,
 				32CEEF4623AD2A6C0039BA98 /* MXCrossSigningKey.m in Sources */,
 				B14EF2482397E90400758AF0 /* MXEncryptedAttachments.m in Sources */,
+				ED7019E92886C33100FC31B9 /* MXKeyVerificationRequestV2.swift in Sources */,
 				EC05478525FF99450047ECD7 /* MXRoomAccountDataUpdater.m in Sources */,
 				ECD289A926EBB0FE00F268CF /* MXRoomListDataFetcherDelegate.swift in Sources */,
 				EC0B941027184E8A00B4D440 /* MXUsersTrustLevelSummaryMO.swift in Sources */,
@@ -7311,6 +7380,7 @@
 				EC60ED60265CFC2C00B39A4E /* MXSyncResponse.m in Sources */,
 				3A108AB825812995005EEBE9 /* MXKeyProvider.m in Sources */,
 				B14EF2822397E90400758AF0 /* MXDeviceList.m in Sources */,
+				ED7019E62886C32900FC31B9 /* MXSASTransactionV2.swift in Sources */,
 				ECCA02BF27348FE300B6F34F /* MXThread.swift in Sources */,
 				320B3937239FA56900BE2C06 /* MXKeyVerificationByDMRequest.m in Sources */,
 				B14EF2832397E90400758AF0 /* MXRoomCreateContent.m in Sources */,
@@ -7385,6 +7455,7 @@
 				B1E09A262397FCE90057C069 /* MXPushRuleUnitTests.m in Sources */,
 				EDF1B6942876CD8600BBBCEE /* MXTaskQueueUnitTests.swift in Sources */,
 				B1E09A442397FD940057C069 /* Dummy.swift in Sources */,
+				ED7019F82886CA6C00FC31B9 /* VerificationRequest+Stub.swift in Sources */,
 				18121F76273E6D2400B68ADF /* MXPollBuilderTests.swift in Sources */,
 				B1E09A1A2397FCE90057C069 /* MXAggregatedEditsTests.m in Sources */,
 				B1E09A1F2397FCE90057C069 /* MXAutoDiscoveryTests.m in Sources */,
@@ -7419,6 +7490,7 @@
 				B1E09A212397FCE90057C069 /* DirectRoomTests.m in Sources */,
 				32AF9293241112850008A0FD /* MXCryptoSecretShareTests.m in Sources */,
 				B1E09A462397FD990057C069 /* MXMediaScanStoreUnitTests.m in Sources */,
+				ED7019F62886CA6C00FC31B9 /* MXKeyVerificationRequestV2UnitTests.swift in Sources */,
 				ECB6FA8F267CFF4300A941E4 /* MXCredentialsUnitTests.swift in Sources */,
 				3A858DE9275511A4006322C1 /* MXRoomAliasAvailabilityCheckerResultTests.swift in Sources */,
 				ED7019DF2886C25600FC31B9 /* MXDeviceInfoUnitTests.swift in Sources */,
@@ -7446,6 +7518,7 @@
 				32EEA84B2603FDD60041425B /* MXResponseUnitTests.swift in Sources */,
 				32B0E3E823A3864C0054FF1A /* MXEventReferenceUnitTests.swift in Sources */,
 				B1E09A402397FD820057C069 /* MXVoIPTests.m in Sources */,
+				ED7019FC2886CA6C00FC31B9 /* MXSASTransactionV2UnitTests.swift in Sources */,
 				32B4778F2638133D00EA5800 /* MXJSONModelUnitTests.m in Sources */,
 				B1F939F626289F2600D0E525 /* MXSpaceChildContentTests.swift in Sources */,
 				EC40386828A279220067D5B8 /* MXKeyBackupUnitTests.swift in Sources */,
@@ -7462,6 +7535,7 @@
 				32B477902638133D00EA5800 /* MXAggregatedReferenceUnitTests.m in Sources */,
 				EC116598270FCA8B0089FA56 /* MXBackgroundTaskUnitTests.swift in Sources */,
 				B1E09A322397FD750057C069 /* MXRoomTests.m in Sources */,
+				ED7019FA2886CA6C00FC31B9 /* Sas+Stub.swift in Sources */,
 				ED21F68628104DA2002FF83D /* MXMegolmEncryptionTests.swift in Sources */,
 				ED44F01B28180F4000452A5D /* MXSharedHistoryKeyManagerUnitTests.swift in Sources */,
 				322985CC26FAF898001890BC /* MXSession.swift in Sources */,

--- a/MatrixSDK/Crypto/CrossSigning/Data/MXCrossSigningInfo.h
+++ b/MatrixSDK/Crypto/CrossSigning/Data/MXCrossSigningInfo.h
@@ -35,7 +35,7 @@ extern NSString *const MXCrossSigningInfoTrustLevelDidChangeNotification;
 
 #if DEBUG && TARGET_OS_IPHONE
 /**
- Initialize cross signing with MatrixSDKCrypto user identity 
+ Initialize cross signing with MatrixSDKCrypto user identity
  */
 - (instancetype)initWithUserIdentity:(MXCryptoUserIdentityWrapper *)userIdentity;
 #endif

--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoProtocols.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoProtocols.swift
@@ -59,4 +59,17 @@ protocol MXCryptoCrossSigning {
     func bootstrapCrossSigning(authParams: [AnyHashable: Any]) async throws
 }
 
+@available(iOS 13.0.0, *)
+protocol MXCryptoVerification {
+    func requestVerification(userId: String, roomId: String, methods: [String]) async throws -> VerificationRequest
+    func verificationRequest(userId: String, flowId: String) -> VerificationRequest?
+    
+    func verification(userId: String, flowId: String) -> Verification?
+    func beginSasVerification(userId: String, flowId: String) async throws -> Sas
+    func confirmVerification(userId: String, flowId: String) async throws
+    func cancelVerification(userId: String, flowId: String, cancelCode: String) async throws
+    
+    func emojiIndexes(sas: Sas) throws -> [Int]
+}
+
 #endif

--- a/MatrixSDK/Crypto/Verification/MXKeyVerificationManager.m
+++ b/MatrixSDK/Crypto/Verification/MXKeyVerificationManager.m
@@ -771,7 +771,14 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
     
     [self sendToOtherInTransaction:transaction eventType:kMXEventTypeStringKeyVerificationCancel content:cancel.JSONDictionary success:^{
         
-        transaction.reasonCancelCode = code;
+        if ([transaction isKindOfClass:[MXDefaultKeyVerificationTransaction class]])
+        {
+            ((MXDefaultKeyVerificationTransaction *)transaction).reasonCancelCode = code;
+        }
+        else
+        {
+            MXLogFailure(@"[MXKeyVerification] cancelTransaction: Cannot set cancellation reason on unknown transaction type: %@", NSStringFromClass([transaction class]))
+        }
         
         if (success)
         {
@@ -1700,7 +1707,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
 - (nullable NSDate*)oldestRequestDate
 {
     NSDate *oldestRequestDate;
-    for (id<MXKeyVerificationRequest> request in pendingRequestsMap.allValues)
+    for (MXDefaultKeyVerificationRequest *request in pendingRequestsMap.allValues)
     {
         if (!oldestRequestDate
             || request.timestamp < oldestRequestDate.timeIntervalSince1970)
@@ -1711,7 +1718,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
     return oldestRequestDate;
 }
 
-- (BOOL)isRequestStillValid:(id<MXKeyVerificationRequest>)request
+- (BOOL)isRequestStillValid:(MXDefaultKeyVerificationRequest *)request
 {
     NSDate *requestDate = [NSDate dateWithTimeIntervalSince1970:(request.timestamp / 1000)];
     return (requestDate.timeIntervalSinceNow > -_requestTimeout);
@@ -1759,7 +1766,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
 - (void)checkRequestTimeoutsWithCompletion:(dispatch_block_t)completionBlock
 {
     dispatch_group_t group = dispatch_group_create();
-    for (id<MXKeyVerificationRequest> request in pendingRequestsMap.allValues)
+    for (MXDefaultKeyVerificationRequest *request in pendingRequestsMap.allValues)
     {
         if (![self isRequestStillValid:request])
         {
@@ -1859,7 +1866,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
 - (nullable NSDate*)oldestTransactionCreationDate
 {
     NSDate *oldestCreationDate;
-    for (id<MXKeyVerificationTransaction> transaction in transactions.allObjects)
+    for (MXDefaultKeyVerificationTransaction *transaction in transactions.allObjects)
     {
         if (!oldestCreationDate
             || transaction.creationDate.timeIntervalSince1970 < oldestCreationDate.timeIntervalSince1970)
@@ -1870,7 +1877,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
     return oldestCreationDate;
 }
 
-- (BOOL)isCreationDateValid:(id<MXKeyVerificationTransaction>)transaction
+- (BOOL)isCreationDateValid:(MXDefaultKeyVerificationTransaction *)transaction
 {
     return (transaction.creationDate.timeIntervalSinceNow > -MXTransactionTimeout);
 }
@@ -1934,7 +1941,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
 
 - (void)checkTransactionTimeouts
 {
-    for (id<MXKeyVerificationTransaction> transaction in transactions.allObjects)
+    for (MXDefaultKeyVerificationTransaction *transaction in transactions.allObjects)
     {
         if (![self isCreationDateValid:transaction])
         {

--- a/MatrixSDK/Crypto/Verification/MXKeyVerificationManagerV2.swift
+++ b/MatrixSDK/Crypto/Verification/MXKeyVerificationManagerV2.swift
@@ -1,0 +1,238 @@
+//
+//  MXKeyVerificationManagerV2.swift
+//  MatrixSDK
+//
+//  Created by Element on 05/07/2022.
+//
+
+import Foundation
+
+#if DEBUG && os(iOS)
+
+import MatrixSDKCrypto
+
+@available(iOS 13.0.0, *)
+class MXKeyVerificationManagerV2: MXKeyVerificationManager {
+    typealias GetOrCreateDMRoomId = (_ userId: String) async throws -> String
+    
+    override var requestTimeout: TimeInterval {
+        set {
+            log.debug("Not implemented")
+        }
+        get {
+            log.debug("Not implemented")
+            return 1000
+        }
+    }
+    
+    private let verification: MXCryptoVerification
+    private let getOrCreateDMRoomId: GetOrCreateDMRoomId
+    
+    private var requests: [MXKeyVerificationRequestV2]
+    private var transactions: [MXSASTransactionV2]
+    
+    private let log = MXNamedLog(name: "MXKeyVerificationManagerV2")
+    
+    init(verification: MXCryptoVerification, getOrCreateDMRoomId: @escaping GetOrCreateDMRoomId) {
+        self.verification = verification
+        self.getOrCreateDMRoomId = getOrCreateDMRoomId
+        
+        self.requests = []
+        self.transactions = []
+        
+        super.init()
+    }
+    
+    func updatePendingRequests() {
+        for request in requests {
+            guard let req = verification.verificationRequest(userId: request.otherUser, flowId: request.requestId) else {
+                log.debug("No request found for id \(request.requestId)")
+                continue
+            }
+            request.update(request: req)
+        }
+        
+        for transaction in transactions {
+            guard let verification = verification.verification(userId: transaction.otherUserId, flowId: transaction.transactionId) else {
+                log.debug("No transaction found for id \(transaction.transactionId)")
+                continue
+            }
+            guard case .sasV1(let sas) = verification else {
+                assertionFailure("Not implemented")
+                continue
+            }
+            transaction.update(sas: sas)
+        }
+    }
+    
+    override func requestVerificationByToDevice(
+        withUserId userId: String,
+        deviceIds: [String]?,
+        methods: [String],
+        success: @escaping (MXKeyVerificationRequest) -> Void,
+        failure: @escaping (Error) -> Void
+    ) {
+        log.debug("Not implemented")
+        success(MXDefaultKeyVerificationRequest())
+    }
+    
+    override func requestVerificationByDM(
+        withUserId userId: String,
+        roomId: String?,
+        fallbackText: String,
+        methods: [String],
+        success: @escaping (MXKeyVerificationRequest) -> Void,
+        failure: @escaping (Error) -> Void
+    ) {
+        Task {
+            do {
+                let roomId = try await getOrCreateDMRoomId(userId)
+                let req = try await verification.requestVerification(
+                    userId: userId,
+                    roomId: roomId,
+                    methods: methods
+                )
+                let request = MXKeyVerificationRequestV2(request: req) { [weak self] request, code in
+                    self?.cancel(request: request, code: code)
+                }
+                requests.append(request)
+                await MainActor.run {
+                    success(request)
+                }
+            } catch {
+                log.error("Cannot request verification", error: error)
+                await MainActor.run {
+                    failure(error)
+                }
+            }
+        }
+    }
+    
+    override var pendingRequests: [MXKeyVerificationRequest] {
+        return requests
+    }
+    
+    override func beginKeyVerification(
+        withUserId userId: String,
+        andDeviceId deviceId: String,
+        method: String,
+        success: @escaping (MXKeyVerificationTransaction) -> Void,
+        failure: @escaping (Error) -> Void
+    ) {
+        log.debug("Not implemented")
+        success(MXDefaultKeyVerificationTransaction())
+    }
+    
+    override func beginKeyVerification(
+        from request: MXKeyVerificationRequest,
+        method: String,
+        success: @escaping (MXKeyVerificationTransaction) -> Void,
+        failure: @escaping (Error) -> Void
+    ) {
+        Task {
+            do {
+                let sas = try await verification.beginSasVerification(userId: request.otherUser, flowId: request.requestId)
+                let transaction = MXSASTransactionV2(
+                    sas: sas,
+                    getEmojisAction: { [weak self] in
+                        self?.getEmojis(sas: $0) ?? []
+                    },
+                    confirmMatchAction: { [weak self] in
+                        self?.confirm(transaction: $0)
+                    },
+                    cancelAction: { [weak self] in
+                        self?.cancel(transaction: $0, code: $1)
+                    }
+                )
+                transactions.append(transaction)
+                
+                await MainActor.run {
+                    success(transaction)
+                }
+            } catch {
+                MXLog.error("[MXKeyVerificationRequestV2] error \(error)")
+                await MainActor.run {
+                    failure(error)
+                }
+            }
+        }
+    }
+    
+    override func transactions(_ complete: @escaping ([MXKeyVerificationTransaction]) -> Void) {
+        complete(transactions)
+    }
+    
+    override func keyVerification(
+        fromKeyVerificationEvent event: MXEvent,
+        success: @escaping (MXKeyVerification) -> Void,
+        failure: @escaping (Error) -> Void
+    ) -> MXHTTPOperation? {
+        log.debug("Not implemented")
+        success(MXKeyVerification())
+        return MXHTTPOperation()
+    }
+    
+    override func keyVerificationId(fromDMEvent event: MXEvent) -> String? {
+        log.debug("Not implemented")
+        return nil
+    }
+    
+    override func qrCodeTransaction(withTransactionId transactionId: String) -> MXQRCodeTransaction? {
+        log.debug("Not implemented")
+        return nil
+    }
+    
+    override func removeQRCodeTransaction(withTransactionId transactionId: String) {
+        log.debug("Not implemented")
+    }
+    
+    override func notifyOthersOfAcceptance(withTransactionId transactionId: String, acceptedUserId: String, acceptedDeviceId: String, success: @escaping () -> Void, failure: @escaping (Error) -> Void) {
+        log.debug("Not implemented")
+        success()
+    }
+    
+    private func getEmojis(sas: Sas) -> [MXEmojiRepresentation] {
+        do {
+            let indices = try verification.emojiIndexes(sas: sas)
+            let emojis = MXDefaultSASTransaction.allEmojiRepresentations()
+            return indices.compactMap { idx in
+                idx < emojis.count ? emojis[idx] : nil
+            }
+        } catch {
+            log.error("Cannot get emoji indices", error: error)
+            return []
+        }
+    }
+    
+    private func cancel(request: MXKeyVerificationRequest, code: MXTransactionCancelCode) {
+        Task {
+            do {
+                try await verification.cancelVerification(userId: request.otherUser, flowId: request.requestId, cancelCode: code.value)
+            } catch {
+                log.error("Cannot cancel request", error: error)
+            }
+        }
+    }
+    
+    private func confirm(transaction: MXSASTransaction) {
+        Task {
+            do {
+                try await verification.confirmVerification(userId: transaction.otherUserId, flowId: transaction.transactionId)
+            } catch {
+                log.error("Cannot confirm transaction", error: error)
+            }
+        }
+    }
+    
+    private func cancel(transaction: MXSASTransaction, code: MXTransactionCancelCode) {
+        Task {
+            do {
+                try await verification.cancelVerification(userId: transaction.otherUserId, flowId: transaction.transactionId, cancelCode: code.value)
+            } catch {
+                log.error("Cannot cancel request", error: error)
+            }
+        }
+    }
+}
+
+#endif

--- a/MatrixSDK/Crypto/Verification/Requests/MXKeyVerificationRequest.h
+++ b/MatrixSDK/Crypto/Verification/Requests/MXKeyVerificationRequest.h
@@ -68,38 +68,27 @@ Accept an incoming key verification request.
                      failure:(void(^ _Nullable)(NSError *error))failure;
 
 /**
- The cancellation reason, if any.
+ Current state of the request
  */
-@property (nonatomic, nullable) MXTransactionCancelCode *reasonCancelCode;
-
-// Current state
 @property (nonatomic, readonly) MXKeyVerificationRequestState state;
 
-// Original data for this request
-@property (nonatomic, readonly) MXEvent *event;
+/**
+ The cancellation reason, if state is cancelled
+ */
+@property (nonatomic, readonly, nullable) MXTransactionCancelCode *reasonCancelCode;
 
 // Is it a request made by our user?
 @property (nonatomic, readonly) BOOL isFromMyUser;
 @property (nonatomic, readonly) BOOL isFromMyDevice;
 
-
 // Shortcuts to the original request
 @property (nonatomic, readonly) NSString *requestId;
 @property (nonatomic, readonly) MXKeyVerificationTransport transport;
-@property (nonatomic, readonly) NSString *fromDevice;
-@property (nonatomic, readonly) uint64_t timestamp;
 @property (nonatomic, readonly) NSArray<NSString*> *methods;
 
 // The other party
 @property (nonatomic, readonly) NSString *otherUser;
 @property (nonatomic, readonly, nullable) NSString *otherDevice;  // This is unknown and nil while the request has not been accepted
-
-
-// Original data from the accepted (aka m.verification.ready) event
-@property (nonatomic, readonly, nullable) MXKeyVerificationReady *acceptedData;
-
-// Shortcuts to the accepted event
-@property (nonatomic, readonly, nullable) NSArray<NSString*> *acceptedMethods;
 
 // Shortcuts of methods according to the point of view
 @property (nonatomic, readonly, nullable) NSArray<NSString*> *myMethods;
@@ -111,6 +100,17 @@ Accept an incoming key verification request.
  Default implementation of verification request used by the SDK
  */
 @interface MXDefaultKeyVerificationRequest : NSObject <MXKeyVerificationRequest>
+
+// Original data for this request
+@property (nonatomic, readonly) MXEvent *event;
+
+// Shortcuts to the accepted event
+@property (nonatomic, readonly) NSString *fromDevice;
+@property (nonatomic, readonly) uint64_t timestamp;
+
+// Original data from the accepted (aka m.verification.ready) event
+@property (nonatomic, readonly, nullable) MXKeyVerificationReady *acceptedData;
+@property (nonatomic, readonly, nullable) NSArray<NSString*> *acceptedMethods;
 
 @end
 

--- a/MatrixSDK/Crypto/Verification/Requests/MXKeyVerificationRequest.m
+++ b/MatrixSDK/Crypto/Verification/Requests/MXKeyVerificationRequest.m
@@ -20,6 +20,7 @@
 
 #import "MXCrypto_Private.h"
 
+#warning File has not been annotated with nullability, see MX_ASSUME_MISSING_NULLABILITY_BEGIN
 
 #pragma mark - Constants
 NSString * const MXKeyVerificationRequestDidChangeNotification = @"MXKeyVerificationRequestDidChangeNotification";

--- a/MatrixSDK/Crypto/Verification/Requests/MXKeyVerificationRequestV2.swift
+++ b/MatrixSDK/Crypto/Verification/Requests/MXKeyVerificationRequestV2.swift
@@ -1,0 +1,128 @@
+// 
+// Copyright 2022 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+#if DEBUG && os(iOS)
+
+import MatrixSDKCrypto
+
+/// Verification request originating from `MatrixSDKCrypto`
+class MXKeyVerificationRequestV2: NSObject, MXKeyVerificationRequest {
+    typealias CancelAction = (MXKeyVerificationRequest, MXTransactionCancelCode) -> Void
+    
+    var state: MXKeyVerificationRequestState {
+        // State as enum will be moved to MatrixSDKCrypto in the future
+        // to avoid the mapping of booleans into state
+        if request.isDone {
+            return MXKeyVerificationRequestStateAccepted
+        } else if request.isCancelled {
+            return MXKeyVerificationRequestStateCancelled
+        } else if request.isReady {
+            return MXKeyVerificationRequestStateReady
+        } else if request.isPassive {
+            return MXKeyVerificationRequestStatePending
+        }
+        return MXKeyVerificationRequestStatePending
+    }
+    
+    var reasonCancelCode: MXTransactionCancelCode? {
+        guard let info = request.cancelInfo else {
+            return nil
+        }
+        return .init(
+            value: info.cancelCode,
+            humanReadable: info.reason
+        )
+    }
+    
+    var isFromMyUser: Bool {
+        return request.weStarted
+    }
+    
+    var isFromMyDevice: Bool {
+        // Not exposed on the underlying request,
+        // assuming that if request is from us, it is from our devide
+        log.debug("Not fully implemented")
+        return isFromMyUser
+    }
+    
+    var requestId: String {
+        return request.flowId
+    }
+    
+    var transport: MXKeyVerificationTransport {
+        log.debug("Not fully implemented")
+        return .directMessage
+    }
+    
+    var otherUser: String {
+        return request.otherUserId
+    }
+    
+    var otherDevice: String? {
+        return request.otherDeviceId
+    }
+    
+    var methods: [String] {
+        return (isFromMyUser ? myMethods : otherMethods) ?? []
+    }
+    
+    var myMethods: [String]? {
+        return request.ourMethods
+    }
+    
+    var otherMethods: [String]? {
+        return request.theirMethods
+    }
+    
+    private var request: VerificationRequest
+    private let cancelAction: CancelAction
+    
+    private let log = MXNamedLog(name: "MXKeyVerificationRequestV2")
+    
+    init(request: VerificationRequest, cancelAction: @escaping CancelAction) {
+        self.request = request
+        self.cancelAction = cancelAction
+    }
+    
+    func update(request: VerificationRequest) {
+        guard self.request != request else {
+            return
+        }
+        self.request = request
+        NotificationCenter.default.post(name: .MXKeyVerificationRequestDidChange, object: self)
+    }
+    
+    func accept(
+        withMethods methods: [String],
+        success: @escaping () -> Void,
+        failure: @escaping (Error) -> Void
+    ) {
+        log.debug("Not implemented")
+    }
+    
+    func cancel(
+        with code: MXTransactionCancelCode,
+        success: (() -> Void)?,
+        failure: ((Error) -> Void)? = nil
+    ) {
+        cancelAction(self, code)
+        success?()
+    }
+}
+
+#endif

--- a/MatrixSDK/Crypto/Verification/Requests/MXKeyVerificationRequest_Private.h
+++ b/MatrixSDK/Crypto/Verification/Requests/MXKeyVerificationRequest_Private.h
@@ -19,6 +19,8 @@
 #import "MXKeyVerificationReady.h"
 #import "MXKeyVerificationCancel.h"
 
+MX_ASSUME_MISSING_NULLABILITY_BEGIN
+
 @class MXKeyVerificationManager, MXHTTPOperation;
 
 
@@ -31,6 +33,7 @@
 
 - (instancetype)initWithEvent:(MXEvent*)event andManager:(MXKeyVerificationManager*)manager;
 
+@property (nonatomic, nullable) MXTransactionCancelCode *reasonCancelCode;
 @property (nonatomic) BOOL isFromMyUser;
 @property (nonatomic) BOOL isFromMyDevice;
 
@@ -42,3 +45,5 @@
 - (void)handleCancel:(MXKeyVerificationCancel*)cancelContent;
 
 @end
+
+MX_ASSUME_MISSING_NULLABILITY_END

--- a/MatrixSDK/Crypto/Verification/Transactions/MXKeyVerificationTransaction.h
+++ b/MatrixSDK/Crypto/Verification/Transactions/MXKeyVerificationTransaction.h
@@ -53,17 +53,7 @@ typedef NS_ENUM(NSInteger, MXKeyVerificationTransport) {
 /**
  YES for an incoming verification request.
  */
-@property (nonatomic) BOOL isIncoming;
-
-/**
- The creation date.
- */
-@property (nonatomic, strong) NSDate *creationDate;
-
-/**
- The other user device.
- */
-@property (nonatomic, readonly) MXDeviceInfo *otherDevice;
+@property (nonatomic, readonly) BOOL isIncoming;
 
 /**
  The other user id.
@@ -78,12 +68,17 @@ typedef NS_ENUM(NSInteger, MXKeyVerificationTransport) {
 /**
  The cancellation reason, if any.
  */
-@property (nonatomic, nullable) MXTransactionCancelCode *reasonCancelCode;
+@property (nonatomic, readonly, nullable) MXTransactionCancelCode *reasonCancelCode;
 
 /**
  The occured error (like network error), if any.
  */
-@property (nonatomic, nullable) NSError *error;
+@property (nonatomic, readonly, nullable) NSError *error;
+
+#pragma mark Direct message
+
+@property (nonatomic, nullable, readonly) NSString *dmRoomId;
+@property (nonatomic, nullable, readonly) NSString *dmEventId;
 
 /**
  Cancel this transaction.
@@ -105,10 +100,6 @@ typedef NS_ENUM(NSInteger, MXKeyVerificationTransport) {
 
 
 #pragma mark - Transport layer
-#pragma mark Direct message
-
-@property (nonatomic, nullable, readonly) NSString *dmRoomId;
-@property (nonatomic, nullable, readonly) NSString *dmEventId;
 
 @end
 
@@ -116,6 +107,25 @@ typedef NS_ENUM(NSInteger, MXKeyVerificationTransport) {
  Default implementation of verification transaction used by the SDK
  */
 @interface MXDefaultKeyVerificationTransaction: NSObject <MXKeyVerificationTransaction>
+
+/**
+ The creation date.
+ */
+@property (nonatomic, strong) NSDate *creationDate;
+
+@property (nonatomic) BOOL isIncoming;
+
+/**
+ The other user device.
+ */
+@property (nonatomic, readonly) MXDeviceInfo *otherDevice;
+
+@property (nonatomic, nullable) MXTransactionCancelCode *reasonCancelCode;
+
+/**
+ The occured error (like network error), if any.
+ */
+@property (nonatomic, nullable) NSError *error;
 
 @end
 

--- a/MatrixSDK/Crypto/Verification/Transactions/SAS/MXSASTransaction.h
+++ b/MatrixSDK/Crypto/Verification/Transactions/SAS/MXSASTransaction.h
@@ -50,22 +50,17 @@ typedef enum : NSUInteger
  */
 @protocol MXSASTransaction <MXKeyVerificationTransaction>
 
-@property (nonatomic) MXSASTransactionState state;
-
-/**
- The Short Authentication Code bytes data.
- */
-@property (nonatomic, nullable) NSData *sasBytes;
-
-/**
- `self.sasBytes` represented by a three 4-digit numbers string.
- */
-@property (nonatomic, readonly, nullable) NSString *sasDecimal;
+@property (nonatomic, readonly) MXSASTransactionState state;
 
 /**
  `self.sasBytes` represented by a 7 emojis string.
  */
 @property (nonatomic, readonly, nullable) NSArray<MXEmojiRepresentation*> *sasEmoji;
+
+/**
+ `self.sasBytes` represented by a three 4-digit numbers string.
+ */
+@property (nonatomic, readonly, nullable) NSString *sasDecimal;
 
 /**
  To be called by the app when the user confirms that the SAS matches with the SAS
@@ -79,6 +74,14 @@ typedef enum : NSUInteger
  Default implementation of SAS transaction used by the SDK
  */
 @interface MXDefaultSASTransaction : MXDefaultKeyVerificationTransaction <MXSASTransaction>
+
++ (NSArray<MXEmojiRepresentation*> *)allEmojiRepresentations;
+
+/**
+ The Short Authentication Code bytes data.
+ */
+@property (nonatomic, nullable) NSData *sasBytes;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/MatrixSDK/Crypto/Verification/Transactions/SAS/MXSASTransaction.m
+++ b/MatrixSDK/Crypto/Verification/Transactions/SAS/MXSASTransaction.m
@@ -567,6 +567,11 @@ static NSArray<MXEmojiRepresentation*> *kSasEmojis;
                    ];
 }
 
++ (NSArray<MXEmojiRepresentation*> *)allEmojiRepresentations
+{
+    return kSasEmojis;
+}
+
 + (NSArray<MXEmojiRepresentation*> *)emojiRepresentationForSas:(NSData*)sas
 {
     UInt8 *sasBytes = (UInt8 *)sas.bytes;

--- a/MatrixSDK/Crypto/Verification/Transactions/SAS/MXSASTransactionV2.swift
+++ b/MatrixSDK/Crypto/Verification/Transactions/SAS/MXSASTransactionV2.swift
@@ -1,0 +1,139 @@
+// 
+// Copyright 2022 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+#if DEBUG && os(iOS)
+
+import MatrixSDKCrypto
+
+/// SAS transaction originating from `MatrixSDKCrypto`
+class MXSASTransactionV2: NSObject, MXSASTransaction {
+    typealias GetEmojisAction = (Sas) -> [MXEmojiRepresentation]
+    typealias ConfirmMatchAction = (MXSASTransaction) -> Void
+    typealias CancelAction = (MXSASTransaction, MXTransactionCancelCode) -> Void
+    
+    var state: MXSASTransactionState {
+        // State as enum will be moved to MatrixSDKCrypto in the future
+        // to avoid the mapping of booleans into state
+        if sas.isDone {
+            return MXSASTransactionStateVerified
+        } else if sas.isCancelled {
+            return MXSASTransactionStateCancelled
+        } else if sas.canBePresented {
+            return MXSASTransactionStateShowSAS
+        } else if sas.hasBeenAccepted && !sas.haveWeConfirmed {
+            return MXSASTransactionStateIncomingShowAccept
+        } else if sas.haveWeConfirmed {
+            return MXSASTransactionStateOutgoingWaitForPartnerToAccept
+        }
+        return MXSASTransactionStateUnknown
+    }
+    
+    var sasEmoji: [MXEmojiRepresentation]? {
+        return getEmojisAction(sas)
+    }
+    
+    var sasDecimal: String? {
+        log.debug("Not implemented")
+        return nil
+    }
+    
+    var transactionId: String {
+        return sas.flowId
+    }
+    
+    var transport: MXKeyVerificationTransport {
+        log.debug("Not fully implemented")
+        return .directMessage
+    }
+    
+    var isIncoming: Bool {
+        return !sas.weStarted
+    }
+    
+    var otherUserId: String {
+        return sas.otherUserId
+    }
+    
+    var otherDeviceId: String {
+        return sas.otherDeviceId
+    }
+    
+    var reasonCancelCode: MXTransactionCancelCode? {
+        guard let info = sas.cancelInfo else {
+            return nil
+        }
+        return MXTransactionCancelCode(
+            value: info.cancelCode,
+            humanReadable: info.reason
+        )
+    }
+    
+    var error: Error? {
+        return nil
+    }
+
+    var dmRoomId: String? {
+        return sas.roomId
+    }
+
+    var dmEventId: String? {
+        return transactionId
+    }
+    
+    private var sas: Sas
+    private let getEmojisAction: GetEmojisAction
+    private let confirmMatchAction: ConfirmMatchAction
+    private let cancelAction: CancelAction
+    
+    private let log = MXNamedLog(name: "MXSASTransactionV2")
+    
+    init(
+        sas: Sas,
+        getEmojisAction: @escaping GetEmojisAction,
+        confirmMatchAction: @escaping ConfirmMatchAction,
+        cancelAction: @escaping CancelAction
+    ) {
+        self.sas = sas
+        self.getEmojisAction = getEmojisAction
+        self.confirmMatchAction = confirmMatchAction
+        self.cancelAction = cancelAction
+    }
+    
+    func update(sas: Sas) {
+        guard self.sas != sas else {
+            return
+        }
+        self.sas = sas
+        NotificationCenter.default.post(name: .MXKeyVerificationTransactionDidChange, object: self)
+    }
+    
+    func confirmSASMatch() {
+        confirmMatchAction(self)
+    }
+    
+    func cancel(with code: MXTransactionCancelCode) {
+        cancelAction(self, code)
+    }
+    
+    func cancel(with code: MXTransactionCancelCode, success: @escaping () -> Void, failure: @escaping (Error) -> Void) {
+        cancelAction(self, code)
+        success()
+    }
+}
+
+#endif

--- a/MatrixSDK/Crypto/Verification/Transactions/SAS/MXSASTransaction_Private.h
+++ b/MatrixSDK/Crypto/Verification/Transactions/SAS/MXSASTransaction_Private.h
@@ -39,6 +39,7 @@ FOUNDATION_EXPORT NSArray<NSString*> *kKnownShortCodes;
  */
 @interface MXDefaultSASTransaction ()
 
+@property (nonatomic) MXSASTransactionState state;
 @property (nonatomic) OLMSAS *olmSAS;
 @property (nonatomic, nullable) MXSASKeyVerificationStart *startContent;
 @property (nonatomic) MXKeyVerificationAccept *accepted;

--- a/MatrixSDKTests/Crypto/Verification/Requests/MXKeyVerificationRequestV2UnitTests.swift
+++ b/MatrixSDKTests/Crypto/Verification/Requests/MXKeyVerificationRequestV2UnitTests.swift
@@ -1,0 +1,140 @@
+// 
+// Copyright 2022 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import XCTest
+
+#if DEBUG && os(iOS)
+
+import MatrixSDKCrypto
+@testable import MatrixSDK
+
+class MXKeyVerificationRequestV2UnitTests: XCTestCase {
+    func test_usesCorrectProperties() {
+        let stub = VerificationRequest.stub(
+            otherUserId: "Bob",
+            otherDeviceId: "Device2",
+            flowId: "123",
+            weStarted: true,
+            theirMethods: ["sas", "qr"],
+            ourMethods: ["sas", "unknown"]
+        )
+        
+        let request = MXKeyVerificationRequestV2(
+            request: stub,
+            cancelAction: { _, _ in }
+        )
+        
+        XCTAssertTrue(request.isFromMyUser)
+        XCTAssertTrue(request.isFromMyDevice)
+        XCTAssertEqual(request.requestId, "123")
+        XCTAssertEqual(request.transport, MXKeyVerificationTransport.directMessage)
+        XCTAssertEqual(request.otherUser, "Bob")
+        XCTAssertEqual(request.otherDevice, "Device2")
+        XCTAssertEqual(request.methods, ["sas", "unknown"])
+        XCTAssertEqual(request.myMethods, ["sas", "unknown"])
+        XCTAssertEqual(request.otherMethods, ["sas", "qr"])
+    }
+    
+    func test_state() {
+        let testCases: [(VerificationRequest, MXKeyVerificationRequestState)] = [
+            (.stub(
+                isReady: false,
+                isPassive: false,
+                isDone: false,
+                isCancelled: false
+            ), MXKeyVerificationRequestStatePending),
+            (.stub(
+                isReady: false,
+                isPassive: false,
+                isDone: true,
+                isCancelled: false
+            ), MXKeyVerificationRequestStateAccepted),
+            (.stub(
+                isReady: true,
+                isPassive: false,
+                isDone: false,
+                isCancelled: false
+            ), MXKeyVerificationRequestStateReady),
+            (.stub(
+                isReady: false,
+                isPassive: false,
+                isDone: false,
+                isCancelled: true
+            ), MXKeyVerificationRequestStateCancelled),
+            (.stub(
+                isReady: false,
+                isPassive: true,
+                isDone: false,
+                isCancelled: false
+            ), MXKeyVerificationRequestStatePending),
+            (.stub(
+                isReady: true,
+                isPassive: true,
+                isDone: true,
+                isCancelled: true
+            ), MXKeyVerificationRequestStateAccepted),
+            (.stub(
+                isReady: true,
+                isPassive: true,
+                isDone: false,
+                isCancelled: true
+            ), MXKeyVerificationRequestStateCancelled),
+        ]
+        
+        for (stub, state) in testCases {
+            let request = MXKeyVerificationRequestV2(
+                request: stub,
+                cancelAction: { _, _ in }
+            )
+            XCTAssertEqual(request.state, state)
+        }
+    }
+    
+    func test_reasonCancelCode() {
+        let cancelInfo = CancelInfo(
+            cancelCode: "123",
+            reason: "Changed mind",
+            cancelledByUs: true
+        )
+        
+        let request = MXKeyVerificationRequestV2(
+            request: .stub(cancelInfo: cancelInfo),
+            cancelAction: { _, _ in }
+        )
+        
+        XCTAssertEqual(request.reasonCancelCode?.value, "123")
+        XCTAssertEqual(request.reasonCancelCode?.humanReadable, "Changed mind")
+    }
+    
+    func test_update_postsNotification_ifChanged() {
+        let exp = expectation(description: "exp")
+        let request = MXKeyVerificationRequestV2(
+            request: .stub(isReady: false),
+            cancelAction: { _, _ in }
+        )
+        NotificationCenter.default.addObserver(forName: .MXKeyVerificationRequestDidChange, object: request, queue: OperationQueue.main) { notif in
+            XCTAssertEqual(request.state, MXKeyVerificationRequestStateReady)
+            exp.fulfill()
+        }
+        
+        request.update(request: .stub(isReady: true))
+        
+        waitForExpectations(timeout: 1)
+    }
+}
+
+#endif

--- a/MatrixSDKTests/Crypto/Verification/Requests/VerificationRequest+Stub.swift
+++ b/MatrixSDKTests/Crypto/Verification/Requests/VerificationRequest+Stub.swift
@@ -1,0 +1,55 @@
+// 
+// Copyright 2022 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+#if DEBUG && os(iOS)
+
+import MatrixSDKCrypto
+
+extension VerificationRequest {
+    static func stub(
+        otherUserId: String = "Bob",
+        otherDeviceId: String = "Device2",
+        flowId: String = "123",
+        roomId: String = "ABC",
+        weStarted: Bool = true,
+        isReady: Bool = false,
+        isPassive: Bool = false,
+        isDone: Bool = false,
+        isCancelled: Bool = false,
+        cancelInfo: CancelInfo? = nil,
+        theirMethods: [String] = ["sas"],
+        ourMethods: [String] = ["sas"]
+    ) -> VerificationRequest {
+        return .init(
+            otherUserId: otherUserId,
+            otherDeviceId: otherDeviceId,
+            flowId: flowId,
+            roomId: roomId,
+            weStarted: weStarted,
+            isReady: isReady,
+            isPassive: isPassive,
+            isDone: isDone,
+            isCancelled: isCancelled,
+            cancelInfo: cancelInfo,
+            theirMethods: theirMethods,
+            ourMethods: ourMethods
+        )
+    }
+}
+
+#endif

--- a/MatrixSDKTests/Crypto/Verification/Transactions/SAS/MXSASTransactionV2UnitTests.swift
+++ b/MatrixSDKTests/Crypto/Verification/Transactions/SAS/MXSASTransactionV2UnitTests.swift
@@ -1,0 +1,180 @@
+// 
+// Copyright 2022 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import XCTest
+
+#if os(iOS)
+
+import MatrixSDKCrypto
+@testable import MatrixSDK
+
+class MXSASTransactionV2UnitTests: XCTestCase {
+    func test_usesCorrectProperties() {
+        let stub = Sas.stub(
+            otherUserId: "Bob",
+            otherDeviceId: "Device2",
+            flowId: "123",
+            roomId: "ABC",
+            weStarted: true,
+            supportsEmoji: true
+        )
+        
+        let transaction = MXSASTransactionV2(
+            sas: stub,
+            getEmojisAction: { _ in [] },
+            confirmMatchAction: { _ in },
+            cancelAction: { _, _ in }
+        )
+        
+        XCTAssertEqual(transaction.transactionId, "123")
+        XCTAssertEqual(transaction.transport, MXKeyVerificationTransport.directMessage)
+        XCTAssertFalse(transaction.isIncoming)
+        XCTAssertEqual(transaction.otherUserId, "Bob")
+        XCTAssertEqual(transaction.otherDeviceId, "Device2")
+        XCTAssertEqual(transaction.dmRoomId, "ABC")
+        XCTAssertEqual(transaction.dmEventId, "123")
+    }
+    
+    func test_state() {
+        let testCases: [(Sas, MXSASTransactionState)] = [
+            (.stub(
+                hasBeenAccepted: false,
+                canBePresented: false,
+                haveWeConfirmed: false,
+                isDone: false,
+                isCancelled: false
+            ), MXSASTransactionStateUnknown),
+            (.stub(
+                hasBeenAccepted: false,
+                canBePresented: false,
+                haveWeConfirmed: false,
+                isDone: true,
+                isCancelled: false
+            ), MXSASTransactionStateVerified),
+            (.stub(
+                hasBeenAccepted: false,
+                canBePresented: false,
+                haveWeConfirmed: false,
+                isDone: false,
+                isCancelled: true
+            ), MXSASTransactionStateCancelled),
+            (.stub(
+                hasBeenAccepted: false,
+                canBePresented: true,
+                haveWeConfirmed: false,
+                isDone: false,
+                isCancelled: false
+            ), MXSASTransactionStateShowSAS),
+            (.stub(
+                hasBeenAccepted: true,
+                canBePresented: false,
+                haveWeConfirmed: false,
+                isDone: false,
+                isCancelled: false
+            ), MXSASTransactionStateIncomingShowAccept),
+            (.stub(
+                hasBeenAccepted: false,
+                canBePresented: false,
+                haveWeConfirmed: true,
+                isDone: false,
+                isCancelled: false
+            ), MXSASTransactionStateOutgoingWaitForPartnerToAccept),
+        ]
+
+        for (stub, state) in testCases {
+            let transaction = MXSASTransactionV2(
+                sas: stub,
+                getEmojisAction: { _ in [] },
+                confirmMatchAction: { _ in },
+                cancelAction: { _, _ in }
+            )
+            XCTAssertEqual(transaction.state, state)
+        }
+    }
+
+    func test_reasonCancelCode() {
+        let cancelInfo = CancelInfo(
+            cancelCode: "123",
+            reason: "Changed mind",
+            cancelledByUs: true
+        )
+
+        let transaction = MXSASTransactionV2(
+            sas: .stub(cancelInfo: cancelInfo),
+            getEmojisAction: { _ in [] },
+            confirmMatchAction: { _ in },
+            cancelAction: { _, _ in }
+        )
+
+        XCTAssertEqual(transaction.reasonCancelCode?.value, "123")
+        XCTAssertEqual(transaction.reasonCancelCode?.humanReadable, "Changed mind")
+    }
+
+    func test_update_postsNotification_ifChanged() {
+        let exp = expectation(description: "exp")
+        let transaction = MXSASTransactionV2(
+            sas: .stub(isDone: false),
+            getEmojisAction: { _ in [] },
+            confirmMatchAction: { _ in },
+            cancelAction: { _, _ in }
+        )
+        NotificationCenter.default.addObserver(forName: .MXKeyVerificationTransactionDidChange, object: transaction, queue: OperationQueue.main) { notif in
+            XCTAssertEqual(transaction.state, MXSASTransactionStateVerified)
+            exp.fulfill()
+        }
+
+        transaction.update(sas: .stub(isDone: true))
+
+        waitForExpectations(timeout: 1)
+    }
+    
+    func test_sasEmoji_picksCorrectEmoji() {
+        let emoji = [
+            MXEmojiRepresentation(emoji: "A", andName: "A"),
+            MXEmojiRepresentation(emoji: "B", andName: "B"),
+            MXEmojiRepresentation(emoji: "C", andName: "C"),
+        ]
+        
+        let transaction = MXSASTransactionV2(
+            sas: .stub(),
+            getEmojisAction: { _ in emoji },
+            confirmMatchAction: { _ in },
+            cancelAction: { _, _ in }
+        )
+        
+        XCTAssertEqual(transaction.sasEmoji, emoji)
+    }
+    
+    func test_confirmSASMatch() {
+        let exp = expectation(description: "exp")
+        let transaction = MXSASTransactionV2(
+            sas: .stub(),
+            getEmojisAction: { _ in [] },
+            confirmMatchAction: { _ in
+                XCTAssertTrue(true)
+                exp.fulfill()
+            },
+            cancelAction: { _, _ in }
+        )
+        
+        transaction.confirmSASMatch()
+        
+        waitForExpectations(timeout: 1)
+    }
+}
+
+#endif

--- a/MatrixSDKTests/Crypto/Verification/Transactions/SAS/Sas+Stub.swift
+++ b/MatrixSDKTests/Crypto/Verification/Transactions/SAS/Sas+Stub.swift
@@ -1,0 +1,55 @@
+// 
+// Copyright 2022 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+#if DEBUG && os(iOS)
+
+import MatrixSDKCrypto
+
+extension Sas {
+    static func stub(
+        otherUserId: String = "Bob",
+        otherDeviceId: String = "Device2",
+        flowId: String = "123",
+        roomId: String = "ABC",
+        weStarted: Bool = true,
+        hasBeenAccepted: Bool = false,
+        canBePresented: Bool = false,
+        supportsEmoji: Bool = true,
+        haveWeConfirmed: Bool = false,
+        isDone: Bool = false,
+        isCancelled: Bool = false,
+        cancelInfo: CancelInfo? = nil
+    ) -> Sas {
+        return .init(
+            otherUserId: otherUserId,
+            otherDeviceId: otherDeviceId,
+            flowId: flowId,
+            roomId: roomId,
+            weStarted: weStarted,
+            hasBeenAccepted: hasBeenAccepted,
+            canBePresented: canBePresented,
+            supportsEmoji: supportsEmoji,
+            haveWeConfirmed: haveWeConfirmed,
+            isDone: isDone,
+            isCancelled: isCancelled,
+            cancelInfo: cancelInfo
+        )
+    }
+}
+
+#endif

--- a/changelog.d/6443.feature
+++ b/changelog.d/6443.feature
@@ -1,0 +1,1 @@
+CryptoSDK: Outgoing SAS User Verification Flow


### PR DESCRIPTION
Resolves https://github.com/vector-im/element-ios/issues/6443

Implement (outgoing) verification flow using SAS / emojis, incl sending initial request, responding via SAS methods, accepting or rejecting matching emojis and displaying the verification status of user after verification is complete.

## Changes in the PR
- Add `MXKeyVerificationManagerV2` which uses Rust-based crypto machine under the hood
- Expose `OlmMachine` verification methods under `MXCryptoVerification`
- Hide some of the [previously exposed](https://github.com/matrix-org/matrix-ios-sdk/pull/1528) protocol methods inside legacy implementations, as they are not / shoud not be needed by every verification implementation
- Implement Rust-based verification request and sas transactions that can be used with existing views and view models

## Missing bits
- Some methods are still not implemented, which is signalled via added logs. It is not yet clear whether these methods are really needed or can be hidden inside legacy implementations
- Incoming flow is not yet implemented, i.e. another device asking to verify does not currently hook up to the Crypto Machine
- Verification only uses direct room mechanism, and assumes DM with a given user already exists

All of these will be resolved in future PRs