### PR TITLE
Key gossiping with Crypto V2

### DIFF
--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoProtocols.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoProtocols.swift
@@ -56,10 +56,11 @@ protocol MXCryptoUserIdentitySource: MXCryptoIdentity {
 }
 
 /// Event encryption and decryption
-protocol MXCryptoEventEncrypting: MXCryptoIdentity {
+protocol MXCryptoRoomEventEncrypting: MXCryptoIdentity {
     func shareRoomKeysIfNecessary(roomId: String, users: [String]) async throws
-    func encrypt(_ content: [AnyHashable: Any], roomId: String, eventType: String, users: [String]) async throws -> [String: Any]
-    func decryptEvent(_ event: MXEvent) throws -> MXEventDecryptionResult
+    func encryptRoomEvent(content: [AnyHashable: Any], roomId: String, eventType: String, users: [String]) async throws -> [String: Any]
+    func decryptRoomEvent(_ event: MXEvent) -> MXEventDecryptionResult
+    func requestRoomKey(event: MXEvent) async throws
     func discardRoomKey(roomId: String)
 }
 

--- a/changelog.d/6773.change
+++ b/changelog.d/6773.change
@@ -1,0 +1,1 @@
+CryptoV2: Key gossiping


### PR DESCRIPTION
Resolves https://github.com/vector-im/element-ios/issues/6773 and https://github.com/vector-im/element-ios/issues/6774

Expose specific decryptionError when room keys are missing (which is displayed as "re-request keys" message on iOS), and implement `requestRoomKey` which will send out `m.room_key_request` message to other verified devices of the same user. Once recieved by the other device, its OlmMachine will automatically send out `m.forwarded_room_key` if necessary.