### PR TITLE
Manual device verification with Crypto V2

### DIFF
--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoMachine.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoMachine.swift
@@ -464,6 +464,10 @@ extension MXCryptoMachine: MXCryptoCrossSigning {
             requests.uploadSignatures(request: result.signatureRequest)
         ]
     }
+    
+    func exportCrossSigningKeys() -> CrossSigningKeyExport? {
+        machine.exportCrossSigningKeys()
+    }
 }
 
 extension MXCryptoMachine: MXCryptoVerificationRequesting {
@@ -518,6 +522,11 @@ extension MXCryptoMachine: MXCryptoVerificationRequesting {
             throw Error.cannotCancelVerification
         }
         try await handleOutgoingVerificationRequest(request)
+    }
+    
+    func manuallyVerifyDevice(userId: String, deviceId: String) async throws {
+        let request = try machine.verifyDevice(userId: userId, deviceId: deviceId)
+        try await requests.uploadSignatures(request: request)
     }
     
     // MARK: - Private

--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoMachine.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoMachine.swift
@@ -524,6 +524,11 @@ extension MXCryptoMachine: MXCryptoVerificationRequesting {
         try await handleOutgoingVerificationRequest(request)
     }
     
+    func manuallyVerifyUser(userId: String) async throws {
+        let request = try machine.verifyIdentity(userId: userId)
+        try await requests.uploadSignatures(request: request)
+    }
+    
     func manuallyVerifyDevice(userId: String, deviceId: String) async throws {
         let request = try machine.verifyDevice(userId: userId, deviceId: deviceId)
         try await requests.uploadSignatures(request: request)

--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoProtocols.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoProtocols.swift
@@ -53,6 +53,7 @@ protocol MXCryptoUserIdentitySource: MXCryptoIdentity {
     func userIdentity(userId: String) -> UserIdentity?
     func isUserVerified(userId: String) -> Bool
     func downloadKeys(users: [String]) async throws
+    func manuallyVerifyDevice(userId: String, deviceId: String) async throws
 }
 
 /// Event encryption and decryption
@@ -68,6 +69,7 @@ protocol MXCryptoRoomEventEncrypting: MXCryptoIdentity {
 protocol MXCryptoCrossSigning: MXCryptoUserIdentitySource {
     func crossSigningStatus() -> CrossSigningStatus
     func bootstrapCrossSigning(authParams: [AnyHashable: Any]) async throws
+    func exportCrossSigningKeys() -> CrossSigningKeyExport?
 }
 
 /// Lifecycle of verification request

--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoProtocols.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoProtocols.swift
@@ -53,6 +53,7 @@ protocol MXCryptoUserIdentitySource: MXCryptoIdentity {
     func userIdentity(userId: String) -> UserIdentity?
     func isUserVerified(userId: String) -> Bool
     func downloadKeys(users: [String]) async throws
+    func manuallyVerifyUser(userId: String) async throws
     func manuallyVerifyDevice(userId: String, deviceId: String) async throws
 }
 

--- a/MatrixSDK/Crypto/Data/Store/MXCryptoSecretStore.h
+++ b/MatrixSDK/Crypto/Data/Store/MXCryptoSecretStore.h
@@ -17,6 +17,8 @@
 #ifndef MXCryptoSecretStore_h
 #define MXCryptoSecretStore_h
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  The `MXCryptoSecretStore` protocol defines an interface that must be implemented in order to store
  local secrets in the context of SSSS.
@@ -29,7 +31,7 @@
  @param secret the secret.
  @param secretId the id of the secret.
  */
-- (void)storeSecret:(NSString*)secret withSecretId:(NSString*)secretId;
+- (void)storeSecret:(NSString *)secret withSecretId:(NSString *)secretId;
 
 /**
  Retrieve a secret.
@@ -37,7 +39,7 @@
  @param secretId the id of the secret.
  @return the secret. Nil if the secret does not exist.
  */
-- (NSString*)secretWithSecretId:(NSString*)secretId;
+- (nullable NSString *)secretWithSecretId:(NSString *)secretId;
 
 
 /**
@@ -45,8 +47,10 @@
  
  @param secretId the id of the secret.
  */
-- (void)deleteSecretWithSecretId:(NSString*)secretId;
+- (void)deleteSecretWithSecretId:(NSString *)secretId;
 
 @end
+
+NS_ASSUME_NONNULL_END
 
 #endif /* MXCryptoSecretStore_h */

--- a/MatrixSDK/Crypto/Devices/Data/MXCryptoDeviceWrapper.swift
+++ b/MatrixSDK/Crypto/Devices/Data/MXCryptoDeviceWrapper.swift
@@ -41,9 +41,19 @@ import MatrixSDKCrypto
         unsignedData = [
             "device_display_name": device.displayName as Any
         ]
-        trustLevel = MXDeviceTrustLevel(
+        
+        let status: MXDeviceVerification
+        if device.isBlocked {
+            status = .blocked
+        } else if device.locallyTrusted {
+            status = .verified
+        } else {
             // Note: currently not distinguishing between unknown and unverified
-            localVerificationStatus: device.locallyTrusted ? .verified : .unknown,
+            status = .unknown
+        }
+        
+        trustLevel = MXDeviceTrustLevel(
+            localVerificationStatus: status,
             crossSigningVerified: device.crossSigningTrusted
         )
     }

--- a/MatrixSDK/Crypto/MXCryptoV2.swift
+++ b/MatrixSDK/Crypto/MXCryptoV2.swift
@@ -71,6 +71,7 @@ import MatrixSDKCrypto
 private class MXCryptoV2: MXCrypto {
     enum Error: Swift.Error {
         case missingRoom
+        case missingDevice
     }
     
     public override var deviceCurve25519Key: String! {
@@ -184,7 +185,8 @@ private class MXCryptoV2: MXCrypto {
                 secretStorage: secretsStorage,
                 secretStore: MXCryptoSecretStoreV2(
                     backup: keyBackup,
-                    backupEngine: backupEngine
+                    backupEngine: backupEngine,
+                    crossSigning: machine
                 ),
                 crossSigning: crossSign,
                 cryptoQueue: cryptoQueue
@@ -437,7 +439,57 @@ private class MXCryptoV2: MXCrypto {
             })
     }
     
-    // MARK: - Users, devices and verification
+    public override func setUserVerification(
+        _ verificationStatus: Bool,
+        forUser userId: String!,
+        success: (() -> Void)!,
+        failure: ((Swift.Error?) -> Void)!
+    ) {
+        log.failure("Crypto V2 does not support manual user verification")
+    }
+    
+    public override func setDeviceVerification(
+        _ verificationStatus: MXDeviceVerification,
+        forDevice deviceId: String!,
+        ofUser userId: String!,
+        success: (() -> Void)!,
+        failure: ((Swift.Error?) -> Void)!
+    ) {
+        guard let userId = userId, let deviceId = deviceId else {
+            log.failure("Missing user/device")
+            failure(Error.missingDevice)
+            return
+        }
+        
+        log.debug("Setting device verification status manually")
+        
+        switch verificationStatus {
+        case .unverified, .blocked, .unknown:
+            log.error("Not implemented")
+        case .verified:
+            Task {
+                do {
+                    try await machine.manuallyVerifyDevice(userId: userId, deviceId: deviceId)
+                    log.debug("Successfully marked device as verified")
+                    await MainActor.run {                        
+                        success?()
+                    }
+                } catch {
+                    log.error("Failed marking device as verified", context: error)
+                    await MainActor.run {
+                        failure?(error)
+                    }
+                }
+            }
+        @unknown default:
+            log.failure("Unknown verification status", context: [
+                "status": verificationStatus
+            ])
+            failure?(nil)
+        }
+    }
+    
+    // MARK: - Users and devices
     
     public override func eventDeviceInfo(_ event: MXEvent!) -> MXDeviceInfo! {
         guard
@@ -450,15 +502,7 @@ private class MXCryptoV2: MXCrypto {
         return device(withDeviceId: deviceId, ofUser: userId)
     }
     
-    public override func setDeviceVerification(_ verificationStatus: MXDeviceVerification, forDevice deviceId: String!, ofUser userId: String!, success: (() -> Void)!, failure: ((Swift.Error?) -> Void)!) {
-        log.debug("Not implemented")
-    }
-    
     public override func setDevicesKnown(_ devices: MXUsersDevicesMap<MXDeviceInfo>!, complete: (() -> Void)!) {
-        log.debug("Not implemented")
-    }
-    
-    public override func setUserVerification(_ verificationStatus: Bool, forUser userId: String!, success: (() -> Void)!, failure: ((Swift.Error?) -> Void)!) {
         log.debug("Not implemented")
     }
     

--- a/MatrixSDK/Crypto/Recovery/MXRecoveryService.h
+++ b/MatrixSDK/Crypto/Recovery/MXRecoveryService.h
@@ -37,7 +37,8 @@ typedef NS_ENUM(NSInteger, MXRecoveryServiceErrorCode)
 };
 
 @protocol MXRecoveryServiceDelegate <NSObject>
-- (void)setUserVerification:(BOOL)verificationStatus forUser:(NSString*)userId
+- (void)setUserVerification:(BOOL)verificationStatus
+                    forUser:(NSString*)userId
                     success:(void (^)(void))success
                     failure:(void (^)(NSError *error))failure;
 @end

--- a/MatrixSDK/Crypto/SecretStorage/MXCryptoSecretStoreV2.swift
+++ b/MatrixSDK/Crypto/SecretStorage/MXCryptoSecretStoreV2.swift
@@ -16,6 +16,8 @@
 
 import Foundation
 
+#if DEBUG && os(iOS)
+
 /// Secret store compatible with Rust-based Crypto V2, where
 /// backup secrets are stored internally in the Crypto machine
 /// and others have to be managed manually.
@@ -68,3 +70,5 @@ class MXCryptoSecretStoreV2: NSObject, MXCryptoSecretStore {
         log.error("Not implemented")
     }
 }
+
+#endif

--- a/MatrixSDKTests/Crypto/CryptoMachine/Device+Stub.swift
+++ b/MatrixSDKTests/Crypto/CryptoMachine/Device+Stub.swift
@@ -25,6 +25,7 @@ extension Device {
         userId: String = "Alice",
         deviceId: String = "Device1",
         displayName: String = "Alice's iPhone",
+        isBlocked: Bool = false,
         locallyTrusted: Bool = true,
         crossSigningTrusted: Bool = true
     ) -> Device {
@@ -40,7 +41,7 @@ extension Device {
                 "curve25519"
             ],
             displayName: displayName,
-            isBlocked: false,
+            isBlocked: isBlocked,
             locallyTrusted: locallyTrusted,
             crossSigningTrusted: crossSigningTrusted
         )

--- a/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoProtocolStubs.swift
+++ b/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoProtocolStubs.swift
@@ -58,11 +58,12 @@ class UserIdentitySourceStub: CryptoIdentityStub, MXCryptoUserIdentitySource {
     }
     
     func downloadKeys(users: [String]) async throws {
-        
+    }
+    
+    func manuallyVerifyUser(userId: String) async throws {
     }
     
     func manuallyVerifyDevice(userId: String, deviceId: String) async throws {
-        
     }
 }
 
@@ -96,8 +97,10 @@ class CryptoCrossSigningStub: CryptoIdentityStub, MXCryptoCrossSigning {
     func downloadKeys(users: [String]) async throws {
     }
     
+    func manuallyVerifyUser(userId: String) async throws {
+    }
+    
     func manuallyVerifyDevice(userId: String, deviceId: String) async throws {
-        
     }
 }
 

--- a/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoProtocolStubs.swift
+++ b/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoProtocolStubs.swift
@@ -60,6 +60,10 @@ class UserIdentitySourceStub: CryptoIdentityStub, MXCryptoUserIdentitySource {
     func downloadKeys(users: [String]) async throws {
         
     }
+    
+    func manuallyVerifyDevice(userId: String, deviceId: String) async throws {
+        
+    }
 }
 
 class CryptoCrossSigningStub: CryptoIdentityStub, MXCryptoCrossSigning {
@@ -75,6 +79,10 @@ class CryptoCrossSigningStub: CryptoIdentityStub, MXCryptoCrossSigning {
     func bootstrapCrossSigning(authParams: [AnyHashable : Any]) async throws {
     }
     
+    func exportCrossSigningKeys() -> CrossSigningKeyExport? {
+        return nil
+    }
+    
     var stubbedIdentities = [String: UserIdentity]()
     func userIdentity(userId: String) -> UserIdentity? {
         stubbedIdentities[userId]
@@ -86,6 +94,10 @@ class CryptoCrossSigningStub: CryptoIdentityStub, MXCryptoCrossSigning {
     }
     
     func downloadKeys(users: [String]) async throws {
+    }
+    
+    func manuallyVerifyDevice(userId: String, deviceId: String) async throws {
+        
     }
 }
 

--- a/MatrixSDKTests/Crypto/Devices/Data/MXDeviceInfoUnitTests.swift
+++ b/MatrixSDKTests/Crypto/Devices/Data/MXDeviceInfoUnitTests.swift
@@ -77,6 +77,16 @@ class MXDeviceInfoUnitTests: XCTestCase {
                 crossSigningVerified: false
             )
         )
+        
+        let device4 = Device.stub(isBlocked: true, locallyTrusted: true, crossSigningTrusted: false)
+        let info4 = MXDeviceInfo(device: .init(device: device4))
+        XCTAssertEqual(
+            info4?.trustLevel,
+            MXDeviceTrustLevel(
+                localVerificationStatus: .blocked,
+                crossSigningVerified: false
+            )
+        )
     }
 }
 

--- a/changelog.d/6781.change
+++ b/changelog.d/6781.change
@@ -1,0 +1,1 @@
+CryptoV2: Manual device verification


### PR DESCRIPTION
Resolved https://github.com/vector-im/element-ios/issues/6781

- implement functionality to manually verify a device (and upload its signatures)
- reflect trust status when a device is blocked
- return cross signing keys as secrets when available