### PR TITLE
Send an empty dictionary when calling /join to be spec compliant.

### DIFF
--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -2470,6 +2470,11 @@ andUnauthenticatedHandler: (MXRestClientUnauthenticatedHandler)unauthenticatedHa
                        @"third_party_signed":thirdPartySigned
                        };
     }
+    else
+    {
+        // A body is required even if empty
+        parameters = @{};
+    }
 
     // Characters in a room alias need to be escaped in the URL
     NSString *path = [NSString stringWithFormat:@"%@/join/%@",

--- a/changelog.d/6481.bugfix
+++ b/changelog.d/6481.bugfix
@@ -1,0 +1,1 @@
+MXRestClient: Send an empty dictionary when calling /join to be spec compliant.


### PR DESCRIPTION
The SDK isn't sending spec-complaint joins, and Synapse is about to stop handling these: https://github.com/matrix-org/synapse/issues/13388.

Fixes https://github.com/vector-im/element-ios/issues/6481.
