### PR TITLE
Remove event from tracking

### DIFF
--- a/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
+++ b/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
@@ -889,7 +889,7 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
         else
         {
             MXLogErrorDetails(@"[MXRealmCryptoStore] performSessionOperationWithDevice. Error: olm session not found", @{
-                @"sessionId": sessionId
+                @"sessionId": sessionId ?: @"unknown"
             });
             block(nil);
         }
@@ -1008,7 +1008,7 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
             else
             {
                 MXLogErrorDetails(@"[MXRealmCryptoStore] performSessionOperationWithGroupSessionWithId. Error: Cannot build MXOlmInboundGroupSession for megolm session", @{
-                    @"sessionId": sessionId
+                    @"sessionId": sessionId ?: @"unknown"
                 });
                 block(nil);
             }
@@ -1016,7 +1016,7 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
         else
         {
             MXLogErrorDetails(@"[MXRealmCryptoStore] performSessionOperationWithGroupSessionWithId. Error: megolm session not found", @{
-                @"sessionId": sessionId
+                @"sessionId": sessionId ?: @"unknown"
             });
             block(nil);
         }

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -663,10 +663,10 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
         {
             NSDictionary *details = @{
                 @"event_id": event.eventId ?: @"unknown",
-                @"error": result.error ?: @"unknown",
-                @"event": event.JSONDictionary ?: @"unknown"
+                @"error": result.error ?: @"unknown"
             };
             MXLogErrorDetails(@"[MXCrypto] decryptEvent", details);
+            MXLogDebug(@"[MXCrypto] decryptEvent: Unable to decrypt event %@", event.JSONDictionary);
             
             if ([result.error.domain isEqualToString:MXDecryptingErrorDomain]
                 && result.error.code == MXDecryptingErrorBadEncryptedMessageCode)

--- a/MatrixSDKTests/Utils/MXSessionTracker.swift
+++ b/MatrixSDKTests/Utils/MXSessionTracker.swift
@@ -50,12 +50,12 @@ class MXSessionTracker {
     
     func printOpenMXSessions() {
         for (trackId, trackedMXSession) in trackedMXSessions {
-            MXLog.error("MXSession for user is not closed. It was created from:", context: [
+            MXLog.error("MXSession for user is not closed", context: [
                 "track_id": trackId,
-                "user_id": trackedMXSession.userDeviceId
             ])
+            MXLog.debug("MXSession was created from:")
             trackedMXSession.callStack.forEach { call in
-                MXLog.error("    -", context: call)
+                MXLog.debug("    - \(call)")
             }
         }
     }


### PR DESCRIPTION
Remove encrypted event from being tracked to analytics via Sentry, only track the eventId.