### PR TITLE
Remove megolm decrypt cache build flag

### DIFF
--- a/MatrixSDK/MXSDKOptions.h
+++ b/MatrixSDK/MXSDKOptions.h
@@ -217,14 +217,6 @@ NS_ASSUME_NONNULL_BEGIN
 #endif
 
 /**
- Enable performance optimization where inbound group sessions are cached between decryption of events
- rather than fetched from the store every time.
- 
- @remark YES by default
- */
-@property (nonatomic) BOOL enableGroupSessionCache;
-
-/**
  Enable symmetric room key backups
  
  @remark NO by default

--- a/MatrixSDK/MXSDKOptions.m
+++ b/MatrixSDK/MXSDKOptions.m
@@ -59,7 +59,6 @@ static MXSDKOptions *sharedOnceInstance = nil;
         _enableCryptoV2 = NO;
         #endif
         
-        _enableGroupSessionCache = YES;
         _enableSymmetricBackup = NO;
         _enableNewClientInformationFeature = NO;
     }

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -1412,7 +1412,6 @@ typedef void (^MXOnResumeDone)(void);
     dispatch_group_t initialSyncDispatchGroup = dispatch_group_create();
     
     __block MXTaskProfile *syncTaskProfile;
-    __block StopDurationTracking stopDurationTracking;
     __block MXSyncResponse *syncResponse;
     __block BOOL useLiveResponse = YES;
 
@@ -1444,13 +1443,6 @@ typedef void (^MXOnResumeDone)(void);
             BOOL isInitialSync = !self.isEventStreamInitialised;
             MXTaskProfileName taskName = isInitialSync ? MXTaskProfileNameStartupInitialSync : MXTaskProfileNameStartupIncrementalSync;
             syncTaskProfile = [MXSDKOptions.sharedInstance.profiler startMeasuringTaskWithName:taskName];
-            if (isInitialSync) {
-                // Temporarily tracking performance both by `MXSDKOptions.sharedInstance.profiler` (manually measuring time)
-                // and `MXSDKOptions.sharedInstance.analyticsDelegate` (delegating to performance monitoring tool).
-                // This ambiguity will be resolved in the future
-                NSString *operation = MXSDKOptions.sharedInstance.enableGroupSessionCache ? @"initialSync.enableGroupSessionCache" : @"initialSync.diableGroupSessionCache";
-                stopDurationTracking = [MXSDKOptions.sharedInstance.analyticsDelegate startDurationTrackingForName:@"MXSession" operation:operation];
-            }
         }
         
         NSString * streamToken = self.store.eventStreamToken;
@@ -1493,9 +1485,6 @@ typedef void (^MXOnResumeDone)(void);
             syncTaskProfile.units = syncResponse.rooms.join.count;
             
             [MXSDKOptions.sharedInstance.profiler stopMeasuringTaskWithProfile:syncTaskProfile];
-            if (stopDurationTracking) {
-                stopDurationTracking();
-            }
         }
         
         BOOL isInitialSync = !self.isEventStreamInitialised;

--- a/changelog.d/pr-1606.change
+++ b/changelog.d/pr-1606.change
@@ -1,0 +1,1 @@
+Crypto: Remove megolm decrypt cache build flag


### PR DESCRIPTION
After a brief stabilization period with the cache variant set to YES, we can now remove the flag altogether