### PR TITLE
Avoid main thread assertion if we can't get the application

### DIFF
--- a/MatrixSDK/Utils/MXUIKitApplicationStateService.swift
+++ b/MatrixSDK/Utils/MXUIKitApplicationStateService.swift
@@ -66,8 +66,6 @@ public class MXUIKitApplicationStateService: NSObject {
         applicationState = .inactive
         super.init()
         
-        // The service must be created on the main tread
-        assert(Thread.isMainThread, "[MXUIKitApplicationStateService] initialized on non-main thread.")
         applicationState = self.sharedApplicationState
 
         registerApplicationStateChangeNotifications()
@@ -114,8 +112,13 @@ public class MXUIKitApplicationStateService: NSObject {
     
     private var sharedApplicationState: UIApplication.State {
         get {
+            guard let application = self.sharedApplication else {
+                return .inactive
+            }
+
             // Can be only called from the main thread
-            self.sharedApplication?.applicationState ?? .inactive
+            assert(Thread.isMainThread, "[MXUIKitApplicationStateService] UIApplication.applicationState called on non-main thread.")
+            return application.applicationState
         }
     }
 }

--- a/changelog.d/6754.misc
+++ b/changelog.d/6754.misc
@@ -1,0 +1,1 @@
+Avoid main thread assertion if we can't get the application


### PR DESCRIPTION
The main thread assertion can be triggered when running or debugging the NSE extension (which can run in parallel and on varying threads). However, app extensions can't access `UIApplication.shared` anyway so we can delay the assertion to the point where `UIApplication.applicationState` is actually accessed.

Fixes: https://github.com/vector-im/element-ios/issues/6754

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request contains a changelog file in ./changelog.d. See https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog
* [ ] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
