### PR TITLE
README: Update the badge header

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,13 @@
-.. image:: https://codecov.io/gh/matrix-org/matrix-ios-sdk/branch/develop/graph/badge.svg?token=2c9mzJoVpu:target: https://codecov.io/gh/matrix-org/matrix-ios-sdk
+.. image:: https://img.shields.io/cocoapods/v/MatrixSDK?style=flat-square 
+   :target: https://github.com/matrix-org/matrix-ios-sdk/releases
+.. image:: https://img.shields.io/cocoapods/p/MatrixSDK?style=flat-square
+   :target: README.rst
+.. image:: https://img.shields.io/github/workflow/status/matrix-org/matrix-ios-sdk/Lint%20CI/develop?style=flat-square 
+   :target: https://github.com/matrix-org/matrix-ios-sdk/actions?query=branch%3Adevelop
+.. image:: https://codecov.io/gh/matrix-org/matrix-ios-sdk/branch/develop/graph/badge.svg?token=2c9mzJoVpu 
+   :target: https://codecov.io/gh/matrix-org/matrix-ios-sdk
+.. image:: https://img.shields.io/badge/License-Apache%202.0-yellowgreen.svg?style=flat-square 
+   :target: https://opensource.org/licenses/Apache-2.0
 
 Matrix iOS SDK
 ==============

--- a/changelog.d/pr-1569.doc
+++ b/changelog.d/pr-1569.doc
@@ -1,0 +1,1 @@
+README: Update the badge header


### PR DESCRIPTION
More importantly, fix the coverage one to make it open the codevoc.io URL correctly.

The new header looks like that now:
<img width="451" alt="image" src="https://user-images.githubusercontent.com/8418515/187696976-23d11522-dfb9-4352-b32c-457c03a0f1a6.png">
