### PR TITLE
Wait for all verification requests in integration tests

### DIFF
--- a/MatrixSDKTests/MXCrossSigningVerificationTests.m
+++ b/MatrixSDKTests/MXCrossSigningVerificationTests.m
@@ -662,9 +662,8 @@
                          XCTAssertNotNil(requestJSON);
                          
                          // - Alice accepts it and creates a QR code transaction
-                         
-                         // Wait a bit
-                         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+                         [self observeKeyVerificationRequestInSession:aliceSession block:^(id<MXKeyVerificationRequest>  _Nullable request) {
+
                              // - Alice accepts the incoming request
                              id<MXKeyVerificationRequest> requestFromAlicePOV = aliceSession.crypto.keyVerificationManager.pendingRequests.firstObject;
                              XCTAssertNotNil(requestFromAlicePOV);
@@ -683,7 +682,7 @@
                                  XCTFail(@"The request should not fail - NSError: %@", error);
                                  [expectation fulfill];
                              }];
-                         });
+                         }];
                      }
                  }];
                 


### PR DESCRIPTION
Change existing key verification tests in a way that each side awaits incoming key request rather than assuming the incoming order (and hacking a delay time)