### PR TITLE
Unencrypted verification events in Crypto V2

### DIFF
--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoProtocols.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoProtocols.swift
@@ -75,6 +75,7 @@ protocol MXCryptoCrossSigning: MXCryptoUserIdentitySource {
 
 /// Lifecycle of verification request
 protocol MXCryptoVerificationRequesting: MXCryptoIdentity {
+    func receiveUnencryptedVerificationEvent(event: MXEvent, roomId: String)
     func requestSelfVerification(methods: [String]) async throws -> VerificationRequest
     func requestVerification(userId: String, roomId: String, methods: [String]) async throws -> VerificationRequest
     func verificationRequests(userId: String) -> [VerificationRequest]
@@ -96,6 +97,7 @@ protocol MXCryptoSASVerifying: MXCryptoVerifying {
     func startSasVerification(userId: String, deviceId: String) async throws -> Sas
     func acceptSasVerification(userId: String, flowId: String) async throws
     func emojiIndexes(sas: Sas) throws -> [Int]
+    func sasDecimals(sas: Sas) throws -> [Int]
 }
 
 /// Lifecycle of QR code-specific verification transaction

--- a/MatrixSDK/Crypto/Verification/Requests/MXKeyVerificationRequestV2.swift
+++ b/MatrixSDK/Crypto/Verification/Requests/MXKeyVerificationRequestV2.swift
@@ -112,7 +112,7 @@ class MXKeyVerificationRequestV2: NSObject, MXKeyVerificationRequest {
             return .noUpdates
         }
         
-        log.debug("Request was updated \(request)")
+        log.debug("Request was updated - \(request)")
         self.request = request
         return .updated
     }

--- a/MatrixSDK/Crypto/Verification/Transactions/QRCode/MXQRCodeTransactionV2.swift
+++ b/MatrixSDK/Crypto/Verification/Transactions/QRCode/MXQRCodeTransactionV2.swift
@@ -168,7 +168,7 @@ extension MXQRCodeTransactionV2: MXKeyVerificationTransactionV2 {
             return .noUpdates
         }
         
-        log.debug("Transaction was updated \(qrCode)")
+        log.debug("Transaction was updated - \(qrCode)")
         self.qrCode = qrCode
         return .updated
     }

--- a/MatrixSDK/Crypto/Verification/Transactions/SAS/MXOutgoingSASTransaction.m
+++ b/MatrixSDK/Crypto/Verification/Transactions/SAS/MXOutgoingSASTransaction.m
@@ -29,11 +29,6 @@
 
 @implementation MXOutgoingSASTransaction
 
-- (void)accept
-{
-    MXLogFailure(@"[MXKeyVerification] Cannot accept outgoing transaction");
-}
-
 - (void)start;
 {
     MXLogDebug(@"[MXKeyVerification][MXOutgoingSASTransaction] start");

--- a/MatrixSDK/Crypto/Verification/Transactions/SAS/MXSASTransaction.m
+++ b/MatrixSDK/Crypto/Verification/Transactions/SAS/MXSASTransaction.m
@@ -51,6 +51,11 @@ static NSArray<MXEmojiRepresentation*> *kSasEmojis;
 @synthesize state = _state;
 @synthesize sasBytes = _sasBytes;
 
+- (void)accept
+{
+    MXLogFailure(@"[MXKeyVerification] Cannot accept outgoing transaction");
+}
+
 - (NSString *)sasDecimal
 {
     NSString *sasDecimal;

--- a/MatrixSDK/Crypto/Verification/Transactions/SAS/MXSASTransactionV2.swift
+++ b/MatrixSDK/Crypto/Verification/Transactions/SAS/MXSASTransactionV2.swift
@@ -54,8 +54,13 @@ class MXSASTransactionV2: NSObject, MXSASTransaction {
     }
     
     var sasDecimal: String? {
-        log.debug("Not implemented")
-        return nil
+        do {
+            let decimals = try handler.sasDecimals(sas: sas)
+            return decimals.map(String.init).joined(separator: " ")
+        } catch {
+            log.error("Cannot get sas indices", context: error)
+            return nil
+        }
     }
     
     var transactionId: String {
@@ -173,7 +178,7 @@ extension MXSASTransactionV2: MXKeyVerificationTransactionV2 {
             return .noUpdates
         }
         
-        log.debug("Transaction was updated \(sas)")
+        log.debug("Transaction was updated - \(sas)")
         self.sas = sas
         return .updated
     }

--- a/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoProtocolStubs.swift
+++ b/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoProtocolStubs.swift
@@ -109,10 +109,14 @@ class CryptoVerificationStub: CryptoIdentityStub {
     var stubbedTransactions = [String: Verification]()
     var stubbedErrors = [String: Error]()
     var stubbedEmojis = [String: [Int]]()
+    var stubbedDecimals = [String: [Int]]()
     var stubbedQRData = Data()
 }
 
 extension CryptoVerificationStub: MXCryptoVerificationRequesting {
+    func receiveUnencryptedVerificationEvent(event: MXEvent, roomId: String) {
+    }
+    
     func requestSelfVerification(methods: [String]) async throws -> VerificationRequest {
         .stub(ourMethods: methods)
     }
@@ -165,6 +169,10 @@ extension CryptoVerificationStub: MXCryptoSASVerifying {
     
     func emojiIndexes(sas: Sas) throws -> [Int] {
         stubbedEmojis[sas.flowId] ?? []
+    }
+    
+    func sasDecimals(sas: Sas) throws -> [Int] {
+        return stubbedDecimals[sas.flowId] ?? []
     }
 }
 

--- a/MatrixSDKTests/Crypto/Verification/Transactions/SAS/MXSASTransactionV2UnitTests.swift
+++ b/MatrixSDKTests/Crypto/Verification/Transactions/SAS/MXSASTransactionV2UnitTests.swift
@@ -75,6 +75,19 @@ class MXSASTransactionV2UnitTests: XCTestCase {
         XCTAssertEqual(emoji, expectedEmojis)
     }
     
+    func test_sasDecimals() {
+        verification.stubbedDecimals = [
+            "123": [1, 3, 10, 20]
+        ]
+        
+        let transaction = makeTransaction(for: .stub(
+            flowId: "123"
+        ))
+        
+        let decimals = transaction.sasDecimal
+        XCTAssertEqual(decimals, "1 3 10 20")
+    }
+    
     func test_state() {
         let testCases: [(Sas, MXSASTransactionState)] = [
             (.stub(

--- a/changelog.d/pr-1605.change
+++ b/changelog.d/pr-1605.change
@@ -1,0 +1,1 @@
+CryptoV2: Unencrypted verification events


### PR DESCRIPTION
The last few changes (for a while) in verification for Crypto V2:

- process unencrypted verification events manually (they obviously cannot be handled automatically when calling `decryptRoomEvent`)
- add support for SAS decimals
- restore pending verification requests after app relaunch