### PR TITLE
Create lazy in-memory room encryptors

### DIFF
--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -2527,9 +2527,39 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 {
     if (![algorithm isEqualToString:kMXCryptoMegolmAlgorithm])
     {
+        MXLogErrorDetails(@"[MXCrypto] getRoomEncryptor: algorithm is not supported", @{
+            @"algorithm": algorithm ?: @"unknown"
+        });
         return nil;
     }
-    return roomEncryptors[roomId];
+
+    id<MXEncrypting> alg = roomEncryptors[roomId];
+    if (alg)
+    {
+        return alg;
+    }
+    
+    NSString *existingAlgorithm = [self.store algorithmForRoom:roomId];
+    if ([algorithm isEqualToString:existingAlgorithm])
+    {
+        MXLogErrorDetails(@"[MXCrypto] getRoomEncryptor: algorithm does not match the room", @{
+            @"algorithm": algorithm ?: @"unknown"
+        });
+        return nil;
+    }
+    
+    Class algClass = [[MXCryptoAlgorithms sharedAlgorithms] encryptorClassForAlgorithm:algorithm];
+    if (!algClass)
+    {
+        MXLogErrorDetails(@"[MXCrypto] getRoomEncryptor: cannot get encryptor for algorithm", @{
+            @"algorithm": algorithm ?: @"unknown"
+        });
+        return nil;
+    }
+    
+    alg = [[algClass alloc] initWithCrypto:self andRoom:roomId];
+    roomEncryptors[roomId] = alg;
+    return alg;
 }
 
 - (NSDictionary*)signObject:(NSDictionary*)object

--- a/changelog.d/pr-1570.change
+++ b/changelog.d/pr-1570.change
@@ -1,0 +1,1 @@
+Crypto: Create lazy in-memory room encryptors


### PR DESCRIPTION
The existing `[MXCrypto getRoomEncryptor]` method is used by a variety of codepaths, incl. re-sharing room keys etc. It returns a cached / in-memory value of `MXMegolmEncryptor`, but only if it was previously set to memory, typically by `ensureEncryptionInRoom` method (which performs a bunch of other actions). This method is typically called when a user starts typing in a given room.

When a user launches the app the `roomEncryptors` dictionary will be empty for all rooms, and encryptors will only be created if a user types a message in that room, or some message arrives to this device. It is not however created when the user receives a `m.room_key_request` for this room, and thus silently fails in re-sharing a given key, leaving the requester with UISIs.

To solve this, this PR ensures that `getRoomEncryptor` can instantiate an in-memory encryptor if it does not exist already, rather than waiting on `ensureEncryptionInRoom` to be called. That way we always return an encryptor when needed, and the client will respond to key requests even after fresh app start