### PR TITLE
Fix incoming calls sometimes ringing after being answered on another client

### DIFF
--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -1345,13 +1345,6 @@ typedef void (^MXOnResumeDone)(void);
     if (self.preventPauseCount > 0)
     {
         self.preventPauseCount--;
-#if TARGET_OS_IPHONE
-        if (self.preventPauseCount == 0
-            && self.applicationStateService.applicationState == UIApplicationStateBackground)
-        {
-            [self pause];
-        }
-#endif
     }
 }
 
@@ -1376,6 +1369,15 @@ typedef void (^MXOnResumeDone)(void);
         {
             MXLogDebug(@"[MXSession] setPreventPauseCount: Actually pause the session");
             [self pause];
+        } else {
+#if TARGET_OS_IPHONE
+            // Pause the session if app is already in the background/inactive but pause wasn't requested
+            if (self.applicationStateService.applicationState != UIApplicationStateActive)
+            {
+                MXLogDebug(@"[MXSession] setPreventPauseCount: Pause session on already backgrounded/inactive app");
+                [self pause];
+            }
+#endif
         }
     }
 }

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -1369,7 +1369,9 @@ typedef void (^MXOnResumeDone)(void);
         {
             MXLogDebug(@"[MXSession] setPreventPauseCount: Actually pause the session");
             [self pause];
-        } else {
+        }
+        else
+        {
 #if TARGET_OS_IPHONE
             // Pause the session if app is already in the background/inactive but pause wasn't requested
             if (self.applicationStateService.applicationState != UIApplicationStateActive)

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -195,6 +195,10 @@ typedef void (^MXOnResumeDone)(void);
  */
 @property (nonatomic) NSUInteger preventPauseCount;
 
+#if TARGET_OS_IPHONE
+@property (nonatomic, strong, readonly) MXUIKitApplicationStateService *applicationStateService;
+#endif
+
 @property (nonatomic, readwrite) MXScanManager *scanManager;
 
 /**
@@ -233,6 +237,9 @@ typedef void (^MXOnResumeDone)(void);
         _accountData = [[MXAccountData alloc] init];
         peekingRooms = [NSMutableArray array];
         _preventPauseCount = 0;
+#if TARGET_OS_IPHONE
+        _applicationStateService = [MXUIKitApplicationStateService new];
+#endif
         directRoomsOperationsQueue = [NSMutableArray array];
         publicisedGroupsByUserId = [[NSMutableDictionary alloc] init];
         nativeToVirtualRoomIds = [NSMutableDictionary dictionary];
@@ -1338,6 +1345,13 @@ typedef void (^MXOnResumeDone)(void);
     if (self.preventPauseCount > 0)
     {
         self.preventPauseCount--;
+#if TARGET_OS_IPHONE
+        if (self.preventPauseCount == 0
+            && self.applicationStateService.applicationState == UIApplicationStateBackground)
+        {
+            [self pause];
+        }
+#endif
     }
 }
 

--- a/changelog.d/6614.bugfix
+++ b/changelog.d/6614.bugfix
@@ -1,0 +1,1 @@
+Fix incoming calls sometimes ringing after being answered on another client


### PR DESCRIPTION
Potential fix for https://github.com/vector-im/element-ios/issues/6614

Allows the MXSession to be paused if app is already in background when the preventPauseCount reaches 0.