### PR TITLE
Fix `kickUser` to set `"leave"` membership

### DIFF
--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -2632,7 +2632,7 @@ andUnauthenticatedHandler: (MXRestClientUnauthenticatedHandler)unauthenticatedHa
                       [MXTools encodeURIComponent:userId]];
     
     NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
-    parameters[@"membership"] = @"kick";
+    parameters[@"membership"] = @"leave";
     
     if (reason)
     {


### PR DESCRIPTION
There is no such thing as a `"kick"` membership in the spec. The fact that Synapse aliases `"kick"` to `"leave"` is unspecced behaviour.