### PR TITLE
Extract key backup engine

### DIFF
--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -1211,7 +1211,7 @@
 		B14EF3522397E90400758AF0 /* MXSASTransaction.h in Headers */ = {isa = PBXBuildFile; fileRef = 321CFDE422525A49004D31DF /* MXSASTransaction.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B14EF3532397E90400758AF0 /* MXNotificationCenter.h in Headers */ = {isa = PBXBuildFile; fileRef = 32DC15CD1A8CF7AE006F9AD3 /* MXNotificationCenter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B14EF3542397E90400758AF0 /* MXLoginPolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = 3275FD9A21A6B60B00B9C13D /* MXLoginPolicy.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B14EF3552397E90400758AF0 /* MXCryptoTools.h in Headers */ = {isa = PBXBuildFile; fileRef = 3250E7C8220C913900736CB5 /* MXCryptoTools.h */; };
+		B14EF3552397E90400758AF0 /* MXCryptoTools.h in Headers */ = {isa = PBXBuildFile; fileRef = 3250E7C8220C913900736CB5 /* MXCryptoTools.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B14EF3562397E90400758AF0 /* MXGroup.h in Headers */ = {isa = PBXBuildFile; fileRef = F0173EAA1FCF0E8800B5F6A3 /* MXGroup.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B14EF3572397E90400758AF0 /* MX3PidAddSession.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D2CC0123422462002BD8CA /* MX3PidAddSession.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B14EF3582397E90400758AF0 /* MXUser.h in Headers */ = {isa = PBXBuildFile; fileRef = 329FB17D1A0B665800A5E88E /* MXUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1895,6 +1895,10 @@
 		EDBCF33A281A8D3D00ED5044 /* MXSharedHistoryKeyService.m in Sources */ = {isa = PBXBuildFile; fileRef = EDBCF338281A8D3D00ED5044 /* MXSharedHistoryKeyService.m */; };
 		EDC2A0E628369E740039F3D6 /* CryptoTests.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = EDC2A0E528369E740039F3D6 /* CryptoTests.xctestplan */; };
 		EDC2A0E728369E740039F3D6 /* CryptoTests.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = EDC2A0E528369E740039F3D6 /* CryptoTests.xctestplan */; };
+		EDD4197E28DCAA5F007F3757 /* MXNativeKeyBackupEngine.h in Headers */ = {isa = PBXBuildFile; fileRef = EDD4197D28DCAA5F007F3757 /* MXNativeKeyBackupEngine.h */; };
+		EDD4197F28DCAA5F007F3757 /* MXNativeKeyBackupEngine.h in Headers */ = {isa = PBXBuildFile; fileRef = EDD4197D28DCAA5F007F3757 /* MXNativeKeyBackupEngine.h */; };
+		EDD4198128DCAA7B007F3757 /* MXNativeKeyBackupEngine.m in Sources */ = {isa = PBXBuildFile; fileRef = EDD4198028DCAA7B007F3757 /* MXNativeKeyBackupEngine.m */; };
+		EDD4198228DCAA7B007F3757 /* MXNativeKeyBackupEngine.m in Sources */ = {isa = PBXBuildFile; fileRef = EDD4198028DCAA7B007F3757 /* MXNativeKeyBackupEngine.m */; };
 		EDD578E12881C37C006739DD /* MXDeviceInfoSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD578DC2881C37C006739DD /* MXDeviceInfoSource.swift */; };
 		EDD578E22881C37C006739DD /* MXDeviceInfoSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD578DC2881C37C006739DD /* MXDeviceInfoSource.swift */; };
 		EDD578E32881C37C006739DD /* MXTrustLevelSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD578DD2881C37C006739DD /* MXTrustLevelSource.swift */; };
@@ -1909,6 +1913,11 @@
 		EDD578ED2881C38C006739DD /* MXCrossSigningV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD578EB2881C38C006739DD /* MXCrossSigningV2.swift */; };
 		EDE1B13B28B7BEAB000DEEE8 /* MXCrossSigningV2UnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDE1B13A28B7BEAB000DEEE8 /* MXCrossSigningV2UnitTests.swift */; };
 		EDE1B13C28B7BEAB000DEEE8 /* MXCrossSigningV2UnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDE1B13A28B7BEAB000DEEE8 /* MXCrossSigningV2UnitTests.swift */; };
+		EDE70DC528DA1B7F00099736 /* MXCryptoTools.h in Headers */ = {isa = PBXBuildFile; fileRef = 3250E7C8220C913900736CB5 /* MXCryptoTools.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EDE70DC828DA22F800099736 /* MXKeyBackupEngine.h in Headers */ = {isa = PBXBuildFile; fileRef = EDE70DC728DA22F800099736 /* MXKeyBackupEngine.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EDE70DC928DA22F800099736 /* MXKeyBackupEngine.h in Headers */ = {isa = PBXBuildFile; fileRef = EDE70DC728DA22F800099736 /* MXKeyBackupEngine.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EDEC2E5E28DCADE400982DD3 /* MXKeyBackupPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDEC2E5D28DCADE400982DD3 /* MXKeyBackupPayload.swift */; };
+		EDEC2E5F28DCADE400982DD3 /* MXKeyBackupPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDEC2E5D28DCADE400982DD3 /* MXKeyBackupPayload.swift */; };
 		EDF1B6902876CD2C00BBBCEE /* MXTaskQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF1B68F2876CD2C00BBBCEE /* MXTaskQueue.swift */; };
 		EDF1B6912876CD2C00BBBCEE /* MXTaskQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF1B68F2876CD2C00BBBCEE /* MXTaskQueue.swift */; };
 		EDF1B6932876CD8600BBBCEE /* MXTaskQueueUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF1B6922876CD8600BBBCEE /* MXTaskQueueUnitTests.swift */; };
@@ -2959,6 +2968,8 @@
 		EDBCF335281A8AB900ED5044 /* MXSharedHistoryKeyService.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXSharedHistoryKeyService.h; sourceTree = "<group>"; };
 		EDBCF338281A8D3D00ED5044 /* MXSharedHistoryKeyService.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXSharedHistoryKeyService.m; sourceTree = "<group>"; };
 		EDC2A0E528369E740039F3D6 /* CryptoTests.xctestplan */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CryptoTests.xctestplan; sourceTree = "<group>"; };
+		EDD4197D28DCAA5F007F3757 /* MXNativeKeyBackupEngine.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXNativeKeyBackupEngine.h; sourceTree = "<group>"; };
+		EDD4198028DCAA7B007F3757 /* MXNativeKeyBackupEngine.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXNativeKeyBackupEngine.m; sourceTree = "<group>"; };
 		EDD578DC2881C37C006739DD /* MXDeviceInfoSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXDeviceInfoSource.swift; sourceTree = "<group>"; };
 		EDD578DD2881C37C006739DD /* MXTrustLevelSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXTrustLevelSource.swift; sourceTree = "<group>"; };
 		EDD578DE2881C37C006739DD /* MXCrossSigningInfoSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXCrossSigningInfoSource.swift; sourceTree = "<group>"; };
@@ -2966,6 +2977,8 @@
 		EDD578E02881C37C006739DD /* MXCryptoUserIdentityWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXCryptoUserIdentityWrapper.swift; sourceTree = "<group>"; };
 		EDD578EB2881C38C006739DD /* MXCrossSigningV2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXCrossSigningV2.swift; sourceTree = "<group>"; };
 		EDE1B13A28B7BEAB000DEEE8 /* MXCrossSigningV2UnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXCrossSigningV2UnitTests.swift; sourceTree = "<group>"; };
+		EDE70DC728DA22F800099736 /* MXKeyBackupEngine.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXKeyBackupEngine.h; sourceTree = "<group>"; };
+		EDEC2E5D28DCADE400982DD3 /* MXKeyBackupPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXKeyBackupPayload.swift; sourceTree = "<group>"; };
 		EDF1B68F2876CD2C00BBBCEE /* MXTaskQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXTaskQueue.swift; sourceTree = "<group>"; };
 		EDF1B6922876CD8600BBBCEE /* MXTaskQueueUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXTaskQueueUnitTests.swift; sourceTree = "<group>"; };
 		EDF4678627E3331D00435913 /* EventsEnumeratorDataSourceStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsEnumeratorDataSourceStub.swift; sourceTree = "<group>"; };
@@ -3975,6 +3988,7 @@
 		32BBAE642178E99100D85F46 /* KeyBackup */ = {
 			isa = PBXGroup;
 			children = (
+				EDE70DC628DA22E200099736 /* Engine */,
 				32BBAE652178E99100D85F46 /* Data */,
 				32BBAE722179CF4000D85F46 /* MXKeyBackup.h */,
 				32BBAE732179CF4000D85F46 /* MXKeyBackup.m */,
@@ -5350,6 +5364,17 @@
 			path = JSONModels;
 			sourceTree = "<group>";
 		};
+		EDE70DC628DA22E200099736 /* Engine */ = {
+			isa = PBXGroup;
+			children = (
+				EDEC2E5D28DCADE400982DD3 /* MXKeyBackupPayload.swift */,
+				EDE70DC728DA22F800099736 /* MXKeyBackupEngine.h */,
+				EDD4197D28DCAA5F007F3757 /* MXNativeKeyBackupEngine.h */,
+				EDD4198028DCAA7B007F3757 /* MXNativeKeyBackupEngine.m */,
+			);
+			path = Engine;
+			sourceTree = "<group>";
+		};
 		F03EF4F91DF014D9009DF592 /* Media */ = {
 			isa = PBXGroup;
 			children = (
@@ -5464,6 +5489,7 @@
 				327F8DB21C6112BA00581CA3 /* MXRoomThirdPartyInvite.h in Headers */,
 				B19A309E240424BD00FB6F35 /* MXQRCodeTransaction_Private.h in Headers */,
 				EC40384A289A7F260067D5B8 /* MXAes256KeyBackupAlgorithm.h in Headers */,
+				EDD4197E28DCAA5F007F3757 /* MXNativeKeyBackupEngine.h in Headers */,
 				32BBAE742179CF4000D85F46 /* MXKeyBackup.h in Headers */,
 				92634B821EF2E3C400DB9F60 /* MXCallKitConfiguration.h in Headers */,
 				32618E7120ED2DF500E1D2EA /* MXFilterJSONModel.h in Headers */,
@@ -5552,6 +5578,7 @@
 				EC619D9324DD834B00663A80 /* MXPushGatewayRestClient.h in Headers */,
 				32C78B68256CFC4D008130B1 /* MXCryptoVersion.h in Headers */,
 				320B3934239FA56900BE2C06 /* MXKeyVerificationByDMRequest.h in Headers */,
+				EDE70DC528DA1B7F00099736 /* MXCryptoTools.h in Headers */,
 				EC60EDE8265CFF3100B39A4E /* MXRoomInviteState.h in Headers */,
 				324DD2A6246AE81300377005 /* MXSecretStorageKeyContent.h in Headers */,
 				EC60ED8F265CFD3B00B39A4E /* MXRoomSync.h in Headers */,
@@ -5614,6 +5641,7 @@
 				321CFDFF2254E8C4004D31DF /* MXEmojiRepresentation.h in Headers */,
 				324BE4681E3FADB1008D99D4 /* MXMegolmExportEncryption.h in Headers */,
 				EC8A539B25B1BC77004E0802 /* MXCallAnswerEventContent.h in Headers */,
+				EDE70DC828DA22F800099736 /* MXKeyBackupEngine.h in Headers */,
 				ECDA764C27BA963D000C48CF /* MXBooleanCapability.h in Headers */,
 				3274538A23FD918800438328 /* MXKeyVerificationByToDeviceRequest.h in Headers */,
 				B1136963230AC9D900E2B2FA /* MXIdentityServerRestClient.h in Headers */,
@@ -5844,6 +5872,7 @@
 				B14EF2BE2397E90400758AF0 /* MXEvent.h in Headers */,
 				EC0B9430271D95CC00B4D440 /* MXFileRoomSummaryStore.h in Headers */,
 				B14EF2BF2397E90400758AF0 /* MXRoomThirdPartyInvite.h in Headers */,
+				EDD4197F28DCAA5F007F3757 /* MXNativeKeyBackupEngine.h in Headers */,
 				ECBF657F26DE2A4900AA3A99 /* MXMemoryRoomOutgoingMessagesStore.h in Headers */,
 				EC8A538C25B1BC77004E0802 /* MXCallCandidate.h in Headers */,
 				B14EF2C12397E90400758AF0 /* MXKeyBackup.h in Headers */,
@@ -6034,6 +6063,7 @@
 				B14EF32E2397E90400758AF0 /* MXMediaLoader.h in Headers */,
 				ECDA763A27B6B74C000C48CF /* MXCapabilities.h in Headers */,
 				B14EF32F2397E90400758AF0 /* MXAccountData.h in Headers */,
+				EDE70DC928DA22F800099736 /* MXKeyBackupEngine.h in Headers */,
 				B135066C27EA1F5E00BD3276 /* MXEventAssetType.h in Headers */,
 				B14EF3302397E90400758AF0 /* MXEnumConstants.h in Headers */,
 				ECBF658626DE3DF800AA3A99 /* MXFileRoomOutgoingMessagesStore.h in Headers */,
@@ -6477,12 +6507,14 @@
 				32C235731F827F3800E38FC5 /* MXRoomOperation.m in Sources */,
 				322A51C41D9AC8FE00C8536D /* MXCryptoAlgorithms.m in Sources */,
 				B1798D0824091A0100308A8F /* MXBase64Tools.m in Sources */,
+				EDEC2E5E28DCADE400982DD3 /* MXKeyBackupPayload.swift in Sources */,
 				B182B08823167A640057972E /* MXIdentityServerHashDetails.m in Sources */,
 				EC60EDBE265CFE8600B39A4E /* MXRoomSyncAccountData.m in Sources */,
 				EC1165BE27107E330089FA56 /* MXSuggestedRoomListDataFetcher.swift in Sources */,
 				324DD2A2246AE1EF00377005 /* MXEncryptedSecretContent.m in Sources */,
 				329FB1761A0A3A1600A5E88E /* MXRoomMember.m in Sources */,
 				B16C2455283AB0DE00F5D1FE /* MXRealmBeaconMapper.swift in Sources */,
+				EDD4198128DCAA7B007F3757 /* MXNativeKeyBackupEngine.m in Sources */,
 				3251D41F25AF01D7001E6E77 /* MXUIKitApplicationStateService.swift in Sources */,
 				B1136965230AC9D900E2B2FA /* MXIdentityService.m in Sources */,
 				66836AB727CFA17200515780 /* MXEventStreamService.swift in Sources */,
@@ -7076,12 +7108,14 @@
 				B14EF1F32397E90400758AF0 /* MXServerNotices.m in Sources */,
 				B14EF1F42397E90400758AF0 /* MXMemoryStore.m in Sources */,
 				B14EF1F52397E90400758AF0 /* MXAggregationPaginatedResponse.m in Sources */,
+				EDEC2E5F28DCADE400982DD3 /* MXKeyBackupPayload.swift in Sources */,
 				B14EF1F62397E90400758AF0 /* MXEventReplace.m in Sources */,
 				B16F35A325F916A00029AE98 /* MXRoomTypeMapper.swift in Sources */,
 				EC1165BF27107E330089FA56 /* MXSuggestedRoomListDataFetcher.swift in Sources */,
 				B14EF1F72397E90400758AF0 /* MXLoginTerms.m in Sources */,
 				B14EF1F82397E90400758AF0 /* MXReplyEventParts.m in Sources */,
 				B16C2456283AB0DE00F5D1FE /* MXRealmBeaconMapper.swift in Sources */,
+				EDD4198228DCAA7B007F3757 /* MXNativeKeyBackupEngine.m in Sources */,
 				3259D02426037A7200C365DB /* NSArray.swift in Sources */,
 				3A108A8125810C96005EEBE9 /* MXKeyData.m in Sources */,
 				66836AB827CFA17200515780 /* MXEventStreamService.swift in Sources */,

--- a/MatrixSDK/Crypto/KeyBackup/Engine/MXKeyBackupEngine.h
+++ b/MatrixSDK/Crypto/KeyBackup/Engine/MXKeyBackupEngine.h
@@ -1,0 +1,171 @@
+// 
+// Copyright 2022 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#ifndef MXKeyBackupStore_h
+#define MXKeyBackupStore_h
+
+#import "MXMegolmSessionData.h"
+#import "MXMegolmBackupCreationInfo.h"
+#import "MXKeyBackupVersionTrust.h"
+#import "MXKeyBackupAlgorithm.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class MXKeyBackupPayload;
+
+/**
+ Backup engine responsible for managing and storing internal key backups, incl private keys and room keys
+ */
+@protocol MXKeyBackupEngine <NSObject>
+
+#pragma mark - Enable / Disable engine
+
+/**
+ Is the engine enabled to backup room keys
+ */
+@property (nonatomic, readonly) BOOL enabled;
+
+/**
+ Current version of the backup
+ */
+@property (nonatomic, readonly) NSString *version;
+
+/**
+ Enable a new backup version that will replace any previous version
+ */
+- (BOOL)enableBackupWithVersion:(MXKeyBackupVersion *)version
+                          error:(NSError **)error;
+/**
+ Disable the current backup and reset any backup-related state
+ */
+- (void)disableBackup;
+
+#pragma mark - Private / Recovery key management
+
+/**
+ Get the private key of the current backup version
+ */
+- (nullable NSData *)privateKey;
+
+/**
+ Save a new private key
+ */
+- (void)savePrivateKey:(NSString *)privateKey;
+
+/**
+ Save a new private key using a recovery key
+ */
+- (void)saveRecoveryKey:(NSString *)recoveryKey;
+
+/**
+ Delete the currently stored private key
+ */
+- (void)deletePrivateKey;
+
+/**
+ Check if a private key matches current key backup version
+ */
+- (BOOL)isValidPrivateKey:(NSData *)privateKey
+                    error:(NSError **)error;
+
+/**
+ Check if a private key matches key backup version
+ */
+- (BOOL)isValidPrivateKey:(NSData *)privateKey
+      forKeyBackupVersion:(MXKeyBackupVersion *)keyBackupVersion
+                    error:(NSError **)error;
+
+/**
+ Check if a recovery key matches key backup authentication data
+ */
+- (BOOL)isValidRecoveryKey:(NSString *)recoveryKey
+       forKeyBackupVersion:(MXKeyBackupVersion *)keyBackupVersion
+                     error:(NSError **)error;
+
+- (void)validateKeyBackupVersion:(MXKeyBackupVersion *)keyBackupVersion;
+
+/**
+ Compute the recovery key from a password and key backup auth data
+ */
+- (nullable NSString *)recoveryKeyFromPassword:(NSString *)password
+                           inKeyBackupVersion:(MXKeyBackupVersion *)keyBackupVersion
+                                        error:(NSError **)error;
+
+#pragma mark - Backup versions
+
+/**
+ Prepare a new backup version to be uploaded to the server
+ */
+- (void)prepareKeyBackupVersionWithPassword:(NSString *)password
+                                  algorithm:(NSString *)algorithm
+                                    success:(void (^)(MXMegolmBackupCreationInfo *))success
+                                    failure:(void (^)(NSError *))failure;
+
+/**
+ Get the current trust level of the backup version
+ */
+- (MXKeyBackupVersionTrust *)trustForKeyBackupVersionFromCryptoQueue:(MXKeyBackupVersion *)keyBackupVersion;
+
+/**
+ Extract authentication data from a backup
+ */
+- (nullable id<MXBaseKeyBackupAuthData>)megolmBackupAuthDataFromKeyBackupVersion:(MXKeyBackupVersion *)keyBackupVersion
+                                                                           error:(NSError **)error;
+
+/**
+ Sign an object with backup signing key
+ */
+- (NSDictionary *)signObject:(NSDictionary *)object;
+
+#pragma mark - Backup keys
+
+/**
+ Are there any keys that have not yet been backed up
+ */
+- (BOOL)hasKeysToBackup;
+
+/**
+ The ratio of total vs backed up keys
+ */
+- (NSProgress *)backupProgress;
+
+/**
+ Payload of room keys to be backed up to the server
+ */
+- (nullable MXKeyBackupPayload *)roomKeysBackupPayload;
+
+/**
+ Decrypt backup data using private key
+ */
+- (nullable MXMegolmSessionData *)decryptKeyBackupData:(MXKeyBackupData *)keyBackupData
+                                      keyBackupVersion:(MXKeyBackupVersion *)keyBackupVersion
+                                            privateKey:(NSData *)privateKey
+                                            forSession:(NSString *)sessionId
+                                                inRoom:(NSString *)roomId;
+
+/**
+ Import decrypted room keys
+ */
+- (void)importMegolmSessionDatas:(NSArray<MXMegolmSessionData*>*)keys
+                          backUp:(BOOL)backUp
+                         success:(void (^)(NSUInteger total, NSUInteger imported))success
+                         failure:(void (^)(NSError *error))failure;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif /* MXKeyBackupStore_h */

--- a/MatrixSDK/Crypto/KeyBackup/Engine/MXKeyBackupPayload.swift
+++ b/MatrixSDK/Crypto/KeyBackup/Engine/MXKeyBackupPayload.swift
@@ -1,0 +1,30 @@
+// 
+// Copyright 2022 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+/// Payload of room keys to backup and a completion block to call after
+/// successful backup.
+@objcMembers
+public class MXKeyBackupPayload: NSObject {
+    public let backupData: MXKeysBackupData
+    public let completion: ([AnyHashable: Any]) -> Void
+    
+    @objc public init(backupData: MXKeysBackupData, completion: @escaping ([AnyHashable: Any]) -> Void) {
+        self.backupData = backupData
+        self.completion = completion
+    }
+}

--- a/MatrixSDK/Crypto/KeyBackup/Engine/MXNativeKeyBackupEngine.h
+++ b/MatrixSDK/Crypto/KeyBackup/Engine/MXNativeKeyBackupEngine.h
@@ -1,0 +1,37 @@
+// 
+// Copyright 2022 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#ifndef MXNativeKeyBackupEngine_h
+#define MXNativeKeyBackupEngine_h
+
+#import "MXKeyBackupEngine.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MXNativeKeyBackupEngine : NSObject <MXKeyBackupEngine>
+
+- (instancetype)initWithCrypto:(MXCrypto *)crypto;
+
+/**
+ The backup algorithm being used. Nil if key backup not enabled yet.
+ */
+@property (nonatomic, nullable, readonly) id<MXKeyBackupAlgorithm> keyBackupAlgorithm;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif /* MXNativeKeyBackupEngine_h */

--- a/MatrixSDK/Crypto/KeyBackup/Engine/MXNativeKeyBackupEngine.m
+++ b/MatrixSDK/Crypto/KeyBackup/Engine/MXNativeKeyBackupEngine.m
@@ -1,0 +1,625 @@
+// 
+// Copyright 2022 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+#import "MXNativeKeyBackupEngine.h"
+#import "MXCrypto.h"
+#import "MXCrypto_Private.h"
+#import "MXCrossSigning_Private.h"
+#import "MXKeyBackupAlgorithm.h"
+#import "OLMInboundGroupSession.h"
+#import "MatrixSDKSwiftHeader.h"
+#import "MXRecoveryKey.h"
+
+/**
+ Maximum number of keys to send at a time to the homeserver.
+ */
+NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
+
+static NSDictionary<NSString*, Class<MXKeyBackupAlgorithm>> *AlgorithmClassesByName;
+static Class DefaultAlgorithmClass;
+
+@interface MXNativeKeyBackupEngine ()
+
+@property (nonatomic, weak) MXCrypto *crypto;
+@property (nonatomic, nullable) MXKeyBackupVersion *keyBackupVersion;
+@property (nonatomic, nullable) id<MXKeyBackupAlgorithm> keyBackupAlgorithm;
+
+@end
+
+@implementation MXNativeKeyBackupEngine
+
++ (void)initialize
+{
+    if (MXSDKOptions.sharedInstance.enableSymmetricBackup)
+    {
+        AlgorithmClassesByName = @{
+            kMXCryptoCurve25519KeyBackupAlgorithm: MXCurve25519KeyBackupAlgorithm.class,
+            kMXCryptoAes256KeyBackupAlgorithm: MXAes256KeyBackupAlgorithm.class
+        };
+    }
+    else
+    {
+        AlgorithmClassesByName = @{
+            kMXCryptoCurve25519KeyBackupAlgorithm: MXCurve25519KeyBackupAlgorithm.class,
+        };
+    }
+    DefaultAlgorithmClass = MXCurve25519KeyBackupAlgorithm.class;
+}
+
+- (instancetype)initWithCrypto:(MXCrypto *)crypto
+{
+    self = [self init];
+    if (self)
+    {
+        _crypto = crypto;
+    }
+    return self;
+}
+
+#pragma mark - Enable / Disable engine
+
+- (BOOL)enabled
+{
+    return self.version != nil;
+}
+
+- (NSString *)version
+{
+    return self.crypto.store.backupVersion;
+}
+
+- (BOOL)enableBackupWithVersion:(MXKeyBackupVersion *)version error:(NSError **)error
+{
+    id<MXBaseKeyBackupAuthData> authData = [self megolmBackupAuthDataFromKeyBackupVersion:version error:error];
+    if (!authData)
+    {
+        return NO;
+    }
+    
+    self.keyBackupVersion = version;
+    self.crypto.store.backupVersion = version.version;
+    Class algorithmClass = AlgorithmClassesByName[version.algorithm];
+    //  store the desired backup algorithm
+    self.keyBackupAlgorithm = [[algorithmClass alloc] initWithCrypto:self.crypto authData:authData keyGetterBlock:^NSData * _Nullable{
+        return self.privateKey;
+    }];
+    MXLogDebug(@"[MXNativeKeyBackupEngine] enableBackupWithVersion: Algorithm set to: %@", self.keyBackupAlgorithm);
+    return YES;
+}
+
+- (void)disableBackup
+{
+    self.keyBackupVersion = nil;
+    self.crypto.store.backupVersion = nil;
+    [self.crypto.store deleteSecretWithSecretId:MXSecretId.keyBackup];
+    self.keyBackupAlgorithm = nil;
+
+    // Reset backup markers
+    [self.crypto.store resetBackupMarkers];
+}
+
+#pragma mark - Private / Recovery key management
+
+- (nullable NSData*)privateKey
+{
+    NSString *privateKeyBase64 = [self.crypto.store secretWithSecretId:MXSecretId.keyBackup];
+    if (!privateKeyBase64)
+    {
+        MXLogDebug(@"[MXNativeKeyBackupEngine] privateKey. Error: No secret in crypto store");
+        return nil;
+    }
+
+    return [MXBase64Tools dataFromBase64:privateKeyBase64];
+}
+
+- (void)savePrivateKey:(NSString *)privateKey
+{
+    [self.crypto.store storeSecret:privateKey withSecretId:MXSecretId.keyBackup];
+}
+
+- (void)saveRecoveryKey:(NSString *)recoveryKey
+{
+    NSError *error;
+    OLMPkDecryption *decryption = [self pkDecryptionFromRecoveryKey:recoveryKey error:&error];
+    if (!decryption)
+    {
+        MXLogDebug(@"[MXNativeKeyBackupEngine] saveRecoveryKey: Cannot create OLMPkDecryption. Error: %@", error);
+        return;
+    }
+    
+    NSString *privateKeyBase64 = [MXBase64Tools unpaddedBase64FromData:decryption.privateKey];
+    [self savePrivateKey:privateKeyBase64];
+}
+
+- (void)deletePrivateKey
+{
+    [self.crypto.store deleteSecretWithSecretId:MXSecretId.keyBackup];
+}
+
+- (BOOL)isValidPrivateKey:(NSData *)privateKey
+                    error:(NSError **)error
+{
+    return [self.keyBackupAlgorithm keyMatches:privateKey error:error];
+}
+
+- (BOOL)isValidPrivateKey:(NSData *)privateKey
+      forKeyBackupVersion:(MXKeyBackupVersion *)keyBackupVersion
+                    error:(NSError **)error
+{
+    id<MXKeyBackupAlgorithm> algorithm = [self getOrCreateKeyBackupAlgorithmFor:keyBackupVersion privateKey:privateKey];
+    return [algorithm keyMatches:privateKey error:error];
+}
+
+- (BOOL)isValidRecoveryKey:(NSString*)recoveryKey
+       forKeyBackupVersion:(MXKeyBackupVersion*)keyBackupVersion
+                     error:(NSError **)error
+{
+    NSData *privateKey = [MXRecoveryKey decode:recoveryKey error:error];
+
+    if (*error)
+    {
+        MXLogDebug(@"[MXNativeKeyBackupEngine] isValidRecoveryKey: Invalid recovery key. Error: %@", *error);
+
+        // Return a generic error
+        *error = [NSError errorWithDomain:MXKeyBackupErrorDomain
+                                     code:MXKeyBackupErrorInvalidRecoveryKeyCode
+                                 userInfo:@{
+            NSLocalizedDescriptionKey: @"Invalid recovery key or password"
+        }];
+        return NO;
+    }
+
+    Class<MXKeyBackupAlgorithm> algorithm = AlgorithmClassesByName[keyBackupVersion.algorithm];
+    if (algorithm == NULL)
+    {
+        MXLogDebug(@"[MXNativeKeyBackupEngine] isValidRecoveryKey: unknown algorithm: %@", keyBackupVersion.algorithm);
+
+        *error = [NSError errorWithDomain:MXKeyBackupErrorDomain
+                                     code:MXKeyBackupErrorUnknownAlgorithm
+                                 userInfo:@{
+            NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Unknown algorithm (%@)", keyBackupVersion.algorithm]
+        }];
+        return NO;
+    }
+    BOOL result = [algorithm keyMatches:privateKey withAuthData:keyBackupVersion.authData error:error];
+
+    if (!result)
+    {
+        MXLogDebug(@"[MXNativeKeyBackupEngine] isValidRecoveryKey: Public keys mismatch");
+
+        *error = [NSError errorWithDomain:MXKeyBackupErrorDomain
+                                     code:MXKeyBackupErrorInvalidRecoveryKeyCode
+                                 userInfo:@{
+            NSLocalizedDescriptionKey: @"Invalid recovery key or password: public keys mismatch"
+        }];
+    }
+
+    return result;
+}
+
+- (void)validateKeyBackupVersion:(MXKeyBackupVersion *)keyBackupVersion
+{
+    // Check private keys
+    if (self.privateKey)
+    {
+        Class<MXKeyBackupAlgorithm> algorithmClass = AlgorithmClassesByName[keyBackupVersion.algorithm];
+        if (algorithmClass == NULL)
+        {
+            NSString *message = [NSString stringWithFormat:@"[MXNativeKeyBackupEngine] validateKeyBackupVersion: unknown algorithm: %@", keyBackupVersion.algorithm];
+            MXLogError(message);
+            return;
+        }
+        if (![algorithmClass checkBackupVersion:keyBackupVersion])
+        {
+            MXLogError(@"[MXNativeKeyBackupEngine] validateKeyBackupVersion: invalid backup data returned");
+            return;
+        }
+
+        NSData *privateKey = self.privateKey;
+        NSError *error;
+        BOOL keyMatches = [algorithmClass keyMatches:privateKey withAuthData:keyBackupVersion.authData error:&error];
+        if (error || !keyMatches)
+        {
+            MXLogDebug(@"[MXNativeKeyBackupEngine] validateKeyBackupVersion: -> private key does not match: %@, will be removed", error);
+            [self.crypto.store deleteSecretWithSecretId:MXSecretId.keyBackup];
+        }
+    }
+}
+
+- (nullable NSString*)recoveryKeyFromPassword:(NSString*)password
+                           inKeyBackupVersion:(MXKeyBackupVersion*)keyBackupVersion
+                                        error:(NSError **)error
+{
+    // Extract MXBaseKeyBackupAuthData
+    id<MXBaseKeyBackupAuthData> authData = [self megolmBackupAuthDataFromKeyBackupVersion:keyBackupVersion error:error];
+    if (*error)
+    {
+        return nil;
+    }
+
+    if (!authData.privateKeySalt || !authData.privateKeyIterations)
+    {
+        MXLogDebug(@"[MXNativeKeyBackupEngine] recoveryFromPassword: Salt and/or iterations not found in key backup auth data");
+        *error = [NSError errorWithDomain:MXKeyBackupErrorDomain
+                                     code:MXKeyBackupErrorMissingPrivateKeySaltCode
+                                 userInfo:@{
+                                            NSLocalizedDescriptionKey: @"Salt and/or iterations not found in key backup auth data"
+                                            }];
+        return nil;
+    }
+
+
+    // Extract the recovery key from the passphrase
+    NSData *recoveryKeyData = [MXKeyBackupPassword retrievePrivateKeyWithPassword:password salt:authData.privateKeySalt iterations:authData.privateKeyIterations error:error];
+    if (*error)
+    {
+        MXLogDebug(@"[MXNativeKeyBackupEngine] recoveryFromPassword: retrievePrivateKeyWithPassword failed: %@", *error);
+        return nil;
+    }
+
+    return [MXRecoveryKey encode:recoveryKeyData];
+}
+
+#pragma mark - Backup versions
+
+- (void)prepareKeyBackupVersionWithPassword:(NSString *)password
+                                  algorithm:(NSString *)algorithm
+                                    success:(void (^)(MXMegolmBackupCreationInfo *))success
+                                    failure:(void (^)(NSError *))failure
+{
+    Class<MXKeyBackupAlgorithm> algorithmClass = algorithm ? AlgorithmClassesByName[algorithm] : DefaultAlgorithmClass;
+    if (algorithmClass == NULL)
+    {
+        if (failure)
+        {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                NSError *error = [NSError errorWithDomain:MXKeyBackupErrorDomain
+                                                     code:MXKeyBackupErrorUnknownAlgorithm
+                                                 userInfo:@{
+                    NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Unknown algorithm (%@) to prepare the backup", algorithm]
+                }];
+                failure(error);
+            });
+        }
+        return;
+    }
+    NSError *error;
+    MXKeyBackupPreparationInfo *preparationInfo = [algorithmClass prepareWith:password error:&error];
+    if (error)
+    {
+        if (failure)
+        {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                failure(error);
+            });
+        }
+        return;
+    }
+    id<MXBaseKeyBackupAuthData> authData = preparationInfo.authData;
+    
+    MXMegolmBackupCreationInfo *keyBackupCreationInfo = [MXMegolmBackupCreationInfo new];
+    keyBackupCreationInfo.algorithm = [algorithmClass algorithmName];
+    keyBackupCreationInfo.authData = authData;
+    keyBackupCreationInfo.recoveryKey = [MXRecoveryKey encode:preparationInfo.privateKey];
+    
+    NSString *myUserId = self.crypto.matrixRestClient.credentials.userId;
+    NSMutableDictionary *signatures = [NSMutableDictionary dictionary];
+    
+    NSDictionary *deviceSignature = [self.crypto signObject:authData.signalableJSONDictionary];
+    [signatures addEntriesFromDictionary:deviceSignature[myUserId]];
+    
+    if ([self.crypto.crossSigning canCrossSign] == NO)
+    {
+        authData.signatures = @{myUserId: signatures};
+        keyBackupCreationInfo.authData = authData;
+        
+        if (success)
+        {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                success(keyBackupCreationInfo);
+            });
+        }
+        
+        return;
+    }
+    
+    [self.crypto.crossSigning signObject:authData.signalableJSONDictionary withKeyType:MXCrossSigningKeyType.master success:^(NSDictionary *signedObject) {
+        
+        [signatures addEntriesFromDictionary:signedObject[@"signatures"][myUserId]];
+        
+        authData.signatures = @{myUserId: signatures};
+        keyBackupCreationInfo.authData = authData;
+        
+        if (success)
+        {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                success(keyBackupCreationInfo);
+            });
+        }
+    } failure:^(NSError *error) {
+        if (failure)
+        {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                failure(error);
+            });
+        }
+    }];
+}
+
+- (MXKeyBackupVersionTrust *)trustForKeyBackupVersionFromCryptoQueue:(MXKeyBackupVersion *)keyBackupVersion
+{
+    NSString *myUserId = self.crypto.matrixRestClient.credentials.userId;
+
+    MXKeyBackupVersionTrust *keyBackupVersionTrust = [MXKeyBackupVersionTrust new];
+
+    NSError *error;
+    id<MXBaseKeyBackupAuthData> authData = [self megolmBackupAuthDataFromKeyBackupVersion:keyBackupVersion error:&error];
+    if (error)
+    {
+        MXLogDebug(@"[MXNativeKeyBackupEngine] trustForKeyBackupVersion: Key backup is absent or missing required data");
+        return keyBackupVersionTrust;
+    }
+
+    NSData *privateKey = self.privateKey;
+    if (privateKey)
+    {
+        id<MXKeyBackupAlgorithm> algorithm = [self getOrCreateKeyBackupAlgorithmFor:keyBackupVersion privateKey:privateKey];
+        if ([algorithm keyMatches:privateKey error:nil])
+        {
+            MXLogDebug(@"[MXNativeKeyBackupEngine] trustForKeyBackupVersionFromCryptoQueue: Backup is trusted locally");
+            keyBackupVersionTrust.trustedLocally = YES;
+        }
+    }
+
+    NSDictionary *mySigs = authData.signatures[myUserId];
+    NSMutableArray<MXKeyBackupVersionTrustSignature*> *signatures = [NSMutableArray array];
+    for (NSString *keyId in mySigs)
+    {
+        // XXX: is this how we're supposed to get the device id?
+        NSString *deviceId;
+        NSArray<NSString *> *components = [keyId componentsSeparatedByString:@":"];
+        if (components.count == 2)
+        {
+            deviceId = components[1];
+        }
+
+        if (deviceId)
+        {
+            BOOL valid = NO;
+
+            MXDeviceInfo *device = [self.crypto.deviceList storedDevice:myUserId deviceId:deviceId];
+            if (device)
+            {
+                NSError *error;
+                valid = [self.crypto.olmDevice verifySignature:device.fingerprint JSON:authData.signalableJSONDictionary signature:mySigs[keyId] error:&error];
+
+                if (!valid)
+                {
+                    MXLogDebug(@"[MXNativeKeyBackupEngine] trustForKeyBackupVersion: Bad signature from device %@: %@", device.deviceId, error);
+                }
+                
+                MXKeyBackupVersionTrustSignature *signature = [MXKeyBackupVersionTrustSignature new];
+                signature.deviceId = deviceId;
+                signature.device = device;
+                signature.valid = valid;
+                [signatures addObject:signature];
+            }
+            else // Try interpreting it as the MSK public key
+            {
+                NSError *error;
+                BOOL valid = [self.crypto.crossSigning.crossSigningTools pkVerifyObject:authData.JSONDictionary userId:myUserId publicKey:deviceId error:&error];
+                
+                if (!valid)
+                {
+                    MXLogDebug(@"[MXNativeKeyBackupEngine] trustForKeyBackupVersion: Signature with unknown key %@", deviceId);
+                }
+                else
+                {
+                    MXKeyBackupVersionTrustSignature *signature = [MXKeyBackupVersionTrustSignature new];
+                    signature.keys = deviceId;
+                    signature.valid = valid;
+                    [signatures addObject:signature];
+                }
+            }
+        }
+    }
+
+    keyBackupVersionTrust.signatures = signatures;
+
+    for (MXKeyBackupVersionTrustSignature *signature in keyBackupVersionTrust.signatures)
+    {
+        if (signature.valid && signature.device && signature.device.trustLevel.isVerified)
+        {
+            keyBackupVersionTrust.usable = YES;
+        }
+    }
+    keyBackupVersionTrust.usable = keyBackupVersionTrust.usable || keyBackupVersionTrust.isTrustedLocally;
+
+    return keyBackupVersionTrust;
+}
+
+- (nullable id<MXBaseKeyBackupAuthData>)megolmBackupAuthDataFromKeyBackupVersion:(MXKeyBackupVersion*)keyBackupVersion error:(NSError**)error
+{
+    Class<MXKeyBackupAlgorithm> algorithmClass = AlgorithmClassesByName[keyBackupVersion.algorithm];
+    if (algorithmClass == NULL)
+    {
+        NSString *message = [NSString stringWithFormat:@"[MXNativeKeyBackupEngine] megolmBackupAuthDataFromKeyBackupVersion: Key backup for unknown algorithm: %@", keyBackupVersion.algorithm];
+        MXLogError(message);
+
+        *error = [NSError errorWithDomain:MXKeyBackupErrorDomain
+                                     code:MXKeyBackupErrorUnknownAlgorithm
+                                 userInfo:@{
+            NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Unknown algorithm (%@) for the backup", keyBackupVersion.algorithm]
+        }];
+
+        return nil;
+    }
+
+    return [algorithmClass authDataFromJSON:keyBackupVersion.authData error:error];
+}
+
+- (NSDictionary *)signObject:(NSDictionary *)object
+{
+    return [self.crypto signObject:object];
+}
+
+#pragma mark - Backup keys
+
+- (BOOL)hasKeysToBackup
+{
+    return [self.crypto.store inboundGroupSessionsToBackup:1].count > 0;
+}
+
+- (NSProgress *)backupProgress
+{
+    NSUInteger keys = [self.crypto.store inboundGroupSessionsCount:NO];
+    NSUInteger backedUpkeys = [self.crypto.store inboundGroupSessionsCount:YES];
+
+    NSProgress *progress = [NSProgress progressWithTotalUnitCount:keys];
+    progress.completedUnitCount = backedUpkeys;
+    return progress;
+}
+
+- (MXKeyBackupPayload *)roomKeysBackupPayload
+{
+    if (!self.keyBackupAlgorithm)
+    {
+        MXLogDebug(@"[MXNativeKeyBackupEngine] roomKeysBackupPayload: No known backup algorithm");
+        return nil;
+    }
+    
+    // Get a chunk of keys to backup
+    NSArray<MXOlmInboundGroupSession*> *sessions = [self.crypto.store inboundGroupSessionsToBackup:kMXKeyBackupSendKeysMaxCount];
+
+    MXLogDebug(@"[MXNativeKeyBackupEngine] roomKeysBackupPayload: 1 - %@ sessions to back up", @(sessions.count));
+
+    // Gather data to send to the homeserver
+    // roomId -> sessionId -> MXKeyBackupData
+    NSMutableDictionary<NSString *,
+        NSMutableDictionary<NSString *, MXKeyBackupData*> *> *roomsKeyBackup = [NSMutableDictionary dictionary];
+
+    for (MXOlmInboundGroupSession *session in sessions)
+    {
+        MXKeyBackupData *keyBackupData = [self.keyBackupAlgorithm encryptGroupSession:session];
+
+        if (keyBackupData)
+        {
+            if (!roomsKeyBackup[session.roomId])
+            {
+                roomsKeyBackup[session.roomId] = [NSMutableDictionary dictionary];
+            }
+            roomsKeyBackup[session.roomId][session.session.sessionIdentifier] = keyBackupData;
+        }
+    }
+
+    MXLogDebug(@"[MXNativeKeyBackupEngine] roomKeysBackupPayload: 2 - Finalising data to send");
+
+    // Finalise data to send
+    NSMutableDictionary<NSString*, MXRoomKeysBackupData*> *rooms = [NSMutableDictionary dictionary];
+    for (NSString *roomId in roomsKeyBackup)
+    {
+        NSMutableDictionary<NSString*, MXKeyBackupData*> *roomSessions = [NSMutableDictionary dictionary];
+        for (NSString *sessionId in roomsKeyBackup[roomId])
+        {
+            roomSessions[sessionId] = roomsKeyBackup[roomId][sessionId];
+        }
+        MXRoomKeysBackupData *roomKeysBackupData = [MXRoomKeysBackupData new];
+        roomKeysBackupData.sessions = roomSessions;
+
+        rooms[roomId] = roomKeysBackupData;
+    }
+
+    MXKeysBackupData *keysBackupData = [MXKeysBackupData new];
+    keysBackupData.rooms = rooms;
+    
+    MXWeakify(self);
+    return [[MXKeyBackupPayload alloc] initWithBackupData:keysBackupData
+                                                             completion:^(NSDictionary *JSONResponse) {
+        MXStrongifyAndReturnIfNil(self);
+        [self.crypto.store markBackupDoneForInboundGroupSessions:sessions];
+    }];
+}
+
+- (MXMegolmSessionData *)decryptKeyBackupData:(MXKeyBackupData *)keyBackupData
+                             keyBackupVersion:(MXKeyBackupVersion *)keyBackupVersion
+                                   privateKey:(NSData *)privateKey
+                                   forSession:(NSString *)sessionId
+                                       inRoom:(NSString *)roomId
+{
+    id<MXKeyBackupAlgorithm> algorithm = [self getOrCreateKeyBackupAlgorithmFor:keyBackupVersion privateKey:privateKey];
+    return [algorithm decryptKeyBackupData:keyBackupData forSession:sessionId inRoom:roomId];
+}
+
+- (void)importMegolmSessionDatas:(NSArray<MXMegolmSessionData *> *)keys
+                          backUp:(BOOL)backUp
+                         success:(void (^)(NSUInteger, NSUInteger))success
+                         failure:(void (^)(NSError * _Nonnull))failure
+{
+    [self.crypto importMegolmSessionDatas:keys backUp:backUp success:success failure:failure];
+}
+
+#pragma mark - Private methods -
+
+- (id<MXKeyBackupAlgorithm>)getOrCreateKeyBackupAlgorithmFor:(MXKeyBackupVersion*)keyBackupVersion privateKey:(NSData*)privateKey
+{
+    if (self.enabled
+        && [self.keyBackupVersion.JSONDictionary isEqualToDictionary:keyBackupVersion.JSONDictionary]
+        && [self.privateKey isEqualToData:privateKey])
+    {
+        return self.keyBackupAlgorithm;
+    }
+    Class<MXKeyBackupAlgorithm> algorithmClass = AlgorithmClassesByName[keyBackupVersion.algorithm];
+    if (algorithmClass == NULL)
+    {
+        NSString *message = [NSString stringWithFormat:@"[MXNativeKeyBackupEngine] getOrCreateKeyBackupAlgorithmFor: unknown algorithm: %@", keyBackupVersion.algorithm];
+        MXLogError(message);
+        return nil;
+    }
+    if (![algorithmClass checkBackupVersion:keyBackupVersion])
+    {
+        MXLogError(@"[MXNativeKeyBackupEngine] getOrCreateKeyBackupAlgorithmFor: invalid backup data returned");
+        return nil;
+    }
+    NSError *error;
+    id<MXBaseKeyBackupAuthData> authData = [self megolmBackupAuthDataFromKeyBackupVersion:keyBackupVersion error:&error];
+    if (error)
+    {
+        MXLogError(@"[MXNativeKeyBackupEngine] getOrCreateKeyBackupAlgorithmFor: invalid auth data");
+        return nil;
+    }
+    return [[algorithmClass.class alloc] initWithCrypto:self.crypto authData:authData keyGetterBlock:^NSData * _Nullable{
+        return privateKey;
+    }];
+}
+
+- (OLMPkDecryption*)pkDecryptionFromRecoveryKey:(NSString*)recoveryKey error:(NSError **)error
+{
+    // Extract the private key
+    NSData *privateKey = [MXRecoveryKey decode:recoveryKey error:error];
+
+    // Built the PK decryption with it
+    OLMPkDecryption *decryption;
+    if (privateKey)
+    {
+        decryption = [OLMPkDecryption new];
+        [decryption setPrivateKey:privateKey error:error];
+    }
+
+    return decryption;
+}
+
+@end

--- a/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.h
+++ b/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.h
@@ -396,11 +396,6 @@ FOUNDATION_EXPORT NSString *const kMXKeyBackupDidStateChangeNotification;
 @property (nonatomic, readonly, nullable) MXKeyBackupVersion *keyBackupVersion;
 
 /**
- The backup algorithm being used. Nil if key backup not enabled yet.
- */
-@property (nonatomic, readonly, nullable) id<MXKeyBackupAlgorithm> keyBackupAlgorithm;
-
-/**
  Indicate if their are keys to backup.
  */
 @property (nonatomic, readonly) BOOL hasKeysToBackup;

--- a/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.m
+++ b/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.m
@@ -30,11 +30,8 @@
 #import "MXRawDataKey.h"
 #import "MXCrossSigning_Private.h"
 #import "MXSharedHistoryKeyService.h"
-#import "MXCurve25519BackupAuthData.h"
-#import "MXAes256BackupAuthData.h"
-#import "MXKeyBackupAlgorithm.h"
-#import "MXCurve25519KeyBackupAlgorithm.h"
-#import "MXAes256KeyBackupAlgorithm.h"
+#import "MXKeyBackupEngine.h"
+#import "MatrixSDKSwiftHeader.h"
 
 #pragma mark - Constants definitions
 
@@ -45,18 +42,8 @@ NSString *const kMXKeyBackupDidStateChangeNotification = @"kMXKeyBackupDidStateC
  */
 NSUInteger const kMXKeyBackupWaitingTimeToSendKeyBackup = 10000;
 
-/**
- Maximum number of keys to send at a time to the homeserver.
- */
-NSUInteger const kMXKeyBackupSendKeysMaxCount = 100;
-
-static NSDictionary<NSString*, Class<MXKeyBackupAlgorithm>> *AlgorithmClassesByName;
-static Class DefaultAlgorithmClass;
-
 @interface MXKeyBackup ()
 {
-    __weak MXCrypto *crypto;
-
     // The queue to run background tasks
     dispatch_queue_t cryptoQueue;
 
@@ -67,37 +54,29 @@ static Class DefaultAlgorithmClass;
     void (^backupAllGroupSessionsFailure)(NSError *error);
 }
 
+@property (nonatomic, strong) id<MXKeyBackupEngine> engine;
+@property (nonatomic, strong) MXRestClient *restClient;
+@property (nonatomic, strong) MXSecretShareManager *secretShareManager;
+
 @end
 
 @implementation MXKeyBackup
 
 #pragma mark - SDK-Private methods -
 
-+ (void)initialize
-{
-    if (MXSDKOptions.sharedInstance.enableSymmetricBackup)
-    {
-        AlgorithmClassesByName = @{
-            kMXCryptoCurve25519KeyBackupAlgorithm: MXCurve25519KeyBackupAlgorithm.class,
-            kMXCryptoAes256KeyBackupAlgorithm: MXAes256KeyBackupAlgorithm.class
-        };
-    }
-    else
-    {
-        AlgorithmClassesByName = @{
-            kMXCryptoCurve25519KeyBackupAlgorithm: MXCurve25519KeyBackupAlgorithm.class,
-        };
-    }
-    DefaultAlgorithmClass = MXCurve25519KeyBackupAlgorithm.class;
-}
-
-- (instancetype)initWithCrypto:(MXCrypto *)theCrypto
+- (instancetype)initWithEngine:(id<MXKeyBackupEngine>)engine
+                    restClient:(MXRestClient *)restClient
+            secretShareManager:(MXSecretShareManager *)secretShareManager
+                         queue:(dispatch_queue_t)queue
 {
     self = [self init];
+    if (self)
     {
         _state = MXKeyBackupStateUnknown;
-        crypto = theCrypto;
-        cryptoQueue = crypto.cryptoQueue;
+        _engine = engine;
+        _restClient = restClient;
+        _secretShareManager = secretShareManager;
+        cryptoQueue = queue;
     }
     return self;
 }
@@ -142,45 +121,21 @@ static Class DefaultAlgorithmClass;
         return;
     }
 
-    MXKeyBackupVersionTrust *trustInfo = [self trustForKeyBackupVersionFromCryptoQueue:keyBackupVersion];
+    MXKeyBackupVersionTrust *trustInfo = [self.engine trustForKeyBackupVersionFromCryptoQueue:keyBackupVersion];
 
     if (trustInfo.usable)
     {
         MXLogDebug(@"[MXKeyBackup] checkAndStartWithKeyBackupVersion: Found usable key backup. version: %@", keyBackupVersion.version);
 
         // Check the version we used at the previous app run
-        NSString *versionInStore = crypto.store.backupVersion;
+        NSString *versionInStore = self.engine.version;
         if (versionInStore && ![versionInStore isEqualToString:keyBackupVersion.version])
         {
             MXLogDebug(@"[MXKeyBackup] -> clean the previously used version(%@)", versionInStore);
             [self resetKeyBackupData];
         }
-        
-        // Check private keys
-        if (self.hasPrivateKeyInCryptoStore)
-        {
-            Class<MXKeyBackupAlgorithm> algorithmClass = AlgorithmClassesByName[keyBackupVersion.algorithm];
-            if (algorithmClass == NULL)
-            {
-                NSString *message = [NSString stringWithFormat:@"[MXKeyBackup] checkAndStartWithKeyBackupVersion: unknown algorithm: %@", keyBackupVersion.algorithm];
-                MXLogError(message);
-                return;
-            }
-            if (![algorithmClass checkBackupVersion:keyBackupVersion])
-            {
-                MXLogError(@"[MXKeyBackup] checkAndStartWithKeyBackupVersion: invalid backup data returned");
-                return;
-            }
 
-            NSData *privateKey = self.privateKeyFromCryptoStore;
-            NSError *error;
-            BOOL keyMatches = [algorithmClass keyMatches:privateKey withAuthData:keyBackupVersion.authData error:&error];
-            if (error || !keyMatches)
-            {
-                MXLogDebug(@"[MXKeyBackup] checkAndStartWithKeyBackupVersion: -> private key does not match: %@, will be removed", error);
-                [crypto.store deleteSecretWithSecretId:MXSecretId.keyBackup];
-            }
-        }
+        [self.engine validateKeyBackupVersion:keyBackupVersion];
         
         MXLogDebug(@"[MXKeyBackup]    -> enabling key backups");
         [self enableKeyBackup:keyBackupVersion];
@@ -189,7 +144,7 @@ static Class DefaultAlgorithmClass;
     {
         MXLogDebug(@"[MXKeyBackup] checkAndStartWithKeyBackupVersion: No usable key backup. version: %@", keyBackupVersion.version);
 
-        if (crypto.store.backupVersion)
+        if (self.engine.version)
         {
             MXLogDebug(@"[MXKeyBackup]    -> disable the current version");
             [self resetKeyBackupData];
@@ -208,24 +163,16 @@ static Class DefaultAlgorithmClass;
 - (NSError*)enableKeyBackup:(MXKeyBackupVersion*)version
 {
     NSError *error;
-    id<MXBaseKeyBackupAuthData> authData = [self megolmBackupAuthDataFromKeyBackupVersion:version error:&error];
-    if (!error)
+    if (![self.engine enableBackupWithVersion:version error:&error])
     {
-        _keyBackupVersion = version;
-        crypto.store.backupVersion = version.version;
-        Class algorithmClass = AlgorithmClassesByName[version.algorithm];
-        //  store the desired backup algorithm
-        _keyBackupAlgorithm = [[algorithmClass alloc] initWithCrypto:crypto authData:authData keyGetterBlock:^NSData * _Nullable{
-            return self.privateKeyFromCryptoStore;
-        }];
-        MXLogDebug(@"[MXKeyBackup] Algorithm set to: %@", _keyBackupAlgorithm);
-
-        self.state = MXKeyBackupStateReadyToBackUp;
-        
-        [self maybeSendKeyBackup];
+        return error;
     }
+    _keyBackupVersion = version;
+    self.state = MXKeyBackupStateReadyToBackUp;
+        
+    [self maybeSendKeyBackup];
 
-    return error;
+    return nil;
 }
 
 - (void)resetKeyBackupData
@@ -233,13 +180,7 @@ static Class DefaultAlgorithmClass;
     MXLogDebug(@"[MXKeyBackup] resetKeyBackupData");
     
     [self resetBackupAllGroupSessionsObjects];
-    
-    self->crypto.store.backupVersion = nil;
-    [self->crypto.store deleteSecretWithSecretId:MXSecretId.keyBackup];
-    _keyBackupAlgorithm = nil;
-
-    // Reset backup markers
-    [self->crypto.store resetBackupMarkers];
+    [self.engine disableBackup];
 }
 
 - (void)maybeSendKeyBackup
@@ -275,13 +216,8 @@ static Class DefaultAlgorithmClass;
 - (void)sendKeyBackup
 {
     MXLogDebug(@"[MXKeyBackup] sendKeyBackup");
-
-    // Get a chunk of keys to backup
-    NSArray<MXOlmInboundGroupSession*> *sessions = [crypto.store inboundGroupSessionsToBackup:kMXKeyBackupSendKeysMaxCount];
-
-    MXLogDebug(@"[MXKeyBackup] sendKeyBackup: 1 - %@ sessions to back up", @(sessions.count));
-
-    if (!sessions.count)
+    
+    if (!self.engine.hasKeysToBackup)
     {
         // Backup is up to date
         self.state = MXKeyBackupStateReadyToBackUp;
@@ -295,7 +231,7 @@ static Class DefaultAlgorithmClass;
     }
 
     // Sanity check
-    if (!self.enabled || !_keyBackupAlgorithm || !_keyBackupVersion)
+    if (!self.enabled || !_keyBackupVersion)
     {
         MXLogDebug(@"[MXKeyBackup] sendKeyBackup: Invalid state: %@", @(_state));
         if (backupAllGroupSessionsFailure)
@@ -313,59 +249,27 @@ static Class DefaultAlgorithmClass;
     self.state = MXKeyBackupStateBackingUp;
 
     MXLogDebug(@"[MXKeyBackup] sendKeyBackup: 2 - Encrypting keys");
-
-    // Gather data to send to the homeserver
-    // roomId -> sessionId -> MXKeyBackupData
-    NSMutableDictionary<NSString *,
-        NSMutableDictionary<NSString *, MXKeyBackupData*> *> *roomsKeyBackup = [NSMutableDictionary dictionary];
-
-    for (MXOlmInboundGroupSession *session in sessions)
+    
+    MXKeyBackupPayload *payload = [self.engine roomKeysBackupPayload];
+    if (!payload)
     {
-        MXKeyBackupData *keyBackupData = [_keyBackupAlgorithm encryptGroupSession:session];
-
-        if (keyBackupData)
-        {
-            if (!roomsKeyBackup[session.roomId])
-            {
-                roomsKeyBackup[session.roomId] = [NSMutableDictionary dictionary];
-            }
-            roomsKeyBackup[session.roomId][session.session.sessionIdentifier] = keyBackupData;
-        }
+        MXLogError(@"[MXKeyBackup] sendKeyBackup: Cannot get room key backups");
+        return;
     }
-
-    MXLogDebug(@"[MXKeyBackup] sendKeyBackup: 3 - Finalising data to send");
-
-    // Finalise data to send
-    NSMutableDictionary<NSString*, MXRoomKeysBackupData*> *rooms = [NSMutableDictionary dictionary];
-    for (NSString *roomId in roomsKeyBackup)
-    {
-        NSMutableDictionary<NSString*, MXKeyBackupData*> *roomSessions = [NSMutableDictionary dictionary];
-        for (NSString *sessionId in roomsKeyBackup[roomId])
-        {
-            roomSessions[sessionId] = roomsKeyBackup[roomId][sessionId];
-        }
-        MXRoomKeysBackupData *roomKeysBackupData = [MXRoomKeysBackupData new];
-        roomKeysBackupData.sessions = roomSessions;
-
-        rooms[roomId] = roomKeysBackupData;
-    }
-
-    MXKeysBackupData *keysBackupData = [MXKeysBackupData new];
-    keysBackupData.rooms = rooms;
 
     MXLogDebug(@"[MXKeyBackup] sendKeyBackup: 4 - Sending request");
 
     // Make the request
     MXWeakify(self);
-    [crypto.matrixRestClient sendKeysBackup:keysBackupData version:_keyBackupVersion.version success:^{
+    [self.restClient sendKeysBackup:payload.backupData version:_keyBackupVersion.version success:^(NSDictionary *JSONResponse){
         MXStrongifyAndReturnIfNil(self);
 
         MXLogDebug(@"[MXKeyBackup] sendKeyBackup: 5a - Request complete");
 
         // Mark keys as backed up
-        [self->crypto.store markBackupDoneForInboundGroupSessions:sessions];
+        payload.completion(JSONResponse);
 
-        if (sessions.count < kMXKeyBackupSendKeysMaxCount)
+        if (!self.engine.hasKeysToBackup)
         {
             MXLogDebug(@"[MXKeyBackup] sendKeyBackup: All keys have been backed up");
             self.state = MXKeyBackupStateReadyToBackUp;
@@ -440,7 +344,7 @@ static Class DefaultAlgorithmClass;
     }
     
     // Check private keys
-    if (!self.hasPrivateKeyInCryptoStore)
+    if (!self.engine.privateKey)
     {
         MXLogDebug(@"[MXKeyBackup] restoreKeyBackupAutomatically. Error: No private key");
         onComplete();
@@ -448,13 +352,13 @@ static Class DefaultAlgorithmClass;
     }
     
     // Check private keys validity
-    NSData *privateKey = self.privateKeyFromCryptoStore;
+    NSData *privateKey = self.engine.privateKey;
     NSError *error;
-    BOOL keyMatches = [_keyBackupAlgorithm keyMatches:privateKey error:&error];
-    if (error || !keyMatches)
+    BOOL keyMatches = [self.engine isValidPrivateKey:privateKey error:&error];
+    if (!keyMatches)
     {
         MXLogDebug(@"[MXKeyBackup] restoreKeyBackupAutomatically. Error: Private key does not match: %@", error);
-        [crypto.store deleteSecretWithSecretId:MXSecretId.keyBackup];
+        [self.engine deletePrivateKey];
         onComplete();
         return;
     }
@@ -497,7 +401,7 @@ static Class DefaultAlgorithmClass;
 
 - (MXHTTPOperation *)versionFromCryptoQueue:(NSString *)version success:(void (^)(MXKeyBackupVersion * _Nullable))success failure:(void (^)(NSError * _Nonnull))failure
 {
-    return [crypto.matrixRestClient keyBackupVersion:version success:success failure:^(NSError *error) {
+    return [self.restClient keyBackupVersion:version success:success failure:^(NSError *error) {
 
         // Workaround because the homeserver currently returns  M_NOT_FOUND when there is
         // no key backup
@@ -524,84 +428,7 @@ static Class DefaultAlgorithmClass;
     MXWeakify(self);
     dispatch_async(cryptoQueue, ^{
         MXStrongifyAndReturnIfNil(self);
-
-        Class<MXKeyBackupAlgorithm> algorithmClass = algorithm ? AlgorithmClassesByName[algorithm] : DefaultAlgorithmClass;
-        if (algorithmClass == NULL)
-        {
-            if (failure)
-            {
-                dispatch_async(dispatch_get_main_queue(), ^{
-                    NSError *error = [NSError errorWithDomain:MXKeyBackupErrorDomain
-                                                         code:MXKeyBackupErrorUnknownAlgorithm
-                                                     userInfo:@{
-                        NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Unknown algorithm (%@) to prepare the backup", algorithm]
-                    }];
-                    failure(error);
-                });
-            }
-            return;
-        }
-        NSError *error;
-        MXKeyBackupPreparationInfo *preparationInfo = [algorithmClass prepareWith:password error:&error];
-        if (error)
-        {
-            if (failure)
-            {
-                dispatch_async(dispatch_get_main_queue(), ^{
-                    failure(error);
-                });
-            }
-            return;
-        }
-        id<MXBaseKeyBackupAuthData> authData = preparationInfo.authData;
-        
-        MXMegolmBackupCreationInfo *keyBackupCreationInfo = [MXMegolmBackupCreationInfo new];
-        keyBackupCreationInfo.algorithm = [algorithmClass algorithmName];
-        keyBackupCreationInfo.authData = authData;
-        keyBackupCreationInfo.recoveryKey = [MXRecoveryKey encode:preparationInfo.privateKey];
-        
-        NSString *myUserId = self->crypto.matrixRestClient.credentials.userId;
-        NSMutableDictionary *signatures = [NSMutableDictionary dictionary];
-        
-        NSDictionary *deviceSignature = [self->crypto signObject:authData.signalableJSONDictionary];
-        [signatures addEntriesFromDictionary:deviceSignature[myUserId]];
-        
-        if ([self->crypto.crossSigning canCrossSign] == NO)
-        {
-            authData.signatures = @{myUserId: signatures};
-            keyBackupCreationInfo.authData = authData;
-            
-            if (success)
-            {
-                dispatch_async(dispatch_get_main_queue(), ^{
-                    success(keyBackupCreationInfo);
-                });
-            }
-            
-            return;
-        }
-        
-        [self->crypto.crossSigning signObject:authData.signalableJSONDictionary withKeyType:MXCrossSigningKeyType.master success:^(NSDictionary *signedObject) {
-            
-            [signatures addEntriesFromDictionary:signedObject[@"signatures"][myUserId]];
-            
-            authData.signatures = @{myUserId: signatures};
-            keyBackupCreationInfo.authData = authData;
-            
-            if (success)
-            {
-                dispatch_async(dispatch_get_main_queue(), ^{
-                    success(keyBackupCreationInfo);
-                });
-            }
-        } failure:^(NSError *error) {
-            if (failure)
-            {
-                dispatch_async(dispatch_get_main_queue(), ^{
-                    failure(error);
-                });
-            }
-        }];
+        [self.engine prepareKeyBackupVersionWithPassword:password algorithm:algorithm success:success failure:failure];
     });
 }
 
@@ -621,13 +448,13 @@ static Class DefaultAlgorithmClass;
         keyBackupVersion.algorithm = keyBackupCreationInfo.algorithm;
         keyBackupVersion.authData = keyBackupCreationInfo.authData.JSONDictionary;
 
-        MXHTTPOperation *operation2 = [self->crypto.matrixRestClient createKeyBackupVersion:keyBackupVersion success:^(NSString *version) {
+        MXHTTPOperation *operation2 = [self.restClient createKeyBackupVersion:keyBackupVersion success:^(NSString *version) {
+            
+            // Disable current backup
+            [self.engine disableBackup];
 
             // Store the fresh new private key
-            [self storePrivateKeyWithRecoveryKey:keyBackupCreationInfo.recoveryKey];
-            
-            // Reset backup markers
-            [self->crypto.store resetBackupMarkers];
+            [self.engine saveRecoveryKey:keyBackupCreationInfo.recoveryKey];
 
             keyBackupVersion.version = version;
 
@@ -679,7 +506,7 @@ static Class DefaultAlgorithmClass;
         }
 
         MXWeakify(self);
-        MXHTTPOperation *operation2 = [self->crypto.matrixRestClient deleteKeyBackupVersion:version success:^{
+        MXHTTPOperation *operation2 = [self.restClient deleteKeyBackupVersion:version success:^{
             MXStrongifyAndReturnIfNil(self);
 
             // Do not stay in MXKeyBackupStateUnknown but check what is available on the homeserver
@@ -874,13 +701,8 @@ static Class DefaultAlgorithmClass;
     MXWeakify(self);
     dispatch_async(cryptoQueue, ^{
         MXStrongifyAndReturnIfNil(self);
-
-        NSUInteger keys = [self->crypto.store inboundGroupSessionsCount:NO];
-        NSUInteger backedUpkeys = [self->crypto.store inboundGroupSessionsCount:YES];
-
-        NSProgress *progress = [NSProgress progressWithTotalUnitCount:keys];
-        progress.completedUnitCount = backedUpkeys;
-
+        
+        NSProgress *progress = self.engine.backupProgress;
         dispatch_async(dispatch_get_main_queue(), ^{
             backupProgress(progress);
         });
@@ -915,7 +737,7 @@ static Class DefaultAlgorithmClass;
 
         // Check if the recovery is valid before going any further
         NSError *error;
-        BOOL isValidRecoveryKey = [self isValidRecoveryKey:recoveryKey forKeyBackupVersion:keyBackupVersion error:&error];
+        BOOL isValidRecoveryKey = [self.engine isValidRecoveryKey:recoveryKey forKeyBackupVersion:keyBackupVersion error:&error];
         NSData *privateKey = [MXRecoveryKey decode:recoveryKey error:&error];
         if (error || !isValidRecoveryKey || !privateKey)
         {
@@ -934,7 +756,7 @@ static Class DefaultAlgorithmClass;
             // Catch the private key from the recovery key and store it locally
             if ([self.keyBackupVersion.version isEqualToString:keyBackupVersion.version])
             {
-                [self storePrivateKeyWithRecoveryKey:recoveryKey];
+                [self.engine saveRecoveryKey:recoveryKey];
             }
 
             if (success)
@@ -971,9 +793,11 @@ static Class DefaultAlgorithmClass;
             {
                 sessionsFromHSCount++;
                 MXKeyBackupData *keyBackupData = keysBackupData.rooms[roomId].sessions[sessionId];
-
-                id<MXKeyBackupAlgorithm> algorithm = [self getOrCreateKeyBackupAlgorithmFor:keyBackupVersion privateKey:privateKey];
-                MXMegolmSessionData *sessionData = [algorithm decryptKeyBackupData:keyBackupData forSession:sessionId inRoom:roomId];
+                MXMegolmSessionData *sessionData = [self.engine decryptKeyBackupData:keyBackupData
+                                                                    keyBackupVersion:keyBackupVersion
+                                                                          privateKey:privateKey
+                                                                          forSession:sessionId
+                                                                              inRoom:roomId];
                 
                 if (sessionData)
                 {
@@ -992,7 +816,7 @@ static Class DefaultAlgorithmClass;
         }
         
         // Import them into the crypto store
-        [self->crypto importMegolmSessionDatas:sessionDatas backUp:backUp success:success failure:^(NSError *error) {
+        [self.engine importMegolmSessionDatas:sessionDatas backUp:backUp success:success failure:^(NSError *error) {
             if (failure)
             {
                 dispatch_async(dispatch_get_main_queue(), ^{
@@ -1028,7 +852,7 @@ static Class DefaultAlgorithmClass;
 
         // Retrieve the private key from the password
         NSError *error;
-        NSString *recoveryKey = [self recoveryKeyFromPassword:password inKeyBackupVersion:keyBackupVersion error:&error];
+        NSString *recoveryKey = [self.engine recoveryKeyFromPassword:password inKeyBackupVersion:keyBackupVersion error:&error];
 
         if (!error)
         {
@@ -1063,9 +887,9 @@ static Class DefaultAlgorithmClass;
     dispatch_async(cryptoQueue, ^{
         MXStrongifyAndReturnIfNil(self);
 
-        NSData *privateKey = self.privateKeyFromCryptoStore;
+        NSData *privateKey = self.engine.privateKey;
         NSError *error;
-        if (error || ![[self getOrCreateKeyBackupAlgorithmFor:keyBackupVersion privateKey:privateKey] keyMatches:privateKey error:&error])
+        if (![self.engine isValidPrivateKey:privateKey forKeyBackupVersion:keyBackupVersion error:&error])
         {
             MXLogDebug(@"[MXKeyBackup] restoreUsingPrivateKeyKeyBackup. Error: Private key does not match: %@, for: %@", error, keyBackupVersion);
             if (failure)
@@ -1091,9 +915,8 @@ static Class DefaultAlgorithmClass;
 
 - (BOOL)hasPrivateKeyInCryptoStore
 {
-    return [crypto.store secretWithSecretId:MXSecretId.keyBackup] != nil;
+    return self.engine.privateKey != nil;
 }
-
 
 #pragma mark - Backup trust
 
@@ -1101,104 +924,12 @@ static Class DefaultAlgorithmClass;
 {
     dispatch_async(cryptoQueue, ^{
 
-        MXKeyBackupVersionTrust *keyBackupVersionTrust = [self trustForKeyBackupVersionFromCryptoQueue:keyBackupVersion];
+        MXKeyBackupVersionTrust *keyBackupVersionTrust = [self.engine trustForKeyBackupVersionFromCryptoQueue:keyBackupVersion];
 
         dispatch_async(dispatch_get_main_queue(), ^{
             onComplete(keyBackupVersionTrust);
         });
     });
-}
-
-- (MXKeyBackupVersionTrust *)trustForKeyBackupVersionFromCryptoQueue:(MXKeyBackupVersion *)keyBackupVersion
-{
-    NSString *myUserId = crypto.matrixRestClient.credentials.userId;
-
-    MXKeyBackupVersionTrust *keyBackupVersionTrust = [MXKeyBackupVersionTrust new];
-
-    NSError *error;
-    id<MXBaseKeyBackupAuthData> authData = [self megolmBackupAuthDataFromKeyBackupVersion:keyBackupVersion error:&error];
-    if (error)
-    {
-        MXLogDebug(@"[MXKeyBackup] trustForKeyBackupVersion: Key backup is absent or missing required data");
-        return keyBackupVersionTrust;
-    }
-
-    NSData *privateKey = self.privateKeyFromCryptoStore;
-    if (privateKey)
-    {
-        id<MXKeyBackupAlgorithm> algorithm = [self getOrCreateKeyBackupAlgorithmFor:keyBackupVersion privateKey:privateKey];
-        if ([algorithm keyMatches:privateKey error:nil])
-        {
-            MXLogDebug(@"[MXKeyBackup] trustForKeyBackupVersionFromCryptoQueue: Backup is trusted locally");
-            keyBackupVersionTrust.trustedLocally = YES;
-        }
-    }
-
-    NSDictionary *mySigs = authData.signatures[myUserId];
-    NSMutableArray<MXKeyBackupVersionTrustSignature*> *signatures = [NSMutableArray array];
-    for (NSString *keyId in mySigs)
-    {
-        // XXX: is this how we're supposed to get the device id?
-        NSString *deviceId;
-        NSArray<NSString *> *components = [keyId componentsSeparatedByString:@":"];
-        if (components.count == 2)
-        {
-            deviceId = components[1];
-        }
-
-        if (deviceId)
-        {
-            BOOL valid = NO;
-
-            MXDeviceInfo *device = [self->crypto.deviceList storedDevice:myUserId deviceId:deviceId];
-            if (device)
-            {
-                NSError *error;
-                valid = [self->crypto.olmDevice verifySignature:device.fingerprint JSON:authData.signalableJSONDictionary signature:mySigs[keyId] error:&error];
-
-                if (!valid)
-                {
-                    MXLogDebug(@"[MXKeyBackup] trustForKeyBackupVersion: Bad signature from device %@: %@", device.deviceId, error);
-                }
-                
-                MXKeyBackupVersionTrustSignature *signature = [MXKeyBackupVersionTrustSignature new];
-                signature.deviceId = deviceId;
-                signature.device = device;
-                signature.valid = valid;
-                [signatures addObject:signature];
-            }
-            else // Try interpreting it as the MSK public key
-            {
-                NSError *error;
-                BOOL valid = [crypto.crossSigning.crossSigningTools pkVerifyObject:authData.JSONDictionary userId:myUserId publicKey:deviceId error:&error];
-                
-                if (!valid)
-                {
-                    MXLogDebug(@"[MXKeyBackup] trustForKeyBackupVersion: Signature with unknown key %@", deviceId);
-                }
-                else
-                {
-                    MXKeyBackupVersionTrustSignature *signature = [MXKeyBackupVersionTrustSignature new];
-                    signature.keys = deviceId;
-                    signature.valid = valid;
-                    [signatures addObject:signature];
-                }
-            }
-        }
-    }
-
-    keyBackupVersionTrust.signatures = signatures;
-
-    for (MXKeyBackupVersionTrustSignature *signature in keyBackupVersionTrust.signatures)
-    {
-        if (signature.valid && signature.device && signature.device.trustLevel.isVerified)
-        {
-            keyBackupVersionTrust.usable = YES;
-        }
-    }
-    keyBackupVersionTrust.usable = keyBackupVersionTrust.usable || keyBackupVersionTrust.isTrustedLocally;
-
-    return keyBackupVersionTrust;
 }
 
 - (MXHTTPOperation *)trustKeyBackupVersion:(MXKeyBackupVersion *)keyBackupVersion
@@ -1214,11 +945,11 @@ static Class DefaultAlgorithmClass;
     dispatch_async(cryptoQueue, ^{
         MXStrongifyAndReturnIfNil(self);
 
-        NSString *myUserId = self->crypto.matrixRestClient.credentials.userId;
+        NSString *myUserId = self.restClient.credentials.userId;
 
         // Get auth data to update it
         NSError *error;
-        id<MXBaseKeyBackupAuthData> authData = [self megolmBackupAuthDataFromKeyBackupVersion:keyBackupVersion error:&error];
+        id<MXBaseKeyBackupAuthData> authData = [self.engine megolmBackupAuthDataFromKeyBackupVersion:keyBackupVersion error:&error];
         if (error)
         {
             MXLogDebug(@"[MXKeyBackup] trustKeyBackupVersion:trust: Key backup is missing required data");
@@ -1246,12 +977,12 @@ static Class DefaultAlgorithmClass;
         // Add or remove current device signature
         if (trust)
         {
-            NSDictionary *deviceSignatures = [self->crypto signObject:authData.signalableJSONDictionary][myUserId];
+            NSDictionary *deviceSignatures = [self.engine signObject:authData.signalableJSONDictionary][myUserId];
             [myUserSignatures addEntriesFromDictionary:deviceSignatures];
         }
         else
         {
-            NSString *myDeviceId = self->crypto.store.deviceId;
+            NSString *myDeviceId = self.restClient.credentials.deviceId;
             NSString *deviceSignKeyId = [NSString stringWithFormat:@"ed25519:%@", myDeviceId];
             [myUserSignatures removeObjectForKey:deviceSignKeyId];
         }
@@ -1265,7 +996,7 @@ static Class DefaultAlgorithmClass;
         newKeyBackupVersion.authData = authData.JSONDictionary;
 
         // And send it to the homeserver
-        MXHTTPOperation *operation2 = [self->crypto.matrixRestClient updateKeyBackupVersion:newKeyBackupVersion success:^(void) {
+        MXHTTPOperation *operation2 = [self.restClient updateKeyBackupVersion:newKeyBackupVersion success:^(void) {
 
             // Relaunch the state machine on this updated backup version
             [self checkAndStartWithKeyBackupVersion:newKeyBackupVersion];
@@ -1306,7 +1037,7 @@ static Class DefaultAlgorithmClass;
         MXStrongifyAndReturnIfNil(self);
 
         NSError *error;
-        [self isValidRecoveryKey:recoveryKey forKeyBackupVersion:keyBackupVersion error:&error];
+        [self.engine isValidRecoveryKey:recoveryKey forKeyBackupVersion:keyBackupVersion error:&error];
         if (!error)
         {
             MXHTTPOperation *operation2 = [self trustKeyBackupVersion:keyBackupVersion trust:YES success:success failure:failure];
@@ -1342,7 +1073,7 @@ static Class DefaultAlgorithmClass;
         MXStrongifyAndReturnIfNil(self);
 
         NSError *error;
-        NSString *recoveryKey = [self recoveryKeyFromPassword:password inKeyBackupVersion:keyBackupVersion error:&error];
+        NSString *recoveryKey = [self.engine recoveryKeyFromPassword:password inKeyBackupVersion:keyBackupVersion error:&error];
 
         if (!error)
         {
@@ -1375,7 +1106,7 @@ static Class DefaultAlgorithmClass;
     MXLogDebug(@"[MXKeyBackup] requestPrivateKeysToDeviceIds: %@", deviceIds);
 
     MXWeakify(self);
-    [crypto.secretShareManager requestSecret:MXSecretId.keyBackup toDeviceIds:deviceIds success:^(NSString * _Nonnull requestId) {
+    [self.secretShareManager requestSecret:MXSecretId.keyBackup toDeviceIds:deviceIds success:^(NSString * _Nonnull requestId) {
     } onSecretReceived:^BOOL(NSString * _Nonnull secret) {
         MXStrongifyAndReturnValueIfNil(self, NO);
         
@@ -1385,7 +1116,7 @@ static Class DefaultAlgorithmClass;
         MXLogDebug(@"[MXKeyBackup] requestPrivateKeysToDeviceIds: Got key. isSecretValid: %@", @(isSecretValid));
         if (isSecretValid)
         {
-            [self->crypto.store storeSecret:secret withSecretId:MXSecretId.keyBackup];
+            [self.engine savePrivateKey:secret];
             onPrivateKeysReceived();
         }
         return isSecretValid;
@@ -1395,20 +1126,19 @@ static Class DefaultAlgorithmClass;
 - (BOOL)isSecretValid:(NSString*)secret forKeyBackupVersion:(MXKeyBackupVersion*)keyBackupVersion
 {
     NSData *privateKey = [MXBase64Tools dataFromBase64:secret];
-    id<MXKeyBackupAlgorithm> algorithm = [self getOrCreateKeyBackupAlgorithmFor:keyBackupVersion privateKey:privateKey];
-    return [algorithm keyMatches:privateKey error:nil];
+    return [self.engine isValidPrivateKey:privateKey forKeyBackupVersion:keyBackupVersion error:nil];
 }
 
 #pragma mark - Backup state
 
 - (BOOL)enabled
 {
-    return _state >= MXKeyBackupStateReadyToBackUp;
+    return _state >= MXKeyBackupStateReadyToBackUp && self.engine.enabled;
 }
 
 - (BOOL)hasKeysToBackup
 {
-    return [crypto.store inboundGroupSessionsToBackup:1].count > 0;
+    return [self.engine hasKeysToBackup];
 }
 
 - (BOOL)canBeRefreshed
@@ -1417,38 +1147,6 @@ static Class DefaultAlgorithmClass;
 }
 
 #pragma mark - Private methods -
-
-- (id<MXKeyBackupAlgorithm>)getOrCreateKeyBackupAlgorithmFor:(MXKeyBackupVersion*)keyBackupVersion privateKey:(NSData*)privateKey
-{
-    if (self.enabled
-        && [_keyBackupVersion.JSONDictionary isEqualToDictionary:keyBackupVersion.JSONDictionary]
-        && [self.privateKeyFromCryptoStore isEqualToData:privateKey])
-    {
-        return _keyBackupAlgorithm;
-    }
-    Class<MXKeyBackupAlgorithm> algorithmClass = AlgorithmClassesByName[keyBackupVersion.algorithm];
-    if (algorithmClass == NULL)
-    {
-        NSString *message = [NSString stringWithFormat:@"[MXKeyBackup] getOrCreateKeyBackupAlgorithmFor: unknown algorithm: %@", keyBackupVersion.algorithm];
-        MXLogError(message);
-        return nil;
-    }
-    if (![algorithmClass checkBackupVersion:keyBackupVersion])
-    {
-        MXLogError(@"[MXKeyBackup] getOrCreateKeyBackupAlgorithmFor: invalid backup data returned");
-        return nil;
-    }
-    NSError *error;
-    id<MXBaseKeyBackupAuthData> authData = [self megolmBackupAuthDataFromKeyBackupVersion:keyBackupVersion error:&error];
-    if (error)
-    {
-        MXLogError(@"[MXKeyBackup] getOrCreateKeyBackupAlgorithmFor: invalid auth data");
-        return nil;
-    }
-    return [[algorithmClass.class alloc] initWithCrypto:crypto authData:authData keyGetterBlock:^NSData * _Nullable{
-        return privateKey;
-    }];
-}
 
 - (void)setState:(MXKeyBackupState)state
 {
@@ -1473,11 +1171,11 @@ static Class DefaultAlgorithmClass;
 
     if (!sessionId && !roomId)
     {
-        operation = [crypto.matrixRestClient keysBackup:version success:success failure:failure];
+        operation = [self.restClient keysBackup:version success:success failure:failure];
     }
     else if (!sessionId)
     {
-        operation = [crypto.matrixRestClient keysBackupInRoom:roomId version:version success:^(MXRoomKeysBackupData *roomKeysBackupData) {
+        operation = [self.restClient keysBackupInRoom:roomId version:version success:^(MXRoomKeysBackupData *roomKeysBackupData) {
 
             MXKeysBackupData *keysBackupData = [MXKeysBackupData new];
             keysBackupData.rooms = @{
@@ -1490,7 +1188,7 @@ static Class DefaultAlgorithmClass;
     }
     else
     {
-        operation =  [crypto.matrixRestClient keyBackupForSession:sessionId inRoom:roomId version:version success:^(MXKeyBackupData *keyBackupData) {
+        operation =  [self.restClient keyBackupForSession:sessionId inRoom:roomId version:version success:^(MXKeyBackupData *keyBackupData) {
 
             MXRoomKeysBackupData *roomKeysBackupData = [MXRoomKeysBackupData new];
             roomKeysBackupData.sessions = @{
@@ -1508,168 +1206,6 @@ static Class DefaultAlgorithmClass;
     }
 
     return operation;
-}
-
-- (OLMPkDecryption*)pkDecryptionFromRecoveryKey:(NSString*)recoveryKey error:(NSError **)error
-{
-    // Extract the private key
-    NSData *privateKey = [MXRecoveryKey decode:recoveryKey error:error];
-
-    // Built the PK decryption with it
-    OLMPkDecryption *decryption;
-    if (privateKey)
-    {
-        decryption = [OLMPkDecryption new];
-        [decryption setPrivateKey:privateKey error:error];
-    }
-
-    return decryption;
-}
-
-- (void)storePrivateKeyWithRecoveryKey:(NSString*)recoveryKey
-{
-    NSError *error;
-    OLMPkDecryption *decryption = [self pkDecryptionFromRecoveryKey:recoveryKey error:&error];
-    if (!decryption)
-    {
-        MXLogDebug(@"[MXKeyBackup] storePrivateKeyWithRecoveryKey] Cannot create OLMPkDecryption. Error: %@", error);
-        return;
-    }
-    
-    NSString *privateKeyBase64 = [MXBase64Tools unpaddedBase64FromData:decryption.privateKey];
-    [crypto.store storeSecret:privateKeyBase64 withSecretId:MXSecretId.keyBackup];
-}
-
-- (nullable NSData*)privateKeyFromCryptoStore
-{
-    NSString *privateKeyBase64 = [crypto.store secretWithSecretId:MXSecretId.keyBackup];
-    if (!privateKeyBase64)
-    {
-        MXLogDebug(@"[MXKeyBackup] privateKeyFromCryptoStore. Error: No secret in crypto store");
-        return nil;
-    }
-
-    return [MXBase64Tools dataFromBase64:privateKeyBase64];
-}
-
-/**
- Extract megolm back up authentication data from a backup.
-
- @param keyBackupVersion the key backup
- @param error the encountered error in case of failure.
- @return the authentication if found and valid.
- */
-- (nullable id<MXBaseKeyBackupAuthData>)megolmBackupAuthDataFromKeyBackupVersion:(MXKeyBackupVersion*)keyBackupVersion error:(NSError**)error
-{
-    Class<MXKeyBackupAlgorithm> algorithmClass = AlgorithmClassesByName[keyBackupVersion.algorithm];
-    if (algorithmClass == NULL)
-    {
-        NSString *message = [NSString stringWithFormat:@"[MXKeyBackup] megolmBackupAuthDataFromKeyBackupVersion: Key backup for unknown algorithm: %@", keyBackupVersion.algorithm];
-        MXLogError(message);
-
-        *error = [NSError errorWithDomain:MXKeyBackupErrorDomain
-                                     code:MXKeyBackupErrorUnknownAlgorithm
-                                 userInfo:@{
-            NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Unknown algorithm (%@) for the backup", keyBackupVersion.algorithm]
-        }];
-
-        return nil;
-    }
-
-    return [algorithmClass authDataFromJSON:keyBackupVersion.authData error:error];
-}
-
-/**
- Compute the recovery key from a password and key backup auth data.
-
- @param password the password.
- @param keyBackupVersion the backup and its auth data.
- @param error the encountered error in case of failure.
- @return the recovery key if successful.
- */
-- (nullable NSString*)recoveryKeyFromPassword:(NSString*)password inKeyBackupVersion:(MXKeyBackupVersion*)keyBackupVersion error:(NSError **)error
-{
-    // Extract MXBaseKeyBackupAuthData
-    id<MXBaseKeyBackupAuthData> authData = [self megolmBackupAuthDataFromKeyBackupVersion:keyBackupVersion error:error];
-    if (*error)
-    {
-        return nil;
-    }
-
-    if (!authData.privateKeySalt || !authData.privateKeyIterations)
-    {
-        MXLogDebug(@"[MXKeyBackup] recoveryFromPassword: Salt and/or iterations not found in key backup auth data");
-        *error = [NSError errorWithDomain:MXKeyBackupErrorDomain
-                                     code:MXKeyBackupErrorMissingPrivateKeySaltCode
-                                 userInfo:@{
-                                            NSLocalizedDescriptionKey: @"Salt and/or iterations not found in key backup auth data"
-                                            }];
-        return nil;
-    }
-
-
-    // Extract the recovery key from the passphrase
-    NSData *recoveryKeyData = [MXKeyBackupPassword retrievePrivateKeyWithPassword:password salt:authData.privateKeySalt iterations:authData.privateKeyIterations error:error];
-    if (*error)
-    {
-        MXLogDebug(@"[MXKeyBackup] recoveryFromPassword: retrievePrivateKeyWithPassword failed: %@", *error);
-        return nil;
-    }
-
-    return [MXRecoveryKey encode:recoveryKeyData];
-}
-
-/**
- Check if a recovery key matches key backup authentication data.
-
- @param recoveryKey the recovery key to challenge.
- @param keyBackupVersion the backup and its auth data.
- @param error the encountered error in case of failure.
- @return YES if successful.
- */
-- (BOOL)isValidRecoveryKey:(NSString*)recoveryKey forKeyBackupVersion:(MXKeyBackupVersion*)keyBackupVersion error:(NSError **)error
-{
-    NSData *privateKey = [MXRecoveryKey decode:recoveryKey error:error];
-
-    if (*error)
-    {
-        MXLogDebug(@"[MXKeyBackup] isValidRecoveryKey: Invalid recovery key. Error: %@", *error);
-
-        // Return a generic error
-        *error = [NSError errorWithDomain:MXKeyBackupErrorDomain
-                                     code:MXKeyBackupErrorInvalidRecoveryKeyCode
-                                 userInfo:@{
-            NSLocalizedDescriptionKey: @"Invalid recovery key or password"
-        }];
-        return NO;
-    }
-
-    Class<MXKeyBackupAlgorithm> algorithm = AlgorithmClassesByName[keyBackupVersion.algorithm];
-    if (algorithm == NULL)
-    {
-        MXLogDebug(@"[MXKeyBackup] isValidRecoveryKey: unknown algorithm: %@", keyBackupVersion.algorithm);
-
-        *error = [NSError errorWithDomain:MXKeyBackupErrorDomain
-                                     code:MXKeyBackupErrorUnknownAlgorithm
-                                 userInfo:@{
-            NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Unknown algorithm (%@)", keyBackupVersion.algorithm]
-        }];
-        return NO;
-    }
-    BOOL result = [algorithm keyMatches:privateKey withAuthData:keyBackupVersion.authData error:error];
-
-    if (!result)
-    {
-        MXLogDebug(@"[MXKeyBackup] isValidRecoveryKey: Public keys mismatch");
-
-        *error = [NSError errorWithDomain:MXKeyBackupErrorDomain
-                                     code:MXKeyBackupErrorInvalidRecoveryKeyCode
-                                 userInfo:@{
-            NSLocalizedDescriptionKey: @"Invalid recovery key or password: public keys mismatch"
-        }];
-    }
-
-    return result;
 }
 
 @end

--- a/MatrixSDK/Crypto/KeyBackup/MXKeyBackup_Private.h
+++ b/MatrixSDK/Crypto/KeyBackup/MXKeyBackup_Private.h
@@ -15,6 +15,8 @@
  */
 
 #import "MXKeyBackup.h"
+#import "MXKeyBackupEngine.h"
+#import "MXSecretShareManager.h"
 
 @class MXCrypto;
 
@@ -28,9 +30,15 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Constructor.
 
- @param crypto the related 'MXCrypto'.
+ @param engine backup engine that stores and manages keys
+ @param restClient rest client to perform http requests
+ @param secretShareManager manages of secrets hsaring
+ @param queue dispatch queue to perform all operations on
  */
-- (instancetype)initWithCrypto:(MXCrypto *)crypto;
+- (instancetype)initWithEngine:(id<MXKeyBackupEngine>)engine
+                    restClient:(MXRestClient *)restClient
+            secretShareManager:(MXSecretShareManager *)secretShareManager
+                         queue:(dispatch_queue_t)queue;
 
 /**
  Check the server for an active key backup.

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -53,6 +53,8 @@
 
 #import "MatrixSDKSwiftHeader.h"
 #import "MXSharedHistoryKeyService.h"
+#import "MXNativeKeyBackupEngine.h"
+
 /**
  The store to use for crypto.
  */
@@ -2032,11 +2034,6 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 
         oneTimeKeyCount = -1;
 
-        if ([MXSDKOptions sharedInstance].enableKeyBackupWhenStartingMXCrypto)
-        {
-            _backup = [[MXKeyBackup alloc] initWithCrypto:self];
-        }
-
         outgoingRoomKeyRequestManager = [[MXOutgoingRoomKeyRequestManager alloc]
                                          initWithMatrixRestClient:_matrixRestClient
                                          deviceId:_myDevice.deviceId
@@ -2053,6 +2050,15 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
         _crossSigning = [[MXCrossSigning alloc] initWithCrypto:self];
         
         _recoveryService = [[MXRecoveryService alloc] initWithCrypto:self];
+        
+        if ([MXSDKOptions sharedInstance].enableKeyBackupWhenStartingMXCrypto)
+        {
+            id<MXKeyBackupEngine> engine = [[MXNativeKeyBackupEngine alloc] initWithCrypto:self];
+            _backup = [[MXKeyBackup alloc] initWithEngine:engine
+                                               restClient:_matrixRestClient
+                                       secretShareManager:_secretShareManager
+                                                    queue:_cryptoQueue];
+        }
         
         cryptoMigration = [[MXCryptoMigration alloc] initWithCrypto:self];
         

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -2554,7 +2554,7 @@ Note: Clients should consider avoiding this endpoint for URLs posted in encrypte
  */
 - (MXHTTPOperation*)sendKeysBackup:(MXKeysBackupData*)keysBackupData
                            version:(NSString*)version
-                           success:(void (^)(void))success
+                           success:(void (^)(NSDictionary *JSONResponse))success
                            failure:(void (^)(NSError *error))failure;
 
 /**

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -5026,7 +5026,9 @@ andUnauthenticatedHandler: (MXRestClientUnauthenticatedHandler)unauthenticatedHa
         return nil;
     }
 
-    return [self sendBackup:keyBackupData.JSONDictionary path:path success:success failure:failure];
+    return [self sendBackup:keyBackupData.JSONDictionary path:path success:^(NSDictionary *JSONResponse) {
+        success();
+    } failure:failure];
 }
 
 - (MXHTTPOperation*)sendRoomKeysBackup:(MXRoomKeysBackupData*)roomKeysBackupData
@@ -5043,12 +5045,14 @@ andUnauthenticatedHandler: (MXRestClientUnauthenticatedHandler)unauthenticatedHa
         return nil;
     }
 
-    return [self sendBackup:roomKeysBackupData.JSONDictionary path:path success:success failure:failure];
+    return [self sendBackup:roomKeysBackupData.JSONDictionary path:path success:^(NSDictionary *JSONResponse) {
+        success();
+    } failure:failure];
 }
 
 - (MXHTTPOperation*)sendKeysBackup:(MXKeysBackupData*)keysBackupData
                            version:(NSString*)version
-                           success:(void (^)(void))success
+                           success:(void (^)(NSDictionary *JSONResponse))success
                            failure:(void (^)(NSError *error))failure
 {
     NSString *path = [self keyBackupPath:nil session:nil version:version];
@@ -5064,7 +5068,7 @@ andUnauthenticatedHandler: (MXRestClientUnauthenticatedHandler)unauthenticatedHa
 
 - (MXHTTPOperation*)sendBackup:(NSDictionary*)backupData
                           path:(NSString*)path
-                       success:(void (^)(void))success
+                       success:(void (^)(NSDictionary *JSONResponse))success
                        failure:(void (^)(NSError *error))failure
 {
     MXWeakify(self);
@@ -5078,7 +5082,7 @@ andUnauthenticatedHandler: (MXRestClientUnauthenticatedHandler)unauthenticatedHa
                                      {
                                          [self dispatchProcessing:nil
                                                     andCompletion:^{
-                                                        success();
+                                                        success(JSONResponse);
                                                     }];
                                      }
                                  } failure:^(NSError *error) {

--- a/MatrixSDKTests/MXBaseKeyBackupTests.m
+++ b/MatrixSDKTests/MXBaseKeyBackupTests.m
@@ -24,6 +24,7 @@
 #import "MXCrossSigning_Private.h"
 #import "MXKeyBackupAlgorithm.h"
 #import "MXAes256BackupAuthData.h"
+#import "MXNativeKeyBackupEngine.h"
 
 @implementation MXBaseKeyBackupTests
 
@@ -612,14 +613,23 @@
 
         [aliceSession.crypto.backup prepareKeyBackupVersionWithPassword:nil algorithm:self.algorithm success:^(MXMegolmBackupCreationInfo * _Nonnull keyBackupCreationInfo) {
             [aliceSession.crypto.backup createKeyBackupVersion:keyBackupCreationInfo success:^(MXKeyBackupVersion * _Nonnull keyBackupVersion) {
-
+                
+                // This test relies on internal implementation detail (keyBackupAlgorithm class) only available with crypto v1.
+                // When run as V2 this test should fail until a better test is written
+                id<MXKeyBackupEngine> engine = [aliceSession.crypto.backup valueForKey:@"engine"];
+                if (!engine || ![engine isKindOfClass:[MXNativeKeyBackupEngine class]]) {
+                    XCTFail(@"Cannot verify test");
+                    [expectation fulfill];
+                }
+                id<MXKeyBackupAlgorithm> keyBackupAlgorithm = ((MXNativeKeyBackupEngine *)engine).keyBackupAlgorithm;
+                
                 // - Check [MXKeyBackupAlgorithm encryptGroupSession] returns stg
-                MXKeyBackupData *keyBackupData = [aliceSession.crypto.backup.keyBackupAlgorithm encryptGroupSession:session];
+                MXKeyBackupData *keyBackupData = [keyBackupAlgorithm encryptGroupSession:session];
                 XCTAssertNotNil(keyBackupData);
                 XCTAssertNotNil(keyBackupData.sessionData);
 
                 // - Check [MXKeyBackupAlgorithm decryptKeyBackupData] returns stg
-                MXMegolmSessionData *sessionData = [aliceSession.crypto.backup.keyBackupAlgorithm decryptKeyBackupData:keyBackupData forSession:session.session.sessionIdentifier inRoom:roomId];
+                MXMegolmSessionData *sessionData = [keyBackupAlgorithm decryptKeyBackupData:keyBackupData forSession:session.session.sessionIdentifier inRoom:roomId];
                 XCTAssertNotNil(sessionData);
                 XCTAssertEqual(sessionData.isUntrusted, self.isUntrusted);
 

--- a/changelog.d/pr-1578.change
+++ b/changelog.d/pr-1578.change
@@ -1,0 +1,1 @@
+Crypto: Extract key backup engine


### PR DESCRIPTION
As part of implementing key backups with Rust-based CryptoSDK I need to separate out shared and distinct backup functionality in the existing codebase. In the past I have simply duplicated a class (`MXCrypto`, `MXKeyVerificationManager`) and overriden all of its methods, but this approach is not suitable for backups, because a lot more code ends up being shared (state management, enabling/disabling backups, restoring, sending http requests etc).

The approach I have chosen instead is to identify all of the code specific to native / legacy implementation and refactor it as new `MXKeyBackupEngine` protocol. At the moment only `Native` implementation exists, but in a future PR I will add the rust-based variant. It is absent from this PR to make the refactor cleaner and easier to review.

As for the refactor I have copy-pasted entire chunks of code with no or very minimal changes to avoid any regressions. There are some integration tests that cover this functionality, but given the complexity of this code it is best to be extra careful. In reviewing I recommend comparing the deleted and added chunks to confirm there are no behaviour changes.