### PR TITLE
Curate MXCrypto protocol methods

### DIFF
--- a/MatrixSDK/Crypto/CrossSigning/MXCrossSigning.h
+++ b/MatrixSDK/Crypto/CrossSigning/MXCrossSigning.h
@@ -159,6 +159,14 @@ typedef NS_ENUM(NSInteger, MXCrossSigningErrorCode)
                    success:(void (^)(void))success
                    failure:(void (^)(NSError *error))failure;
 
+/**
+ Get the stored cross-siging information of a user.
+
+ @param userId The user.
+ @return the cross-signing information if any.
+ */
+- (nullable MXCrossSigningInfo *)crossSigningKeysForUser:(NSString*)userId;
+
 @end
 
 @interface MXLegacyCrossSigning : NSObject <MXCrossSigning>

--- a/MatrixSDK/Crypto/CrossSigning/MXCrossSigning.m
+++ b/MatrixSDK/Crypto/CrossSigning/MXCrossSigning.m
@@ -314,6 +314,11 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
     });
 }
 
+- (MXCrossSigningInfo *)crossSigningKeysForUser:(NSString *)userId
+{
+    return [self.crypto.store crossSigningKeysForUser:userId];
+}
+
 - (void)requestPrivateKeysToDeviceIds:(nullable NSArray<NSString*>*)deviceIds
                               success:(void (^)(void))success
                 onPrivateKeysReceived:(void (^)(void))onPrivateKeysReceived

--- a/MatrixSDK/Crypto/CrossSigning/MXCrossSigningInfoSource.swift
+++ b/MatrixSDK/Crypto/CrossSigning/MXCrossSigningInfoSource.swift
@@ -39,14 +39,6 @@ struct MXCrossSigningInfoSource {
             )
         )
     }
-    
-    func crossSigningInfo(userIds: [String]) -> [String: MXCrossSigningInfo] {
-        return userIds
-            .compactMap(crossSigningInfo(userId:))
-            .reduce(into: [String: MXCrossSigningInfo] ()) { dict, info in
-                return dict[info.userId] = info
-            }
-    }
 }
 
 #endif

--- a/MatrixSDK/Crypto/CrossSigning/MXCrossSigningV2.swift
+++ b/MatrixSDK/Crypto/CrossSigning/MXCrossSigningV2.swift
@@ -184,6 +184,10 @@ class MXCrossSigningV2: NSObject, MXCrossSigning {
         }
     }
     
+    func crossSigningKeys(forUser userId: String) -> MXCrossSigningInfo? {
+        return infoSource.crossSigningInfo(userId: userId)
+    }
+    
     // MARK: - Private
     
     private func authParameters(password: String) async throws -> [AnyHashable: Any] {

--- a/MatrixSDK/Crypto/Verification/MXKeyVerificationManager.m
+++ b/MatrixSDK/Crypto/Verification/MXKeyVerificationManager.m
@@ -1582,7 +1582,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
     {
         MXVerifyingAnotherUserQRCodeData *verifyingAnotherUserQRCodeData = (MXVerifyingAnotherUserQRCodeData*)otherQRCodeData;
         
-        MXCrossSigningInfo *otherUserCrossSigningKeys = [self.crypto crossSigningKeysForUser:otherUserId];
+        MXCrossSigningInfo *otherUserCrossSigningKeys = [self.crypto.crossSigning crossSigningKeysForUser:otherUserId];
         NSString *otherUserMasterKeyPublic = otherUserCrossSigningKeys.masterKeys.keys;
     
         // verifyingAnotherUserQRCodeData.otherUserCrossSigningMasterKeyPublic -> Current user master key public
@@ -1968,7 +1968,7 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
                                                                                otherUserId:(NSString*)otherUserId
 {
     MXCrossSigningInfo *myUserCrossSigningKeys = self.crypto.crossSigning.myUserCrossSigningKeys;
-    MXCrossSigningInfo *otherUserCrossSigningKeys = [self.crypto crossSigningKeysForUser:otherUserId];
+    MXCrossSigningInfo *otherUserCrossSigningKeys = [self.crypto.crossSigning crossSigningKeysForUser:otherUserId];
 
     NSString *userCrossSigningMasterKeyPublic = myUserCrossSigningKeys.masterKeys.keys;
     NSString *otherUserCrossSigningMasterKeyPublic = otherUserCrossSigningKeys.masterKeys.keys;

--- a/MatrixSDK/Crypto/Verification/Transactions/SAS/MXSASTransaction.m
+++ b/MatrixSDK/Crypto/Verification/Transactions/SAS/MXSASTransaction.m
@@ -368,8 +368,8 @@ static NSArray<MXEmojiRepresentation*> *kSasEmojis;
 
         __block MXTransactionCancelCode *cancelCode;
         dispatch_group_t group = dispatch_group_create();
-        
-        MXCrossSigningKey *otherUserMasterKeys= [self.manager.crypto crossSigningKeysForUser:self.otherDevice.userId].masterKeys;
+
+        MXCrossSigningKey *otherUserMasterKeys= [self.manager.crypto.crossSigning crossSigningKeysForUser:self.otherDevice.userId].masterKeys;
 
         for (NSString *keyFullId in self.theirMac.mac)
         {

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -124,7 +124,7 @@ NSInteger const kMXRoomInvalidInviteSenderErrorCode = 9002;
         _roomId = roomId;
         mxSession = mxSession2;
         
-        if (mxSession.crypto)
+        if ([mxSession.crypto isKindOfClass:[MXLegacyCrypto class]])
         {
             MXMegolmDecryption *decryption = [[MXMegolmDecryption alloc] initWithCrypto:mxSession.crypto];
             sharedHistoryKeyManager = [[MXSharedHistoryKeyManager alloc] initWithRoomId:roomId
@@ -3733,17 +3733,7 @@ NSInteger const kMXRoomInvalidInviteSenderErrorCode = 9002;
                 [memberIds addObject:member.userId];
             }
             
-            if (forceDownload)
-            {
-                [crypto trustLevelSummaryForUserIds:memberIds success:success failure:failure];
-            }
-            else
-            {
-                [crypto trustLevelSummaryForUserIds:memberIds onComplete:^(MXUsersTrustLevelSummary *trustLevelSummary) {
-                    success(trustLevelSummary);
-                }];
-            }
-            
+            [crypto trustLevelSummaryForUserIds:memberIds forceDownload:forceDownload success:success failure:failure];
         } failure:failure];
     }
     else

--- a/MatrixSDK/MXSession.h
+++ b/MatrixSDK/MXSession.h
@@ -1559,17 +1559,6 @@ typedef void (^MXOnBackgroundSyncFail)(NSError *error);
 
 
 #pragma mark - Crypto
-/**
- Decrypt an event and update its data.
-
- @warning This method is deprecated, use -[MXSession decryptEvents:inTimeline:onComplete:] instead.
- 
- @param event the event to decrypt.
- @param timeline the id of the timeline where the event is decrypted. It is used
-        to prevent replay attack.
- @return YES if decryption is successful.
- */
-- (BOOL)decryptEvent:(MXEvent*)event inTimeline:(NSString*)timeline __attribute__((deprecated("use -[MXSession decryptEvents:inTimeline:onComplete:] instead")));
 
 /**
  Decrypt events asynchronously and update their data.

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -1926,9 +1926,9 @@ typedef void (^MXOnResumeDone)(void);
  */
 - (void)validateAccountData
 {
-    // Detecting an issue where more than one valid SSSS key is present on the client
+    // Detecting an issue in legacy crypto where more than one valid SSSS key is present on the client
     // https://github.com/vector-im/element-ios/issues/4569
-    NSInteger keysCount = self.crypto.secretStorage.numberOfValidKeys;
+    NSInteger keysCount = ((MXLegacyCrypto *)self.crypto).secretStorage.numberOfValidKeys;
     if (keysCount > 1)
     {
         MXLogErrorDetails(@"[MXSession] validateAccountData: Detected multiple valid SSSS keys, should only have one at most", @{
@@ -4827,33 +4827,6 @@ typedef void (^MXOnResumeDone)(void);
         MXLogDebug(@"[MXSession] Start crypto -> No crypto");
         success();
     }
-}
-
-- (BOOL)decryptEvent:(MXEvent*)event inTimeline:(NSString*)timeline
-{
-    MXEventDecryptionResult *result;
-    if (event.eventType == MXEventTypeRoomEncrypted)
-    {
-        if (_crypto)
-        {
-            // TODO: One day, this method will be async
-            result = [_crypto decryptEvent:event inTimeline:timeline];
-        }
-        else
-        {
-            // Encryption not enabled
-            result = [MXEventDecryptionResult new];
-            result.error = [NSError errorWithDomain:MXDecryptingErrorDomain
-                                               code:MXDecryptingErrorEncryptionNotEnabledCode
-                                           userInfo:@{
-                                               NSLocalizedDescriptionKey: MXDecryptingErrorEncryptionNotEnabledReason
-                                           }];
-        }
-        
-        [event setClearData:result];
-    }
-    
-    return (result.error == nil);
 }
 
 - (void)decryptEvents:(NSArray<MXEvent*> *)events

--- a/MatrixSDK/Utils/MXTaskQueue.swift
+++ b/MatrixSDK/Utils/MXTaskQueue.swift
@@ -48,6 +48,7 @@ public actor MXTaskQueue {
             assertionFailure("Failing to get value of the correct type should not be possible")
             throw Error.valueUnavailable
         }
+        previousTask = nil
         return value
     }
 

--- a/MatrixSDKTests/Crypto/CrossSigning/MXCrossSigningInfoSourceUnitTests.swift
+++ b/MatrixSDKTests/Crypto/CrossSigning/MXCrossSigningInfoSourceUnitTests.swift
@@ -55,29 +55,6 @@ class MXCrossSigningInfoSourceUnitTests: XCTestCase {
         XCTAssertEqual(info?.userId, "Alice")
         XCTAssertEqual(info?.trustLevel.isVerified, true)
     }
-    
-    func test_crossSigningInfo_returnsMultipleIdentities() {
-        cryptoSource.identities = [
-            "Bob": UserIdentity.own(
-                userId: "Bob",
-                trustsOurOwnDevice: true,
-                masterKey: "master",
-                selfSigningKey: "self",
-                userSigningKey: "user"
-            ),
-            "Charlie": UserIdentity.other(
-                userId: "Charlie",
-                masterKey: "master",
-                selfSigningKey: "self"
-            )
-        ]
-        
-        let infos = source.crossSigningInfo(userIds: ["Alice", "Bob", "Charlie"])
-        
-        XCTAssertEqual(infos.count, 2)
-        XCTAssertEqual(infos["Bob"]?.userId, "Bob")
-        XCTAssertEqual(infos["Charlie"]?.userId, "Charlie")
-    }
 }
 
 #endif

--- a/MatrixSDKTests/MXCrossSigningTests.m
+++ b/MatrixSDKTests/MXCrossSigningTests.m
@@ -362,7 +362,7 @@
             XCTAssertTrue(aliceDevice1Trust.isCrossSigningVerified);
             
             // -> Alice must see their cross-signing info trusted
-            MXCrossSigningInfo *aliceCrossSigningInfo = [aliceSession.crypto crossSigningKeysForUser:aliceSession.myUserId];
+            MXCrossSigningInfo *aliceCrossSigningInfo = [aliceSession.crypto.crossSigning crossSigningKeysForUser:aliceSession.myUserId];
             XCTAssertNotNil(aliceCrossSigningInfo);
             XCTAssertTrue(aliceCrossSigningInfo.trustLevel.isVerified);
             XCTAssertTrue(aliceCrossSigningInfo.trustLevel.isLocallyVerified);

--- a/MatrixSDKTests/MXCryptoRecoveryServiceTests.m
+++ b/MatrixSDKTests/MXCryptoRecoveryServiceTests.m
@@ -481,7 +481,7 @@
                 XCTAssertEqual(recoveryService.secretsStoredLocally.count, 3);
                 
                 // -> No more underlying SSSS
-                MXSecretStorage *secretStorage = aliceSession.crypto.secretStorage;
+                MXSecretStorage *secretStorage = aliceSession.legacyCrypto.secretStorage;
                 XCTAssertNil(secretStorage.defaultKey);
                 XCTAssertFalse([secretStorage hasSecretWithSecretId:MXSecretId.crossSigningMaster withSecretStorageKeyId:ssssKeyId]);
                 XCTAssertFalse([secretStorage hasSecretWithSecretId:MXSecretId.crossSigningSelfSigning withSecretStorageKeyId:ssssKeyId]);

--- a/MatrixSDKTests/MXCryptoSecretShareTests.m
+++ b/MatrixSDKTests/MXCryptoSecretShareTests.m
@@ -107,7 +107,7 @@
             [newAliceSession.crypto setDeviceVerification:MXDeviceVerified forDevice:aliceSession.myDeviceId ofUser:aliceSession.myUserId success:nil failure:nil];
             
             // - Alice requests the secret from the new device
-            [newAliceSession.crypto.secretShareManager requestSecret:secretId toDeviceIds:nil success:^(NSString * _Nonnull requestId) {
+            [newAliceSession.legacyCrypto.secretShareManager requestSecret:secretId toDeviceIds:nil success:^(NSString * _Nonnull requestId) {
                 XCTAssertNotNil(requestId);
             } onSecretReceived:^BOOL(NSString * _Nonnull sharedSecret) {
                 
@@ -157,10 +157,10 @@
             [aliceSession pause];
             
             // - Alice requests the secret from the new device
-            [newAliceSession.crypto.secretShareManager requestSecret:secretId toDeviceIds:nil success:^(NSString * _Nonnull requestId) {
+            [newAliceSession.legacyCrypto.secretShareManager requestSecret:secretId toDeviceIds:nil success:^(NSString * _Nonnull requestId) {
                 
                 // - Alice cancels the request
-                [newAliceSession.crypto.secretShareManager cancelRequestWithRequestId:requestId success:^{
+                [newAliceSession.legacyCrypto.secretShareManager cancelRequestWithRequestId:requestId success:^{
                 } failure:^(NSError * _Nonnull error) {
                     XCTFail(@"The operation should not fail - NSError: %@", error);
                     [expectation fulfill];

--- a/MatrixSDKTests/MXCryptoSecretStorageTests.m
+++ b/MatrixSDKTests/MXCryptoSecretStorageTests.m
@@ -22,6 +22,7 @@
 
 #import "MatrixSDKTestsData.h"
 #import "MatrixSDKTestsE2EData.h"
+#import "MatrixSDKTestsSwiftHeader.h"
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-retain-cycles"
@@ -176,7 +177,7 @@ UInt8 privateKeyBytes[] = {
     [matrixSDKTestsE2EData doE2ETestWithAliceInARoom:self readyToTest:^(MXSession *aliceSession, NSString *roomId, XCTestExpectation *expectation) {
         
         // - Create a new secret storage key
-        MXSecretStorage *secretStorage = aliceSession.crypto.secretStorage;
+        MXSecretStorage *secretStorage = aliceSession.legacyCrypto.secretStorage;
         [secretStorage createKeyWithKeyId:nil keyName:nil passphrase:nil success:^(MXSecretStorageKeyCreationInfo * _Nonnull keyCreationInfo) {
             
             // -> MXSecretStorageKeyCreationInfo must be filled as expected
@@ -226,7 +227,7 @@ UInt8 privateKeyBytes[] = {
 
         
         // - Create a new secret storage key
-        MXSecretStorage *secretStorage = aliceSession.crypto.secretStorage;
+        MXSecretStorage *secretStorage = aliceSession.legacyCrypto.secretStorage;
         [secretStorage createKeyWithKeyId:KEY_ID keyName:KEY_NAME passphrase:PASSPHRASE success:^(MXSecretStorageKeyCreationInfo * _Nonnull keyCreationInfo) {
             
             // -> MXSecretStorageKeyCreationInfo must be filled as expected
@@ -278,7 +279,7 @@ UInt8 privateKeyBytes[] = {
     [matrixSDKTestsE2EData doE2ETestWithAliceInARoom:self readyToTest:^(MXSession *aliceSession, NSString *roomId, XCTestExpectation *expectation) {
         
         // - Create a new secret storage key
-        __weak MXSecretStorage *secretStorage = aliceSession.crypto.secretStorage;
+        __weak MXSecretStorage *secretStorage = aliceSession.legacyCrypto.secretStorage;
         [secretStorage createKeyWithKeyId:nil keyName:nil passphrase:nil success:^(MXSecretStorageKeyCreationInfo * _Nonnull keyCreationInfo) {
             
             // - Set it as default
@@ -328,7 +329,7 @@ UInt8 privateKeyBytes[] = {
     [matrixSDKTestsE2EData doE2ETestWithAliceInARoom:self readyToTest:^(MXSession *aliceSession, NSString *roomId, XCTestExpectation *expectation) {
         
         // - Create a secret storage key
-        MXSecretStorage *secretStorage = aliceSession.crypto.secretStorage;
+        MXSecretStorage *secretStorage = aliceSession.legacyCrypto.secretStorage;
         [secretStorage createKeyWithKeyId:nil keyName:nil passphrase:nil success:^(MXSecretStorageKeyCreationInfo * _Nonnull keyCreationInfo) {
             
             // - Set it as default
@@ -364,7 +365,7 @@ UInt8 privateKeyBytes[] = {
     // - Have Alice with SSSS bootstrapped
     [self createScenarioWithMatrixJsSDKData:^(MXSession *aliceSession, NSString *roomId, XCTestExpectation *expectation) {
         
-        MXSecretStorage *secretStorage = aliceSession.crypto.secretStorage;
+        MXSecretStorage *secretStorage = aliceSession.legacyCrypto.secretStorage;
         
         NSError *error;
         NSData *privateKey = [MXRecoveryKey decode:jsSDKDataRecoveryKey error:&error];
@@ -406,7 +407,7 @@ UInt8 privateKeyBytes[] = {
     [self createScenarioWithMatrixJsSDKData:^(MXSession *aliceSession, NSString *roomId, XCTestExpectation *expectation) {
         
         // -> Should only have one SSSS key
-        MXSecretStorage *secretStorage = aliceSession.crypto.secretStorage;
+        MXSecretStorage *secretStorage = aliceSession.legacyCrypto.secretStorage;
         XCTAssertEqual(secretStorage.numberOfValidKeys, 1);
         
         // - Add two more SSSS without deleting previous ones
@@ -414,7 +415,7 @@ UInt8 privateKeyBytes[] = {
             [aliceSession setAccountData:ssssKeyContent forType:@"m.secret_storage.key.BBBB" success:^{
                 
                 // -> Should now have 3 SSSS keys
-                MXSecretStorage *secretStorage = aliceSession.crypto.secretStorage;
+                MXSecretStorage *secretStorage = aliceSession.legacyCrypto.secretStorage;
                 XCTAssertEqual(secretStorage.numberOfValidKeys, 3);
                 [expectation fulfill];
                         
@@ -441,7 +442,7 @@ UInt8 privateKeyBytes[] = {
     // - Have Alice with SSSS bootstrapped
     [self createScenarioWithMatrixJsSDKData:^(MXSession *aliceSession, NSString *roomId, XCTestExpectation *expectation) {
         
-        MXSecretStorage *secretStorage = aliceSession.crypto.secretStorage;
+        MXSecretStorage *secretStorage = aliceSession.legacyCrypto.secretStorage;
         
         // Test scenario creation
         MXSecretStorageKeyContent *defaultKey = secretStorage.defaultKey;
@@ -468,7 +469,7 @@ UInt8 privateKeyBytes[] = {
     // - Have Alice with SSSS bootstrapped
     [self createScenarioWithMatrixJsSDKData:^(MXSession *aliceSession, NSString *roomId, XCTestExpectation *expectation) {
         
-        MXSecretStorage *secretStorage = aliceSession.crypto.secretStorage;
+        MXSecretStorage *secretStorage = aliceSession.legacyCrypto.secretStorage;
         
         NSError *error;
         NSData *privateKey = [MXRecoveryKey decode:jsSDKDataRecoveryKey error:&error];
@@ -512,7 +513,7 @@ UInt8 privateKeyBytes[] = {
                    
         NSString *theSecretId = @"theSecretId";
 
-        MXSecretStorage *secretStorage = aliceSession.crypto.secretStorage;
+        MXSecretStorage *secretStorage = aliceSession.legacyCrypto.secretStorage;
 
         NSError *error;
         NSData *privateKey = [MXRecoveryKey decode:jsSDKDataRecoveryKey error:&error];
@@ -570,7 +571,7 @@ UInt8 privateKeyBytes[] = {
         
         NSString *theSecretId = @"theSecretId";
         
-        MXSecretStorage *secretStorage = aliceSession.crypto.secretStorage;
+        MXSecretStorage *secretStorage = aliceSession.legacyCrypto.secretStorage;
         
         NSError *error;
         NSData *privateKey = [MXRecoveryKey decode:jsSDKDataRecoveryKey error:&error];

--- a/MatrixSDKTests/MXCryptoShareTests.m
+++ b/MatrixSDKTests/MXCryptoShareTests.m
@@ -282,7 +282,7 @@
             
             // - Disable key share requests on Alice2
             [aliceSession2.crypto setOutgoingKeyRequestsEnabled:NO onComplete:nil];
-            aliceSession2.crypto.enableOutgoingKeyRequestsOnceSelfVerificationDone = NO;
+            aliceSession2.legacyCrypto.enableOutgoingKeyRequestsOnceSelfVerificationDone = NO;
             
             NSString *aliceUserId = aliceSession1.matrixRestClient.credentials.userId;
             
@@ -397,7 +397,7 @@
                                             XCTAssertEqual(aliceSession2.legacyCrypto.store.inboundGroupSessions.count, aliceSession1.legacyCrypto.store.inboundGroupSessions.count);
                                             
                                             // -> key share requests on Alice2 are enabled again
-                                            XCTAssertTrue(aliceSession2.crypto.isOutgoingKeyRequestsEnabled);
+                                            XCTAssertTrue(aliceSession2.legacyCrypto.isOutgoingKeyRequestsEnabled);
                                             
                                             [expectation fulfill];
                                         });

--- a/MatrixSDKTests/MXCryptoTests.m
+++ b/MatrixSDKTests/MXCryptoTests.m
@@ -1806,14 +1806,14 @@
                 [bobSession eventWithEventId:eventId inRoom:roomId success:^(MXEvent *event) {
                     
                     // -> But he does not have keys decrypt it
-                    [bobSession.crypto hasKeysToDecryptEvent:event onComplete:^(BOOL hasKeys) {
+                    [bobSession.legacyCrypto hasKeysToDecryptEvent:event onComplete:^(BOOL hasKeys) {
                         XCTAssertFalse(hasKeys);
                         
                         // - Bob resumes his session
                         [bobSession resume:^{
                             
                             // -> He has keys now
-                            [bobSession.crypto hasKeysToDecryptEvent:event onComplete:^(BOOL hasKeys) {
+                            [bobSession.legacyCrypto hasKeysToDecryptEvent:event onComplete:^(BOOL hasKeys) {
                                 XCTAssertTrue(hasKeys);
                                 
                                 [expectation fulfill];
@@ -3292,17 +3292,17 @@
         
         // Visibility is set to not shared by default
         MXSDKOptions.sharedInstance.enableRoomSharedHistoryOnInvite = NO;
-        XCTAssertFalse([session.crypto isRoomSharingHistory:roomId]);
+        XCTAssertFalse([session.legacyCrypto isRoomSharingHistory:roomId]);
         
         // But can be enabled with a build flag
         MXSDKOptions.sharedInstance.enableRoomSharedHistoryOnInvite = YES;
-        XCTAssertTrue([session.crypto isRoomSharingHistory:roomId]);
+        XCTAssertTrue([session.legacyCrypto isRoomSharingHistory:roomId]);
         
         MXRoom *room = [session roomWithRoomId:roomId];
         [room liveTimeline:^(id<MXEventTimeline> liveTimeline) {
             [liveTimeline listenToEventsOfTypes:@[kMXEventTypeStringRoomHistoryVisibility] onEvent:^(MXEvent * _Nonnull event, MXTimelineDirection direction, MXRoomState * _Nullable roomState) {
                 
-                BOOL sharedHistory = [session.crypto isRoomSharingHistory:roomId];
+                BOOL sharedHistory = [session.legacyCrypto isRoomSharingHistory:roomId];
                 BOOL expectsSharedHistory = [caseOutcomes[caseIndex].lastObject boolValue];
                 XCTAssertEqual(expectsSharedHistory, sharedHistory);
                 

--- a/changelog.d/pr-1618.change
+++ b/changelog.d/pr-1618.change
@@ -1,0 +1,1 @@
+Crypto: Curate MXCrypto protocol methods


### PR DESCRIPTION
A number of related changes to the `MXCrypto` protocol:

- cleanup `MXCrypto` protocol by moving a number of methods and properties into `MXLegacyCrypto`, because they are used only with the legacy implementation of the crypto module, and thus do not need to be implemented by `MXCryptoV2`
- consolidate similar methods `trustLevelSummary` into one
- deprecate legacy synchronous `decryptEvent` method
- track duration of encrypting an event with Crypto V2

Note that in the future PR the remaining unimplemented methods in CryptoV2 will be dealt with