### PR TITLE
e2ee should not hinder verification

### DIFF
--- a/MatrixSDK/Crypto/Algorithms/MXEncrypting.h
+++ b/MatrixSDK/Crypto/Algorithms/MXEncrypting.h
@@ -60,7 +60,7 @@
 
  @return a MXHTTPOperation instance. May be nil if all required materials is already in place.
  */
-- (MXHTTPOperation*)ensureSessionForUsers:(NSArray<NSString*>*)users
+- (MXHTTPOperation*)ensureSessionForUsers:(NSArray<NSString*>*)users forceDistributeToUnverified: (BOOL) forceDistributeToUnverified
                                   success:(void (^)(NSObject *sessionInfo))success
                                   failure:(void (^)(NSError *error))failure;
 

--- a/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmEncryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmEncryption.m
@@ -93,7 +93,8 @@
     queuedEncryption.failure = failure;
     [pendingEncryptions addObject:queuedEncryption];
 
-    return [self ensureSessionForUsers:users success:^(NSObject *sessionInfo) {
+    BOOL forceDistributeToUnverified = [self isVerificationEvent:eventType eventContent:eventContent];
+    return [self ensureSessionForUsers:users forceDistributeToUnverified:forceDistributeToUnverified success:^(NSObject *sessionInfo) {
 
         MXOutboundSessionInfo *session = (MXOutboundSessionInfo*)sessionInfo;
         [self processPendingEncryptionsInSession:session withError:nil];
@@ -103,14 +104,37 @@
     }];
 }
 
-- (MXHTTPOperation*)ensureSessionForUsers:(NSArray<NSString*>*)users
+- (BOOL) isVerificationEvent:(MXEventTypeString) eventType eventContent:(NSDictionary*)eventContent
+{
+    switch ([MXTools eventType:eventType])
+    {
+        case MXEventTypeKeyVerificationKey:
+        case MXEventTypeKeyVerificationMac:
+        case MXEventTypeKeyVerificationDone:
+        case MXEventTypeKeyVerificationReady:
+        case MXEventTypeKeyVerificationStart:
+        case MXEventTypeKeyVerificationAccept:
+        case MXEventTypeKeyVerificationCancel: {
+            return YES;
+        }
+        case MXEventTypeRoomMessage: {
+            NSString *msgType = eventContent[kMXMessageTypeKey];
+            return [msgType isEqualToString:kMXMessageTypeKeyVerificationRequest];
+        }
+        default: {
+            return NO;
+        }
+    }
+}
+
+- (MXHTTPOperation*)ensureSessionForUsers:(NSArray<NSString*>*)users forceDistributeToUnverified: (BOOL) forceDistributeToUnverified
                                   success:(void (^)(NSObject *sessionInfo))success
                                   failure:(void (^)(NSError *error))failure
 {
     NSDate *startDate = [NSDate date];
 
     MXHTTPOperation *operation;
-    operation = [self getDevicesInRoom:users success:^(MXUsersDevicesMap<MXDeviceInfo *> *devicesInRoom) {
+    operation = [self getDevicesInRoom:users forceDistributeToUnverified:forceDistributeToUnverified success:^(MXUsersDevicesMap<MXDeviceInfo *> *devicesInRoom) {
 
         MXHTTPOperation *operation2 = [self ensureOutboundSession:devicesInRoom success:^(MXOutboundSessionInfo *session) {
 
@@ -166,6 +190,7 @@
  @param failure A block object called when the operation fails.
 */
 - (MXHTTPOperation *)getDevicesInRoom:(NSArray<NSString*>*)users
+          forceDistributeToUnverified: (BOOL) forceDistributeToUnverified
                               success:(void (^)(MXUsersDevicesMap<MXDeviceInfo *> *devicesInRoom))success
                               failure:(void (^)(NSError *))failure
 {
@@ -198,7 +223,7 @@
                 }
 
                 if (deviceInfo.trustLevel.localVerificationStatus == MXDeviceBlocked
-                    || (!deviceInfo.trustLevel.isVerified && encryptToVerifiedDevicesOnly))
+                    || (!deviceInfo.trustLevel.isVerified && encryptToVerifiedDevicesOnly && !forceDistributeToUnverified))
                 {
                     // Remove any blocked devices
                     MXLogDebug(@"[MXMegolmEncryption] getDevicesInRoom: blocked device: %@", deviceInfo);

--- a/MatrixSDK/Crypto/Algorithms/Olm/MXOlmEncryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Olm/MXOlmEncryption.m
@@ -62,7 +62,7 @@
                                 failure:(void (^)(NSError *error))failure
 {
     MXWeakify(self);
-    return [self ensureSessionForUsers:users success:^(NSObject *sessionInfo) {
+    return [self ensureSessionForUsers:users forceDistributeToUnverified:NO success:^(NSObject *sessionInfo) {
         MXStrongifyAndReturnIfNil(self);
 
         NSMutableArray *participantDevices = [NSMutableArray array];
@@ -99,7 +99,7 @@
     } failure:failure];
 }
 
-- (MXHTTPOperation*)ensureSessionForUsers:(NSArray<NSString*>*)users
+- (MXHTTPOperation*)ensureSessionForUsers:(NSArray<NSString*>*)users forceDistributeToUnverified: (BOOL) forceDistributeToUnverified
                                   success:(void (^)(NSObject *sessionInfo))success
                                   failure:(void (^)(NSError *error))failure
 {

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -757,7 +757,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
                     if (alg)
                     {
                         // Check we have everything to encrypt events
-                        MXHTTPOperation *operation2 = [alg ensureSessionForUsers:userIds success:^(NSObject *sessionInfo) {
+                        MXHTTPOperation *operation2 = [alg ensureSessionForUsers:userIds forceDistributeToUnverified:NO success:^(NSObject *sessionInfo) {
 
                             if (success)
                             {

--- a/changelog.d/6519.bugfix
+++ b/changelog.d/6519.bugfix
@@ -1,0 +1,1 @@
+Can't verify user when option to send keys to verified devices only is selected


### PR DESCRIPTION
### Pull Request Checklist

<!-- Describe shortly what has been changed -->
Fixes [#6519](https://github.com/vector-im/element-ios/issues/6519) 
Verification events sent in e2ee rooms should bypass the encrypt to verified devices only option. If not it renders verification impossible.

## Motivation and context
As per spec:

> When using in-room messages and the room has encryption enabled, clients should ensure that encryption does not hinder the verification. For example, if the verification messages are encrypted, clients must ensure that all the recipient’s unverified devices receive the keys necessary to decrypt the messages, even if they would normally not be given the keys to decrypt messages in the room. Alternatively, verification messages may be sent unencrypted, though this is not encouraged.


* [x] Pull request is based on the develop branch
* [x] Pull request contains a changelog file in ./changelog.d. See https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog
* [ ] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
