### PR TITLE
Cache inbound group sessions when decrypting

### DIFF
--- a/MatrixSDK/Crypto/MXOlmDevice.m
+++ b/MatrixSDK/Crypto/MXOlmDevice.m
@@ -544,17 +544,16 @@ NSInteger const kMXInboundGroupSessionCacheSize = 100;
     
     if (enableCache)
     {
-        __block MXOlmInboundGroupSession *session;
         @synchronized (self.inboundGroupSessionCache)
         {
-            session = (MXOlmInboundGroupSession *)[self.inboundGroupSessionCache get:sessionId];
+            MXOlmInboundGroupSession *session = (MXOlmInboundGroupSession *)[self.inboundGroupSessionCache get:sessionId];
             if (!session)
             {
                 session = [store inboundGroupSessionWithId:sessionId andSenderKey:senderKey];
                 [self.inboundGroupSessionCache put:sessionId object:session];
             }
+            block(session);
         }
-        block(session);
     }
     else
     {

--- a/MatrixSDK/Crypto/MXOlmDevice.m
+++ b/MatrixSDK/Crypto/MXOlmDevice.m
@@ -559,7 +559,10 @@ NSInteger const kMXInboundGroupSessionCacheSize = 100;
     {
         [store performSessionOperationWithGroupSessionWithId:sessionId senderKey:senderKey block:block];
     }
-    stopTracking();
+    if (stopTracking)
+    {
+        stopTracking();
+    }
 }
 
 - (void)resetReplayAttackCheckInTimeline:(NSString*)timeline

--- a/MatrixSDK/MXSDKOptions.h
+++ b/MatrixSDK/MXSDKOptions.h
@@ -214,15 +214,15 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic) BOOL enableCryptoV2;
 
+#endif
+
 /**
  Enable performance optimization where inbound group sessions are cached between decryption of events
  rather than fetched from the store every time.
  
- @remark The value is set randomly between YES / NO to perform a very basic A/B test
+ @remark By default, the value is set randomly between YES / NO to perform a very basic A/B test
  */
 @property (nonatomic) BOOL enableGroupSessionCache;
-
-#endif
 
 @end
 

--- a/MatrixSDK/MXSDKOptions.h
+++ b/MatrixSDK/MXSDKOptions.h
@@ -214,6 +214,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic) BOOL enableCryptoV2;
 
+/**
+ Enable performance optimization where inbound group sessions are cached between decryption of events
+ rather than fetched from the store every time.
+ 
+ @remark The value is set randomly between YES / NO to perform a very basic A/B test
+ */
+@property (nonatomic) BOOL enableGroupSessionCache;
+
 #endif
 
 @end

--- a/MatrixSDK/MXSDKOptions.m
+++ b/MatrixSDK/MXSDKOptions.m
@@ -58,6 +58,10 @@ static MXSDKOptions *sharedOnceInstance = nil;
         #if DEBUG
         _enableCryptoV2 = NO;
         #endif
+        
+        // The value is set randomly between YES / NO to perform a very basic A/B test
+        // measured by `analytics` (if set and enabled)
+        _enableGroupSessionCache = arc4random_uniform(2) == 1;
     }
     
     return self;

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -1406,6 +1406,7 @@ typedef void (^MXOnResumeDone)(void);
     dispatch_group_t initialSyncDispatchGroup = dispatch_group_create();
     
     __block MXTaskProfile *syncTaskProfile;
+    __block StopDurationTracking stopDurationTracking;
     __block MXSyncResponse *syncResponse;
     __block BOOL useLiveResponse = YES;
 
@@ -1437,6 +1438,13 @@ typedef void (^MXOnResumeDone)(void);
             BOOL isInitialSync = !self.isEventStreamInitialised;
             MXTaskProfileName taskName = isInitialSync ? MXTaskProfileNameStartupInitialSync : MXTaskProfileNameStartupIncrementalSync;
             syncTaskProfile = [MXSDKOptions.sharedInstance.profiler startMeasuringTaskWithName:taskName];
+            if (isInitialSync) {
+                // Temporarily tracking performance both by `MXSDKOptions.sharedInstance.profiler` (manually measuring time)
+                // and `MXSDKOptions.sharedInstance.analyticsDelegate` (delegating to performance monitoring tool).
+                // This ambiguity will be resolved in the future
+                NSString *operation = MXSDKOptions.sharedInstance.enableGroupSessionCache ? @"initialSync.enableGroupSessionCache" : @"initialSync.diableGroupSessionCache";
+                stopDurationTracking = [MXSDKOptions.sharedInstance.analyticsDelegate startDurationTrackingForName:@"MXSession" operation:operation];
+            }
         }
         
         NSString * streamToken = self.store.eventStreamToken;
@@ -1479,6 +1487,9 @@ typedef void (^MXOnResumeDone)(void);
             syncTaskProfile.units = syncResponse.rooms.join.count;
             
             [MXSDKOptions.sharedInstance.profiler stopMeasuringTaskWithProfile:syncTaskProfile];
+            if (stopDurationTracking) {
+                stopDurationTracking();
+            }
         }
         
         BOOL isInitialSync = !self.isEventStreamInitialised;

--- a/MatrixSDK/Utils/MXAnalyticsDelegate.h
+++ b/MatrixSDK/Utils/MXAnalyticsDelegate.h
@@ -20,6 +20,12 @@
 #import "MXCallHangupEventContent.h"
 #import "MXTaskProfile.h"
 
+/**
+ Callback function to cancel ongoing duration tracking
+ started by `[MXAnalyticsDelegate startDurationTracking]`
+ */
+typedef void (^StopDurationTracking)(void);
+
 NS_ASSUME_NONNULL_BEGIN
 
 /**
@@ -45,6 +51,21 @@ NS_ASSUME_NONNULL_BEGIN
  @param units the number of items the were completed during the task
  */
 - (void)trackDuration:(NSInteger)milliseconds name:(MXTaskProfileName)name units:(NSUInteger)units;
+
+/**
+ Start tracking the duration of a task and manually cancel when finished using the return handle
+ 
+ @note This method is similar to `trackDuration`, but instead of passing the measured duraction
+       as a parameter, it relies on the implementation of `MXAnalyticsDelegate` to perform the
+       measurements.
+ 
+ @param name Name of the entity being measured (e.g. `RoomsViewController` or `Crypto`)
+ @param operation Short code identifying the type of operation measured (e.g. `viewDidLoad` or `decrypt`)
+
+ 
+ @return Handle that can be used to stop the performance tracking
+ */
+- (StopDurationTracking)startDurationTrackingForName:(NSString *)name operation:(NSString *)operation;
 
 /**
  Report that a call has started.

--- a/MatrixSDK/Utils/MXAnalyticsDelegate.h
+++ b/MatrixSDK/Utils/MXAnalyticsDelegate.h
@@ -21,7 +21,7 @@
 #import "MXTaskProfile.h"
 
 /**
- Callback function to cancel ongoing duration tracking
+ Callback function to stop ongoing duration tracking
  started by `[MXAnalyticsDelegate startDurationTracking]`
  */
 typedef void (^StopDurationTracking)(void);
@@ -53,7 +53,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)trackDuration:(NSInteger)milliseconds name:(MXTaskProfileName)name units:(NSUInteger)units;
 
 /**
- Start tracking the duration of a task and manually cancel when finished using the return handle
+ Start tracking the duration of a task and manually stop when finished using the return handle
  
  @note This method is similar to `trackDuration`, but instead of passing the measured duraction
        as a parameter, it relies on the implementation of `MXAnalyticsDelegate` to perform the

--- a/changelog.d/pr-1566.change
+++ b/changelog.d/pr-1566.change
@@ -1,0 +1,1 @@
+Crypto: Cache inbound group sessions when decrypting


### PR DESCRIPTION
Improve megolm event decryption behaviour by caching rather than re-fetching inbounds group sessions from the store. In anecdotal comparison on a single device this leads to 5x - 10x performance improvement.

In order to observe the impact of this improvement more precisely, the following changes are made:
- add build flag that randomly selects between new cache behaviour and old fetch behaviour, which will result in a very basic form of A/B test
- add duration tracking to analytics to measure the difference between both (this is performed by Sentry in element-ios)
- add duration tracking for MXSession.initialSync which calls megolm decrypt methods

Note that the new performance tracking method conflicts with existing `MXProfiler` which does the time tracking manually, whereas Sentry handles performance measurements internally. This ambiguity will be resolved in a future PR

Once in Sentry, the following dashboards can be constructed from these events:

<img width="1162" alt="Screenshot 2022-08-26 at 16 33 33" src="https://user-images.githubusercontent.com/3922159/186941063-de21c30d-ebe6-4380-a78f-361b3c87c2f4.png">

