### PR TITLE
Allow setting room alias regardless of join rule

### DIFF
--- a/MatrixSDK/Contrib/Swift/MXSession.swift
+++ b/MatrixSDK/Contrib/Swift/MXSession.swift
@@ -163,6 +163,7 @@ public extension MXSession {
         let parameters = MXRoomCreationParameters()
         parameters.name = name
         parameters.topic = topic
+        parameters.roomAlias = aliasLocalPart
         
         let stateEventBuilder = MXRoomInitialStateEventBuilder()
         
@@ -173,7 +174,6 @@ public extension MXSession {
             }
             parameters.preset = kMXRoomPresetPublicChat
             parameters.visibility = kMXRoomDirectoryVisibilityPublic
-            parameters.roomAlias = aliasLocalPart
             let guestAccessStateEvent = stateEventBuilder.buildGuestAccessEvent(withAccess: .canJoin)
             parameters.addOrUpdateInitialStateEvent(guestAccessStateEvent)
             let historyVisibilityStateEvent = stateEventBuilder.buildHistoryVisibilityEvent(withVisibility: .worldReadable)

--- a/changelog.d/pr-1559.change
+++ b/changelog.d/pr-1559.change
@@ -1,0 +1,1 @@
+Allow setting room alias regardless of join rule


### PR DESCRIPTION
This simply allows to set a room alias on room creation regardless of join rule.