### PR TITLE
Upgrade minimum iOS and OSX deployment target

### DIFF
--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -22,13 +22,13 @@ Pod::Spec.new do |s|
   s.requires_arc  = true
   s.swift_versions = ['5.1', '5.2']
   
-  s.ios.deployment_target = "11.0"
-  s.osx.deployment_target = "10.12"
+  s.ios.deployment_target = "13.0"
+  s.osx.deployment_target = "10.15"
   
   s.default_subspec = 'Core'
   s.subspec 'Core' do |ss|
-      ss.ios.deployment_target = "11.0"
-      ss.osx.deployment_target = "10.12"
+      ss.ios.deployment_target = "13.0"
+      ss.osx.deployment_target = "10.15"
       
       ss.source_files = "MatrixSDK", "MatrixSDK/**/*.{h,m}", "MatrixSDK/**/*.{swift}"
       ss.osx.exclude_files = "MatrixSDK/VoIP/MXiOSAudioOutputRoute*.swift"
@@ -49,7 +49,7 @@ Pod::Spec.new do |s|
   end
 
   s.subspec 'JingleCallStack' do |ss|
-    ss.ios.deployment_target = "12.0"
+    ss.ios.deployment_target = "13.0"
     
     ss.source_files  = "MatrixSDKExtensions/VoIP/Jingle/**/*.{h,m}"
     

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -7652,8 +7652,8 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_SWIFT_FLAGS = "-D DEBUG";
@@ -7709,8 +7709,8 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = "";
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -7845,7 +7845,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = org.matrix.MatrixSDK;
 				PRODUCT_NAME = MatrixSDK;
@@ -7873,7 +7873,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = org.matrix.MatrixSDK;
 				PRODUCT_NAME = MatrixSDK;
@@ -7905,7 +7905,6 @@
 				INFOPLIST_FILE = MatrixSDKTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "matrix.org.MatrixSDKTests-macOS";
@@ -7937,7 +7936,6 @@
 				INFOPLIST_FILE = MatrixSDKTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "matrix.org.MatrixSDKTests-macOS";
 				PRODUCT_NAME = MatrixSDKTests;

--- a/MatrixSDK/Contrib/Swift/Data/MXRoom.swift
+++ b/MatrixSDK/Contrib/Swift/Data/MXRoom.swift
@@ -39,7 +39,6 @@ public extension MXRoom {
     /**
      The current list of members of the room using async API.
      */
-    @available(iOS 13.0.0, macOS 10.15.0, *)
     func members() async throws -> MXRoomMembers? {
         try await performCallbackRequest {
             members(completion: $0)

--- a/MatrixSDK/Contrib/Swift/MXResponse.swift
+++ b/MatrixSDK/Contrib/Swift/MXResponse.swift
@@ -227,7 +227,6 @@ internal func uncurryResponse<T>(_ response: MXResponse<T>, success: @escaping (
 ///     room.members($0)
 /// }
 /// ```
-@available(iOS 13.0.0, macOS 10.15.0, *)
 internal func performCallbackRequest<T>(_ request: (@escaping (MXResponse<T>) -> Void) -> Void) async throws -> T {
     return try await withCheckedThrowingContinuation { continuation in
         request {

--- a/MatrixSDK/Crypto/CrossSigning/MXCrossSigningInfoSource.swift
+++ b/MatrixSDK/Crypto/CrossSigning/MXCrossSigningInfoSource.swift
@@ -20,7 +20,6 @@ import Foundation
 
 /// Convenience struct which transforms `MatrixSDKCrypto` cross signing info formats
 /// into `MatrixSDK` `MXCrossSigningInfo` formats.
-@available(iOS 13.0.0, *)
 struct MXCrossSigningInfoSource {
     private let source: MXCryptoUserIdentitySource
     

--- a/MatrixSDK/Crypto/CrossSigning/MXCrossSigningV2.swift
+++ b/MatrixSDK/Crypto/CrossSigning/MXCrossSigningV2.swift
@@ -21,7 +21,6 @@ import Foundation
 /// A work-in-progress subclass of `MXCrossSigning` instantiated and used by `MXCryptoV2`.
 ///
 /// Note: `MXCrossSigning` will be defined as a protocol in the future to avoid subclasses.
-@available(iOS 13.0.0, *)
 class MXCrossSigningV2: MXCrossSigning {
     enum Error: Swift.Error {
         case missingAuthSession

--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoMachine.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoMachine.swift
@@ -27,7 +27,6 @@ typealias GetRoomAction = (String) -> MXRoom?
 /// Two main responsibilities of the `MXCryptoMachine` are:
 /// - mapping to and from raw strings passed into the Rust machine
 /// - performing network requests and marking them as completed on behalf of the Rust machine
-@available(iOS 13.0.0, *)
 class MXCryptoMachine {
     actor RoomQueues {
         private var queues = [String: MXTaskQueue]()
@@ -98,7 +97,6 @@ class MXCryptoMachine {
     }
 }
 
-@available(iOS 13.0.0, *)
 extension MXCryptoMachine: MXCryptoIdentity {
     var userId: String {
         return machine.userId()
@@ -125,7 +123,6 @@ extension MXCryptoMachine: MXCryptoIdentity {
     }
 }
 
-@available(iOS 13.0.0, *)
 extension MXCryptoMachine: MXCryptoSyncing {
     func handleSyncResponse(
         toDevice: MXToDeviceSyncResponse?,
@@ -244,7 +241,6 @@ extension MXCryptoMachine: MXCryptoSyncing {
     }
 }
 
-@available(iOS 13.0.0, *)
 extension MXCryptoMachine: MXCryptoDevicesSource {
     func devices(userId: String) -> [Device] {
         do {
@@ -265,7 +261,6 @@ extension MXCryptoMachine: MXCryptoDevicesSource {
     }
 }
 
-@available(iOS 13.0.0, *)
 extension MXCryptoMachine: MXCryptoUserIdentitySource {
     func isUserVerified(userId: String) -> Bool {
         do {
@@ -292,7 +287,6 @@ extension MXCryptoMachine: MXCryptoUserIdentitySource {
     }
 }
 
-@available(iOS 13.0.0, *)
 extension MXCryptoMachine: MXCryptoEventEncrypting {
     func shareRoomKeysIfNecessary(roomId: String, users: [String]) async throws {
         try await sessionsQueue.sync { [weak self] in
@@ -376,7 +370,6 @@ extension MXCryptoMachine: MXCryptoEventEncrypting {
     }
 }
 
-@available(iOS 13.0.0, *)
 extension MXCryptoMachine: MXCryptoCrossSigning {
     func crossSigningStatus() -> CrossSigningStatus {
         return machine.crossSigningStatus()
@@ -391,7 +384,6 @@ extension MXCryptoMachine: MXCryptoCrossSigning {
     }
 }
 
-@available(iOS 13.0.0, *)
 extension MXCryptoMachine: MXCryptoVerificationRequesting {
     func requestSelfVerification(methods: [String]) async throws -> VerificationRequest {
         guard let result = try machine.requestSelfVerification(methods: methods) else {
@@ -467,7 +459,6 @@ extension MXCryptoMachine: MXCryptoVerificationRequesting {
     }
 }
 
-@available(iOS 13.0.0, *)
 extension MXCryptoMachine: MXCryptoVerifying {
     func verification(userId: String, flowId: String) -> Verification? {
         return machine.getVerification(userId: userId, flowId: flowId)
@@ -495,7 +486,6 @@ extension MXCryptoMachine: MXCryptoVerifying {
     }
 }
 
-@available(iOS 13.0.0, *)
 extension MXCryptoMachine: MXCryptoSASVerifying {
     func startSasVerification(userId: String, flowId: String) async throws -> Sas {
         guard let result = try machine.startSasVerification(userId: userId, flowId: flowId) else {
@@ -520,7 +510,6 @@ extension MXCryptoMachine: MXCryptoSASVerifying {
     }
 }
 
-@available(iOS 13.0.0, *)
 extension MXCryptoMachine: Logger {
     func log(logLine: String) {
         MXLog.debug("[MXCryptoMachine] \(logLine)")

--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoProtocols.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoProtocols.swift
@@ -23,7 +23,6 @@ import MatrixSDKCrypto
 /// A set of protocols defining the functionality in `MatrixSDKCrypto` and separating them into logical units
 
 /// Cryptographic identity of the currently signed-in user
-@available(iOS 13.0.0, *)
 protocol MXCryptoIdentity {
     var userId: String { get }
     var deviceId: String { get }
@@ -32,7 +31,6 @@ protocol MXCryptoIdentity {
 }
 
 /// Handler for cryptographic events in the sync loop
-@available(iOS 13.0.0, *)
 protocol MXCryptoSyncing: MXCryptoIdentity {
     func handleSyncResponse(
         toDevice: MXToDeviceSyncResponse?,
@@ -45,14 +43,12 @@ protocol MXCryptoSyncing: MXCryptoIdentity {
 }
 
 /// Source of user devices and their cryptographic trust status
-@available(iOS 13.0.0, *)
 protocol MXCryptoDevicesSource: MXCryptoIdentity {
     func device(userId: String, deviceId: String) -> Device?
     func devices(userId: String) -> [Device]
 }
 
 /// Source of user identities and their cryptographic trust status
-@available(iOS 13.0.0, *)
 protocol MXCryptoUserIdentitySource: MXCryptoIdentity {
     func userIdentity(userId: String) -> UserIdentity?
     func isUserVerified(userId: String) -> Bool
@@ -60,7 +56,6 @@ protocol MXCryptoUserIdentitySource: MXCryptoIdentity {
 }
 
 /// Event encryption and decryption
-@available(iOS 13.0.0, *)
 protocol MXCryptoEventEncrypting: MXCryptoIdentity {
     func shareRoomKeysIfNecessary(roomId: String, users: [String]) async throws
     func encrypt(_ content: [AnyHashable: Any], roomId: String, eventType: String, users: [String]) async throws -> [String: Any]
@@ -68,14 +63,12 @@ protocol MXCryptoEventEncrypting: MXCryptoIdentity {
 }
 
 /// Cross-signing functionality
-@available(iOS 13.0.0, *)
 protocol MXCryptoCrossSigning: MXCryptoUserIdentitySource {
     func crossSigningStatus() -> CrossSigningStatus
     func bootstrapCrossSigning(authParams: [AnyHashable: Any]) async throws
 }
 
 /// Lifecycle of verification request
-@available(iOS 13.0.0, *)
 protocol MXCryptoVerificationRequesting: MXCryptoIdentity {
     func requestSelfVerification(methods: [String]) async throws -> VerificationRequest
     func requestVerification(userId: String, roomId: String, methods: [String]) async throws -> VerificationRequest
@@ -85,7 +78,6 @@ protocol MXCryptoVerificationRequesting: MXCryptoIdentity {
 }
 
 /// Lifecycle of verification transaction
-@available(iOS 13.0.0, *)
 protocol MXCryptoVerifying: MXCryptoIdentity {
     func verification(userId: String, flowId: String) -> Verification?
     func confirmVerification(userId: String, flowId: String) async throws
@@ -93,7 +85,6 @@ protocol MXCryptoVerifying: MXCryptoIdentity {
 }
 
 /// Lifecycle of SAS-specific verification transaction
-@available(iOS 13.0.0, *)
 protocol MXCryptoSASVerifying: MXCryptoVerifying {
     func startSasVerification(userId: String, flowId: String) async throws -> Sas
     func acceptSasVerification(userId: String, flowId: String) async throws

--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoRequests.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoRequests.swift
@@ -22,7 +22,6 @@ import MatrixSDKCrypto
 
 /// Convenience class to delegate network requests originating in Rust crypto module
 /// to the native REST API client
-@available(iOS 13.0.0, *)
 struct MXCryptoRequests {
     private let restClient: MXRestClient
     init(restClient: MXRestClient) {
@@ -109,7 +108,6 @@ struct MXCryptoRequests {
 }
 
 /// Convenience structs mapping Rust requests to data for native REST API requests
-@available(iOS 13.0.0, *)
 extension MXCryptoRequests {
     enum Error: Swift.Error {
         case cannotCreateRequest
@@ -178,7 +176,6 @@ extension MXCryptoRequests {
     }
 }
 
-@available(iOS 13.0.0, *)
 extension UploadSigningKeysRequest {
     func jsonKeys() throws -> [AnyHashable: Any] {
         guard
@@ -197,7 +194,6 @@ extension UploadSigningKeysRequest {
     }
 }
 
-@available(iOS 13.0.0, *)
 extension SignatureUploadRequest {
     func jsonSignature() throws -> [AnyHashable: Any] {
         guard let signatures = MXTools.deserialiseJSONString(body) as? [AnyHashable: Any] else {

--- a/MatrixSDK/Crypto/Devices/MXDeviceInfoSource.swift
+++ b/MatrixSDK/Crypto/Devices/MXDeviceInfoSource.swift
@@ -20,7 +20,6 @@ import Foundation
 
 /// Convenience struct which transforms `MatrixSDKCrypto` device formats
 /// into `MatrixSDK` `MXDeviceInfo` formats.
-@available(iOS 13.0.0, *)
 struct MXDeviceInfoSource {
     private let source: MXCryptoDevicesSource
     

--- a/MatrixSDK/Crypto/MXCryptoV2.swift
+++ b/MatrixSDK/Crypto/MXCryptoV2.swift
@@ -28,9 +28,6 @@ public extension MXCrypto {
         let log = MXNamedLog(name: "MXCryptoV2")
         
         #if os(iOS)
-            guard #available(iOS 13.0.0, *) else {
-                return nil
-            }
             guard MXSDKOptions.sharedInstance().enableCryptoV2 else {
                 return nil
             }
@@ -71,7 +68,6 @@ import MatrixSDKCrypto
 ///
 /// Another benefit of using a subclass and overriding every method with new implementation is that existing integration tests
 /// for crypto-related functionality can still run (and eventually pass) without any changes.
-@available(iOS 13.0.0, *)
 private class MXCryptoV2: MXCrypto {
     enum Error: Swift.Error {
         case missingRoom

--- a/MatrixSDK/Crypto/Trust/MXTrustLevelSource.swift
+++ b/MatrixSDK/Crypto/Trust/MXTrustLevelSource.swift
@@ -20,7 +20,6 @@ import Foundation
 
 /// Convenience struct which transforms `MatrixSDKCrypto` trust levels
 /// into `MatrixSDK` `MXUserTrustLevel`, `MXDeviceTrustLevel` and `MXUsersTrustLevelSummary` formats.
-@available(iOS 13.0.0, *)
 struct MXTrustLevelSource {
     private let userIdentitySource: MXCryptoUserIdentitySource
     private let devicesSource: MXCryptoDevicesSource

--- a/MatrixSDK/Crypto/Verification/MXKeyVerificationManagerV2.swift
+++ b/MatrixSDK/Crypto/Verification/MXKeyVerificationManagerV2.swift
@@ -22,10 +22,8 @@ enum MXKeyVerificationUpdateResult {
     case removed
 }
 
-@available(iOS 13.0.0, *)
 typealias MXCryptoVerification = MXCryptoVerificationRequesting & MXCryptoSASVerifying
 
-@available(iOS 13.0.0, *)
 class MXKeyVerificationManagerV2: MXKeyVerificationManager {
     enum Error: Swift.Error {
         case notSupported

--- a/MatrixSDK/Crypto/Verification/Requests/MXKeyVerificationRequestV2.swift
+++ b/MatrixSDK/Crypto/Verification/Requests/MXKeyVerificationRequestV2.swift
@@ -21,7 +21,6 @@ import Foundation
 import MatrixSDKCrypto
 
 /// Verification request originating from `MatrixSDKCrypto`
-@available(iOS 13.0.0, *)
 class MXKeyVerificationRequestV2: NSObject, MXKeyVerificationRequest {
     var state: MXKeyVerificationRequestState {
         // State as enum will be moved to MatrixSDKCrypto in the future

--- a/MatrixSDK/Crypto/Verification/Transactions/SAS/MXSASTransactionV2.swift
+++ b/MatrixSDK/Crypto/Verification/Transactions/SAS/MXSASTransactionV2.swift
@@ -21,7 +21,6 @@ import Foundation
 import MatrixSDKCrypto
 
 /// SAS transaction originating from `MatrixSDKCrypto`
-@available(iOS 13.0.0, *)
 class MXSASTransactionV2: NSObject, MXSASTransaction {
     
     var state: MXSASTransactionState {

--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
@@ -2217,29 +2217,22 @@ static NSUInteger preloadOptions;
  */
 - (void)saveObject:(id)object toFile:(NSString *)file
 {
-    if (@available(iOS 11.0, *))
+    NSError *error;
+    NSData *data = [NSKeyedArchiver archivedDataWithRootObject:object requiringSecureCoding:NO error:&error];
+    if (error)
     {
-        NSError *error;
-        NSData *data = [NSKeyedArchiver archivedDataWithRootObject:object requiringSecureCoding:NO error:&error];
-        if (error)
-        {
-            MXLogFailureDetails(@"[MXFileStore] Failed archiving root object", error);
-            return;
-        }
-        
-        BOOL success = [data writeToFile:file options:0 error:&error];
-        if (success)
-        {
-            MXLogDebug(@"[MXFileStore] Saved data successfully");
-        }
-        else
-        {
-            MXLogFailureDetails(@"[MXFileStore] Failed saving data", error);
-        }
+        MXLogFailureDetails(@"[MXFileStore] Failed archiving root object", error);
+        return;
+    }
+    
+    BOOL success = [data writeToFile:file options:0 error:&error];
+    if (success)
+    {
+        MXLogDebug(@"[MXFileStore] Saved data successfully");
     }
     else
     {
-        [NSKeyedArchiver archiveRootObject:object toFile:file];
+        MXLogFailureDetails(@"[MXFileStore] Failed saving data", error);
     }
 }
 
@@ -2252,30 +2245,23 @@ static NSUInteger preloadOptions;
  */
 - (id)loadObjectOfClasses:(NSSet<Class> *)classes fromFile:(NSString *)file
 {
-    if (@available(iOS 11.0, *))
+    NSError *error;
+    NSData *data = [NSData dataWithContentsOfFile:file];
+    if (!data)
     {
-        NSError *error;
-        NSData *data = [NSData dataWithContentsOfFile:file];
-        if (!data)
-        {
-            MXLogDebug(@"[MXFileStore] No data to load at file %@", file);
-            return nil;
-        }
-        
-        id object = [NSKeyedUnarchiver unarchivedObjectOfClasses:classes fromData:data error:&error];
-        if (object && !error)
-        {
-            return object;
-        }
-        else
-        {
-            MXLogFailureDetails(@"[MXFileStore] Failed loading object from class", error);
-            return nil;
-        }
+        MXLogDebug(@"[MXFileStore] No data to load at file %@", file);
+        return nil;
+    }
+    
+    id object = [NSKeyedUnarchiver unarchivedObjectOfClasses:classes fromData:data error:&error];
+    if (object && !error)
+    {
+        return object;
     }
     else
     {
-        return [NSKeyedUnarchiver unarchiveObjectWithFile:file];
+        MXLogFailureDetails(@"[MXFileStore] Failed loading object from class", error);
+        return nil;
     }
 }
 
@@ -2289,38 +2275,31 @@ static NSUInteger preloadOptions;
  */
 - (id)loadRootObjectWithoutSecureCodingFromFile:(NSString *)file
 {
-    if (@available(iOS 11.0, *))
+    NSError *error;
+    NSData *data = [NSData dataWithContentsOfFile:file];
+    if (!data)
     {
-        NSError *error;
-        NSData *data = [NSData dataWithContentsOfFile:file];
-        if (!data)
-        {
-            MXLogDebug(@"[MXFileStore] No data to load at file %@", file);
-            return nil;
-        }
-        NSKeyedUnarchiver *unarchiver = [[NSKeyedUnarchiver alloc] initForReadingFromData:data error:&error];
-        if (error && !unarchiver)
-        {
-            MXLogFailureDetails(@"[MXFileStore] Cannot create unarchiver", error);
-            return nil;
-        }
-        unarchiver.requiresSecureCoding = NO;
-        
-        // Seems to be an implementation detaul
-        id object = [unarchiver decodeTopLevelObjectForKey:NSKeyedArchiveRootObjectKey error:&error];
-        if (object && !error)
-        {
-            return object;
-        }
-        else
-        {
-            MXLogFailureDetails(@"[MXFileStore] Failed loading object from class", error);
-            return nil;
-        }
+        MXLogDebug(@"[MXFileStore] No data to load at file %@", file);
+        return nil;
+    }
+    NSKeyedUnarchiver *unarchiver = [[NSKeyedUnarchiver alloc] initForReadingFromData:data error:&error];
+    if (error && !unarchiver)
+    {
+        MXLogFailureDetails(@"[MXFileStore] Cannot create unarchiver", error);
+        return nil;
+    }
+    unarchiver.requiresSecureCoding = NO;
+    
+    // Seems to be an implementation detaul
+    id object = [unarchiver decodeTopLevelObjectForKey:NSKeyedArchiveRootObjectKey error:&error];
+    if (object && !error)
+    {
+        return object;
     }
     else
     {
-        return [NSKeyedUnarchiver unarchiveObjectWithFile:file];
+        MXLogFailureDetails(@"[MXFileStore] Failed loading object from class", error);
+        return nil;
     }
 }
 

--- a/MatrixSDK/Utils/MXMemory.swift
+++ b/MatrixSDK/Utils/MXMemory.swift
@@ -72,10 +72,6 @@ public class MXMemory: NSObject {
     }
     
     public static func formattedMemoryAvailable() -> String {
-        guard #available(iOS 13.0, *) else {
-            return "Unsupported on this OS"
-        }
-        
         let freeBytes = self.memoryAvailable()
         let freeMB = Double(freeBytes) / 1024 / 1024
         guard let formattedStr = numberFormatter.string(from: NSNumber(value: freeMB)) else {

--- a/MatrixSDK/Utils/MXTaskQueue.swift
+++ b/MatrixSDK/Utils/MXTaskQueue.swift
@@ -27,7 +27,6 @@ public typealias Block<T> = () async throws -> T
 ///
 /// The solution to this problem is using serial task queues where work is scheduled, but only executed once all of the previously
 /// scheduled tasks have completed. This is an analogous mechanism to using serial `DispatchQueue`s.
-@available(iOS 13.0.0, macOS 10.15.0, *)
 public actor MXTaskQueue {
     public enum Error: Swift.Error {
         case valueUnavailable

--- a/MatrixSDK/VoIP/MXiOSAudioOutputRouter.swift
+++ b/MatrixSDK/VoIP/MXiOSAudioOutputRouter.swift
@@ -18,7 +18,6 @@ import Foundation
 import AVFoundation
 
 /// Audio output router class
-@available(iOS 10.0, *)
 @objcMembers
 public class MXiOSAudioOutputRouter: NSObject {
     

--- a/MatrixSDK/VoIP/MXiOSAudioOutputRouterDelegate.swift
+++ b/MatrixSDK/VoIP/MXiOSAudioOutputRouterDelegate.swift
@@ -17,7 +17,6 @@
 import Foundation
 
 /// Audio output router delegate
-@available(iOS 10.0, *)
 @objc
 public protocol MXiOSAudioOutputRouterDelegate: AnyObject {
     /// Delegate method to be called when output route changes, for both user actions and system changes

--- a/MatrixSDKTests/Crypto/CrossSigning/MXCrossSigningInfoSourceUnitTests.swift
+++ b/MatrixSDKTests/Crypto/CrossSigning/MXCrossSigningInfoSourceUnitTests.swift
@@ -22,7 +22,6 @@ import XCTest
 
 import MatrixSDKCrypto
 
-@available(iOS 13.0.0, *)
 class MXCrossSigningInfoSourceUnitTests: XCTestCase {
     var cryptoSource: UserIdentitySourceStub!
     var source: MXCrossSigningInfoSource!

--- a/MatrixSDKTests/Crypto/CrossSigning/MXCrossSigningV2UnitTests.swift
+++ b/MatrixSDKTests/Crypto/CrossSigning/MXCrossSigningV2UnitTests.swift
@@ -22,7 +22,6 @@ import XCTest
 
 import MatrixSDKCrypto
 
-@available(iOS 13.0.0, *)
 class MXCrossSigningV2UnitTests: XCTestCase {
     
     var crypto: CryptoCrossSigningStub!

--- a/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoProtocolStubs.swift
+++ b/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoProtocolStubs.swift
@@ -46,7 +46,6 @@ class DevicesSourceStub: CryptoIdentityStub, MXCryptoDevicesSource {
     }
 }
 
-@available(iOS 13.0.0, *)
 class UserIdentitySourceStub: CryptoIdentityStub, MXCryptoUserIdentitySource {
     var identities = [String: UserIdentity]()
     func userIdentity(userId: String) -> UserIdentity? {
@@ -63,7 +62,6 @@ class UserIdentitySourceStub: CryptoIdentityStub, MXCryptoUserIdentitySource {
     }
 }
 
-@available(iOS 13.0.0, *)
 class CryptoCrossSigningStub: CryptoIdentityStub, MXCryptoCrossSigning {
     var stubbedStatus = CrossSigningStatus(
         hasMaster: false,
@@ -91,7 +89,6 @@ class CryptoCrossSigningStub: CryptoIdentityStub, MXCryptoCrossSigning {
     }
 }
 
-@available(iOS 13.0.0, *)
 class CryptoVerificationStub: CryptoIdentityStub {
     var stubbedRequests = [String: VerificationRequest]()
     var stubbedTransactions = [String: Verification]()
@@ -99,7 +96,6 @@ class CryptoVerificationStub: CryptoIdentityStub {
     var stubbedEmojis = [String: [Int]]()
 }
 
-@available(iOS 13.0.0, *)
 extension CryptoVerificationStub: MXCryptoVerificationRequesting {
     func requestSelfVerification(methods: [String]) async throws -> VerificationRequest {
         .stub()
@@ -126,7 +122,6 @@ extension CryptoVerificationStub: MXCryptoVerificationRequesting {
     }
 }
 
-@available(iOS 13.0.0, *)
 extension CryptoVerificationStub: MXCryptoVerifying {
     func verification(userId: String, flowId: String) -> Verification? {
         return stubbedTransactions[flowId]
@@ -136,7 +131,6 @@ extension CryptoVerificationStub: MXCryptoVerifying {
     }
 }
 
-@available(iOS 13.0.0, *)
 extension CryptoVerificationStub: MXCryptoSASVerifying {
     func startSasVerification(userId: String, flowId: String) async throws -> Sas {
         .stub()

--- a/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoRequestsUnitTests.swift
+++ b/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoRequestsUnitTests.swift
@@ -21,7 +21,6 @@ import Foundation
 
 import MatrixSDKCrypto
 
-@available(iOS 13.0.0, *)
 class MXCryptoRequestsUnitTests: XCTestCase {
     func test_canCreateToDeviceRequest() {
         let body: [String: [String: NSDictionary]] = [

--- a/MatrixSDKTests/Crypto/Data/MXOlmInboundGroupSessionUnitTests.swift
+++ b/MatrixSDKTests/Crypto/Data/MXOlmInboundGroupSessionUnitTests.swift
@@ -35,7 +35,6 @@ class MXOlmInboundGroupSessionUnitTests: XCTestCase {
         XCTAssert(data?.sharedHistory == true)
     }
     
-    @available(iOS 11.0, *)
     func testCanEncodeAndDecodeObject() {
         let session = MXOlmInboundGroupSession()
         session.senderKey = "A"

--- a/MatrixSDKTests/Crypto/Devices/MXDeviceInfoSourceUnitTests.swift
+++ b/MatrixSDKTests/Crypto/Devices/MXDeviceInfoSourceUnitTests.swift
@@ -22,7 +22,6 @@ import XCTest
 
 import MatrixSDKCrypto
 
-@available(iOS 13.0.0, *)
 class MXDeviceInfoSourceUnitTests: XCTestCase {
     var cryptoSource: DevicesSourceStub!
     var source: MXDeviceInfoSource!

--- a/MatrixSDKTests/Crypto/Trust/MXTrustLevelSourceUnitTests.swift
+++ b/MatrixSDKTests/Crypto/Trust/MXTrustLevelSourceUnitTests.swift
@@ -22,7 +22,6 @@ import XCTest
 
 import MatrixSDKCrypto
 
-@available(iOS 13.0.0, *)
 class MXTrustLevelSourceUnitTests: XCTestCase {
     var userIdentitySource: UserIdentitySourceStub!
     var devicesSource: DevicesSourceStub!

--- a/MatrixSDKTests/Crypto/Verification/Requests/MXKeyVerificationRequestV2UnitTests.swift
+++ b/MatrixSDKTests/Crypto/Verification/Requests/MXKeyVerificationRequestV2UnitTests.swift
@@ -22,7 +22,6 @@ import XCTest
 import MatrixSDKCrypto
 @testable import MatrixSDK
 
-@available(iOS 13.0.0, *)
 class MXKeyVerificationRequestV2UnitTests: XCTestCase {
     enum Error: Swift.Error, Equatable {
         case dummy

--- a/MatrixSDKTests/Crypto/Verification/Transactions/SAS/MXSASTransactionV2UnitTests.swift
+++ b/MatrixSDKTests/Crypto/Verification/Transactions/SAS/MXSASTransactionV2UnitTests.swift
@@ -22,7 +22,6 @@ import XCTest
 import MatrixSDKCrypto
 @testable import MatrixSDK
 
-@available(iOS 13.0.0, *)
 class MXSASTransactionV2UnitTests: XCTestCase {
     var verification: CryptoVerificationStub!
     override func setUp() {

--- a/MatrixSDKTests/MXEventAnnotationUnitTests.swift
+++ b/MatrixSDKTests/MXEventAnnotationUnitTests.swift
@@ -66,7 +66,6 @@ class MXEventAnnotationUnitTests: XCTestCase {
         }
     }
 
-    @available(iOS 9.0, OSX 10.11, *)
     func testNSCoding() {
         let event = MXEvent(fromJSON: eventJSON)
 

--- a/MatrixSDKTests/MXEventReferenceUnitTests.swift
+++ b/MatrixSDKTests/MXEventReferenceUnitTests.swift
@@ -65,7 +65,6 @@ class MXEventReferenceUnitTests: XCTestCase {
         }
     }
 
-    @available(iOS 9.0, OSX 10.11, *)
     func testNSCoding() {
         let event = MXEvent(fromJSON: eventJSON)
 

--- a/MatrixSDKTests/Utils/MXTaskQueueUnitTests.swift
+++ b/MatrixSDKTests/Utils/MXTaskQueueUnitTests.swift
@@ -18,7 +18,6 @@ import Foundation
 import XCTest
 @testable import MatrixSDK
 
-@available(iOS 13.0.0, macOS 10.15.0, *)
 class MXTaskQueueUnitTests: XCTestCase {
     /// Dummy error that can be thrown by a task
     enum Error: Swift.Error {

--- a/changelog.d/pr-1574.change
+++ b/changelog.d/pr-1574.change
@@ -1,0 +1,1 @@
+Upgrade minimum iOS and OSX deployment target to 13.0 and 10.15 respectively


### PR DESCRIPTION
Element iOS targets iOS 14 as a minimum whereas the SDK was several versions behind, making it not possible to use Swift concurrency without @available flags. Increasing the iOS and OSX deployment targets to 13 and 10.15 respectively lets us remove these conditionals