### PR TITLE
Fix user display name (PSB-201)

### DIFF
--- a/MatrixSDK/Data/MXRoomMembers.h
+++ b/MatrixSDK/Data/MXRoomMembers.h
@@ -38,6 +38,17 @@
  @return The newly-initialized MXRoomMembers.
  */
 - (instancetype)initWithRoomState:(MXRoomState*)state andMatrixSession:(MXSession*)matrixSession;
+
+/**
+ Create a `MXRoomMembers` instance.
+
+ @param members The members the created instance will be copied from.
+ @param isLive Indicate if this instance is used to store the live state of the room or the state of the room in the history.
+
+ @return The newly-initialized MXRoomMembers.
+ */
+- (instancetype)initWithMembers:(MXRoomMembers*)members isLive:(BOOL)isLive;
+
 /**
  A copy of the list of room members.
  */

--- a/MatrixSDK/Data/MXRoomMembers.m
+++ b/MatrixSDK/Data/MXRoomMembers.m
@@ -62,6 +62,15 @@
     return self;
 }
 
+- (instancetype)initWithMembers:(MXRoomMembers *)members isLive:(BOOL)isLive
+{
+    self = [members copy];
+    if (self) {
+        self->isLive = isLive;
+    }
+    return self;
+}
+
 - (NSArray<MXRoomMember *> *)members
 {
     return [members allValues];

--- a/MatrixSDK/Data/MXRoomState.m
+++ b/MatrixSDK/Data/MXRoomState.m
@@ -154,6 +154,7 @@
     if (self)
     {
         _isLive = NO;
+        _members = [[MXRoomMembers alloc] initWithMembers:_members isLive:NO];
 
         // At the beginning of pagination, the back room state must be the same
         // as the current current room state.

--- a/changelog.d/6850.bugfix
+++ b/changelog.d/6850.bugfix
@@ -1,0 +1,1 @@
+Fix users' display name in messages.


### PR DESCRIPTION
Ticket -> https://element-io.atlassian.net/browse/PSB-201?atlOrigin=eyJpIjoiY2YwNjNiMjU3M2IxNGQyNmFjOGVhZTM1Mzc0NTYxZDUiLCJwIjoiaiJ9
GitHub issue -> https://github.com/vector-im/element-ios/issues/6850

**Description**
This PR fixes the user's display name for messages sent before the user changed his display name.