### PR TITLE
Stop using the room ID from the space child state events.

### DIFF
--- a/MatrixSDK/Space/MXSpaceService.swift
+++ b/MatrixSDK/Space/MXSpaceService.swift
@@ -376,12 +376,12 @@ public class MXSpaceService: NSObject {
                             spaceChildEventsPerChildRoomId[event.stateKey] = event.wireContent
 
                             var parentIds = parentIdsPerChildRoomId[event.stateKey] ?? Set()
-                            parentIds.insert(event.roomId)
+                            parentIds.insert(room.roomId)
                             parentIdsPerChildRoomId[event.stateKey] = parentIds
 
-                            var childrenIds = childrenIdsPerChildRoomId[event.roomId] ?? []
+                            var childrenIds = childrenIdsPerChildRoomId[room.roomId] ?? []
                             childrenIds.append(event.stateKey)
-                            childrenIdsPerChildRoomId[event.roomId] = childrenIds
+                            childrenIdsPerChildRoomId[room.roomId] = childrenIds
                         }
                     }
                     

--- a/changelog.d/6547.bugfix
+++ b/changelog.d/6547.bugfix
@@ -1,0 +1,1 @@
+MXSpaceService: Fix a crash on Synapse 1.65 following changes to the /hierarchy API.


### PR DESCRIPTION
This property was removed in Synapse 1.65 as it was going against the spec.

For more info see https://github.com/matrix-org/synapse/pull/13365 and https://github.com/vector-im/element-ios/issues/6547.