### PR TITLE
Release 0.23.17

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## Changes in 0.23.17 (2022-08-31)
+
+🙌 Improvements
+
+- KeyBackups: Add build flag for symmetric backup ([#1567](https://github.com/matrix-org/matrix-ios-sdk/pull/1567))
+
+
 ## Changes in 0.23.16 (2022-08-24)
 
 ✨ Features

--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "MatrixSDK"
-  s.version      = "0.23.16"
+  s.version      = "0.23.17"
   s.summary      = "The iOS SDK to build apps compatible with Matrix (https://www.matrix.org)"
 
   s.description  = <<-DESC

--- a/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.m
+++ b/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.m
@@ -75,10 +75,19 @@ static Class DefaultAlgorithmClass;
 
 + (void)initialize
 {
-    AlgorithmClassesByName = @{
-        kMXCryptoCurve25519KeyBackupAlgorithm: MXCurve25519KeyBackupAlgorithm.class,
-        kMXCryptoAes256KeyBackupAlgorithm: MXAes256KeyBackupAlgorithm.class
-    };
+    if (MXSDKOptions.sharedInstance.enableSymmetricBackup)
+    {
+        AlgorithmClassesByName = @{
+            kMXCryptoCurve25519KeyBackupAlgorithm: MXCurve25519KeyBackupAlgorithm.class,
+            kMXCryptoAes256KeyBackupAlgorithm: MXAes256KeyBackupAlgorithm.class
+        };
+    }
+    else
+    {
+        AlgorithmClassesByName = @{
+            kMXCryptoCurve25519KeyBackupAlgorithm: MXCurve25519KeyBackupAlgorithm.class,
+        };
+    }
     DefaultAlgorithmClass = MXCurve25519KeyBackupAlgorithm.class;
 }
 

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -664,9 +664,9 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
             NSDictionary *details = @{
                 @"event_id": event.eventId ?: @"unknown",
                 @"error": result.error ?: @"unknown",
-                @"event": event.JSONDictionary ?: @"unknown"
             };
             MXLogErrorDetails(@"[MXCrypto] decryptEvent", details);
+            MXLogDebug(@"[MXCrypto] decryptEvent: Unable to decrypt event %@", event.JSONDictionary);
             
             if ([result.error.domain isEqualToString:MXDecryptingErrorDomain]
                 && result.error.code == MXDecryptingErrorBadEncryptedMessageCode)

--- a/MatrixSDK/MXSDKOptions.h
+++ b/MatrixSDK/MXSDKOptions.h
@@ -216,6 +216,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 #endif
 
+/**
+ Enable symmetric room key backups
+ 
+ @remark NO by default
+ */
+@property (nonatomic) BOOL enableSymmetricBackup;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/MatrixSDK/MXSDKOptions.m
+++ b/MatrixSDK/MXSDKOptions.m
@@ -58,6 +58,8 @@ static MXSDKOptions *sharedOnceInstance = nil;
         #if DEBUG
         _enableCryptoV2 = NO;
         #endif
+        
+        _enableSymmetricBackup = NO;
     }
     
     return self;

--- a/MatrixSDK/MatrixSDKVersion.m
+++ b/MatrixSDK/MatrixSDKVersion.m
@@ -16,4 +16,4 @@
 
 #import <Foundation/Foundation.h>
 
-NSString *const MatrixSDKVersion = @"0.23.16";
+NSString *const MatrixSDKVersion = @"0.23.17";

--- a/MatrixSDKTests/MXAes256KeyBackupTests.m
+++ b/MatrixSDKTests/MXAes256KeyBackupTests.m
@@ -29,6 +29,16 @@
 
 @implementation MXAes256KeyBackupTests
 
+- (void)setUp
+{
+    MXSDKOptions.sharedInstance.enableSymmetricBackup = YES;
+}
+
+- (void)tearDown
+{
+    MXSDKOptions.sharedInstance.enableSymmetricBackup = NO;
+}
+
 - (NSString *)algorithm
 {
     return kMXCryptoAes256KeyBackupAlgorithm;

--- a/changelog.d/pr-1567.change
+++ b/changelog.d/pr-1567.change
@@ -1,1 +1,0 @@
-KeyBackups: Add build flag for symmetric backup

--- a/changelog.d/pr-1567.change
+++ b/changelog.d/pr-1567.change
@@ -1,0 +1,1 @@
+KeyBackups: Add build flag for symmetric backup


### PR DESCRIPTION
This PR prepares the release of MatrixSDK v0.23.17.

Notes:
- This PR targets `release/0.23.17/master`, which has been cut from `master`.
- It includes changes to the `Podfile`, but _not_ the corresponding changes to `Podfile.lock`, as `pod install` hasn't yet been run.
  This is because the `Podfile` targets future versions of dependencies yet to be released, so `pod install` wouldn't be able to find them yet.
- When the CI runs its checks, it will temporarily point to the pending release branches of those dependencies beforehand
- It is only during `release:finish` that `pod update` will be run -- updating the `Podfile.lock`
to use the now officially released dependencies -- before ultimately merging `release/0.23.17/master` into `master` to tag the release.

---

➡️  Once this PR is merged, you will need to first ensure that the products this one depends on are fully released,
   then run `bundle exec rake release:finish` to close this release.

💡 If you want to review _only_ the changes made since the release branch was cut from `develop`,
   you can [check those here](https://github.com/matrix-org/matrix-ios-sdk/compare/develop...release/0.23.17/release)
