### PR TITLE
Remove partialTextMessage support

### DIFF
--- a/MatrixSDK/Background/MXBackgroundStore.swift
+++ b/MatrixSDK/Background/MXBackgroundStore.swift
@@ -201,15 +201,6 @@ class MXBackgroundStore: NSObject, MXStore {
     func deleteGroup(_ groupId: String) {
     }
 
-    @available(*, deprecated, message: "use storePartialAttributedTextMessage")
-    func storePartialTextMessage(forRoom roomId: String, partialTextMessage: String) {
-    }
-
-    @available(*, deprecated, message: "use partialAttributedTextMessage")
-    func partialTextMessage(ofRoom roomId: String) -> String? {
-        return nil
-    }
-
     func storePartialAttributedTextMessage(forRoom roomId: String, partialAttributedTextMessage: NSAttributedString) {
     }
 

--- a/MatrixSDK/Data/MXRoom.h
+++ b/MatrixSDK/Data/MXRoom.h
@@ -164,15 +164,6 @@ FOUNDATION_EXPORT NSInteger const kMXRoomInvalidInviteSenderErrorCode;
  The text message partially typed by the user but not yet sent.
  The value is stored by the session store. Thus, it can be retrieved
  when the application restarts.
- 
- @deprecated use partialAttributedTextMessage
- */
-@property (nonatomic) NSString *partialTextMessage __deprecated_msg("use partialAttributedTextMessage");
-
-/**
- The text message partially typed by the user but not yet sent.
- The value is stored by the session store. Thus, it can be retrieved
- when the application restarts.
  */
 // @TODO(summary): Move to MXRoomSummary
 @property (nonatomic) NSAttributedString *partialAttributedTextMessage;

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -381,17 +381,6 @@ NSInteger const kMXRoomInvalidInviteSenderErrorCode = 9002;
     return operation;
 }
 
-
-- (void)setPartialTextMessage:(NSString *)partialTextMessage
-{
-    [mxSession.store storePartialTextMessageForRoom:self.roomId partialTextMessage:partialTextMessage];
-}
-
-- (NSString *)partialTextMessage
-{
-    return [mxSession.store partialTextMessageOfRoom:self.roomId];
-}
-
 - (void)setPartialAttributedTextMessage:(NSAttributedString *)partialAttributedTextMessage
 {
     [mxSession.store storePartialAttributedTextMessageForRoom:self.roomId partialAttributedTextMessage:partialAttributedTextMessage];

--- a/MatrixSDK/Data/Store/MXFileStore/MXFileRoomStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileRoomStore.m
@@ -32,8 +32,6 @@
         self.hasReachedHomeServerPaginationEnd = [aDecoder decodeBoolForKey:@"hasReachedHomeServerPaginationEnd"];
         self.hasLoadedAllRoomMembersForRoom = [aDecoder decodeBoolForKey:@"hasLoadedAllRoomMembersForRoom"];
 
-        self.partialTextMessage = [aDecoder decodeObjectForKey:@"partialTextMessage"];
-
         self.partialAttributedTextMessage = [aDecoder decodeObjectForKey:@"partialAttributedTextMessage"];
 
         // Rebuild the messagesByEventIds cache
@@ -67,10 +65,6 @@
     [aCoder encodeBool:self.hasReachedHomeServerPaginationEnd forKey:@"hasReachedHomeServerPaginationEnd"];
     [aCoder encodeBool:self.hasLoadedAllRoomMembersForRoom forKey:@"hasLoadedAllRoomMembersForRoom"];
 
-    if (self.partialTextMessage)
-    {
-        [aCoder encodeObject:self.partialTextMessage forKey:@"partialTextMessage"];
-    }
     if (self.partialAttributedTextMessage)
     {
         [aCoder encodeObject:self.partialAttributedTextMessage forKey:@"partialAttributedTextMessage"];

--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
@@ -440,16 +440,6 @@ static NSUInteger preloadOptions;
     }
 }
 
-- (void)storePartialTextMessageForRoom:(NSString *)roomId partialTextMessage:(NSString *)partialTextMessage
-{
-    [super storePartialTextMessageForRoom:roomId partialTextMessage:partialTextMessage];
-    
-    if (NSNotFound == [roomsToCommitForMessages indexOfObject:roomId])
-    {
-        [roomsToCommitForMessages addObject:roomId];
-    }
-}
-
 - (void)storePartialAttributedTextMessageForRoom:(NSString *)roomId partialAttributedTextMessage:(NSAttributedString *)partialAttributedTextMessage
 {
     [super storePartialAttributedTextMessageForRoom:roomId partialAttributedTextMessage:partialAttributedTextMessage];

--- a/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryRoomStore.h
+++ b/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryRoomStore.h
@@ -113,13 +113,6 @@
 
 /**
  The text message partially typed by the user but not yet sent in the room.
-
- @deprecated use partialAttributedTextMessage
- */
-@property (nonatomic) NSString *partialTextMessage __deprecated_msg("use partialAttributedTextMessage");
-
-/**
- The text message partially typed by the user but not yet sent in the room.
  */
 @property (nonatomic) NSAttributedString *partialAttributedTextMessage;
 

--- a/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryStore.m
+++ b/MatrixSDK/Data/Store/MXMemoryStore/MXMemoryStore.m
@@ -171,18 +171,6 @@
     return [roomStore enumeratorForMessagesWithTypeIn:types];
 }
 
-- (void)storePartialTextMessageForRoom:(NSString *)roomId partialTextMessage:(NSString *)partialTextMessage
-{
-    MXMemoryRoomStore *roomStore = [self getOrCreateRoomStore:roomId];
-    roomStore.partialTextMessage = partialTextMessage;
-}
-
-- (NSString *)partialTextMessageOfRoom:(NSString *)roomId
-{
-    MXMemoryRoomStore *roomStore = [self getOrCreateRoomStore:roomId];
-    return roomStore.partialTextMessage;
-}
-
 - (void)storePartialAttributedTextMessageForRoom:(NSString *)roomId partialAttributedTextMessage:(NSAttributedString *)partialAttributedTextMessage
 {
     MXMemoryRoomStore *roomStore = [self getOrCreateRoomStore:roomId];

--- a/MatrixSDK/Data/Store/MXNoStore/MXNoStore.m
+++ b/MatrixSDK/Data/Store/MXNoStore/MXNoStore.m
@@ -40,9 +40,6 @@
     NSMutableDictionary *lastMessages;
 
     // key: roomId, value: the text message the user typed
-    NSMutableDictionary *partialTextMessages;
-
-    // key: roomId, value: the text message the user typed
     NSMutableDictionary *partialAttributedTextMessages;
 
     NSString *eventStreamToken;
@@ -74,7 +71,6 @@
         hasReachedHomeServerPaginations = [NSMutableDictionary dictionary];
         hasLoadedAllRoomMembersForRooms = [NSMutableDictionary dictionary];
         lastMessages = [NSMutableDictionary dictionary];
-        partialTextMessages = [NSMutableDictionary dictionary];
         partialAttributedTextMessages = [NSMutableDictionary dictionary];
         users = [NSMutableDictionary dictionary];
         groups = [NSMutableDictionary dictionary];
@@ -168,10 +164,6 @@
     {
         [lastMessages removeObjectForKey:roomId];
     }
-    if (partialTextMessages[roomId])
-    {
-        [partialTextMessages removeObjectForKey:roomId];
-    }
     if (partialAttributedTextMessages[roomId])
     {
         [partialAttributedTextMessages removeObjectForKey:roomId];
@@ -187,7 +179,6 @@
     [hasReachedHomeServerPaginations removeAllObjects];
     [hasLoadedAllRoomMembersForRooms removeAllObjects];
     [lastMessages removeAllObjects];
-    [partialTextMessages removeAllObjects];
     [partialAttributedTextMessages removeAllObjects];
     [roomSummaryStore removeAllSummaries];
 }
@@ -381,23 +372,6 @@
     success(nil);
 }
 
-- (void)storePartialTextMessageForRoom:(NSString *)roomId partialTextMessage:(NSString *)partialTextMessage
-{
-    if (partialTextMessage)
-    {
-        partialTextMessages[roomId] = partialTextMessage;
-    }
-    else
-    {
-        [partialTextMessages removeObjectForKey:roomId];
-    }
-}
-
-- (NSString *)partialTextMessageOfRoom:(NSString *)roomId
-{
-    return partialTextMessages[roomId];
-}
-
 - (void)storePartialAttributedTextMessageForRoom:(NSString *)roomId partialAttributedTextMessage:(NSAttributedString *)partialAttributedTextMessage
 {
     if (partialAttributedTextMessage)
@@ -497,7 +471,6 @@
     [highlightCounts removeAllObjects];
     [hasReachedHomeServerPaginations removeAllObjects];
     [lastMessages removeAllObjects];
-    [partialTextMessages removeAllObjects];
     [partialAttributedTextMessages removeAllObjects];
     [users removeAllObjects];
     [groups removeAllObjects];

--- a/MatrixSDK/Data/Store/MXStore.h
+++ b/MatrixSDK/Data/Store/MXStore.h
@@ -230,27 +230,6 @@
 /**
  Store the text message partially typed by the user but not yet sent.
 
- @deprecated use storePartialAttributedTextMessageForRoom
-
- @param roomId the id of the room.
- @param partialTextMessage the text to store. Nil to reset it.
- */
-- (void)storePartialTextMessageForRoom:(nonnull NSString*)roomId
-                    partialTextMessage:(nonnull NSString*)partialTextMessage __deprecated_msg("use storePartialAttributedTextMessageForRoom");
-
-/**
- The text message typed by the user but not yet sent.
-
- @deprecated use partialAttributedTextMessageOfRoom
-
- @param roomId the id of the room.
- @return the text message. Can be nil.
- */
-- (NSString* _Nullable)partialTextMessageOfRoom:(nonnull NSString*)roomId __deprecated_msg("use partialAttributedTextMessageOfRoom");
-
-/**
- Store the text message partially typed by the user but not yet sent.
-
  @param roomId the id of the room.
  @param partialAttributedTextMessage the text to store. Nil to reset it.
  */

--- a/changelog.d/6670.change
+++ b/changelog.d/6670.change
@@ -1,0 +1,1 @@
+Remove MXRoom's partialTextMessage support


### PR DESCRIPTION
Removes the support for MXRoom's partialTextMessage as it has been deprecated for a few months now and since it's usage was the root cause of issue https://github.com/vector-im/element-ios/issues/6670

Part of https://github.com/vector-im/element-ios/pull/6671