### PR TITLE
Fix setting a log level of .none.

### DIFF
--- a/MatrixSDK/Utils/MXLog.swift
+++ b/MatrixSDK/Utils/MXLog.swift
@@ -155,6 +155,7 @@ private var logger: SwiftyBeaver.Type = {
                                sizeLimit: configuration.logFilesSizeLimit)
         
         guard configuration.logLevel != .none else {
+            logger.removeAllDestinations()
             return
         }
         

--- a/changelog.d/sdk-1550.build
+++ b/changelog.d/sdk-1550.build
@@ -1,0 +1,1 @@
+MXLog: Ensure MXLogLevel.none works if it is set after another log level has already been configured.


### PR DESCRIPTION
Fixes #1550. There was a bug where setting the log level to `.none` had no effect if a call to `MXLogDebug` (etc) had already been called as the default configuration would already have been applied.