### PR TITLE
Key backups with Crypto V2

### DIFF
--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -639,7 +639,7 @@
 		32FCAB4D19E578860049C555 /* MXRestClientTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 32FCAB4C19E578860049C555 /* MXRestClientTests.m */; };
 		32FE41361D0AB7070060835E /* MXEnumConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 32FE41341D0AB7070060835E /* MXEnumConstants.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		32FE41371D0AB7070060835E /* MXEnumConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 32FE41351D0AB7070060835E /* MXEnumConstants.m */; };
-		32FFB4F0217E146A00C96002 /* MXRecoveryKey.h in Headers */ = {isa = PBXBuildFile; fileRef = 32FFB4EE217E146A00C96002 /* MXRecoveryKey.h */; };
+		32FFB4F0217E146A00C96002 /* MXRecoveryKey.h in Headers */ = {isa = PBXBuildFile; fileRef = 32FFB4EE217E146A00C96002 /* MXRecoveryKey.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		32FFB4F1217E146A00C96002 /* MXRecoveryKey.m in Sources */ = {isa = PBXBuildFile; fileRef = 32FFB4EF217E146A00C96002 /* MXRecoveryKey.m */; };
 		3489B40A85709695DC4EB17C /* Pods_MatrixSDK_MatrixSDK_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F669A7EDB909643AE4F39F80 /* Pods_MatrixSDK_MatrixSDK_iOS.framework */; };
 		3A0AF06B2705A11400679D1A /* MXSpaceGraphData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0AF06A2705A11400679D1A /* MXSpaceGraphData.swift */; };
@@ -1055,7 +1055,7 @@
 		B14EF2AC2397E90400758AF0 /* MXMemoryStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D7767B1A27860600FC4AA2 /* MXMemoryStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B14EF2AD2397E90400758AF0 /* MXEventAnnotationChunk.h in Headers */ = {isa = PBXBuildFile; fileRef = 327E9AD32284803000A98BC1 /* MXEventAnnotationChunk.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B14EF2AF2397E90400758AF0 /* MXWellKnown.h in Headers */ = {isa = PBXBuildFile; fileRef = 323547D32226D3F500F15F94 /* MXWellKnown.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B14EF2B02397E90400758AF0 /* MXRecoveryKey.h in Headers */ = {isa = PBXBuildFile; fileRef = 32FFB4EE217E146A00C96002 /* MXRecoveryKey.h */; };
+		B14EF2B02397E90400758AF0 /* MXRecoveryKey.h in Headers */ = {isa = PBXBuildFile; fileRef = 32FFB4EE217E146A00C96002 /* MXRecoveryKey.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B14EF2B12397E90400758AF0 /* MXRealmAggregationsStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 32133013228AF4EF0070BA9B /* MXRealmAggregationsStore.h */; };
 		B14EF2B22397E90400758AF0 /* MXFileStoreMetaData.h in Headers */ = {isa = PBXBuildFile; fileRef = 32CE6FB61A409B1F00317F1E /* MXFileStoreMetaData.h */; };
 		B14EF2B32397E90400758AF0 /* MXRoomFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 32A31BC620D401FC005916C7 /* MXRoomFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1828,6 +1828,8 @@
 		ED35652D281150310002BF6A /* MXOlmInboundGroupSessionUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED35652B281150310002BF6A /* MXOlmInboundGroupSessionUnitTests.swift */; };
 		ED35652F281153480002BF6A /* MXMegolmSessionDataUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED35652E281153480002BF6A /* MXMegolmSessionDataUnitTests.swift */; };
 		ED356530281153480002BF6A /* MXMegolmSessionDataUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED35652E281153480002BF6A /* MXMegolmSessionDataUnitTests.swift */; };
+		ED36ED8628DD9E2200C86416 /* MXCryptoKeyBackupEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED36ED8528DD9E2100C86416 /* MXCryptoKeyBackupEngine.swift */; };
+		ED36ED8728DD9E2200C86416 /* MXCryptoKeyBackupEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED36ED8528DD9E2100C86416 /* MXCryptoKeyBackupEngine.swift */; };
 		ED44F01128180BCC00452A5D /* MXSharedHistoryKeyRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED44F01028180BCC00452A5D /* MXSharedHistoryKeyRequest.swift */; };
 		ED44F01228180BCC00452A5D /* MXSharedHistoryKeyRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED44F01028180BCC00452A5D /* MXSharedHistoryKeyRequest.swift */; };
 		ED44F01428180EAB00452A5D /* MXSharedHistoryKeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED44F01328180EAB00452A5D /* MXSharedHistoryKeyManager.swift */; };
@@ -1836,6 +1838,10 @@
 		ED44F01B28180F4000452A5D /* MXSharedHistoryKeyManagerUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED44F01728180F1C00452A5D /* MXSharedHistoryKeyManagerUnitTests.swift */; };
 		ED47CB6D28523995004FD755 /* MXCryptoV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED47CB6C28523995004FD755 /* MXCryptoV2.swift */; };
 		ED47CB6E28523995004FD755 /* MXCryptoV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED47CB6C28523995004FD755 /* MXCryptoV2.swift */; };
+		ED505DC028E1FD160079A3D3 /* MXCryptoKeyBackupEngineUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED505DBD28E1FD130079A3D3 /* MXCryptoKeyBackupEngineUnitTests.swift */; };
+		ED505DC128E1FD170079A3D3 /* MXCryptoKeyBackupEngineUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED505DBD28E1FD130079A3D3 /* MXCryptoKeyBackupEngineUnitTests.swift */; };
+		ED505DC428E206FC0079A3D3 /* MXKeyBackupVersion+Stub.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED505DC328E206FC0079A3D3 /* MXKeyBackupVersion+Stub.swift */; };
+		ED505DC528E206FC0079A3D3 /* MXKeyBackupVersion+Stub.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED505DC328E206FC0079A3D3 /* MXKeyBackupVersion+Stub.swift */; };
 		ED51943928462D130006EEC6 /* MXRoomStateUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED51943828462D130006EEC6 /* MXRoomStateUnitTests.swift */; };
 		ED51943A28462D130006EEC6 /* MXRoomStateUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED51943828462D130006EEC6 /* MXRoomStateUnitTests.swift */; };
 		ED51943C284630090006EEC6 /* MXRestClientStub.m in Sources */ = {isa = PBXBuildFile; fileRef = ED51943B284630090006EEC6 /* MXRestClientStub.m */; };
@@ -1917,10 +1923,16 @@
 		ED8F1D352885B07500F897E7 /* MXCrossSigningInfoUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED8F1D1628857FE600F897E7 /* MXCrossSigningInfoUnitTests.swift */; };
 		ED8F1D3B2885BB2D00F897E7 /* MXCryptoProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED8F1D3A2885BB2D00F897E7 /* MXCryptoProtocols.swift */; };
 		ED8F1D3C2885BB2D00F897E7 /* MXCryptoProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED8F1D3A2885BB2D00F897E7 /* MXCryptoProtocols.swift */; };
-		EDAAC41C28E30F3C00DD89B5 /* MXCryptoSecretStore.h in Headers */ = {isa = PBXBuildFile; fileRef = EDAAC41B28E30F3C00DD89B5 /* MXCryptoSecretStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		EDAAC41D28E30F3C00DD89B5 /* MXCryptoSecretStore.h in Headers */ = {isa = PBXBuildFile; fileRef = EDAAC41B28E30F3C00DD89B5 /* MXCryptoSecretStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		EDAAC41F28E30F4C00DD89B5 /* MXRecoveryServiceDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDAAC41E28E30F4C00DD89B5 /* MXRecoveryServiceDependencies.swift */; };
-		EDAAC42028E30F4C00DD89B5 /* MXRecoveryServiceDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDAAC41E28E30F4C00DD89B5 /* MXRecoveryServiceDependencies.swift */; };
+		EDAAC41928E2FCFE00DD89B5 /* MXCryptoSecretStoreV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDAAC41828E2FCFE00DD89B5 /* MXCryptoSecretStoreV2.swift */; };
+		EDAAC41A28E2FCFE00DD89B5 /* MXCryptoSecretStoreV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDAAC41828E2FCFE00DD89B5 /* MXCryptoSecretStoreV2.swift */; };
+		EDAAC41C28E30F3C00DD89B5 /* (null) in Headers */ = {isa = PBXBuildFile; settings = {ATTRIBUTES = (Public, ); }; };
+		EDAAC41D28E30F3C00DD89B5 /* (null) in Headers */ = {isa = PBXBuildFile; settings = {ATTRIBUTES = (Public, ); }; };
+		EDAAC41F28E30F4C00DD89B5 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		EDAAC42028E30F4C00DD89B5 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		EDAAC42128E3174700DD89B5 /* MXCryptoSecretStore.h in Headers */ = {isa = PBXBuildFile; fileRef = EDAAC41228E2F86800DD89B5 /* MXCryptoSecretStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EDAAC42228E3174700DD89B5 /* MXCryptoSecretStore.h in Headers */ = {isa = PBXBuildFile; fileRef = EDAAC41228E2F86800DD89B5 /* MXCryptoSecretStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EDAAC42428E3177000DD89B5 /* MXRecoveryServiceDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDAAC42328E3177000DD89B5 /* MXRecoveryServiceDependencies.swift */; };
+		EDAAC42528E3177300DD89B5 /* MXRecoveryServiceDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDAAC42328E3177000DD89B5 /* MXRecoveryServiceDependencies.swift */; };
 		EDB4209227DF77390036AF39 /* MXEventsEnumeratorOnArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB4209027DF77310036AF39 /* MXEventsEnumeratorOnArrayTests.swift */; };
 		EDB4209327DF77390036AF39 /* MXEventsEnumeratorOnArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB4209027DF77310036AF39 /* MXEventsEnumeratorOnArrayTests.swift */; };
 		EDB4209527DF822B0036AF39 /* MXEventsByTypesEnumeratorOnArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB4209427DF822B0036AF39 /* MXEventsByTypesEnumeratorOnArrayTests.swift */; };
@@ -2969,10 +2981,13 @@
 		ED2DD11B286C4F3E00F06731 /* MXCryptoRequestsUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXCryptoRequestsUnitTests.swift; sourceTree = "<group>"; };
 		ED35652B281150310002BF6A /* MXOlmInboundGroupSessionUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXOlmInboundGroupSessionUnitTests.swift; sourceTree = "<group>"; };
 		ED35652E281153480002BF6A /* MXMegolmSessionDataUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXMegolmSessionDataUnitTests.swift; sourceTree = "<group>"; };
+		ED36ED8528DD9E2100C86416 /* MXCryptoKeyBackupEngine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXCryptoKeyBackupEngine.swift; sourceTree = "<group>"; };
 		ED44F01028180BCC00452A5D /* MXSharedHistoryKeyRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXSharedHistoryKeyRequest.swift; sourceTree = "<group>"; };
 		ED44F01328180EAB00452A5D /* MXSharedHistoryKeyManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXSharedHistoryKeyManager.swift; sourceTree = "<group>"; };
 		ED44F01728180F1C00452A5D /* MXSharedHistoryKeyManagerUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXSharedHistoryKeyManagerUnitTests.swift; sourceTree = "<group>"; };
 		ED47CB6C28523995004FD755 /* MXCryptoV2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXCryptoV2.swift; sourceTree = "<group>"; };
+		ED505DBD28E1FD130079A3D3 /* MXCryptoKeyBackupEngineUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXCryptoKeyBackupEngineUnitTests.swift; sourceTree = "<group>"; };
+		ED505DC328E206FC0079A3D3 /* MXKeyBackupVersion+Stub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MXKeyBackupVersion+Stub.swift"; sourceTree = "<group>"; };
 		ED51943828462D130006EEC6 /* MXRoomStateUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXRoomStateUnitTests.swift; sourceTree = "<group>"; };
 		ED51943B284630090006EEC6 /* MXRestClientStub.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXRestClientStub.m; sourceTree = "<group>"; };
 		ED51943E284630100006EEC6 /* MXRestClientStub.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXRestClientStub.h; sourceTree = "<group>"; };
@@ -3015,8 +3030,9 @@
 		ED8F1D312885AC5700F897E7 /* Device+Stub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Device+Stub.swift"; sourceTree = "<group>"; };
 		ED8F1D332885ADE200F897E7 /* MXCryptoProtocolStubs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXCryptoProtocolStubs.swift; sourceTree = "<group>"; };
 		ED8F1D3A2885BB2D00F897E7 /* MXCryptoProtocols.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXCryptoProtocols.swift; sourceTree = "<group>"; };
-		EDAAC41B28E30F3C00DD89B5 /* MXCryptoSecretStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXCryptoSecretStore.h; sourceTree = "<group>"; };
-		EDAAC41E28E30F4C00DD89B5 /* MXRecoveryServiceDependencies.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXRecoveryServiceDependencies.swift; sourceTree = "<group>"; };
+		EDAAC41228E2F86800DD89B5 /* MXCryptoSecretStore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXCryptoSecretStore.h; sourceTree = "<group>"; };
+		EDAAC41828E2FCFE00DD89B5 /* MXCryptoSecretStoreV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXCryptoSecretStoreV2.swift; sourceTree = "<group>"; };
+		EDAAC42328E3177000DD89B5 /* MXRecoveryServiceDependencies.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXRecoveryServiceDependencies.swift; sourceTree = "<group>"; };
 		EDB4209027DF77310036AF39 /* MXEventsEnumeratorOnArrayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXEventsEnumeratorOnArrayTests.swift; sourceTree = "<group>"; };
 		EDB4209427DF822B0036AF39 /* MXEventsByTypesEnumeratorOnArrayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXEventsByTypesEnumeratorOnArrayTests.swift; sourceTree = "<group>"; };
 		EDB4209827DF842F0036AF39 /* MXEventFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXEventFixtures.swift; sourceTree = "<group>"; };
@@ -3506,6 +3522,7 @@
 				324DD297246AD2B500377005 /* MXSecretStorage.h */,
 				324DD2B0246BDC6800377005 /* MXSecretStorage_Private.h */,
 				324DD298246AD2B500377005 /* MXSecretStorage.m */,
+				EDAAC41828E2FCFE00DD89B5 /* MXCryptoSecretStoreV2.swift */,
 			);
 			path = SecretStorage;
 			sourceTree = "<group>";
@@ -3884,8 +3901,8 @@
 		3284A59C1DB7C00600A09972 /* Store */ = {
 			isa = PBXGroup;
 			children = (
-				EDAAC41B28E30F3C00DD89B5 /* MXCryptoSecretStore.h */,
 				3284A59D1DB7C00600A09972 /* MXCryptoStore.h */,
+				EDAAC41228E2F86800DD89B5 /* MXCryptoSecretStore.h */,
 				3259CD4C1DF85F6D00186944 /* MXRealmCryptoStore */,
 			);
 			path = Store;
@@ -4376,7 +4393,7 @@
 			isa = PBXGroup;
 			children = (
 				325AF3DE24897D2300EF937D /* Data */,
-				EDAAC41E28E30F4C00DD89B5 /* MXRecoveryServiceDependencies.swift */,
+				EDAAC42328E3177000DD89B5 /* MXRecoveryServiceDependencies.swift */,
 				32F00AB92488E1CD00131741 /* MXRecoveryService.h */,
 				32F00ABA2488E1CD00131741 /* MXRecoveryService.m */,
 				32F00ABF2488FB3600131741 /* MXRecoveryService_Private.h */,
@@ -5208,6 +5225,7 @@
 				ED8F1D292885A7DF00F897E7 /* Devices */,
 				ED6DAC0F28C7889A00ECDCB6 /* RoomKeys */,
 				ED44F01628180F1300452A5D /* KeySharing */,
+				ED505DBB28E1FCF50079A3D3 /* KeyBackup */,
 				ED35652A281150230002BF6A /* Data */,
 				ED21F67B28104BA1002FF83D /* Algorithms */,
 				ED2DD11A286C4F3100F06731 /* CryptoMachine */,
@@ -5273,6 +5291,31 @@
 				ED6DAC1D28C79D2000ECDCB6 /* MXUnrequestedForwardedRoomKeyManagerUnitTests.swift */,
 			);
 			path = KeySharing;
+			sourceTree = "<group>";
+		};
+		ED505DBB28E1FCF50079A3D3 /* KeyBackup */ = {
+			isa = PBXGroup;
+			children = (
+				ED505DC228E206F70079A3D3 /* Data */,
+				ED505DBC28E1FCFC0079A3D3 /* Engine */,
+			);
+			path = KeyBackup;
+			sourceTree = "<group>";
+		};
+		ED505DBC28E1FCFC0079A3D3 /* Engine */ = {
+			isa = PBXGroup;
+			children = (
+				ED505DBD28E1FD130079A3D3 /* MXCryptoKeyBackupEngineUnitTests.swift */,
+			);
+			path = Engine;
+			sourceTree = "<group>";
+		};
+		ED505DC228E206F70079A3D3 /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				ED505DC328E206FC0079A3D3 /* MXKeyBackupVersion+Stub.swift */,
+			);
+			path = Data;
 			sourceTree = "<group>";
 		};
 		ED5C753428B3E80300D24E85 /* Logs */ = {
@@ -5474,6 +5517,7 @@
 				EDE70DC728DA22F800099736 /* MXKeyBackupEngine.h */,
 				EDD4197D28DCAA5F007F3757 /* MXNativeKeyBackupEngine.h */,
 				EDD4198028DCAA7B007F3757 /* MXNativeKeyBackupEngine.m */,
+				ED36ED8528DD9E2100C86416 /* MXCryptoKeyBackupEngine.swift */,
 			);
 			path = Engine;
 			sourceTree = "<group>";
@@ -5572,7 +5616,7 @@
 				B146D47421A5945800D8C2C6 /* MXAntivirusScanStatus.h in Headers */,
 				322691361E5EFF8700966A6E /* MXDeviceListOperationsPool.h in Headers */,
 				3281E8B719E42DFE00976E1A /* MXJSONModel.h in Headers */,
-				EDAAC41C28E30F3C00DD89B5 /* MXCryptoSecretStore.h in Headers */,
+				EDAAC41C28E30F3C00DD89B5 /* (null) in Headers */,
 				B135066127E9CB6400BD3276 /* MXBeaconInfo.h in Headers */,
 				EC5C562827A36EDB0014CBE9 /* MXInReplyTo.h in Headers */,
 				EC8A539325B1BC77004E0802 /* MXCallSessionDescription.h in Headers */,
@@ -5716,6 +5760,7 @@
 				B19A30C42404268600FB6F35 /* MXVerifyingAnotherUserQRCodeData.h in Headers */,
 				B1C854EE25E7B497005867D0 /* MXRoomType.h in Headers */,
 				B11BD45422CB583E0064D8B0 /* MXReplyEventBodyParts.h in Headers */,
+				EDAAC42128E3174700DD89B5 /* MXCryptoSecretStore.h in Headers */,
 				32549AF923F2E2790002576B /* MXKeyVerificationReady.h in Headers */,
 				32A151521DAF8A7200400192 /* MXQueuedEncryption.h in Headers */,
 				32A30B181FB4813400C8309E /* MXIncomingRoomKeyRequestManager.h in Headers */,
@@ -6057,6 +6102,7 @@
 				B1EE98CD2804820800AB63F0 /* MXLocation.h in Headers */,
 				B14EF2EA2397E90400758AF0 /* MXDeviceListOperation.h in Headers */,
 				ECD623FF25D3DCC900DC0A0B /* MXOlmDecryption.h in Headers */,
+				EDAAC42228E3174700DD89B5 /* MXCryptoSecretStore.h in Headers */,
 				B14EF2EB2397E90400758AF0 /* MXRoomAccountData.h in Headers */,
 				B14EF2EC2397E90400758AF0 /* MXEventContentRelatesTo.h in Headers */,
 				EC60EDFD265CFFD200B39A4E /* MXInvitedGroupSync.h in Headers */,
@@ -6195,7 +6241,7 @@
 				324AAC7E2399143400380A66 /* MXKeyVerificationCancel.h in Headers */,
 				ED01915528C64E0400ED3A69 /* MXRoomKeyEventContent.h in Headers */,
 				B14EF3372397E90400758AF0 /* MXRoomTombStoneContent.h in Headers */,
-				EDAAC41D28E30F3C00DD89B5 /* MXCryptoSecretStore.h in Headers */,
+				EDAAC41D28E30F3C00DD89B5 /* (null) in Headers */,
 				3274538B23FD918800438328 /* MXKeyVerificationByToDeviceRequest.h in Headers */,
 				B14EF3382397E90400758AF0 /* MXFilterObject.h in Headers */,
 				B14EF3392397E90400758AF0 /* MXRealmReactionCount.h in Headers */,
@@ -6723,6 +6769,7 @@
 				3293C701214BBA4F009B3DDB /* MXPeekingRoomSummary.m in Sources */,
 				C602B58C1F2268F700B67D87 /* MXRoom.swift in Sources */,
 				EC8A53D825B1BCC6004E0802 /* MXThirdPartyProtocolInstance.m in Sources */,
+				EDAAC42428E3177000DD89B5 /* MXRecoveryServiceDependencies.swift in Sources */,
 				3A7509BB26FC61DF00B85773 /* MXSpaceNotificationCounter.swift in Sources */,
 				32E402BA21C957D2004E87A6 /* MXOlmSession.m in Sources */,
 				EC8A53C525B1BC77004E0802 /* MXTurnServerResponse.m in Sources */,
@@ -6768,6 +6815,7 @@
 				3A59A49F25A7A16F00DDA1FC /* MXOlmOutboundGroupSession.m in Sources */,
 				B146D4F221A5AF7F00D8C2C6 /* MXRealmEventScanMapper.m in Sources */,
 				B11BD45A22CB58850064D8B0 /* MXReplyEventFormattedBodyParts.m in Sources */,
+				ED505DC428E206FC0079A3D3 /* MXKeyBackupVersion+Stub.swift in Sources */,
 				B2EC7E2327F483DB00F40C26 /* MXEventAssetTypeMapper.swift in Sources */,
 				32CE6FB91A409B1F00317F1E /* MXFileStoreMetaData.m in Sources */,
 				3264DB921CEC528D00B99881 /* MXAccountData.m in Sources */,
@@ -6838,6 +6886,7 @@
 				32792BD52295A86600F4FC9D /* MXAggregatedReactionsUpdater.m in Sources */,
 				32618E7C20EFA45B00E1D2EA /* MXRoomMembers.m in Sources */,
 				ED2DD118286C450600F06731 /* MXCryptoRequests.swift in Sources */,
+				EDAAC41928E2FCFE00DD89B5 /* MXCryptoSecretStoreV2.swift in Sources */,
 				32B0E34123A378320054FF1A /* MXEventReference.m in Sources */,
 				324DD2A8246AE81300377005 /* MXSecretStorageKeyContent.m in Sources */,
 				02CAD43A217DD12F0074700B /* MXContentScanEncryptedBody.m in Sources */,
@@ -6882,6 +6931,7 @@
 				EC0B94272718E64500B4D440 /* CoreDataContextable.swift in Sources */,
 				324BE4691E3FADB1008D99D4 /* MXMegolmExportEncryption.m in Sources */,
 				32A31BBF20D3F2EC005916C7 /* MXFilterObject.m in Sources */,
+				ED36ED8628DD9E2200C86416 /* MXCryptoKeyBackupEngine.swift in Sources */,
 				320DFDE719DD99B60068622A /* MXHTTPClient.m in Sources */,
 				32FE41371D0AB7070060835E /* MXEnumConstants.m in Sources */,
 				EC60EDF4265CFFAC00B39A4E /* MXGroupsSyncResponse.m in Sources */,
@@ -6929,7 +6979,7 @@
 				324AAC73239913AD00380A66 /* MXKeyVerificationDone.m in Sources */,
 				ED6DABFC28C7542800ECDCB6 /* MXRoomKeyInfoFactory.swift in Sources */,
 				B11556EE230C45C600B2A2CF /* MXIdentityServerRestClient.swift in Sources */,
-				EDAAC41F28E30F4C00DD89B5 /* MXRecoveryServiceDependencies.swift in Sources */,
+				EDAAC41F28E30F4C00DD89B5 /* (null) in Sources */,
 				321CFDE722525A49004D31DF /* MXSASTransaction.m in Sources */,
 				32720D9D222EAA6F0086FFF5 /* MXDiscoveredClientConfig.m in Sources */,
 				EC5C560C2798CEA00014CBE9 /* NSDictionary+MutableDeepCopy.m in Sources */,
@@ -7127,6 +7177,7 @@
 				18121F7A273E6E4200B68ADF /* PollBuilder.swift in Sources */,
 				18121F7F273E837300B68ADF /* PollModels.swift in Sources */,
 				32C03CB62123076F00D92712 /* DirectRoomTests.m in Sources */,
+				ED505DC128E1FD170079A3D3 /* MXCryptoKeyBackupEngineUnitTests.swift in Sources */,
 				329FB17C1A0A963700A5E88E /* MXRoomMemberTests.m in Sources */,
 				ECE3DFA8270CF69500FB4C96 /* MockRoomSummary.swift in Sources */,
 				EC1165CC27107F3E0089FA56 /* MXStoreRoomListDataManagerUnitTests.swift in Sources */,
@@ -7338,6 +7389,7 @@
 				3290293524CB10D000DA7BB6 /* MatrixSDKVersion.m in Sources */,
 				3A7509BC26FC61DF00B85773 /* MXSpaceNotificationCounter.swift in Sources */,
 				B14EF21F2397E90400758AF0 /* MXMyUser.m in Sources */,
+				EDAAC42528E3177300DD89B5 /* MXRecoveryServiceDependencies.swift in Sources */,
 				EC60EDAB265CFE3B00B39A4E /* MXRoomSyncTimeline.m in Sources */,
 				B14EF2202397E90400758AF0 /* (null) in Sources */,
 				B14EF2212397E90400758AF0 /* MX3PID.swift in Sources */,
@@ -7383,6 +7435,7 @@
 				B14EF2322397E90400758AF0 /* MXBugReportRestClient.m in Sources */,
 				B14EF2342397E90400758AF0 /* MXCallKitAdapter.m in Sources */,
 				327C3E4E23A39D91006183D1 /* MXAggregatedReferencesUpdater.m in Sources */,
+				ED505DC528E206FC0079A3D3 /* MXKeyBackupVersion+Stub.swift in Sources */,
 				B2EC7E2427F483DB00F40C26 /* MXEventAssetTypeMapper.swift in Sources */,
 				B14EF2352397E90400758AF0 /* MXRoomPowerLevels.swift in Sources */,
 				32AF9287240EA2430008A0FD /* MXSecretShareRequest.m in Sources */,
@@ -7453,6 +7506,7 @@
 				B14EF24F2397E90400758AF0 /* MXLRUCache.m in Sources */,
 				B14EF2502397E90400758AF0 /* MXIncomingRoomKeyRequestManager.m in Sources */,
 				ED2DD119286C450600F06731 /* MXCryptoRequests.swift in Sources */,
+				EDAAC41A28E2FCFE00DD89B5 /* MXCryptoSecretStoreV2.swift in Sources */,
 				B14EF2512397E90400758AF0 /* MXRoomEventFilter.m in Sources */,
 				B14EF2522397E90400758AF0 /* MXLoginPolicyData.m in Sources */,
 				B19A30C72404268600FB6F35 /* MXQRCodeDataBuilder.m in Sources */,
@@ -7497,6 +7551,7 @@
 				B14EF2622397E90400758AF0 /* MXAntivirusScanStatusFormatter.m in Sources */,
 				EC0B94282718E64500B4D440 /* CoreDataContextable.swift in Sources */,
 				324AAC7C2399140D00380A66 /* MXKeyVerificationStart.m in Sources */,
+				ED36ED8728DD9E2200C86416 /* MXCryptoKeyBackupEngine.swift in Sources */,
 				B14EF2632397E90400758AF0 /* MXReactionCountChange.m in Sources */,
 				324AAC762399140D00380A66 /* MXKeyVerificationCancel.m in Sources */,
 				32AF928D240EA3880008A0FD /* MXSecretShareSend.m in Sources */,
@@ -7544,7 +7599,7 @@
 				B14EF2772397E90400758AF0 /* MXDecryptionResult.m in Sources */,
 				ED6DABFD28C7542800ECDCB6 /* MXRoomKeyInfoFactory.swift in Sources */,
 				B14EF2782397E90400758AF0 /* MXTransactionCancelCode.m in Sources */,
-				EDAAC42028E30F4C00DD89B5 /* MXRecoveryServiceDependencies.swift in Sources */,
+				EDAAC42028E30F4C00DD89B5 /* (null) in Sources */,
 				B14EF2792397E90400758AF0 /* MXEventListener.m in Sources */,
 				B1710B202613D01400A9B429 /* MXSpaceChildrenRequestParameters.swift in Sources */,
 				B14EF27A2397E90400758AF0 /* MXSessionEventListener.swift in Sources */,
@@ -7742,6 +7797,7 @@
 				32C78BA8256D227D008130B1 /* MXCryptoMigrationTests.m in Sources */,
 				18121F7B273E6E4200B68ADF /* PollBuilder.swift in Sources */,
 				18121F80273E837400B68ADF /* PollModels.swift in Sources */,
+				ED505DC028E1FD160079A3D3 /* MXCryptoKeyBackupEngineUnitTests.swift in Sources */,
 				B1E09A2F2397FD750057C069 /* MXErrorUnitTests.m in Sources */,
 				B1660F1D260A20B900C3AA12 /* MXSpaceServiceTest.swift in Sources */,
 				ECE3DFA9270CF69500FB4C96 /* MockRoomSummary.swift in Sources */,

--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoMachine.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoMachine.swift
@@ -60,8 +60,8 @@ class MXCryptoMachine {
     private let syncQueue = MXTaskQueue()
     private var roomQueues = RoomQueues()
     
-    private var hasUploadedKeys = false
-    private var keysUploadCallback: (() -> Void)?
+    private var hasUploadedInitialKeys = false
+    private var initialKeysUploadCallback: (() -> Void)?
     
     private let log = MXNamedLog(name: "MXCryptoMachine")
 
@@ -79,13 +79,13 @@ class MXCryptoMachine {
         setLogger(logger: self)
     }
     
-    func onKeysUpload(callback: @escaping () -> Void) {
+    func onInitialKeysUpload(callback: @escaping () -> Void) {
         log.debug("->")
         
-        if hasUploadedKeys {
+        if hasUploadedInitialKeys {
             callback()
         } else {
-            keysUploadCallback = callback
+            initialKeysUploadCallback = callback
         }
     }
     
@@ -189,7 +189,7 @@ extension MXCryptoMachine: MXCryptoSyncing {
                 request: .init(body: body, deviceId: machine.deviceId())
             )
             try markRequestAsSent(requestId: requestId, requestType: .keysUpload, response: response.jsonString())
-            broadcastKeysUploadIfNecessary()
+            broadcastInitialKeysUploadIfNecessary()
             
         case .keysQuery(let requestId, let users):
             let response = try await requests.queryKeys(users: users)
@@ -259,13 +259,13 @@ extension MXCryptoMachine: MXCryptoSyncing {
         )
     }
     
-    private func broadcastKeysUploadIfNecessary() {
-        guard !hasUploadedKeys else {
+    private func broadcastInitialKeysUploadIfNecessary() {
+        guard !hasUploadedInitialKeys else {
             return
         }
-        hasUploadedKeys = true
-        keysUploadCallback?()
-        keysUploadCallback = nil
+        hasUploadedInitialKeys = true
+        initialKeysUploadCallback?()
+        initialKeysUploadCallback = nil
     }
 }
 

--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoProtocols.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoProtocols.swift
@@ -60,6 +60,7 @@ protocol MXCryptoEventEncrypting: MXCryptoIdentity {
     func shareRoomKeysIfNecessary(roomId: String, users: [String]) async throws
     func encrypt(_ content: [AnyHashable: Any], roomId: String, eventType: String, users: [String]) async throws -> [String: Any]
     func decryptEvent(_ event: MXEvent) throws -> MXEventDecryptionResult
+    func discardRoomKey(roomId: String)
 }
 
 /// Cross-signing functionality
@@ -89,6 +90,23 @@ protocol MXCryptoSASVerifying: MXCryptoVerifying {
     func startSasVerification(userId: String, flowId: String) async throws -> Sas
     func acceptSasVerification(userId: String, flowId: String) async throws
     func emojiIndexes(sas: Sas) throws -> [Int]
+}
+
+/// Room keys backup functionality
+protocol MXCryptoBackup {
+    var isBackupEnabled: Bool { get }
+    var backupKeys: BackupKeys? { get }
+    var roomKeyCounts: RoomKeyCounts? { get }
+    
+    func enableBackup(key: MegolmV1BackupKey, version: String) throws
+    func disableBackup()
+    func saveRecoveryKey(key: BackupRecoveryKey, version: String?) throws
+    
+    func verifyBackup(version: MXKeyBackupVersion) -> Bool
+    func sign(object: [AnyHashable: Any]) throws -> [String: [String: String]]
+    
+    func backupRoomKeys() async throws
+    func importDecryptedKeys(roomKeys: [MXMegolmSessionData], progressListener: ProgressListener) throws -> KeysImportResult
 }
 
 #endif

--- a/MatrixSDK/Crypto/KeyBackup/Engine/MXCryptoKeyBackupEngine.swift
+++ b/MatrixSDK/Crypto/KeyBackup/Engine/MXCryptoKeyBackupEngine.swift
@@ -1,0 +1,389 @@
+// 
+// Copyright 2022 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+#if DEBUG && os(iOS)
+
+import MatrixSDKCrypto
+
+class MXCryptoKeyBackupEngine: NSObject, MXKeyBackupEngine {
+    enum Error: Swift.Error {
+        case unknownBackupVersion
+        case invalidData
+        case invalidPrivateKey
+        case algorithmNotSupported(String)
+    }
+    
+    var enabled: Bool {
+        return backup.isBackupEnabled
+    }
+    
+    var version: String? {
+        return backup.backupKeys?.backupVersion()
+    }
+    
+    private var recoveryKey: BackupRecoveryKey? {
+        return backup.backupKeys?.recoveryKey()
+    }
+    
+    private let backup: MXCryptoBackup
+    private let log = MXNamedLog(name: "MXCryptoKeyBackupEngine")
+    
+    init(backup: MXCryptoBackup) {
+        self.backup = backup
+    }
+    
+    // MARK: - Enable / Disable engine
+    
+    func enableBackup(with keyBackupversion: MXKeyBackupVersion) throws {
+        log.debug("->")
+        
+        guard let version = keyBackupversion.version else {
+            log.error("Unknown backup version")
+            throw Error.unknownBackupVersion
+        }
+        
+        let key = try MegolmV1BackupKey(keyBackupVersion: keyBackupversion)
+        try backup.enableBackup(key: key, version: version)
+        log.debug("Backup enabled")
+    }
+    
+    func disableBackup() {
+        log.debug("->")
+        backup.disableBackup()
+    }
+    
+    // MARK: - Private / Recovery key management
+    
+    func privateKey() -> Data? {
+        guard let recoveryKey = recoveryKey?.toBase58() else {
+            log.debug("No known backup key")
+            return nil
+        }
+        do {
+            return try MXRecoveryKey.decode(recoveryKey)
+        } catch {
+            log.error("Cannot create private key from recovery key", context: error)
+            return nil
+        }
+    }
+    
+    func savePrivateKey(_ privateKey: Data, version: String) {
+        let recoveryKey = MXRecoveryKey.encode(privateKey)
+        do {
+            let key = try BackupRecoveryKey.fromBase58(key: recoveryKey)
+            try backup.saveRecoveryKey(key: key, version: version)
+            log.debug("New private key saved")
+        } catch {
+            log.error("Cannot save private key", context: error)
+        }
+    }
+    
+    func hasValidPrivateKey() -> Bool {
+        return recoveryKey != nil
+    }
+    
+    func hasValidPrivateKey(for keyBackupVersion: MXKeyBackupVersion) -> Bool {
+        guard let recoveryKey = recoveryKey else {
+            log.debug("Not recovery key")
+            return false
+        }
+        return recoveryKey.megolmV1PublicKey().publicKey == publicKey(for: keyBackupVersion)
+    }
+    
+    func validPrivateKey(forRecoveryKey recoveryKey: String, for keyBackupVersion: MXKeyBackupVersion) throws -> Data {
+        let key = try BackupRecoveryKey.fromBase58(key: recoveryKey)
+        guard key.megolmV1PublicKey().publicKey == publicKey(for: keyBackupVersion) else {
+            throw Error.invalidPrivateKey
+        }
+        
+        let privateKey = try MXRecoveryKey.decode(recoveryKey)
+        log.debug("Created valid private key from recovery key")
+        return privateKey
+    }
+    
+    func recoveryKey(fromPassword password: String, in keyBackupVersion: MXKeyBackupVersion) throws -> String {
+        guard
+            let authData = MXCurve25519BackupAuthData(fromJSON: keyBackupVersion.authData),
+            let salt = authData.privateKeySalt
+        else {
+            log.error("Invalid auth data")
+            throw Error.invalidData
+        }
+
+        let key = BackupRecoveryKey.fromPassphrase(
+            passphrase: password,
+            salt: salt,
+            rounds: Int32(authData.privateKeyIterations)
+        )
+        
+        log.debug("Created recovery key from password")
+        return key.toBase58()
+    }
+    
+    // MARK: - Backup versions
+    
+    func prepareKeyBackupVersion(
+        withPassword password: String?,
+        algorithm: String?,
+        success: @escaping (MXMegolmBackupCreationInfo) -> Void,
+        failure: @escaping (Swift.Error) -> Void
+    ) {
+        log.debug("->")
+        
+        guard algorithm == nil || algorithm == kMXCryptoCurve25519KeyBackupAlgorithm else {
+            log.error("Algorithm not supported")
+            failure(Error.algorithmNotSupported(algorithm!))
+            return
+        }
+
+        let key = password != nil ? BackupRecoveryKey.newFromPassphrase(passphrase: password!) : BackupRecoveryKey()
+        let publicKey = key.megolmV1PublicKey()
+
+        let authData = MXCurve25519BackupAuthData()
+        authData.publicKey = publicKey.publicKey
+        if let info = publicKey.passphraseInfo {
+            authData.privateKeySalt = info.privateKeySalt
+            authData.privateKeyIterations = UInt(info.privateKeyIterations)
+        }
+
+        do {
+            authData.signatures = try backup.sign(object: authData.signalableJSONDictionary)
+        } catch {
+            log.error("Cannot create signatures", context: error)
+        }
+
+        let info = MXMegolmBackupCreationInfo()
+        info.algorithm = publicKey.backupAlgorithm
+        info.authData = authData
+        info.recoveryKey = key.toBase58()
+
+        log.debug("Key backup version info is ready")
+        success(info)
+    }
+    
+    func trust(for keyBackupVersion: MXKeyBackupVersion) -> MXKeyBackupVersionTrust {
+        let trust = MXKeyBackupVersionTrust()
+        trust.usable = backup.verifyBackup(version: keyBackupVersion)
+        log.debug("Key backup version is \(trust.usable ? "trusted" : "untrusted")")
+        return trust
+    }
+    
+    func authData(from keyBackupVersion: MXKeyBackupVersion) throws -> MXBaseKeyBackupAuthData {
+        guard let data = MXCurve25519BackupAuthData(fromJSON: keyBackupVersion.authData) else {
+            throw Error.invalidData
+        }
+        return data
+    }
+    
+    func signObject(_ object: [AnyHashable : Any]) -> [AnyHashable : Any] {
+        do {
+            return try backup.sign(object: object)
+        } catch {
+            log.error("Failed signing object", context: error)
+            return [:]
+        }
+    }
+    
+    // MARK: - Backup keys
+    
+    func hasKeysToBackup() -> Bool {
+        guard let counts = backup.roomKeyCounts else {
+            return false
+        }
+        return counts.total > counts.backedUp
+    }
+    
+    func backupProgress() -> Progress {
+        guard let counts = backup.roomKeyCounts else {
+            return Progress()
+        }
+        
+        let progress = Progress(totalUnitCount: counts.total)
+        progress.completedUnitCount = counts.backedUp
+        
+        log.debug("Backed up \(progress.completedUnitCount) out of \(progress.totalUnitCount) keys")
+        return progress
+    }
+    
+    func backupKeys(
+        success: @escaping () -> Void,
+        failure: @escaping (Swift.Error) -> Void
+    ) {
+        log.debug("->")
+        Task {
+            do {
+                try await backup.backupRoomKeys()
+                await MainActor.run {
+                    log.debug("Successfully backed up keys")
+                    success()
+                }
+            } catch {
+                await MainActor.run {
+                    log.error("Failed backing up keys", context: error)
+                    failure(error)
+                }
+            }
+        }
+    }
+    
+    func importKeys(
+        with keysBackupData: MXKeysBackupData,
+        privateKey: Data,
+        keyBackupVersion: MXKeyBackupVersion,
+        success: @escaping (UInt, UInt) -> Void,
+        failure: @escaping (Swift.Error) -> Void
+    ) {
+        let count = keysBackupData.rooms
+            .map { roomId, room in
+                room.sessions.count
+            }
+            .reduce(0, +)
+
+        log.debug("Importing \(count) encrypted sessions")
+        
+        let sessions = keysBackupData.rooms
+            .flatMap { roomId, room in
+                room.sessions
+                    .compactMap { sessionId, keyBackup in
+                        decrypt(
+                            keyBackupData:keyBackup,
+                            keyBackupVersion: keyBackupVersion,
+                            privateKey: privateKey,
+                            forSession: sessionId,
+                            inRoom: roomId
+                        )
+                    }
+            }
+        
+        log.debug("Decrypted \(sessions.count) sessions")
+        
+        do {
+            let result = try backup.importDecryptedKeys(roomKeys: sessions, progressListener: self)
+            log.debug("Successfully imported \(result.imported) out of \(result.total) sessions")
+            success(UInt(result.total), UInt(result.imported))
+        } catch {
+            log.error("Failed importing sessions", context: error)
+            failure(error)
+        }
+    }
+    
+    private func decrypt(
+        keyBackupData: MXKeyBackupData,
+        keyBackupVersion: MXKeyBackupVersion,
+        privateKey: Data,
+        forSession sessionId: String,
+        inRoom roomId: String
+    ) -> MXMegolmSessionData? {
+        log.debug("->")
+        
+        let recoveryKey: BackupRecoveryKey
+        do {
+            let key = MXRecoveryKey.encode(privateKey)
+            recoveryKey = try BackupRecoveryKey.fromBase58(key: key)
+        } catch {
+            log.error("Failed creating recovery key")
+            return nil
+        }
+        
+        guard
+            let ciphertext = keyBackupData.sessionData["ciphertext"] as? String,
+            let mac = keyBackupData.sessionData["mac"] as? String,
+            let ephemeral = keyBackupData.sessionData["ephemeral"] as? String
+        else {
+            log.error("Missing session data properties")
+            return nil
+        }
+        
+        let plaintext: String
+        do {
+            plaintext = try recoveryKey.decryptV1(
+                ephemeralKey: ephemeral,
+                mac: mac,
+                ciphertext: ciphertext
+            )
+        } catch {
+            log.error("Failed decrypting backup data", context: error)
+            return nil
+        }
+        
+        guard
+            let json = MXTools.deserialiseJSONString(plaintext) as? [AnyHashable: Any],
+            let data = MXMegolmSessionData(fromJSON: json)
+        else {
+            log.error("Failed serializing data")
+            return nil
+        }
+        
+        data.sessionId = sessionId
+        data.roomId = roomId
+        data.isUntrusted = true // Asymmetric backups are untrusted by default
+        
+        log.debug("Decrypted key backup data")
+        return data
+    }
+    
+    // MARK: - Private
+    
+    func publicKey(for keyBackupVersion: MXKeyBackupVersion) -> String? {
+        guard let authData = MXCurve25519BackupAuthData(fromJSON: keyBackupVersion.authData) else {
+            log.error("Cannot create auth data for backup version")
+            return nil
+        }
+        return authData.publicKey
+    }
+}
+
+extension MXCryptoKeyBackupEngine: ProgressListener {
+    func onProgress(progress: Int32, total: Int32) {
+        log.debug("Backup progress \(progress) of \(total) total")
+    }
+}
+
+extension MegolmV1BackupKey {
+    enum Error: Swift.Error {
+        case invalidData
+    }
+    
+    init(keyBackupVersion: MXKeyBackupVersion) throws {
+        guard
+            let authData = MXCurve25519BackupAuthData(fromJSON: keyBackupVersion.authData),
+            let signatures = authData.signatures as? [String: [String: String]]
+        else {
+            throw Error.invalidData
+        }
+        
+        let info: PassphraseInfo?
+        if let salt = authData.privateKeySalt {
+            info = PassphraseInfo(
+                privateKeySalt: salt,
+                privateKeyIterations: Int32(authData.privateKeyIterations)
+            )
+        } else {
+            info = nil
+        }
+        
+        self.init(
+            publicKey: authData.publicKey,
+            signatures: signatures,
+            passphraseInfo: info,
+            backupAlgorithm: keyBackupVersion.algorithm
+        )
+    }
+}
+
+#endif

--- a/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.h
+++ b/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.h
@@ -19,8 +19,9 @@
 #import "MXRestClient.h"
 #import "MXMegolmBackupCreationInfo.h"
 #import "MXKeyBackupVersionTrust.h"
+#import "MXSecretShareManager.h"
 
-@protocol MXKeyBackupAlgorithm;
+@protocol MXKeyBackupAlgorithm, MXKeyBackupEngine;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -112,6 +113,19 @@ FOUNDATION_EXPORT NSString *const kMXKeyBackupDidStateChangeNotification;
  to the user's homeserver.
  */
 @interface MXKeyBackup : NSObject
+
+/**
+ Constructor.
+
+ @param engine backup engine that stores and manages keys
+ @param restClient rest client to perform http requests
+ @param secretShareManager manages of secrets sharing
+ @param queue dispatch queue to perform all operations on
+ */
+- (instancetype)initWithEngine:(id<MXKeyBackupEngine>)engine
+                    restClient:(MXRestClient *)restClient
+            secretShareManager:(MXSecretShareManager *)secretShareManager
+                         queue:(dispatch_queue_t)queue;
 
 #pragma mark - Backup management
 
@@ -396,6 +410,19 @@ FOUNDATION_EXPORT NSString *const kMXKeyBackupDidStateChangeNotification;
  Flag indicating the backup can be refreshed, by `forceRefresh:failure:` method.
  */
 @property (nonatomic, readonly) BOOL canBeRefreshed;
+
+/**
+ Check the server for an active key backup.
+
+ If one is present and has a valid signature from one of the user's verified
+ devices, start backing up to it.
+ */
+- (void)checkAndStartKeyBackup;
+
+/**
+ Do a backup if there are new keys.
+ */
+- (void)maybeSendKeyBackup;
 
 @end
 

--- a/MatrixSDK/Crypto/KeyBackup/MXKeyBackup_Private.h
+++ b/MatrixSDK/Crypto/KeyBackup/MXKeyBackup_Private.h
@@ -28,35 +28,9 @@ NS_ASSUME_NONNULL_BEGIN
 @interface MXKeyBackup ()
 
 /**
- Constructor.
-
- @param engine backup engine that stores and manages keys
- @param restClient rest client to perform http requests
- @param secretShareManager manages of secrets sharing
- @param queue dispatch queue to perform all operations on
- */
-- (instancetype)initWithEngine:(id<MXKeyBackupEngine>)engine
-                    restClient:(MXRestClient *)restClient
-            secretShareManager:(MXSecretShareManager *)secretShareManager
-                         queue:(dispatch_queue_t)queue;
-
-/**
- Check the server for an active key backup.
-
- If one is present and has a valid signature from one of the user's verified
- devices, start backing up to it.
- */
-- (void)checkAndStartKeyBackup;
-
-/**
  * Reset all local key backup data.
  */
 - (void)resetKeyBackupData;
-
-/**
- Do a backup if there are new keys.
- */
-- (void)maybeSendKeyBackup;
 
 - (void)requestPrivateKeys:(void (^)(void))onComplete;
 

--- a/MatrixSDK/Crypto/MXCryptoV2.swift
+++ b/MatrixSDK/Crypto/MXCryptoV2.swift
@@ -87,8 +87,7 @@ private class MXCryptoV2: MXCrypto {
     }
     
     public override var backup: MXKeyBackup! {
-        log.debug("Not implemented")
-        return MXKeyBackup()
+        return keyBackup
     }
     
     public override var keyVerificationManager: MXKeyVerificationManager! {
@@ -96,18 +95,15 @@ private class MXCryptoV2: MXCrypto {
     }
     
     public override var recoveryService: MXRecoveryService! {
-        log.debug("Not implemented")
-        return MXRecoveryService()
+        return recovery
     }
     
     public override var secretStorage: MXSecretStorage! {
-        log.debug("Not implemented")
-        return MXSecretStorage()
+        return secretsStorage
     }
     
     public override var secretShareManager: MXSecretShareManager! {
-        log.debug("Not implemented")
-        return MXSecretShareManager()
+        return secretsManager
     }
     
     public override var crossSigning: MXCrossSigning! {
@@ -115,20 +111,27 @@ private class MXCryptoV2: MXCrypto {
     }
     
     private let userId: String
+    private let cryptoQueue: DispatchQueue
+    
     private weak var session: MXSession?
     
     private let machine: MXCryptoMachine
     private let deviceInfoSource: MXDeviceInfoSource
     private let crossSigningInfoSource: MXCrossSigningInfoSource
     private let trustLevelSource: MXTrustLevelSource
-    
     private let crossSign: MXCrossSigningV2
     private let keyVerification: MXKeyVerificationManagerV2
+    private let secretsStorage: MXSecretStorage
+    private let secretsManager: MXSecretShareManager
+    private let backupEngine: MXCryptoKeyBackupEngine
+    private let keyBackup: MXKeyBackup
+    private var recovery: MXRecoveryService
     
     private let log = MXNamedLog(name: "MXCryptoV2")
     
     public init(userId: String, deviceId: String, session: MXSession, restClient: MXRestClient) throws {
         self.userId = userId
+        self.cryptoQueue = DispatchQueue(label: "MXCryptoV2-\(userId)")
         self.session = session
         
         machine = try MXCryptoMachine(
@@ -139,6 +142,7 @@ private class MXCryptoV2: MXCrypto {
                 session?.room(withRoomId: roomId)
             }
         )
+        
         deviceInfoSource = MXDeviceInfoSource(source: machine)
         crossSigningInfoSource = MXCrossSigningInfoSource(source: machine)
         trustLevelSource = MXTrustLevelSource(
@@ -160,6 +164,32 @@ private class MXCryptoV2: MXCrypto {
                 }
                 return roomId
             }
+        )
+        
+        secretsManager = MXSecretShareManager()
+        secretsStorage = MXSecretStorage(matrixSession: session, processingQueue: cryptoQueue)
+        
+        backupEngine = MXCryptoKeyBackupEngine(backup: machine)
+        keyBackup = MXKeyBackup(
+            engine: backupEngine,
+            restClient: restClient,
+            secretShareManager: secretsManager,
+            queue: cryptoQueue
+        )
+        
+        recovery = MXRecoveryService(
+            dependencies: .init(
+                credentials: restClient.credentials,
+                backup: keyBackup,
+                secretStorage: secretsStorage,
+                secretStore: MXCryptoSecretStoreV2(
+                    backup: keyBackup,
+                    backupEngine: backupEngine
+                ),
+                crossSigning: crossSign,
+                cryptoQueue: cryptoQueue
+            ),
+            delegate: keyVerification
         )
         
         super.init()
@@ -184,9 +214,17 @@ private class MXCryptoV2: MXCrypto {
     
     // MARK: - Start / close
     
-    public override func start(_ onComplete: (() -> Void)!, failure: ((Swift.Error?) -> Void)!) {
+    public override func start(
+        _ onComplete: (() -> Void)!,
+        failure: ((Swift.Error?) -> Void)!
+    ) {
         onComplete?()
-        log.debug("Not implemented")
+        machine.onKeysUpload { [weak self] in
+            guard let self = self else { return }
+            
+            self.crossSign.refreshState(success: nil)
+            self.keyBackup.checkAndStart()
+        }
     }
     
     public override func close(_ deleteStore: Bool) {
@@ -301,7 +339,14 @@ private class MXCryptoV2: MXCrypto {
     }
     
     public override func discardOutboundGroupSessionForRoom(withRoomId roomId: String!, onComplete: (() -> Void)!) {
-        log.debug("Not implemented")
+        guard let roomId = roomId else {
+            log.failure("Missing room id")
+            return
+        }
+        
+        log.debug("Discarding room key")
+        machine.discardRoomKey(roomId: roomId)
+        onComplete?()
     }
     
     // MARK: - Sync
@@ -320,6 +365,7 @@ private class MXCryptoV2: MXCrypto {
                 unusedFallbackKeys: syncResponse.unusedFallbackKeys
             )
             keyVerification.handleDeviceEvents(toDevice.events)
+            backup.maybeSend()
         } catch {
             log.error("Cannot handle sync", context: error)
         }

--- a/MatrixSDK/Crypto/MXCryptoV2.swift
+++ b/MatrixSDK/Crypto/MXCryptoV2.swift
@@ -219,7 +219,7 @@ private class MXCryptoV2: MXCrypto {
         failure: ((Swift.Error?) -> Void)!
     ) {
         onComplete?()
-        machine.onKeysUpload { [weak self] in
+        machine.onInitialKeysUpload { [weak self] in
             guard let self = self else { return }
             
             self.crossSign.refreshState(success: nil)

--- a/MatrixSDK/Crypto/SecretStorage/MXCryptoSecretStoreV2.swift
+++ b/MatrixSDK/Crypto/SecretStorage/MXCryptoSecretStoreV2.swift
@@ -1,0 +1,62 @@
+// 
+// Copyright 2022 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+/// Secret store compatible with Rust-based Crypto V2, where
+/// backup secrets are stored internally in the Crypto machine
+/// and others have to be managed manually.
+class MXCryptoSecretStoreV2: NSObject, MXCryptoSecretStore {
+    
+    private let backup: MXKeyBackup
+    private let backupEngine: MXKeyBackupEngine
+    private let log = MXNamedLog(name: "MXCryptoSecretStoreV2")
+    
+    init(backup: MXKeyBackup, backupEngine: MXKeyBackupEngine) {
+        self.backup = backup
+        self.backupEngine = backupEngine
+    }
+    
+    func storeSecret(_ secret: String!, withSecretId secretId: String!) {
+        guard let version = backup.keyBackupVersion?.version else {
+            log.error("No key backup version available")
+            return
+        }
+
+        if secretId == MXSecretId.keyBackup.takeUnretainedValue() as String {
+            let privateKey = MXBase64Tools.data(fromBase64: secret)
+            backupEngine.savePrivateKey(privateKey, version: version)
+        } else {
+            log.error("Not implemented")
+        }
+    }
+    
+    func secret(withSecretId secretId: String!) -> String! {
+        if secretId == MXSecretId.keyBackup.takeUnretainedValue() as String {
+            guard let privateKey = backupEngine.privateKey() else {
+                return nil
+            }
+            return MXBase64Tools.base64(from: privateKey)
+        } else {
+            log.error("Not implemented")
+            return nil
+        }
+    }
+    
+    func deleteSecret(withSecretId secretId: String!) {
+        log.error("Not implemented")
+    }
+}

--- a/MatrixSDK/Crypto/SecretStorage/MXSecretStorage.h
+++ b/MatrixSDK/Crypto/SecretStorage/MXSecretStorage.h
@@ -21,6 +21,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class MXSession;
 
 #pragma mark - Constants
 
@@ -44,6 +45,13 @@ typedef NS_ENUM(NSUInteger, MXSecretStorageErrorCode)
  See https://github.com/uhoreg/matrix-doc/blob/ssss/proposals/1946-secure_server-side_storage.md
  */
 @interface MXSecretStorage : NSObject
+
+/**
+ Constructor.
+ 
+ @param mxSession the related 'MXSession' instance.
+ */
+- (instancetype)initWithMatrixSession:(MXSession *)mxSession  processingQueue:(dispatch_queue_t)processingQueue;
 
 #pragma mark - Secret Storage Key
 

--- a/MatrixSDK/Crypto/SecretStorage/MXSecretStorage_Private.h
+++ b/MatrixSDK/Crypto/SecretStorage/MXSecretStorage_Private.h
@@ -23,13 +23,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MXSecretStorage ()
 
-/**
- Constructor.
- 
- @param mxSession the related 'MXSession' instance.
- */
-- (instancetype)initWithMatrixSession:(MXSession *)mxSession  processingQueue:(dispatch_queue_t)processingQueue;
-
 - (nullable MXEncryptedSecretContent *)encryptedZeroStringWithPrivateKey:(NSData*)privateKey iv:(nullable NSData*)iv error:(NSError**)error;
 
 - (nullable MXEncryptedSecretContent *)encryptSecret:(NSString*)unpaddedBase64Secret withSecretId:(nullable NSString*)secretId privateKey:(NSData*)privateKey iv:(nullable NSData*)iv error:(NSError**)error;

--- a/MatrixSDK/Crypto/Verification/MXKeyVerificationManagerV2.swift
+++ b/MatrixSDK/Crypto/Verification/MXKeyVerificationManagerV2.swift
@@ -301,4 +301,10 @@ class MXKeyVerificationManagerV2: MXKeyVerificationManager {
     }
 }
 
+extension MXKeyVerificationManagerV2: MXRecoveryServiceDelegate {
+    func setUserVerification(_ isTrusted: Bool, forUser: String, success: () -> Void, failure: (Swift.Error) -> Void) {
+        log.error("Not implemented")
+    }
+}
+
 #endif

--- a/MatrixSDK/MatrixSDK.h
+++ b/MatrixSDK/MatrixSDK.h
@@ -173,6 +173,9 @@ FOUNDATION_EXPORT NSString *MatrixSDKVersion;
 #import "MXSharedHistoryKeyService.h"
 #import "MXRoomKeyEventContent.h"
 #import "MXForwardedRoomKeyEventContent.h"
+#import "MXKeyBackupEngine.h"
+#import "MXCryptoTools.h"
+#import "MXRecoveryKey.h"
 
 //  Sync response models
 #import "MXSyncResponse.h"
@@ -197,3 +200,4 @@ FOUNDATION_EXPORT NSString *MatrixSDKVersion;
 #import "MXBeacon.h"
 #import "MXEventAssetType.h"
 #import "MXDevice.h"
+

--- a/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoProtocolStubs.swift
+++ b/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoProtocolStubs.swift
@@ -19,7 +19,7 @@ import Foundation
 
 #if DEBUG && os(iOS)
 
-import MatrixSDKCrypto
+@testable import MatrixSDKCrypto
 
 class CryptoIdentityStub: MXCryptoIdentity {
     var userId: String = "Alice"
@@ -141,6 +141,46 @@ extension CryptoVerificationStub: MXCryptoSASVerifying {
     
     func emojiIndexes(sas: Sas) throws -> [Int] {
         stubbedEmojis[sas.flowId] ?? []
+    }
+}
+
+class CryptoBackupStub: MXCryptoBackup {
+    var isBackupEnabled: Bool = false
+    var backupKeys: BackupKeys?
+    var roomKeyCounts: RoomKeyCounts?
+    
+    var versionSpy: String?
+    var backupKeySpy: MegolmV1BackupKey?
+    var recoveryKeySpy: BackupRecoveryKey?
+    var roomKeysSpy: [MXMegolmSessionData]?
+    
+    func enableBackup(key: MegolmV1BackupKey, version: String) throws {
+        versionSpy = version
+        backupKeySpy = key
+    }
+    
+    func disableBackup() {
+    }
+    
+    func saveRecoveryKey(key: BackupRecoveryKey, version: String?) throws {
+        recoveryKeySpy = key
+    }
+    
+    func verifyBackup(version: MXKeyBackupVersion) -> Bool {
+        return true
+    }
+    
+    var stubbedSignature = [String : [String : String]]()
+    func sign(object: [AnyHashable : Any]) throws -> [String : [String : String]] {
+        return stubbedSignature
+    }
+    
+    func backupRoomKeys() async throws {
+    }
+    
+    func importDecryptedKeys(roomKeys: [MXMegolmSessionData], progressListener: ProgressListener) throws -> KeysImportResult {
+        roomKeysSpy = roomKeys
+        return KeysImportResult(imported: Int64(roomKeys.count), total: Int64(roomKeys.count), keys: [:])
     }
 }
 

--- a/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoRequestsUnitTests.swift
+++ b/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoRequestsUnitTests.swift
@@ -85,6 +85,31 @@ class MXCryptoRequestsUnitTests: XCTestCase {
         XCTAssertEqual(request.devices.map as? [String: [String: String]], keys)
     }
     
+    func test_canCreateKeysBackupRequest() {
+        let rooms: [String: Any] = [
+            "A": [
+                "sessions": [
+                    "1": [
+                        "first_message_index": 1,
+                        "forwarded_count": 0,
+                        "is_verified": true,
+                    ],
+                ]
+            ],
+        ]
+        let string = MXTools.serialiseJSONObject(rooms)
+        
+        do {
+            let request = try MXCryptoRequests.KeysBackupRequest(version: "2", rooms: string ?? "")
+            XCTAssertEqual(request.version, "2")
+            XCTAssertEqual(request.keysBackupData.jsonDictionary() as NSDictionary, [
+                "rooms": rooms
+            ])
+        } catch {
+            XCTFail("Failed creating keys backup request with error - \(error)")
+        }
+    }
+    
     func test_uploadSignatureKeysRequest_canGetJsonKeys() throws {
         let request = UploadSigningKeysRequest(
             masterKey: MXTools.serialiseJSONObject(["key": "A"]),

--- a/MatrixSDKTests/Crypto/KeyBackup/Data/MXKeyBackupVersion+Stub.swift
+++ b/MatrixSDKTests/Crypto/KeyBackup/Data/MXKeyBackupVersion+Stub.swift
@@ -1,0 +1,39 @@
+// 
+// Copyright 2022 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+extension MXKeyBackupVersion {
+    static func stub(
+        version: String = "3",
+        publicKey: String = "ABC"
+    ) -> MXKeyBackupVersion {
+        return MXKeyBackupVersion(fromJSON: [
+            "version": version,
+            "algorithm": kMXCryptoCurve25519KeyBackupAlgorithm,
+            "auth_data": [
+                "public_key": publicKey,
+                "private_key_salt": "salt",
+                "private_key_iterations": 10,
+                "signatures": [
+                    "bob": [
+                        "ABC": "XYZ"
+                    ]
+                ]
+            ]
+        ])!
+    }
+}

--- a/MatrixSDKTests/Crypto/KeyBackup/Engine/MXCryptoKeyBackupEngineUnitTests.swift
+++ b/MatrixSDKTests/Crypto/KeyBackup/Engine/MXCryptoKeyBackupEngineUnitTests.swift
@@ -1,0 +1,214 @@
+// 
+// Copyright 2022 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+@testable import MatrixSDK
+
+#if DEBUG && os(iOS)
+
+import MatrixSDKCrypto
+
+class MXCryptoKeyBackupEngineUnitTests: XCTestCase {
+    var backup: CryptoBackupStub!
+    var engine: MXCryptoKeyBackupEngine!
+    
+    override func setUp() {
+        backup = CryptoBackupStub()
+        engine = MXCryptoKeyBackupEngine(backup: backup)
+    }
+    
+    func test_createsBackupKeyFromVersion() {
+        let version = MXKeyBackupVersion.stub()
+        
+        do {
+            try engine.enableBackup(with: version)
+            
+            XCTAssertEqual(backup.versionSpy, "3")
+            XCTAssertEqual(backup.backupKeySpy?.publicKey, "ABC")
+            XCTAssertEqual(backup.backupKeySpy?.passphraseInfo?.privateKeySalt, "salt")
+            XCTAssertEqual(backup.backupKeySpy?.passphraseInfo?.privateKeyIterations, 10)
+            XCTAssertEqual(backup.backupKeySpy?.signatures, [
+                "bob": [
+                    "ABC": "XYZ"
+                ]
+            ])
+        } catch {
+            XCTFail("Failed enabling backup - \(error)")
+        }
+    }
+    
+    func test_hasKeysToBackup() {
+        backup.roomKeyCounts = .init(total: 0, backedUp: 0)
+        XCTAssertFalse(engine.hasKeysToBackup())
+        
+        backup.roomKeyCounts = .init(total: 1, backedUp: 0)
+        XCTAssertTrue(engine.hasKeysToBackup())
+        
+        backup.roomKeyCounts = .init(total: 2, backedUp: 3)
+        XCTAssertFalse(engine.hasKeysToBackup())
+    }
+    
+    func test_validPrivateKeyFromRecoveryKey_failsForInvalidPublicKey() {
+        let key = BackupRecoveryKey()
+        let invalidVersion = MXKeyBackupVersion.stub(
+            publicKey: "invalid_key"
+        )
+        
+        do {
+            _ = try engine.validPrivateKey(forRecoveryKey: key.toBase58(), for: invalidVersion)
+            XCTFail("Should not succeed")
+        } catch MXCryptoKeyBackupEngine.Error.invalidPrivateKey {
+            XCTAssert(true)
+        } catch {
+            XCTFail("Unknown error \(error)")
+        }
+    }
+    
+    func test_validPrivateKeyFromRecoveryKey_succeedsForInvalidPublicKey() {
+        let key = BackupRecoveryKey()
+        let invalidVersion = MXKeyBackupVersion.stub(
+            publicKey: key.megolmV1PublicKey().publicKey
+        )
+        
+        do {
+            let privateKey = try engine.validPrivateKey(forRecoveryKey: key.toBase58(), for: invalidVersion)
+            XCTAssertEqual(privateKey, try! MXRecoveryKey.decode(key.toBase58()))
+        } catch {
+            XCTFail("Unknown error \(error)")
+        }
+    }
+    
+    func test_prepareKeyBackupVersion() {
+        backup.stubbedSignature = [
+            "Bob": [
+                "ed25519": "123"
+            ]
+        ]
+        
+        let exp = expectation(description: "exp")
+        engine.prepareKeyBackupVersion(
+            withPassword: "pass",
+            algorithm: nil,
+            success: { info in
+                
+                let privateKey = try! MXRecoveryKey.decode(info.recoveryKey)
+                let publicKey = OLMPkDecryption().setPrivateKey(privateKey, error: nil)
+                
+                let authData = info.authData as? MXCurve25519BackupAuthData
+                XCTAssertEqual(info.algorithm, kMXCryptoCurve25519KeyBackupAlgorithm)
+                XCTAssertEqual(authData?.publicKey, publicKey)
+                XCTAssertEqual(authData?.signatures as? NSDictionary, [
+                    "Bob": [
+                        "ed25519": "123"
+                    ]
+                ])
+                
+                exp.fulfill()
+            },
+            failure: {
+                exp.fulfill()
+                XCTFail("Unknown error \($0)")
+            }
+        )
+        
+        waitForExpectations(timeout: 1)
+    }
+    
+    func test_importKeys() {
+        // Prepare private and public key for encryption
+        let key = BackupRecoveryKey()
+        let privateKey = try! MXRecoveryKey.decode(key.toBase58())
+        let publicKey = OLMPkDecryption().setPrivateKey(privateKey, error: nil)
+        
+        // Encrypt some data
+        let encryption = OLMPkEncryption()
+        encryption.setRecipientKey(publicKey)
+        let message = MXTools.serialiseJSONObject([
+            "session_key": "SESSION_KEY_ABC"
+        ])!
+        let encrypted = encryption.encryptMessage(message, error: nil)
+        
+        // Prepare encrypted backup keys
+        let keys = MXKeysBackupData(fromJSON: [
+            "rooms": [
+                "A": [
+                    "sessions": [
+                        "1": [
+                            "session_data": [
+                                "ciphertext": encrypted.ciphertext,
+                                "mac": encrypted.mac,
+                                "ephemeral": encrypted.ephemeralKey
+                            ]
+                        ],
+                        "2": [
+                            "session_data": [
+                                "ciphertext": encrypted.ciphertext,
+                                "mac": encrypted.mac,
+                                "ephemeral": encrypted.ephemeralKey
+                            ]
+                        ]
+                    ]
+                ],
+                "B": [
+                    "sessions": [
+                        "3": [
+                            "session_data": [
+                                "ciphertext": encrypted.ciphertext,
+                                "mac": encrypted.mac,
+                                "ephemeral": encrypted.ephemeralKey
+                            ]
+                        ]
+                    ]
+                ],
+            ]
+        ])!
+
+        // Import keys
+        let exp = expectation(description: "exp")
+        engine.importKeys(
+            with: keys,
+            privateKey: privateKey,
+            keyBackupVersion: .stub(),
+            success: { total, imported in
+                
+                XCTAssertEqual(total, 3)
+                XCTAssertEqual(imported, 3)
+                
+                let decryptedKeys = self.backup.roomKeysSpy!
+                let sessionKeys = decryptedKeys.compactMap { $0.sessionKey }
+                let untrusted = decryptedKeys.compactMap { $0.isUntrusted }
+                let sessionIds = decryptedKeys.compactMap { $0.sessionId }
+                let roomIds = decryptedKeys.compactMap { $0.roomId }
+                
+                XCTAssertEqual(decryptedKeys.count, 3)
+                XCTAssertEqual(Set(sessionKeys), ["SESSION_KEY_ABC", "SESSION_KEY_ABC", "SESSION_KEY_ABC"])
+                XCTAssertEqual(Set(untrusted), [true, true, true])
+                XCTAssertEqual(Set(sessionIds), ["1", "2", "3"])
+                XCTAssertEqual(Set(roomIds), ["A", "B"])
+                
+                exp.fulfill()
+            },
+            failure: {
+                XCTFail("Importing failed with error \($0)")
+                exp.fulfill()
+            }
+        )
+        
+        waitForExpectations(timeout: 1)
+    }
+}
+
+#endif

--- a/MatrixSDKTests/TestPlans/UnitTests.xctestplan
+++ b/MatrixSDKTests/TestPlans/UnitTests.xctestplan
@@ -41,6 +41,7 @@
         "MXCrossSigningInfoSourceUnitTests",
         "MXCrossSigningInfoUnitTests",
         "MXCrossSigningV2UnitTests",
+        "MXCryptoKeyBackupEngineUnitTests",
         "MXCryptoRequestsUnitTests",
         "MXDeviceInfoSourceUnitTests",
         "MXDeviceInfoUnitTests",

--- a/MatrixSDKTests/TestPlans/UnitTestsWithSanitizers.xctestplan
+++ b/MatrixSDKTests/TestPlans/UnitTestsWithSanitizers.xctestplan
@@ -51,6 +51,7 @@
         "MXCrossSigningInfoSourceUnitTests",
         "MXCrossSigningInfoUnitTests",
         "MXCrossSigningV2UnitTests",
+        "MXCryptoKeyBackupEngineUnitTests",
         "MXCryptoRequestsUnitTests",
         "MXDeviceInfoSourceUnitTests",
         "MXDeviceInfoUnitTests",

--- a/changelog.d/6769.change
+++ b/changelog.d/6769.change
@@ -1,0 +1,1 @@
+CryptoV2: Key backups


### PR DESCRIPTION
Resolves https://github.com/vector-im/element-ios/issues/6768 and https://github.com/vector-im/element-ios/issues/6769

This PR adds key backup functionality using rust-based crypto machine. The changes include:

- Implement backup-related functionality from rust-based `OlmMachine`, hidden behind `MXCryptoBackup` protocol
- Implement new backup engine, similar to the one introduced [previously](https://github.com/matrix-org/matrix-ios-sdk/pull/1578)
- Initialize backup and cross signing upon first keys upload via crypto machine
- Allow discarding room keys via `/discardsession` slash command