### PR TITLE
Enable group session cache by default

### DIFF
--- a/MatrixSDK/MXSDKOptions.h
+++ b/MatrixSDK/MXSDKOptions.h
@@ -220,7 +220,7 @@ NS_ASSUME_NONNULL_BEGIN
  Enable performance optimization where inbound group sessions are cached between decryption of events
  rather than fetched from the store every time.
  
- @remark By default, the value is set randomly between YES / NO to perform a very basic A/B test
+ @remark YES by default
  */
 @property (nonatomic) BOOL enableGroupSessionCache;
 

--- a/MatrixSDK/MXSDKOptions.m
+++ b/MatrixSDK/MXSDKOptions.m
@@ -59,10 +59,7 @@ static MXSDKOptions *sharedOnceInstance = nil;
         _enableCryptoV2 = NO;
         #endif
         
-        // The value is set randomly between YES / NO to perform a very basic A/B test
-        // measured by `analytics` (if set and enabled)
-        _enableGroupSessionCache = arc4random_uniform(2) == 1;
-
+        _enableGroupSessionCache = YES;
         _enableSymmetricBackup = NO;
     }
     

--- a/MatrixSDKTests/MXCryptoTests.m
+++ b/MatrixSDKTests/MXCryptoTests.m
@@ -31,6 +31,7 @@
 #import "MXSendReplyEventDefaultStringLocalizer.h"
 #import "MXOutboundSessionInfo.h"
 #import <OLMKit/OLMKit.h>
+#import "MXLRUCache.h"
 
 #import "MXKey.h"
 
@@ -2081,6 +2082,8 @@
 
                 id<MXCryptoStore> bobCryptoStore = (id<MXCryptoStore>)[bobSession.crypto.olmDevice valueForKey:@"store"];
                 [bobCryptoStore removeInboundGroupSessionWithId:sessionId andSenderKey:toDeviceEvent.senderKey];
+                MXLRUCache *cache = [bobSession.crypto.olmDevice valueForKey:@"inboundGroupSessionCache"];
+                [cache clear];
 
                 // So that we cannot decrypt it anymore right now
                 [event setClearData:nil];

--- a/changelog.d/pr-1575.change
+++ b/changelog.d/pr-1575.change
@@ -1,0 +1,1 @@
+Crypto: Enable group session cache by default 


### PR DESCRIPTION
After running a store / cache megolm decryption A/B test for a few weeks we gathered that cache decryption is aprox 10x faster and no new issues have been reported. As a result we can switch to cache variant exclusively, but leave the build flag in for a bit longer as a safety measure.

<img width="971" alt="Screenshot 2022-09-16 at 09 36 58" src="https://user-images.githubusercontent.com/3922159/190595108-4f97fa9b-463f-4ff2-9518-9701549eb576.png">
