### PR TITLE
Add build flag for symmetric backup

### DIFF
--- a/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.m
+++ b/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.m
@@ -75,10 +75,19 @@ static Class DefaultAlgorithmClass;
 
 + (void)initialize
 {
-    AlgorithmClassesByName = @{
-        kMXCryptoCurve25519KeyBackupAlgorithm: MXCurve25519KeyBackupAlgorithm.class,
-        kMXCryptoAes256KeyBackupAlgorithm: MXAes256KeyBackupAlgorithm.class
-    };
+    if (MXSDKOptions.sharedInstance.enableSymmetricBackup)
+    {
+        AlgorithmClassesByName = @{
+            kMXCryptoCurve25519KeyBackupAlgorithm: MXCurve25519KeyBackupAlgorithm.class,
+            kMXCryptoAes256KeyBackupAlgorithm: MXAes256KeyBackupAlgorithm.class
+        };
+    }
+    else
+    {
+        AlgorithmClassesByName = @{
+            kMXCryptoCurve25519KeyBackupAlgorithm: MXCurve25519KeyBackupAlgorithm.class,
+        };
+    }
     DefaultAlgorithmClass = MXCurve25519KeyBackupAlgorithm.class;
 }
 

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -664,9 +664,9 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
             NSDictionary *details = @{
                 @"event_id": event.eventId ?: @"unknown",
                 @"error": result.error ?: @"unknown",
-                @"event": event.JSONDictionary ?: @"unknown"
             };
             MXLogErrorDetails(@"[MXCrypto] decryptEvent", details);
+            MXLogDebug(@"[MXCrypto] decryptEvent: Unable to decrypt event %@", event.JSONDictionary);
             
             if ([result.error.domain isEqualToString:MXDecryptingErrorDomain]
                 && result.error.code == MXDecryptingErrorBadEncryptedMessageCode)

--- a/MatrixSDK/MXSDKOptions.h
+++ b/MatrixSDK/MXSDKOptions.h
@@ -216,6 +216,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 #endif
 
+/**
+ Enable symmetric room key backups
+ 
+ @remark NO by default
+ */
+@property (nonatomic) BOOL enableSymmetricBackup;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/MatrixSDK/MXSDKOptions.m
+++ b/MatrixSDK/MXSDKOptions.m
@@ -58,6 +58,8 @@ static MXSDKOptions *sharedOnceInstance = nil;
         #if DEBUG
         _enableCryptoV2 = NO;
         #endif
+        
+        _enableSymmetricBackup = NO;
     }
     
     return self;

--- a/MatrixSDKTests/MXAes256KeyBackupTests.m
+++ b/MatrixSDKTests/MXAes256KeyBackupTests.m
@@ -29,6 +29,16 @@
 
 @implementation MXAes256KeyBackupTests
 
+- (void)setUp
+{
+    MXSDKOptions.sharedInstance.enableSymmetricBackup = YES;
+}
+
+- (void)tearDown
+{
+    MXSDKOptions.sharedInstance.enableSymmetricBackup = NO;
+}
+
 - (NSString *)algorithm
 {
     return kMXCryptoAes256KeyBackupAlgorithm;

--- a/changelog.d/pr-1567.change
+++ b/changelog.d/pr-1567.change
@@ -1,0 +1,1 @@
+KeyBackups: Add build flag for symmetric backup


### PR DESCRIPTION
Add build flag for symmetric backup, when dynamically constructing backup algoritm class, based on incomming algorithm.

Unrelated: remove event from event tracking, see https://github.com/matrix-org/matrix-ios-sdk/pull/1563