### PR TITLE
Integrate Mac-compatible MatrixSDKCrypto

### DIFF
--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -45,7 +45,7 @@ Pod::Spec.new do |s|
       ss.dependency 'OLMKit', '~> 3.2.5'
       ss.dependency 'Realm', '10.27.0'
       ss.dependency 'libbase58', '~> 0.1.4'
-      ss.ios.dependency 'MatrixSDK/CryptoSDK'
+      ss.dependency 'MatrixSDK/CryptoSDK'
   end
 
   s.subspec 'JingleCallStack' do |ss|
@@ -64,10 +64,9 @@ Pod::Spec.new do |s|
     ss.ios.dependency 'JitsiMeetSDK', '5.0.2'
   end
   
-  # Experimental / NOT production-ready Rust-based crypto library, iOS-only
+  # Experimental / NOT production-ready Rust-based crypto library
   s.subspec 'CryptoSDK' do |ss|
-    ss.platform = :ios
-    ss.dependency 'MatrixSDKCrypto', '0.1.0', :configurations => ["DEBUG"]
+    ss.dependency 'MatrixSDKCrypto', '0.1.2', :configurations => ["DEBUG"]
   end
 
 end

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -1821,6 +1821,10 @@
 		ED1AE92B2881AC7500D3432A /* MXWarnings.h in Headers */ = {isa = PBXBuildFile; fileRef = ED1AE9292881AC7100D3432A /* MXWarnings.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		ED21F68528104DA2002FF83D /* MXMegolmEncryptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED21F68428104DA2002FF83D /* MXMegolmEncryptionTests.swift */; };
 		ED21F68628104DA2002FF83D /* MXMegolmEncryptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED21F68428104DA2002FF83D /* MXMegolmEncryptionTests.swift */; };
+		ED28068428F06C6C0070AE9F /* QrCode+Stub.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED28068328F06C6C0070AE9F /* QrCode+Stub.swift */; };
+		ED28068528F06C6C0070AE9F /* QrCode+Stub.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED28068328F06C6C0070AE9F /* QrCode+Stub.swift */; };
+		ED28068728F06D360070AE9F /* MXQRCodeTransactionV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED28068628F06D360070AE9F /* MXQRCodeTransactionV2.swift */; };
+		ED28068828F06D360070AE9F /* MXQRCodeTransactionV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED28068628F06D360070AE9F /* MXQRCodeTransactionV2.swift */; };
 		ED2DD114286C450600F06731 /* MXCryptoMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED2DD111286C450600F06731 /* MXCryptoMachine.swift */; };
 		ED2DD115286C450600F06731 /* MXCryptoMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED2DD111286C450600F06731 /* MXCryptoMachine.swift */; };
 		ED2DD116286C450600F06731 /* MXEventDecryptionResult+DecryptedEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED2DD112286C450600F06731 /* MXEventDecryptionResult+DecryptedEvent.swift */; };
@@ -1933,6 +1937,8 @@
 		ED8F1D352885B07500F897E7 /* MXCrossSigningInfoUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED8F1D1628857FE600F897E7 /* MXCrossSigningInfoUnitTests.swift */; };
 		ED8F1D3B2885BB2D00F897E7 /* MXCryptoProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED8F1D3A2885BB2D00F897E7 /* MXCryptoProtocols.swift */; };
 		ED8F1D3C2885BB2D00F897E7 /* MXCryptoProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED8F1D3A2885BB2D00F897E7 /* MXCryptoProtocols.swift */; };
+		EDA2CDD628F5C4230088ACE7 /* MXQRCodeTransactionV2UnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDA2CDD528F5C4230088ACE7 /* MXQRCodeTransactionV2UnitTests.swift */; };
+		EDA2CDD728F5C4230088ACE7 /* MXQRCodeTransactionV2UnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDA2CDD528F5C4230088ACE7 /* MXQRCodeTransactionV2UnitTests.swift */; };
 		EDAAC41928E2FCFE00DD89B5 /* MXCryptoSecretStoreV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDAAC41828E2FCFE00DD89B5 /* MXCryptoSecretStoreV2.swift */; };
 		EDAAC41A28E2FCFE00DD89B5 /* MXCryptoSecretStoreV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDAAC41828E2FCFE00DD89B5 /* MXCryptoSecretStoreV2.swift */; };
 		EDAAC41C28E30F3C00DD89B5 /* (null) in Headers */ = {isa = PBXBuildFile; settings = {ATTRIBUTES = (Public, ); }; };
@@ -2987,6 +2993,8 @@
 		ED01915128C64E0400ED3A69 /* MXForwardedRoomKeyEventContent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXForwardedRoomKeyEventContent.h; sourceTree = "<group>"; };
 		ED1AE9292881AC7100D3432A /* MXWarnings.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXWarnings.h; sourceTree = "<group>"; };
 		ED21F68428104DA2002FF83D /* MXMegolmEncryptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXMegolmEncryptionTests.swift; sourceTree = "<group>"; };
+		ED28068328F06C6C0070AE9F /* QrCode+Stub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "QrCode+Stub.swift"; sourceTree = "<group>"; };
+		ED28068628F06D360070AE9F /* MXQRCodeTransactionV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXQRCodeTransactionV2.swift; sourceTree = "<group>"; };
 		ED2DD111286C450600F06731 /* MXCryptoMachine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXCryptoMachine.swift; sourceTree = "<group>"; };
 		ED2DD112286C450600F06731 /* MXEventDecryptionResult+DecryptedEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "MXEventDecryptionResult+DecryptedEvent.swift"; sourceTree = "<group>"; };
 		ED2DD113286C450600F06731 /* MXCryptoRequests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXCryptoRequests.swift; sourceTree = "<group>"; };
@@ -3045,6 +3053,7 @@
 		ED8F1D312885AC5700F897E7 /* Device+Stub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Device+Stub.swift"; sourceTree = "<group>"; };
 		ED8F1D332885ADE200F897E7 /* MXCryptoProtocolStubs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXCryptoProtocolStubs.swift; sourceTree = "<group>"; };
 		ED8F1D3A2885BB2D00F897E7 /* MXCryptoProtocols.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXCryptoProtocols.swift; sourceTree = "<group>"; };
+		EDA2CDD528F5C4230088ACE7 /* MXQRCodeTransactionV2UnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXQRCodeTransactionV2UnitTests.swift; sourceTree = "<group>"; };
 		EDAAC41228E2F86800DD89B5 /* MXCryptoSecretStore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXCryptoSecretStore.h; sourceTree = "<group>"; };
 		EDAAC41828E2FCFE00DD89B5 /* MXCryptoSecretStoreV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXCryptoSecretStoreV2.swift; sourceTree = "<group>"; };
 		EDAAC42328E3177000DD89B5 /* MXRecoveryServiceDependencies.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXRecoveryServiceDependencies.swift; sourceTree = "<group>"; };
@@ -4765,6 +4774,7 @@
 				B19A3099240424BD00FB6F35 /* MXQRCodeTransaction.h */,
 				B19A309A240424BD00FB6F35 /* MXQRCodeTransaction_Private.h */,
 				B19A309B240424BD00FB6F35 /* MXQRCodeTransaction.m */,
+				ED28068628F06D360070AE9F /* MXQRCodeTransactionV2.swift */,
 			);
 			path = QRCode;
 			sourceTree = "<group>";
@@ -5278,6 +5288,15 @@
 			path = Megolm;
 			sourceTree = "<group>";
 		};
+		ED28068228F06C520070AE9F /* QRCode */ = {
+			isa = PBXGroup;
+			children = (
+				ED28068328F06C6C0070AE9F /* QrCode+Stub.swift */,
+				EDA2CDD528F5C4230088ACE7 /* MXQRCodeTransactionV2UnitTests.swift */,
+			);
+			path = QRCode;
+			sourceTree = "<group>";
+		};
 		ED2DD110286C450600F06731 /* CryptoMachine */ = {
 			isa = PBXGroup;
 			children = (
@@ -5416,6 +5435,7 @@
 		ED7019F12886CA6C00FC31B9 /* Transactions */ = {
 			isa = PBXGroup;
 			children = (
+				ED28068228F06C520070AE9F /* QRCode */,
 				ED7019F22886CA6C00FC31B9 /* SAS */,
 			);
 			path = Transactions;
@@ -6894,6 +6914,7 @@
 				323E0C5C1A306D7A00A31D73 /* MXEvent.m in Sources */,
 				F03EF5011DF014D9009DF592 /* MXMediaManager.m in Sources */,
 				32CAB10C1A925B41008C5BB9 /* MXHTTPOperation.m in Sources */,
+				ED28068728F06D360070AE9F /* MXQRCodeTransactionV2.swift in Sources */,
 				32BBAE6C2178E99100D85F46 /* MXKeyBackupData.m in Sources */,
 				32AF928C240EA3880008A0FD /* MXSecretShareSend.m in Sources */,
 				324DD29B246AD2B500377005 /* MXSecretStorage.m in Sources */,
@@ -7174,6 +7195,7 @@
 				32B477842638133C00EA5800 /* MXAggregatedReferenceUnitTests.m in Sources */,
 				32B0E3E423A384D40054FF1A /* MXAggregatedReferenceTests.m in Sources */,
 				32D5D16323E400A600E3E37C /* MXRoomSummaryTrustTests.m in Sources */,
+				ED28068428F06C6C0070AE9F /* QrCode+Stub.swift in Sources */,
 				C61A4AF41E5DD88400442158 /* Dummy.swift in Sources */,
 				32935F61216FA49D00A1BC24 /* MXCurve25519KeyBackupTests.m in Sources */,
 				B1F04B162811EFF700103EBE /* MXBeaconAggregationsTests.swift in Sources */,
@@ -7192,6 +7214,7 @@
 				ED5C95CE2833E85600843D82 /* MXOlmDeviceUnitTests.swift in Sources */,
 				327E37B91A977810007F026F /* MXLoggerUnitTests.m in Sources */,
 				18937E7C273A5AE500902626 /* MXPollRelationTests.m in Sources */,
+				EDA2CDD628F5C4230088ACE7 /* MXQRCodeTransactionV2UnitTests.swift in Sources */,
 				32792BE12296C64200F4FC9D /* MXAggregatedEditsTests.m in Sources */,
 				329571931B0240CE00ABB3BA /* MXVoIPTests.m in Sources */,
 				ED8F1D322885AC5700F897E7 /* Device+Stub.swift in Sources */,
@@ -7520,6 +7543,7 @@
 				B14EF2442397E90400758AF0 /* NSObject+sortedKeys.m in Sources */,
 				B14EF2452397E90400758AF0 /* MXAggregatedReactionsUpdater.m in Sources */,
 				3A59A52C25A7B1B000DDA1FC /* MXOutboundSessionInfo.m in Sources */,
+				ED28068828F06D360070AE9F /* MXQRCodeTransactionV2.swift in Sources */,
 				B14EECE82577F76100448735 /* MXLoginSSOFlow.m in Sources */,
 				B14EF2462397E90400758AF0 /* MXRoomMembers.m in Sources */,
 				32AF927E240EA0190008A0FD /* MXSecretShareManager.m in Sources */,
@@ -7800,6 +7824,7 @@
 				B1E09A222397FCE90057C069 /* MXRoomSummaryTests.m in Sources */,
 				B1E09A3A2397FD820057C069 /* MXStoreTests.m in Sources */,
 				B1E09A342397FD750057C069 /* MXRoomStateDynamicTests.m in Sources */,
+				ED28068528F06C6C0070AE9F /* QrCode+Stub.swift in Sources */,
 				B1E09A272397FD010057C069 /* MXMockCallStack.m in Sources */,
 				B14EECEF2578FE3F00448735 /* MXAuthenticationSessionUnitTests.swift in Sources */,
 				ED7019DE2886C24A00FC31B9 /* MXTrustLevelSourceUnitTests.swift in Sources */,
@@ -7818,6 +7843,7 @@
 				B1E09A2D2397FD750057C069 /* MXRestClientNoAuthAPITests.m in Sources */,
 				ED8943D527E34762000FC39C /* MXMemoryRoomStoreUnitTests.swift in Sources */,
 				ED5C95CF2833E85600843D82 /* MXOlmDeviceUnitTests.swift in Sources */,
+				EDA2CDD728F5C4230088ACE7 /* MXQRCodeTransactionV2UnitTests.swift in Sources */,
 				B1E09A332397FD750057C069 /* MXRoomStateTests.m in Sources */,
 				18937E7D273A5AE500902626 /* MXPollRelationTests.m in Sources */,
 				B1E09A352397FD7D0057C069 /* MXEventTests.m in Sources */,

--- a/MatrixSDK/Crypto/Algorithms/Olm/MXOlmDecryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Olm/MXOlmDecryption.m
@@ -266,6 +266,14 @@
     NSArray<NSString *> *sessionIds = [olmDevice sessionIdsForDevice:theirDeviceIdentityKey];
     
     NSString *messageBody = message[kMXMessageBodyKey];
+    if (![message[@"type"] isKindOfClass:NSNumber.class])
+    {
+        MXLogFailureDetails(@"[MXOlmDecryption] decryptMessage: Invalid type of message", @{
+            @"type": message[@"type"] ?: @"unknown"
+        })
+        return nil;
+    }
+    
     NSUInteger messageType = [((NSNumber*)message[@"type"]) unsignedIntegerValue];
     
     // Try each session in turn

--- a/MatrixSDK/Crypto/CrossSigning/Data/MXCrossSigningInfo.h
+++ b/MatrixSDK/Crypto/CrossSigning/Data/MXCrossSigningInfo.h
@@ -33,7 +33,7 @@ extern NSString *const MXCrossSigningInfoTrustLevelDidChangeNotification;
  */
 @interface MXCrossSigningInfo : NSObject <NSCoding>
 
-#if DEBUG && TARGET_OS_IPHONE
+#if DEBUG
 /**
  Initialize cross signing with MatrixSDKCrypto user identity
  */

--- a/MatrixSDK/Crypto/CrossSigning/Data/MXCrossSigningInfo.m
+++ b/MatrixSDK/Crypto/CrossSigning/Data/MXCrossSigningInfo.m
@@ -23,7 +23,7 @@ NSString *const MXCrossSigningInfoTrustLevelDidChangeNotification = @"MXCrossSig
 
 @implementation MXCrossSigningInfo
 
-#if DEBUG && TARGET_OS_IPHONE
+#if DEBUG
 - (instancetype)initWithUserIdentity:(MXCryptoUserIdentityWrapper *)userIdentity
 {
     self = [self init];

--- a/MatrixSDK/Crypto/CrossSigning/Data/MXCryptoUserIdentityWrapper.swift
+++ b/MatrixSDK/Crypto/CrossSigning/Data/MXCryptoUserIdentityWrapper.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-#if DEBUG && os(iOS)
+#if DEBUG
 
 import MatrixSDKCrypto
 

--- a/MatrixSDK/Crypto/CrossSigning/MXCrossSigningInfoSource.swift
+++ b/MatrixSDK/Crypto/CrossSigning/MXCrossSigningInfoSource.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-#if DEBUG && os(iOS)
+#if DEBUG
 
 /// Convenience struct which transforms `MatrixSDKCrypto` cross signing info formats
 /// into `MatrixSDK` `MXCrossSigningInfo` formats.

--- a/MatrixSDK/Crypto/CrossSigning/MXCrossSigningV2.swift
+++ b/MatrixSDK/Crypto/CrossSigning/MXCrossSigningV2.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-#if DEBUG && os(iOS)
+#if DEBUG
 
 /// A work-in-progress subclass of `MXCrossSigning` instantiated and used by `MXCryptoV2`.
 ///

--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoMachine.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoMachine.swift
@@ -618,6 +618,31 @@ extension MXCryptoMachine: MXCryptoSASVerifying {
     }
 }
 
+extension MXCryptoMachine: MXCryptoQRCodeVerifying {
+    func startQrVerification(userId: String, flowId: String) throws -> QrCode {
+        guard let result = try machine.startQrVerification(userId: userId, flowId: flowId) else {
+            throw Error.missingVerification
+        }
+        return result
+    }
+    
+    func scanQrCode(userId: String, flowId: String, data: Data) async throws -> QrCode {
+        let string = MXBase64Tools.base64(from: data)
+        guard let result = machine.scanQrCode(userId: userId, flowId: flowId, data: string) else {
+            throw Error.missingVerification
+        }
+        try await handleOutgoingVerificationRequest(result.request)
+        return result.qr
+    }
+    
+    func generateQrCode(userId: String, flowId: String) throws -> Data {
+        guard let string = machine.generateQrCode(userId: userId, flowId: flowId) else {
+            throw Error.missingVerification
+        }
+        return MXBase64Tools.data(fromBase64: string)
+    }
+}
+
 extension MXCryptoMachine: MXCryptoBackup {
     var isBackupEnabled: Bool {
         return machine.backupEnabled()

--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoMachine.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoMachine.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-#if DEBUG && os(iOS)
+#if DEBUG
 
 import MatrixSDKCrypto
 
@@ -693,7 +693,7 @@ extension MXCryptoMachine: MXCryptoBackup {
         guard let json = MXTools.serialiseJSONObject(jsonKeys) else {
             throw Error.cannotSerialize
         }
-        return try machine.importDecryptedKeys(keys: json, progressListener: progressListener)
+        return try machine.importDecryptedRoomKeys(keys: json, progressListener: progressListener)
     }
 }
 

--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoProtocols.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoProtocols.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-#if DEBUG && os(iOS)
+#if DEBUG
 
 import MatrixSDKCrypto
 

--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoProtocols.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoProtocols.swift
@@ -98,6 +98,13 @@ protocol MXCryptoSASVerifying: MXCryptoVerifying {
     func emojiIndexes(sas: Sas) throws -> [Int]
 }
 
+/// Lifecycle of QR code-specific verification transaction
+protocol MXCryptoQRCodeVerifying: MXCryptoVerifying {
+    func startQrVerification(userId: String, flowId: String) throws -> QrCode
+    func scanQrCode(userId: String, flowId: String, data: Data) async throws -> QrCode
+    func generateQrCode(userId: String, flowId: String) throws -> Data
+}
+
 /// Room keys backup functionality
 protocol MXCryptoBackup {
     var isBackupEnabled: Bool { get }

--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoRequests.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoRequests.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-#if DEBUG && os(iOS)
+#if DEBUG
 
 import MatrixSDKCrypto
 

--- a/MatrixSDK/Crypto/CryptoMachine/MXEventDecryptionResult+DecryptedEvent.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXEventDecryptionResult+DecryptedEvent.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-#if DEBUG && os(iOS)
+#if DEBUG
 
 import MatrixSDKCrypto
 

--- a/MatrixSDK/Crypto/Devices/Data/MXCryptoDeviceWrapper.swift
+++ b/MatrixSDK/Crypto/Devices/Data/MXCryptoDeviceWrapper.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-#if DEBUG && os(iOS)
+#if DEBUG
 
 import MatrixSDKCrypto
 

--- a/MatrixSDK/Crypto/Devices/Data/MXDeviceInfo.h
+++ b/MatrixSDK/Crypto/Devices/Data/MXDeviceInfo.h
@@ -34,7 +34,7 @@ extern NSString *const MXDeviceInfoTrustLevelDidChangeNotification;
 
 - (instancetype)initWithDeviceId:(NSString *)deviceId;
 
-#if DEBUG && TARGET_OS_IPHONE
+#if DEBUG
 /**
  Initialize device info with MatrixSDKCrypto device
  */

--- a/MatrixSDK/Crypto/Devices/Data/MXDeviceInfo.m
+++ b/MatrixSDK/Crypto/Devices/Data/MXDeviceInfo.m
@@ -35,7 +35,7 @@ NSString *const MXDeviceInfoTrustLevelDidChangeNotification = @"MXDeviceInfoTrus
     return self;
 }
 
-#if DEBUG && TARGET_OS_IPHONE
+#if DEBUG
 - (instancetype)initWithDevice:(MXCryptoDeviceWrapper *)device
 {
     self = [super init];

--- a/MatrixSDK/Crypto/Devices/MXDeviceInfoSource.swift
+++ b/MatrixSDK/Crypto/Devices/MXDeviceInfoSource.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-#if DEBUG && os(iOS)
+#if DEBUG
 
 /// Convenience struct which transforms `MatrixSDKCrypto` device formats
 /// into `MatrixSDK` `MXDeviceInfo` formats.

--- a/MatrixSDK/Crypto/KeyBackup/Engine/MXCryptoKeyBackupEngine.swift
+++ b/MatrixSDK/Crypto/KeyBackup/Engine/MXCryptoKeyBackupEngine.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-#if DEBUG && os(iOS)
+#if DEBUG
 
 import MatrixSDKCrypto
 

--- a/MatrixSDK/Crypto/MXCryptoV2.swift
+++ b/MatrixSDK/Crypto/MXCryptoV2.swift
@@ -27,35 +27,31 @@ public extension MXCrypto {
     @objc static func createCryptoV2IfAvailable(session: MXSession!) -> MXCrypto? {
         let log = MXNamedLog(name: "MXCryptoV2")
         
-        #if os(iOS)
-            guard MXSDKOptions.sharedInstance().enableCryptoV2 else {
-                return nil
-            }
-            
-            guard
-                let session = session,
-                let restClient = session.matrixRestClient,
-                let userId = restClient.credentials?.userId,
-                let deviceId = restClient.credentials?.deviceId
-            else {
-                log.failure("Cannot create crypto V2, missing properties")
-                return nil
-            }
-            
-            do {
-                return try MXCryptoV2(userId: userId, deviceId: deviceId, session: session, restClient: restClient)
-            } catch {
-                log.failure("Error creating crypto V2", context: error)
-                return nil
-            }
-        #else
+        guard MXSDKOptions.sharedInstance().enableCryptoV2 else {
             return nil
-        #endif
+        }
+        
+        guard
+            let session = session,
+            let restClient = session.matrixRestClient,
+            let userId = restClient.credentials?.userId,
+            let deviceId = restClient.credentials?.deviceId
+        else {
+            log.failure("Cannot create crypto V2, missing properties")
+            return nil
+        }
+        
+        do {
+            return try MXCryptoV2(userId: userId, deviceId: deviceId, session: session, restClient: restClient)
+        } catch {
+            log.failure("Error creating crypto V2", context: error)
+            return nil
+        }
     }
 }
 #endif
 
-#if DEBUG && os(iOS)
+#if DEBUG
 
 import MatrixSDKCrypto
 

--- a/MatrixSDK/Crypto/SecretStorage/MXCryptoSecretStoreV2.swift
+++ b/MatrixSDK/Crypto/SecretStorage/MXCryptoSecretStoreV2.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-#if DEBUG && os(iOS)
+#if DEBUG
 
 /// Secret store compatible with Rust-based Crypto V2, where
 /// backup secrets are stored internally in the Crypto machine

--- a/MatrixSDK/Crypto/Trust/MXTrustLevelSource.swift
+++ b/MatrixSDK/Crypto/Trust/MXTrustLevelSource.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-#if DEBUG && os(iOS)
+#if DEBUG
 
 /// Convenience struct which transforms `MatrixSDKCrypto` trust levels
 /// into `MatrixSDK` `MXUserTrustLevel`, `MXDeviceTrustLevel` and `MXUsersTrustLevelSummary` formats.

--- a/MatrixSDK/Crypto/Verification/MXKeyVerificationManagerV2.swift
+++ b/MatrixSDK/Crypto/Verification/MXKeyVerificationManagerV2.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-#if DEBUG && os(iOS)
+#if DEBUG
 
 import MatrixSDKCrypto
 

--- a/MatrixSDK/Crypto/Verification/MXKeyVerificationManagerV2.swift
+++ b/MatrixSDK/Crypto/Verification/MXKeyVerificationManagerV2.swift
@@ -22,7 +22,11 @@ enum MXKeyVerificationUpdateResult {
     case removed
 }
 
-typealias MXCryptoVerificationHandler = MXCryptoVerificationRequesting & MXCryptoSASVerifying
+protocol MXKeyVerificationTransactionV2: MXKeyVerificationTransaction {
+    func processUpdates() -> MXKeyVerificationUpdateResult
+}
+
+typealias MXCryptoVerificationHandler = MXCryptoVerificationRequesting & MXCryptoSASVerifying & MXCryptoQRCodeVerifying
 
 class MXKeyVerificationManagerV2: NSObject, MXKeyVerificationManager {
     enum Error: Swift.Error {
@@ -60,7 +64,7 @@ class MXKeyVerificationManagerV2: NSObject, MXKeyVerificationManager {
     // because various flows / screens subscribe to updates via global notifications
     // posted through them
     private var activeRequests: [String: MXKeyVerificationRequestV2]
-    private var activeTransactions: [String: MXSASTransactionV2]
+    private var activeTransactions: [String: MXKeyVerificationTransactionV2]
     private let resolver: MXKeyVerificationStateResolver
     
     private let log = MXNamedLog(name: "MXKeyVerificationManagerV2")
@@ -244,12 +248,46 @@ class MXKeyVerificationManagerV2: NSObject, MXKeyVerificationManager {
     }
 
     func qrCodeTransaction(withTransactionId transactionId: String) -> MXQRCodeTransaction? {
-        log.debug("Not implemented")
-        return nil
+        if let transaction = activeTransactions[transactionId] as? MXQRCodeTransaction {
+            return transaction
+        }
+        
+        guard let request = activeRequests[transactionId] else {
+            log.error("There is no pending verification request")
+            return nil
+        }
+        
+        do {
+            log.debug("Starting new QR verification")
+            let qr = try handler.startQrVerification(userId: request.otherUser, flowId: transactionId)
+            return addQrTransaction(for: qr, transport: request.transport)
+        } catch {
+            // We may not be able to start QR verification flow (the other device cannot scan our code)
+            // but we might be able to scan theirs, so creating an empty placeholder transaction for this case.
+            log.debug("Adding placeholder QR verification")
+            let qr = QrCode(
+                otherUserId: request.otherUser,
+                otherDeviceId: request.otherDevice ?? "",
+                flowId: request.requestId,
+                roomId: request.roomId,
+                weStarted: request.isFromMyDevice,
+                otherSideScanned: false,
+                hasBeenConfirmed: false,
+                reciprocated: false,
+                isDone: false,
+                isCancelled: false,
+                cancelInfo: nil
+            )
+            return addQrTransaction(for: qr, transport: request.transport)
+        }
     }
     
     func removeQRCodeTransaction(withTransactionId transactionId: String) {
-        log.debug("Not implemented")
+        guard activeTransactions[transactionId] is MXQRCodeTransaction else {
+            return
+        }
+        log.debug("Removed QR verification")
+        activeTransactions[transactionId] = nil
     }
     
     // MARK: - Events
@@ -266,7 +304,7 @@ class MXKeyVerificationManagerV2: NSObject, MXKeyVerificationManager {
     
     private func listenToRoomEvents(in session: MXSession) {
         observer = session.listenToEvents(Array(Self.dmEventTypes)) { [weak self] event, direction, customObject in
-            if direction == .forwards {
+            if direction == .forwards && event.sender != session.myUserId {
                 self?.handleRoomEvent(event)
             }
         }
@@ -326,6 +364,7 @@ class MXKeyVerificationManagerV2: NSObject, MXKeyVerificationManager {
             case .updated:
                 NotificationCenter.default.post(name: .MXKeyVerificationRequestDidChange, object: request)
             case .removed:
+                NotificationCenter.default.post(name: .MXKeyVerificationRequestDidChange, object: request)
                 activeRequests[request.requestId] = nil
             }
         }
@@ -341,6 +380,7 @@ class MXKeyVerificationManagerV2: NSObject, MXKeyVerificationManager {
             case .updated:
                 NotificationCenter.default.post(name: .MXKeyVerificationTransactionDidChange, object: transaction)
             case .removed:
+                NotificationCenter.default.post(name: .MXKeyVerificationTransactionDidChange, object: transaction)
                 activeTransactions[transaction.transactionId] = nil
             }
         }
@@ -426,25 +466,28 @@ class MXKeyVerificationManagerV2: NSObject, MXKeyVerificationManager {
     private func handleIncomingVerification(userId: String, flowId: String, transport: MXKeyVerificationTransport) {
         log.debug(flowId)
         
-        guard activeTransactions[flowId] == nil else {
-            log.debug("Transaction already known, ignoring")
-            return
-        }
-        
         guard let verification = handler.verification(userId: userId, flowId: flowId) else {
-            log.error("Verification is not known", context: [
+            log.failure("Verification is not known", context: [
                 "flow_id": flowId
             ])
             return
         }
 
-        log.debug("Tracking new verification transaction")
         switch verification {
         case .sasV1(let sas):
+            log.debug("Tracking new SAS verification transaction")
             let transaction = addSasTransaction(for: sas, transport: transport)
             transaction.accept()
-        case .qrCodeV1:
-            log.failure("Not implemented")
+        case .qrCodeV1(let qrCode):
+            if activeTransactions[flowId] is MXQRCodeTransaction {
+                // This flow may happen if we have previously started a QR verification, but so has the other side,
+                // and we scanned their code which now takes over the verification flow
+                log.debug("Updating existing QR verification transaction")
+                updatePendingVerification()
+            } else {
+                log.debug("Tracking new QR verification transaction")
+                _ = addQrTransaction(for: qrCode, transport: transport)
+            }
         }
     }
     
@@ -454,6 +497,19 @@ class MXKeyVerificationManagerV2: NSObject, MXKeyVerificationManager {
     ) -> MXSASTransactionV2 {
         let transaction = MXSASTransactionV2(
             sas: sas,
+            transport: transport,
+            handler: handler
+        )
+        activeTransactions[transaction.transactionId] = transaction
+        return transaction
+    }
+    
+    private func addQrTransaction(
+        for qrCode: QrCode,
+        transport: MXKeyVerificationTransport
+    ) -> MXQRCodeTransactionV2 {
+        let transaction = MXQRCodeTransactionV2(
+            qrCode: qrCode,
             transport: transport,
             handler: handler
         )

--- a/MatrixSDK/Crypto/Verification/Requests/MXKeyVerificationRequestV2.swift
+++ b/MatrixSDK/Crypto/Verification/Requests/MXKeyVerificationRequestV2.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-#if DEBUG && os(iOS)
+#if DEBUG
 
 import MatrixSDKCrypto
 

--- a/MatrixSDK/Crypto/Verification/Requests/MXKeyVerificationRequestV2.swift
+++ b/MatrixSDK/Crypto/Verification/Requests/MXKeyVerificationRequestV2.swift
@@ -112,7 +112,7 @@ class MXKeyVerificationRequestV2: NSObject, MXKeyVerificationRequest {
             return .noUpdates
         }
         
-        log.debug("Request was updated")
+        log.debug("Request was updated \(request)")
         self.request = request
         return .updated
     }

--- a/MatrixSDK/Crypto/Verification/Transactions/QRCode/MXQRCodeTransaction.h
+++ b/MatrixSDK/Crypto/Verification/Transactions/QRCode/MXQRCodeTransaction.h
@@ -50,11 +50,6 @@ typedef NS_ENUM(NSInteger, MXQRCodeTransactionState) {
 /**
  Start the key verification process.
  */
-- (void)userHasScannedOtherQrCodeRawData:(NSData*)otherQRCodeRawData;
-
-/**
- Start the key verification process.
- */
 - (void)userHasScannedOtherQrCodeData:(MXQRCodeData*)otherQRCodeData;
 
 /**

--- a/MatrixSDK/Crypto/Verification/Transactions/QRCode/MXQRCodeTransaction.m
+++ b/MatrixSDK/Crypto/Verification/Transactions/QRCode/MXQRCodeTransaction.m
@@ -92,21 +92,6 @@ NSString * const MXKeyVerificationMethodReciprocate = @"m.reciprocate.v1";
     }
 }
 
-- (void)userHasScannedOtherQrCodeRawData:(NSData*)otherQRCodeRawData
-{
-    MXQRCodeData *otherQRCodeData = [self.qrCodeDataCoder decode:otherQRCodeRawData];
-    
-    if (otherQRCodeData)
-    {
-        [self userHasScannedOtherQrCodeData:otherQRCodeData];
-    }
-    else
-    {
-        MXLogDebug(@"[MXKeyVerification][MXQRCodeTransaction] userHasScannedOtherQrCodeRawData: Invalid QR code data: %@", otherQRCodeRawData);
-        [self cancelWithCancelCode:MXTransactionCancelCode.qrCodeInvalid];
-    }
-}
-
 - (void)userHasScannedOtherQrCodeData:(MXQRCodeData*)otherQRCodeData
 {
     BOOL isOtherQRCodeDataKeysValid = [self.manager isOtherQRCodeDataKeysValid:otherQRCodeData otherUserId:self.otherUserId otherDevice:self.otherDevice];

--- a/MatrixSDK/Crypto/Verification/Transactions/QRCode/MXQRCodeTransactionV2.swift
+++ b/MatrixSDK/Crypto/Verification/Transactions/QRCode/MXQRCodeTransactionV2.swift
@@ -1,0 +1,177 @@
+// 
+// Copyright 2022 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+#if DEBUG
+
+import MatrixSDKCrypto
+
+/// QR transaction originating from `MatrixSDKCrypto`
+class MXQRCodeTransactionV2: NSObject, MXQRCodeTransaction {
+    var state: MXQRCodeTransactionState {
+        if qrCode.isDone {
+            return .verified
+        } else if qrCode.isCancelled {
+            return .cancelled
+        } else if qrCode.otherSideScanned || qrCode.hasBeenConfirmed {
+            return .qrScannedByOther
+        } else if qrCode.weStarted {
+            return .waitingOtherConfirm
+        }
+        return .unknown
+    }
+    
+    var qrCodeData: MXQRCodeData? {
+        do {
+            let data = try handler.generateQrCode(userId: otherUserId, flowId: transactionId)
+            log.debug("Generated new QR code")
+            return MXQRCodeDataCoder().decode(data)
+        } catch {
+            log.error("Cannot generate QR code", context: error)
+            return nil
+        }
+    }
+    
+    var transactionId: String {
+        return qrCode.flowId
+    }
+    
+    let transport: MXKeyVerificationTransport
+    
+    var isIncoming: Bool {
+        return !qrCode.weStarted
+    }
+    
+    var otherUserId: String {
+        return qrCode.otherUserId
+    }
+    
+    var otherDeviceId: String {
+        return qrCode.otherDeviceId
+    }
+    
+    var reasonCancelCode: MXTransactionCancelCode? {
+        guard let info = qrCode.cancelInfo else {
+            return nil
+        }
+        return .init(
+            value: info.cancelCode,
+            humanReadable: info.reason
+        )
+    }
+    
+    var error: Error? {
+        return nil
+    }
+    
+    var dmRoomId: String? {
+        return qrCode.roomId
+    }
+    
+    var dmEventId: String? {
+        return qrCode.flowId
+    }
+    
+    private var qrCode: QrCode
+    private let handler: MXCryptoVerificationHandler
+    private let log = MXNamedLog(name: "MXQRCodeTransactionV2")
+    
+    init(qrCode: QrCode, transport: MXKeyVerificationTransport, handler: MXCryptoVerificationHandler) {
+        self.qrCode = qrCode
+        self.transport = transport
+        self.handler = handler
+    }
+    
+    func userHasScannedOtherQrCodeData(_ otherQRCodeData: MXQRCodeData) {
+        log.debug("->")
+        
+        let data = MXQRCodeDataCoder().encode(otherQRCodeData)
+        Task {
+            do {
+                let qrCode = try await handler.scanQrCode(userId: otherUserId, flowId: transactionId, data: data)
+                await MainActor.run {
+                    log.debug("Scanned QR code")
+                    self.qrCode = qrCode
+                }
+            } catch {
+                log.error("Failed scanning QR code", context: error)
+            }
+        }
+    }
+    
+    func otherUserScannedMyQrCode(_ otherUserScanned: Bool) {
+        guard otherUserScanned else {
+            log.debug("Cancelling due to mismatched keys")
+            cancel(with: .mismatchedKeys())
+            return
+        }
+
+        log.debug("Confirming verification")
+        Task {
+            do {
+                try await handler.confirmVerification(userId: otherUserId, flowId: transactionId)
+                log.debug("Verification confirmed")
+            } catch {
+                log.error("Fail", context: error)
+            }
+        }
+    }
+    
+    func cancel(with code: MXTransactionCancelCode) {
+        cancel(with: code, success: {}, failure: { _ in })
+    }
+    
+    func cancel(with code: MXTransactionCancelCode, success: @escaping () -> Void, failure: @escaping (Error) -> Void) {
+        log.debug("Cancelling transaction")
+        Task {
+            do {
+                try await handler.cancelVerification(userId: otherUserId, flowId: transactionId, cancelCode: code.value)
+                await MainActor.run {
+                    log.debug("Transaction cancelled")
+                    success()
+                }
+            } catch {
+                await MainActor.run {
+                    log.error("Failed cancelling transaction", context: error)
+                    failure(error)
+                }
+            }
+        }
+    }
+}
+
+extension MXQRCodeTransactionV2: MXKeyVerificationTransactionV2 {
+    func processUpdates() -> MXKeyVerificationUpdateResult {
+        guard
+            let verification = handler.verification(userId: otherUserId, flowId: transactionId),
+            case .qrCodeV1(let qrCode) = verification
+        else {
+            log.debug("Transaction was removed")
+            return .removed
+        }
+        
+        guard self.qrCode != qrCode else {
+            return .noUpdates
+        }
+        
+        log.debug("Transaction was updated \(qrCode)")
+        self.qrCode = qrCode
+        return .updated
+    }
+}
+
+#endif

--- a/MatrixSDK/Crypto/Verification/Transactions/SAS/MXSASTransactionV2.swift
+++ b/MatrixSDK/Crypto/Verification/Transactions/SAS/MXSASTransactionV2.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-#if DEBUG && os(iOS)
+#if DEBUG
 
 import MatrixSDKCrypto
 

--- a/MatrixSDK/Crypto/Verification/Transactions/SAS/MXSASTransactionV2.swift
+++ b/MatrixSDK/Crypto/Verification/Transactions/SAS/MXSASTransactionV2.swift
@@ -111,24 +111,6 @@ class MXSASTransactionV2: NSObject, MXSASTransaction {
         self.handler = handler
     }
     
-    func processUpdates() -> MXKeyVerificationUpdateResult {
-        guard
-            let verification = handler.verification(userId: otherUserId, flowId: transactionId),
-            case .sasV1(let sas) = verification
-        else {
-            log.debug("Transaction was removed")
-            return .removed
-        }
-        
-        guard self.sas != sas else {
-            return .noUpdates
-        }
-        
-        log.debug("Transaction was updated")
-        self.sas = sas
-        return .updated
-    }
-    
     func accept() {
         Task {
             do {
@@ -174,6 +156,26 @@ class MXSASTransactionV2: NSObject, MXSASTransaction {
                 }
             }
         }
+    }
+}
+
+extension MXSASTransactionV2: MXKeyVerificationTransactionV2 {
+    func processUpdates() -> MXKeyVerificationUpdateResult {
+        guard
+            let verification = handler.verification(userId: otherUserId, flowId: transactionId),
+            case .sasV1(let sas) = verification
+        else {
+            log.debug("Transaction was removed")
+            return .removed
+        }
+        
+        guard self.sas != sas else {
+            return .noUpdates
+        }
+        
+        log.debug("Transaction was updated \(sas)")
+        self.sas = sas
+        return .updated
     }
 }
 

--- a/MatrixSDKTests/Crypto/CrossSigning/Data/MXCrossSigningInfoUnitTests.swift
+++ b/MatrixSDKTests/Crypto/CrossSigning/Data/MXCrossSigningInfoUnitTests.swift
@@ -18,7 +18,7 @@ import Foundation
 import XCTest
 @testable import MatrixSDK
 
-#if DEBUG && os(iOS)
+#if DEBUG
 
 import MatrixSDKCrypto
 

--- a/MatrixSDKTests/Crypto/CrossSigning/MXCrossSigningInfoSourceUnitTests.swift
+++ b/MatrixSDKTests/Crypto/CrossSigning/MXCrossSigningInfoSourceUnitTests.swift
@@ -18,7 +18,7 @@ import Foundation
 import XCTest
 @testable import MatrixSDK
 
-#if DEBUG && os(iOS)
+#if DEBUG
 
 import MatrixSDKCrypto
 

--- a/MatrixSDKTests/Crypto/CrossSigning/MXCrossSigningV2UnitTests.swift
+++ b/MatrixSDKTests/Crypto/CrossSigning/MXCrossSigningV2UnitTests.swift
@@ -18,7 +18,7 @@ import Foundation
 import XCTest
 @testable import MatrixSDK
 
-#if os(iOS)
+#if DEBUG
 
 import MatrixSDKCrypto
 

--- a/MatrixSDKTests/Crypto/CryptoMachine/Device+Stub.swift
+++ b/MatrixSDKTests/Crypto/CryptoMachine/Device+Stub.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-#if DEBUG && os(iOS)
+#if DEBUG
 
 import MatrixSDKCrypto
 

--- a/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoProtocolStubs.swift
+++ b/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoProtocolStubs.swift
@@ -17,7 +17,7 @@
 import Foundation
 @testable import MatrixSDK
 
-#if DEBUG && os(iOS)
+#if DEBUG
 
 @testable import MatrixSDKCrypto
 

--- a/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoProtocolStubs.swift
+++ b/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoProtocolStubs.swift
@@ -109,6 +109,7 @@ class CryptoVerificationStub: CryptoIdentityStub {
     var stubbedTransactions = [String: Verification]()
     var stubbedErrors = [String: Error]()
     var stubbedEmojis = [String: [Int]]()
+    var stubbedQRData = Data()
 }
 
 extension CryptoVerificationStub: MXCryptoVerificationRequesting {
@@ -164,6 +165,20 @@ extension CryptoVerificationStub: MXCryptoSASVerifying {
     
     func emojiIndexes(sas: Sas) throws -> [Int] {
         stubbedEmojis[sas.flowId] ?? []
+    }
+}
+
+extension CryptoVerificationStub: MXCryptoQRCodeVerifying {
+    func startQrVerification(userId: String, flowId: String) throws -> QrCode {
+        return .stub()
+    }
+    
+    func scanQrCode(userId: String, flowId: String, data: Data) async throws -> QrCode {
+        return .stub()
+    }
+    
+    func generateQrCode(userId: String, flowId: String) throws -> Data {
+        return stubbedQRData
     }
 }
 

--- a/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoRequestsUnitTests.swift
+++ b/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoRequestsUnitTests.swift
@@ -17,7 +17,7 @@
 import Foundation
 @testable import MatrixSDK
 
-#if DEBUG && os(iOS)
+#if DEBUG
 
 import MatrixSDKCrypto
 

--- a/MatrixSDKTests/Crypto/Devices/Data/MXDeviceInfoUnitTests.swift
+++ b/MatrixSDKTests/Crypto/Devices/Data/MXDeviceInfoUnitTests.swift
@@ -18,7 +18,7 @@ import Foundation
 import XCTest
 @testable import MatrixSDK
 
-#if DEBUG && os(iOS)
+#if DEBUG
 
 import MatrixSDKCrypto
 

--- a/MatrixSDKTests/Crypto/Devices/MXDeviceInfoSourceUnitTests.swift
+++ b/MatrixSDKTests/Crypto/Devices/MXDeviceInfoSourceUnitTests.swift
@@ -18,7 +18,7 @@ import Foundation
 import XCTest
 @testable import MatrixSDK
 
-#if DEBUG && os(iOS)
+#if DEBUG
 
 import MatrixSDKCrypto
 

--- a/MatrixSDKTests/Crypto/KeyBackup/Engine/MXCryptoKeyBackupEngineUnitTests.swift
+++ b/MatrixSDKTests/Crypto/KeyBackup/Engine/MXCryptoKeyBackupEngineUnitTests.swift
@@ -17,7 +17,7 @@
 import Foundation
 @testable import MatrixSDK
 
-#if DEBUG && os(iOS)
+#if DEBUG
 
 import MatrixSDKCrypto
 

--- a/MatrixSDKTests/Crypto/Trust/MXTrustLevelSourceUnitTests.swift
+++ b/MatrixSDKTests/Crypto/Trust/MXTrustLevelSourceUnitTests.swift
@@ -18,7 +18,7 @@ import Foundation
 import XCTest
 @testable import MatrixSDK
 
-#if DEBUG && os(iOS)
+#if DEBUG
 
 import MatrixSDKCrypto
 

--- a/MatrixSDKTests/Crypto/Verification/MXKeyVerificationManagerV2UnitTests.swift
+++ b/MatrixSDKTests/Crypto/Verification/MXKeyVerificationManagerV2UnitTests.swift
@@ -18,7 +18,7 @@ import Foundation
 import XCTest
 @testable import MatrixSDK
 
-#if DEBUG && os(iOS)
+#if DEBUG
 
 class MXKeyVerificationManagerV2UnitTests: XCTestCase {
     class MockSession: MXSession {

--- a/MatrixSDKTests/Crypto/Verification/Requests/MXKeyVerificationRequestV2UnitTests.swift
+++ b/MatrixSDKTests/Crypto/Verification/Requests/MXKeyVerificationRequestV2UnitTests.swift
@@ -17,7 +17,7 @@
 import Foundation
 import XCTest
 
-#if DEBUG && os(iOS)
+#if DEBUG
 
 import MatrixSDKCrypto
 @testable import MatrixSDK

--- a/MatrixSDKTests/Crypto/Verification/Requests/VerificationRequest+Stub.swift
+++ b/MatrixSDKTests/Crypto/Verification/Requests/VerificationRequest+Stub.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-#if DEBUG && os(iOS)
+#if DEBUG
 
 import MatrixSDKCrypto
 

--- a/MatrixSDKTests/Crypto/Verification/Transactions/QRCode/MXQRCodeTransactionV2UnitTests.swift
+++ b/MatrixSDKTests/Crypto/Verification/Transactions/QRCode/MXQRCodeTransactionV2UnitTests.swift
@@ -1,0 +1,195 @@
+// 
+// Copyright 2022 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import XCTest
+
+#if DEBUG
+
+import MatrixSDKCrypto
+@testable import MatrixSDK
+
+class MXQRCodeTransactionV2UnitTests: XCTestCase {
+    var verification: CryptoVerificationStub!
+    override func setUp() {
+        verification = CryptoVerificationStub()
+    }
+    
+    func makeTransaction(for qrCode: QrCode = .stub()) -> MXQRCodeTransactionV2 {
+        .init(
+            qrCode: qrCode,
+            transport: .directMessage,
+            handler: verification
+        )
+    }
+    
+    // MARK: - Test Properties
+    
+    func test_usesCorrectProperties() {
+        let stub = QrCode.stub(
+            otherUserId: "Bob",
+            otherDeviceId: "Device2",
+            flowId: "123",
+            roomId: "ABC",
+            weStarted: true
+        )
+        
+        let transaction = makeTransaction(for: stub)
+        
+        XCTAssertEqual(transaction.transactionId, "123")
+        XCTAssertEqual(transaction.transport, MXKeyVerificationTransport.directMessage)
+        XCTAssertFalse(transaction.isIncoming)
+        XCTAssertEqual(transaction.otherUserId, "Bob")
+        XCTAssertEqual(transaction.otherDeviceId, "Device2")
+        XCTAssertEqual(transaction.dmRoomId, "ABC")
+        XCTAssertEqual(transaction.dmEventId, "123")
+    }
+    
+    func test_state() {
+        let testCases: [(QrCode, MXQRCodeTransactionState)] = [
+            (.stub(
+                weStarted: false,
+                otherSideScanned: false,
+                hasBeenConfirmed: false,
+                reciprocated: false,
+                isDone: false,
+                isCancelled: false
+            ), .unknown),
+            (.stub(
+                weStarted: false,
+                otherSideScanned: false,
+                hasBeenConfirmed: false,
+                reciprocated: false,
+                isDone: true,
+                isCancelled: false
+            ), .verified),
+            (.stub(
+                weStarted: false,
+                otherSideScanned: false,
+                hasBeenConfirmed: false,
+                reciprocated: false,
+                isDone: false,
+                isCancelled: true
+            ), .cancelled),
+            (.stub(
+                weStarted: false,
+                otherSideScanned: true,
+                hasBeenConfirmed: false,
+                reciprocated: false,
+                isDone: false,
+                isCancelled: false
+            ), .qrScannedByOther),
+            (.stub(
+                weStarted: false,
+                otherSideScanned: false,
+                hasBeenConfirmed: true,
+                reciprocated: false,
+                isDone: false,
+                isCancelled: false
+            ), .qrScannedByOther),
+            (.stub(
+                weStarted: true,
+                otherSideScanned: false,
+                hasBeenConfirmed: false,
+                reciprocated: false,
+                isDone: false,
+                isCancelled: false
+            ), .waitingOtherConfirm),
+        ]
+
+        for (stub, state) in testCases {
+            let transaction = MXQRCodeTransactionV2(
+                qrCode: stub,
+                transport: .directMessage,
+                handler: verification
+            )
+            XCTAssertEqual(transaction.state, state)
+        }
+    }
+
+    func test_isIncomingIfWeStarted() {
+        let transaction1 = makeTransaction(for: .stub(
+            weStarted: true
+        ))
+        XCTAssertFalse(transaction1.isIncoming)
+
+        let transaction2 = makeTransaction(for: .stub(
+            weStarted: true
+        ))
+        XCTAssertFalse(transaction2.isIncoming)
+    }
+
+    func test_reasonCancelCode() {
+        let cancelInfo = CancelInfo(
+            cancelCode: "123",
+            reason: "Changed mind",
+            cancelledByUs: true
+        )
+
+        let transaction = MXQRCodeTransactionV2(
+            qrCode: .stub(cancelInfo: cancelInfo),
+            transport: .directMessage,
+            handler: verification
+        )
+
+        XCTAssertEqual(transaction.reasonCancelCode?.value, "123")
+        XCTAssertEqual(transaction.reasonCancelCode?.humanReadable, "Changed mind")
+    }
+
+    // MARK: - Test Updates
+
+    func test_processUpdated_removedIfNoMatchingRequest() {
+        verification.stubbedTransactions = [:]
+        let transaction = makeTransaction()
+
+        let result = transaction.processUpdates()
+
+        XCTAssertEqual(result, MXKeyVerificationUpdateResult.removed)
+    }
+
+    func test_processUpdated_noUpdatesIfRequestUnchanged() {
+        let stub = QrCode.stub(
+            flowId: "ABC",
+            isDone: false
+        )
+        verification.stubbedTransactions = [stub.flowId: .qrCodeV1(qrcode: stub)]
+        let transaction = makeTransaction(for: stub)
+
+        let result = transaction.processUpdates()
+
+        XCTAssertEqual(result, MXKeyVerificationUpdateResult.noUpdates)
+    }
+
+    func test_processUpdated_updatedIfRequestChanged() {
+        let stub = QrCode.stub(
+            flowId: "ABC",
+            isDone: false
+        )
+        verification.stubbedTransactions = [stub.flowId: .qrCodeV1(qrcode: stub)]
+        let transaction = makeTransaction(for: stub)
+        verification.stubbedTransactions = [stub.flowId: .qrCodeV1(qrcode: .stub(
+            flowId: "ABC",
+            isDone: true
+        ))]
+
+        let result = transaction.processUpdates()
+
+        XCTAssertEqual(result, MXKeyVerificationUpdateResult.updated)
+        XCTAssertEqual(transaction.state, .verified)
+    }
+}
+
+#endif

--- a/MatrixSDKTests/Crypto/Verification/Transactions/QRCode/QrCode+Stub.swift
+++ b/MatrixSDKTests/Crypto/Verification/Transactions/QRCode/QrCode+Stub.swift
@@ -1,0 +1,53 @@
+// 
+// Copyright 2022 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+#if DEBUG
+
+import MatrixSDKCrypto
+
+extension QrCode {
+    static func stub(
+        otherUserId: String = "Bob",
+        otherDeviceId: String = "Device2",
+        flowId: String = "123",
+        roomId: String = "ABC",
+        weStarted: Bool = true,
+        otherSideScanned: Bool = false,
+        hasBeenConfirmed: Bool = false,
+        reciprocated: Bool = false,
+        isDone: Bool = false,
+        isCancelled: Bool = false,
+        cancelInfo: CancelInfo? = nil
+    ) -> QrCode {
+        return .init(
+            otherUserId: otherUserId,
+            otherDeviceId: otherDeviceId,
+            flowId: flowId,
+            roomId: roomId,
+            weStarted: weStarted,
+            otherSideScanned: otherSideScanned,
+            hasBeenConfirmed: hasBeenConfirmed,
+            reciprocated: reciprocated,
+            isDone: isDone,
+            isCancelled: isCancelled,
+            cancelInfo: cancelInfo
+        )
+    }
+}
+
+#endif

--- a/MatrixSDKTests/Crypto/Verification/Transactions/SAS/MXSASTransactionV2UnitTests.swift
+++ b/MatrixSDKTests/Crypto/Verification/Transactions/SAS/MXSASTransactionV2UnitTests.swift
@@ -17,7 +17,7 @@
 import Foundation
 import XCTest
 
-#if os(iOS)
+#if DEBUG
 
 import MatrixSDKCrypto
 @testable import MatrixSDK

--- a/MatrixSDKTests/Crypto/Verification/Transactions/SAS/Sas+Stub.swift
+++ b/MatrixSDKTests/Crypto/Verification/Transactions/SAS/Sas+Stub.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-#if DEBUG && os(iOS)
+#if DEBUG
 
 import MatrixSDKCrypto
 

--- a/MatrixSDKTests/TestPlans/UnitTests.xctestplan
+++ b/MatrixSDKTests/TestPlans/UnitTests.xctestplan
@@ -71,6 +71,7 @@
         "MXOlmInboundGroupSessionUnitTests",
         "MXPushRuleUnitTests",
         "MXQRCodeDataUnitTests",
+        "MXQRCodeTransactionV2UnitTests",
         "MXReplyEventParserUnitTests",
         "MXResponseUnitTests",
         "MXRoomKeyEventContentUnitTests",

--- a/MatrixSDKTests/TestPlans/UnitTestsWithSanitizers.xctestplan
+++ b/MatrixSDKTests/TestPlans/UnitTestsWithSanitizers.xctestplan
@@ -79,6 +79,7 @@
         "MXOlmInboundGroupSessionUnitTests",
         "MXPushRuleUnitTests",
         "MXQRCodeDataUnitTests",
+        "MXQRCodeTransactionV2UnitTests",
         "MXReplyEventParserUnitTests",
         "MXResponseUnitTests",
         "MXRoomKeyEventContentUnitTests",

--- a/Podfile
+++ b/Podfile
@@ -16,11 +16,10 @@ abstract_target 'MatrixSDK' do
     
     pod 'Realm', '10.27.0'
     pod 'libbase58', '~> 0.1.4'
+    pod 'MatrixSDKCrypto', "0.1.2", :configurations => ['DEBUG']
     
     target 'MatrixSDK-iOS' do
         platform :ios, '11.0'
-        
-        pod 'MatrixSDKCrypto', "0.1.0", :configurations => ['DEBUG']
         
         target 'MatrixSDKTests-iOS' do
             inherit! :search_paths

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -16,7 +16,7 @@ PODS:
     - AFNetworking/NSURLSession
   - GZIP (1.3.0)
   - libbase58 (0.1.4)
-  - MatrixSDKCrypto (0.1.0)
+  - MatrixSDKCrypto (0.1.2)
   - OHHTTPStubs (9.1.0):
     - OHHTTPStubs/Default (= 9.1.0)
   - OHHTTPStubs/Core (9.1.0)
@@ -44,7 +44,7 @@ DEPENDENCIES:
   - AFNetworking (~> 4.0.0)
   - GZIP (~> 1.3.0)
   - libbase58 (~> 0.1.4)
-  - MatrixSDKCrypto (= 0.1.0)
+  - MatrixSDKCrypto (= 0.1.2)
   - OHHTTPStubs (~> 9.1.0)
   - OLMKit (~> 3.2.5)
   - Realm (= 10.27.0)
@@ -65,12 +65,12 @@ SPEC CHECKSUMS:
   AFNetworking: 7864c38297c79aaca1500c33288e429c3451fdce
   GZIP: 416858efbe66b41b206895ac6dfd5493200d95b3
   libbase58: 7c040313537b8c44b6e2d15586af8e21f7354efd
-  MatrixSDKCrypto: 4b9146d5ef484550341be056a164c6930038028e
+  MatrixSDKCrypto: e6e69cb16f9e459761567d078af0c17929f6a3c2
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   OLMKit: da115f16582e47626616874e20f7bb92222c7a51
   Realm: 9ca328bd7e700cc19703799785e37f77d1a130f2
   SwiftyBeaver: 84069991dd5dca07d7069100985badaca7f0ce82
 
-PODFILE CHECKSUM: 8a21d32ad6a381e80ea32b6104daee39323c306c
+PODFILE CHECKSUM: fbef7edcb018e39ce5fae5cbd2762001bd6aad26
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.11.3

--- a/changelog.d/6859.change
+++ b/changelog.d/6859.change
@@ -1,0 +1,1 @@
+CryptoV2: QR code verification

--- a/changelog.d/pr-1603.change
+++ b/changelog.d/pr-1603.change
@@ -1,0 +1,1 @@
+CryptoV2: Integrate Mac-compatible MatrixSDKCrypto


### PR DESCRIPTION
We don't really need to support Crypto V2 on the mac, but it does allow us to remove a bunch of annoying compiler flags and finally run unit tests on CI that runs against macos target