### PR TITLE
CryptoV2 changes

### DIFF
--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -66,7 +66,7 @@ Pod::Spec.new do |s|
   
   # Experimental / NOT production-ready Rust-based crypto library
   s.subspec 'CryptoSDK' do |ss|
-    ss.dependency 'MatrixSDKCrypto', '0.1.4', :configurations => ["DEBUG"]
+    ss.dependency 'MatrixSDKCrypto', '0.1.5', :configurations => ["DEBUG"]
   end
 
 end

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -500,8 +500,8 @@
 		32AF9285240EA2430008A0FD /* MXSecretShareRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 32AF9282240EA2430008A0FD /* MXSecretShareRequest.h */; };
 		32AF9286240EA2430008A0FD /* MXSecretShareRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 32AF9283240EA2430008A0FD /* MXSecretShareRequest.m */; };
 		32AF9287240EA2430008A0FD /* MXSecretShareRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 32AF9283240EA2430008A0FD /* MXSecretShareRequest.m */; };
-		32AF928A240EA3880008A0FD /* MXSecretShareSend.h in Headers */ = {isa = PBXBuildFile; fileRef = 32AF9288240EA3880008A0FD /* MXSecretShareSend.h */; };
-		32AF928B240EA3880008A0FD /* MXSecretShareSend.h in Headers */ = {isa = PBXBuildFile; fileRef = 32AF9288240EA3880008A0FD /* MXSecretShareSend.h */; };
+		32AF928A240EA3880008A0FD /* MXSecretShareSend.h in Headers */ = {isa = PBXBuildFile; fileRef = 32AF9288240EA3880008A0FD /* MXSecretShareSend.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		32AF928B240EA3880008A0FD /* MXSecretShareSend.h in Headers */ = {isa = PBXBuildFile; fileRef = 32AF9288240EA3880008A0FD /* MXSecretShareSend.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		32AF928C240EA3880008A0FD /* MXSecretShareSend.m in Sources */ = {isa = PBXBuildFile; fileRef = 32AF9289240EA3880008A0FD /* MXSecretShareSend.m */; };
 		32AF928D240EA3880008A0FD /* MXSecretShareSend.m in Sources */ = {isa = PBXBuildFile; fileRef = 32AF9289240EA3880008A0FD /* MXSecretShareSend.m */; };
 		32AF928F24110ADD0008A0FD /* MXSecretShareManager_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 32AF928E24110ADD0008A0FD /* MXSecretShareManager_Private.h */; };
@@ -1941,6 +1941,8 @@
 		ED8F1D3C2885BB2D00F897E7 /* MXCryptoProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED8F1D3A2885BB2D00F897E7 /* MXCryptoProtocols.swift */; };
 		EDA2CDD628F5C4230088ACE7 /* MXQRCodeTransactionV2UnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDA2CDD528F5C4230088ACE7 /* MXQRCodeTransactionV2UnitTests.swift */; };
 		EDA2CDD728F5C4230088ACE7 /* MXQRCodeTransactionV2UnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDA2CDD528F5C4230088ACE7 /* MXQRCodeTransactionV2UnitTests.swift */; };
+		EDA69340290BA92E00223252 /* MXCryptoMachineUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDA6933F290BA92E00223252 /* MXCryptoMachineUnitTests.swift */; };
+		EDA69341290BA92E00223252 /* MXCryptoMachineUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDA6933F290BA92E00223252 /* MXCryptoMachineUnitTests.swift */; };
 		EDAAC41928E2FCFE00DD89B5 /* MXCryptoSecretStoreV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDAAC41828E2FCFE00DD89B5 /* MXCryptoSecretStoreV2.swift */; };
 		EDAAC41A28E2FCFE00DD89B5 /* MXCryptoSecretStoreV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDAAC41828E2FCFE00DD89B5 /* MXCryptoSecretStoreV2.swift */; };
 		EDAAC41C28E30F3C00DD89B5 /* (null) in Headers */ = {isa = PBXBuildFile; settings = {ATTRIBUTES = (Public, ); }; };
@@ -3059,6 +3061,7 @@
 		ED8F1D332885ADE200F897E7 /* MXCryptoProtocolStubs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXCryptoProtocolStubs.swift; sourceTree = "<group>"; };
 		ED8F1D3A2885BB2D00F897E7 /* MXCryptoProtocols.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXCryptoProtocols.swift; sourceTree = "<group>"; };
 		EDA2CDD528F5C4230088ACE7 /* MXQRCodeTransactionV2UnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXQRCodeTransactionV2UnitTests.swift; sourceTree = "<group>"; };
+		EDA6933F290BA92E00223252 /* MXCryptoMachineUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXCryptoMachineUnitTests.swift; sourceTree = "<group>"; };
 		EDAAC41228E2F86800DD89B5 /* MXCryptoSecretStore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXCryptoSecretStore.h; sourceTree = "<group>"; };
 		EDAAC41828E2FCFE00DD89B5 /* MXCryptoSecretStoreV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXCryptoSecretStoreV2.swift; sourceTree = "<group>"; };
 		EDAAC42328E3177000DD89B5 /* MXRecoveryServiceDependencies.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXRecoveryServiceDependencies.swift; sourceTree = "<group>"; };
@@ -5320,6 +5323,7 @@
 			isa = PBXGroup;
 			children = (
 				ED8F1D332885ADE200F897E7 /* MXCryptoProtocolStubs.swift */,
+				EDA6933F290BA92E00223252 /* MXCryptoMachineUnitTests.swift */,
 				ED2DD11B286C4F3E00F06731 /* MXCryptoRequestsUnitTests.swift */,
 				ED8F1D312885AC5700F897E7 /* Device+Stub.swift */,
 			);
@@ -7155,6 +7159,7 @@
 				32832B5E1BCC048300241108 /* MXStoreNoStoreTests.m in Sources */,
 				A816247C25F60C7700A46F05 /* MXDeviceListOperationsPoolUnitTests.swift in Sources */,
 				B1660F1C260A20B900C3AA12 /* MXSpaceServiceTest.swift in Sources */,
+				EDA69340290BA92E00223252 /* MXCryptoMachineUnitTests.swift in Sources */,
 				ED35652C281150310002BF6A /* MXOlmInboundGroupSessionUnitTests.swift in Sources */,
 				32C9B71823E81A1C00C6F30A /* MXCrossSigningVerificationTests.m in Sources */,
 				323C5A081A70E53500FB0549 /* MXToolsUnitTests.m in Sources */,
@@ -7786,6 +7791,7 @@
 				32C9B71923E81A1C00C6F30A /* MXCrossSigningVerificationTests.m in Sources */,
 				B1E09A1D2397FCE90057C069 /* MXCryptoKeyVerificationTests.m in Sources */,
 				B1E09A472397FD990057C069 /* MXEventScanStoreUnitTests.m in Sources */,
+				EDA69341290BA92E00223252 /* MXCryptoMachineUnitTests.swift in Sources */,
 				ED35652D281150310002BF6A /* MXOlmInboundGroupSessionUnitTests.swift in Sources */,
 				B1E09A3D2397FD820057C069 /* MXStoreFileStoreTests.m in Sources */,
 				32CEEF3E23AD134A0039BA98 /* MXCrossSigningTests.m in Sources */,

--- a/MatrixSDK/Crypto/CrossSigning/MXCrossSigningV2.swift
+++ b/MatrixSDK/Crypto/CrossSigning/MXCrossSigningV2.swift
@@ -121,7 +121,7 @@ class MXCrossSigningV2: NSObject, MXCrossSigning {
         
         Task {
             do {
-                try await crossSigning.downloadKeys(users: [crossSigning.userId])
+                try await crossSigning.updateTrackedUsers(users: [crossSigning.userId])
                 myUserCrossSigningKeys = infoSource.crossSigningInfo(userId: crossSigning.userId)
                 
                 log.debug("Cross signing state refreshed")

--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoProtocols.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoProtocols.swift
@@ -52,7 +52,8 @@ protocol MXCryptoDevicesSource: MXCryptoIdentity {
 protocol MXCryptoUserIdentitySource: MXCryptoIdentity {
     func userIdentity(userId: String) -> UserIdentity?
     func isUserVerified(userId: String) -> Bool
-    func downloadKeys(users: [String]) async throws
+    func isUserTracked(userId: String) -> Bool
+    func updateTrackedUsers(users: [String]) async throws
     func manuallyVerifyUser(userId: String) async throws
     func manuallyVerifyDevice(userId: String, deviceId: String) async throws
     func setLocalTrust(userId: String, deviceId: String, trust: LocalTrust) throws
@@ -61,7 +62,7 @@ protocol MXCryptoUserIdentitySource: MXCryptoIdentity {
 /// Event encryption and decryption
 protocol MXCryptoRoomEventEncrypting: MXCryptoIdentity {
     func shareRoomKeysIfNecessary(roomId: String, users: [String], settings: EncryptionSettings) async throws
-    func encryptRoomEvent(content: [AnyHashable: Any], roomId: String, eventType: String, users: [String]) async throws -> [String: Any]
+    func encryptRoomEvent(content: [AnyHashable: Any], roomId: String, eventType: String) throws -> [String: Any]
     func decryptRoomEvent(_ event: MXEvent) -> MXEventDecryptionResult
     func requestRoomKey(event: MXEvent) async throws
     func discardRoomKey(roomId: String)

--- a/MatrixSDK/Crypto/CryptoMachine/MXEventDecryptionResult+DecryptedEvent.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXEventDecryptionResult+DecryptedEvent.swift
@@ -37,6 +37,7 @@ extension MXEventDecryptionResult {
         senderCurve25519Key = event.senderCurve25519Key
         claimedEd25519Key = event.claimedEd25519Key
         forwardingCurve25519KeyChain = event.forwardingCurve25519Chain
+        isUntrusted = event.verificationState == VerificationState.untrusted
     }
 }
 

--- a/MatrixSDK/Crypto/Devices/Data/MXCryptoDeviceWrapper.swift
+++ b/MatrixSDK/Crypto/Devices/Data/MXCryptoDeviceWrapper.swift
@@ -38,9 +38,13 @@ import MatrixSDKCrypto
         deviceId = device.deviceId
         algorithms = device.algorithms
         keys = device.keys
-        unsignedData = [
-            "device_display_name": device.displayName as Any
-        ]
+        if let displayName = device.displayName {
+            unsignedData = [
+                "device_display_name": displayName
+            ]
+        } else {
+            unsignedData = [:]
+        }
         
         let status: MXDeviceVerification
         if device.isBlocked {

--- a/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.m
+++ b/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.m
@@ -104,7 +104,7 @@ NSUInteger const kMXKeyBackupWaitingTimeToSendKeyBackup = 10000;
     } failure:^(NSError * _Nonnull error) {
         MXStrongifyAndReturnIfNil(self);
 
-        MXLogDebug(@"[MXKeyBackup] checkAndStartKeyBackup: Failed to get current version: %@", error);
+        MXLogErrorDetails(@"[MXKeyBackup] checkAndStartKeyBackup: Failed to get current version", error);
         self.state = MXKeyBackupStateUnknown;
     }];
 }
@@ -270,7 +270,7 @@ NSUInteger const kMXKeyBackupWaitingTimeToSendKeyBackup = 10000;
     } failure:^(NSError *error) {
         MXStrongifyAndReturnIfNil(self);
 
-        MXLogDebug(@"[MXKeyBackup] sendKeyBackup: backupRoomKeysSuccess failed. Error: %@", error);
+        MXLogErrorDetails(@"[MXKeyBackup] sendKeyBackup: backupRoomKeysSuccess failed", error);
 
         void (^backupAllGroupSessionsFailure)(NSError *error) = self->backupAllGroupSessionsFailure;
 
@@ -304,7 +304,7 @@ NSUInteger const kMXKeyBackupWaitingTimeToSendKeyBackup = 10000;
         [self restoreKeyBackupAutomaticallyWithPrivateKey:onComplete];
         
     } failure:^(NSError * _Nonnull error) {
-        MXLogDebug(@"[MXKeyBackup] requestPrivateKeys. Error for requestPrivateKeys: %@", error);
+        MXLogErrorDetails(@"[MXKeyBackup] requestPrivateKeys. Error for requestPrivateKeys", error);
         onComplete();
     }];
 }
@@ -323,15 +323,15 @@ NSUInteger const kMXKeyBackupWaitingTimeToSendKeyBackup = 10000;
                 [self restoreKeyBackupAutomaticallyWithPrivateKey:onComplete];
             }
         } failure:^(NSError * _Nonnull error) {
-            MXLogDebug(@"[MXKeyBackup] restoreKeyBackupAutomatically: Cannot fetch backup version. Error: %@", error);
+            MXLogErrorDetails(@"[MXKeyBackup] restoreKeyBackupAutomatically: Cannot fetch backup version", error);
         }];
         return;
     }
     
     // Check private keys
-    if (!self.engine.hasValidPrivateKey)
+    if (![self.engine hasValidPrivateKeyForKeyBackupVersion:self.keyBackupVersion])
     {
-        MXLogDebug(@"[MXKeyBackup] restoreKeyBackupAutomatically. Error: No valid private key");
+        MXLogError(@"[MXKeyBackup] restoreKeyBackupAutomatically. Error: No valid private key");
         onComplete();
         return;
     }
@@ -343,7 +343,7 @@ NSUInteger const kMXKeyBackupWaitingTimeToSendKeyBackup = 10000;
         onComplete();
         
     } failure:^(NSError * _Nonnull error) {
-        MXLogDebug(@"[MXKeyBackup] restoreKeyBackupAutomatically. Error for restoreKeyBackup: %@", error);
+        MXLogErrorDetails(@"[MXKeyBackup] restoreKeyBackupAutomatically. Error for restoreKeyBackup", error);
         onComplete();
     }];
 }

--- a/MatrixSDK/Crypto/MXCrypto.h
+++ b/MatrixSDK/Crypto/MXCrypto.h
@@ -80,6 +80,11 @@ extern NSString *const MXDeviceListDidUpdateUsersDevicesNotification;
 @protocol MXCrypto <NSObject>
 
 /**
+ Version of the crypto module being used
+ */
+@property (nonatomic, readonly) NSString *version;
+
+/**
  Curve25519 key for the account.
  */
 @property (nullable, nonatomic, readonly) NSString *deviceCurve25519Key;

--- a/MatrixSDK/Crypto/MXCrypto.h
+++ b/MatrixSDK/Crypto/MXCrypto.h
@@ -205,7 +205,7 @@ extern NSString *const MXDeviceListDidUpdateUsersDevicesNotification;
 /**
  Handle the sync response that may contain crypto-related events
  */
-- (void)handleSyncResponse:(MXSyncResponse *)syncResponse;
+- (void)handleSyncResponse:(MXSyncResponse *)syncResponse onComplete:(void (^)(void))onComplete;
 
 #pragma mark - Cross-signing / Local trust
 

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -179,18 +179,16 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 + (void)checkCryptoWithMatrixSession:(MXSession*)mxSession complete:(void (^)(id<MXCrypto> crypto))complete
 {
 #ifdef MX_CRYPTO
-    dispatch_async(dispatch_get_main_queue(), ^{
-        #if DEBUG
-        id<MXCrypto> cryptoV2 = [self createCryptoV2IfAvailableWithSession:mxSession];
-        if (cryptoV2)
-        {
-            complete(cryptoV2);
-            return;
-        }
-        #endif
-        
-        [self checkLegacyCryptoWithMatrixSession:mxSession complete:complete];
-    });
+    #if DEBUG
+    id<MXCrypto> cryptoV2 = [self createCryptoV2IfAvailableWithSession:mxSession];
+    if (cryptoV2)
+    {
+        complete(cryptoV2);
+        return;
+    }
+    #endif
+    
+    [self checkLegacyCryptoWithMatrixSession:mxSession complete:complete];
 #else
     complete(nil);
 #endif

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -1417,6 +1417,11 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 #endif
 }
 
+- (NSString *)version
+{
+    return [NSString stringWithFormat:@"OLM %@", self.olmVersion];
+}
+
 - (NSString *)deviceCurve25519Key
 {
 #ifdef MX_CRYPTO

--- a/MatrixSDK/Crypto/MXCryptoV2.swift
+++ b/MatrixSDK/Crypto/MXCryptoV2.swift
@@ -79,6 +79,13 @@ private class MXCryptoV2: NSObject, MXCrypto {
     
     // MARK: - Public properties
     
+    var version: String {
+        guard let sdkVersion = Bundle(for: OlmMachine.self).infoDictionary?["CFBundleShortVersionString"] else {
+            return "Matrix SDK Crypto"
+        }
+        return "Matrix SDK Crypto \(sdkVersion)"
+    }
+    
     var deviceCurve25519Key: String? {
         return machine.deviceCurve25519Key
     }

--- a/MatrixSDK/Crypto/SecretStorage/MXCryptoSecretStoreV2.swift
+++ b/MatrixSDK/Crypto/SecretStorage/MXCryptoSecretStoreV2.swift
@@ -34,6 +34,8 @@ class MXCryptoSecretStoreV2: NSObject, MXCryptoSecretStore {
     }
     
     func storeSecret(_ secret: String, withSecretId secretId: String) {
+        log.debug("Storing new secret \(secretId)")
+        
         switch secretId as NSString {
         case MXSecretId.crossSigningMaster.takeUnretainedValue():
             crossSigning.importCrossSigningKeys(

--- a/MatrixSDK/Crypto/Verification/Requests/MXKeyVerificationRequestV2.swift
+++ b/MatrixSDK/Crypto/Verification/Requests/MXKeyVerificationRequestV2.swift
@@ -122,6 +122,8 @@ class MXKeyVerificationRequestV2: NSObject, MXKeyVerificationRequest {
         success: @escaping () -> Void,
         failure: @escaping (Error) -> Void
     ) {
+        log.debug("->")
+        
         Task {
             do {
                 try await handler.acceptVerificationRequest(
@@ -147,6 +149,8 @@ class MXKeyVerificationRequestV2: NSObject, MXKeyVerificationRequest {
         success: (() -> Void)?,
         failure: ((Error) -> Void)? = nil
     ) {
+        log.debug("->")
+        
         Task {
             do {
                 try await handler.cancelVerification(

--- a/MatrixSDK/Crypto/Verification/Transactions/SAS/MXSASTransactionV2.swift
+++ b/MatrixSDK/Crypto/Verification/Transactions/SAS/MXSASTransactionV2.swift
@@ -32,8 +32,12 @@ class MXSASTransactionV2: NSObject, MXSASTransaction {
             return sas.cancelInfo?.cancelledByUs == true ? MXSASTransactionStateCancelledByMe : MXSASTransactionStateCancelled
         } else if sas.canBePresented {
             return MXSASTransactionStateShowSAS
+        } else if sas.weStarted {
+            return MXSASTransactionStateOutgoingWaitForPartnerToAccept
+        } else if !sas.hasBeenAccepted {
+            return MXSASTransactionStateIncomingShowAccept
         }
-        return sas.weStarted ? MXSASTransactionStateOutgoingWaitForPartnerToAccept : MXSASTransactionStateIncomingShowAccept
+        return MXSASTransactionStateUnknown
     }
     
     var sasEmoji: [MXEmojiRepresentation]? {
@@ -113,6 +117,8 @@ class MXSASTransactionV2: NSObject, MXSASTransaction {
     }
     
     func accept() {
+        log.debug("->")
+        
         Task {
             do {
                 try await handler.acceptSasVerification(userId: otherUserId, flowId: transactionId)
@@ -124,6 +130,8 @@ class MXSASTransactionV2: NSObject, MXSASTransaction {
     }
     
     func confirmSASMatch() {
+        log.debug("->")
+        
         Task {
             do {
                 try await handler.confirmVerification(userId: otherUserId, flowId: transactionId)

--- a/MatrixSDK/JSONModels/MXJSONModels.m
+++ b/MatrixSDK/JSONModels/MXJSONModels.m
@@ -1283,7 +1283,12 @@ NSString *const kMXPushRuleScopeStringDevice = @"device";
 
 - (NSDictionary *)JSONDictionary
 {
-    return self.responseJSON;
+    NSMutableDictionary *dictionary = [self.responseJSON mutableCopy];
+    if (!dictionary[@"failures"])
+    {
+        dictionary[@"failures"] = @{};
+    }
+    return dictionary.copy;
 }
 
 @end

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -1925,6 +1925,11 @@ typedef void (^MXOnResumeDone)(void);
  */
 - (void)validateAccountData
 {
+    if (![self.crypto isKindOfClass:[MXLegacyCrypto class]])
+    {
+        return;
+    }
+    
     // Detecting an issue in legacy crypto where more than one valid SSSS key is present on the client
     // https://github.com/vector-im/element-ios/issues/4569
     NSInteger keysCount = ((MXLegacyCrypto *)self.crypto).secretStorage.numberOfValidKeys;
@@ -1974,8 +1979,7 @@ typedef void (^MXOnResumeDone)(void);
     else
     {
         // New and all future crypto modules can handle the entire sync response in full
-        [self.crypto handleSyncResponse:syncResponse];
-        onComplete();
+        [self.crypto handleSyncResponse:syncResponse onComplete:onComplete];
     }
 }
 
@@ -2036,7 +2040,10 @@ typedef void (^MXOnResumeDone)(void);
     {
         case MXEventTypeRoomKey:
         {
-            [(MXLegacyCrypto *)_crypto handleRoomKeyEvent:event onComplete:onHandleToDeviceEventDone];
+            if ([_crypto isKindOfClass:[MXLegacyCrypto class]])
+            {
+                [(MXLegacyCrypto *)_crypto handleRoomKeyEvent:event onComplete:onHandleToDeviceEventDone];
+            }
             break;
         }
 

--- a/MatrixSDK/MatrixSDK.h
+++ b/MatrixSDK/MatrixSDK.h
@@ -176,6 +176,7 @@ FOUNDATION_EXPORT NSString *MatrixSDKVersion;
 #import "MXKeyBackupEngine.h"
 #import "MXCryptoTools.h"
 #import "MXRecoveryKey.h"
+#import "MXSecretShareSend.h"
 
 //  Sync response models
 #import "MXSyncResponse.h"

--- a/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoMachineUnitTests.swift
+++ b/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoMachineUnitTests.swift
@@ -1,0 +1,69 @@
+// 
+// Copyright 2022 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+#if DEBUG
+
+import MatrixSDKCrypto
+@testable import MatrixSDK
+
+class MXCryptoMachineUnitTests: XCTestCase {
+    
+    var restClient: MXRestClient!
+    var machine: MXCryptoMachine!
+    
+    override func setUp() {
+        restClient = MXRestClientStub()
+        machine = try! MXCryptoMachine(
+            userId: "@alice:matrix.org",
+            deviceId: "ABCD",
+            restClient: restClient,
+            getRoomAction: {
+                MXRoom(roomId: $0, andMatrixSession: nil)
+            })
+    }
+    
+    func test_handleSyncResponse_canProcessEmptyResponse() throws {
+        let result = try machine.handleSyncResponse(
+            toDevice: nil,
+            deviceLists: nil,
+            deviceOneTimeKeysCounts: [:],
+            unusedFallbackKeys: nil
+        )
+        XCTAssertEqual(result.events.count, 0)
+    }
+    
+    func test_handleSyncResponse_canProcessToDeviceEvents() async throws {
+        let toDevice = MXToDeviceSyncResponse()
+        toDevice.events = [
+            .fixture(type: "m.key.verification.request")
+        ]
+        let deviceList = MXDeviceListResponse()
+        deviceList.changed = ["A", "B"]
+        deviceList.left = ["C", "D"]
+        
+        let result = try machine.handleSyncResponse(
+            toDevice: toDevice,
+            deviceLists: deviceList,
+            deviceOneTimeKeysCounts: [:],
+            unusedFallbackKeys: nil
+        )
+        XCTAssertEqual(result.events.count, 1)
+    }
+}
+
+#endif

--- a/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoProtocolStubs.swift
+++ b/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoProtocolStubs.swift
@@ -57,7 +57,11 @@ class UserIdentitySourceStub: CryptoIdentityStub, MXCryptoUserIdentitySource {
         return verification[userId] ?? false
     }
     
-    func downloadKeys(users: [String]) async throws {
+    func isUserTracked(userId: String) -> Bool {
+        return false
+    }
+    
+    func updateTrackedUsers(users: [String]) async throws {
     }
     
     func manuallyVerifyUser(userId: String) async throws {
@@ -100,7 +104,11 @@ class CryptoCrossSigningStub: CryptoIdentityStub, MXCryptoCrossSigning {
         return stubbedVerifiedUsers.contains(userId)
     }
     
-    func downloadKeys(users: [String]) async throws {
+    func isUserTracked(userId: String) -> Bool {
+        return false
+    }
+    
+    func updateTrackedUsers(users: [String]) async throws {
     }
     
     func manuallyVerifyUser(userId: String) async throws {

--- a/MatrixSDKTests/Crypto/Verification/Transactions/SAS/MXSASTransactionV2UnitTests.swift
+++ b/MatrixSDKTests/Crypto/Verification/Transactions/SAS/MXSASTransactionV2UnitTests.swift
@@ -135,6 +135,14 @@ class MXSASTransactionV2UnitTests: XCTestCase {
                 isDone: false,
                 isCancelled: false
             ), MXSASTransactionStateIncomingShowAccept),
+            (.stub(
+                weStarted: false,
+                hasBeenAccepted: true,
+                canBePresented: false,
+                haveWeConfirmed: false,
+                isDone: false,
+                isCancelled: false
+            ), MXSASTransactionStateUnknown),
         ]
 
         for (stub, state) in testCases {

--- a/MatrixSDKTests/Mocks/MXRestClientStub.m
+++ b/MatrixSDKTests/Mocks/MXRestClientStub.m
@@ -43,13 +43,4 @@
     return [[MXHTTPOperation alloc] init];
 }
 
-- (MXHTTPOperation *)downloadKeysForUsers:(NSArray<NSString *> *)userIds token:(NSString *)token success:(void (^)(MXKeysQueryResponse *))success failure:(void (^)(NSError *))failure
-{
-    if (success)
-    {
-        success([[MXKeysQueryResponse alloc] init]);
-    }
-    return [[MXHTTPOperation alloc] init];
-}
-
 @end

--- a/MatrixSDKTests/Mocks/MXRestClientStub.m
+++ b/MatrixSDKTests/Mocks/MXRestClientStub.m
@@ -43,4 +43,13 @@
     return [[MXHTTPOperation alloc] init];
 }
 
+- (MXHTTPOperation *)downloadKeysForUsers:(NSArray<NSString *> *)userIds token:(NSString *)token success:(void (^)(MXKeysQueryResponse *))success failure:(void (^)(NSError *))failure
+{
+    if (success)
+    {
+        success([[MXKeysQueryResponse alloc] init]);
+    }
+    return [[MXHTTPOperation alloc] init];
+}
+
 @end

--- a/Podfile
+++ b/Podfile
@@ -16,7 +16,7 @@ abstract_target 'MatrixSDK' do
     
     pod 'Realm', '10.27.0'
     pod 'libbase58', '~> 0.1.4'
-    pod 'MatrixSDKCrypto', "0.1.4", :configurations => ['DEBUG']
+    pod 'MatrixSDKCrypto', "0.1.5", :configurations => ['DEBUG']
     
     target 'MatrixSDK-iOS' do
         platform :ios, '11.0'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -16,7 +16,7 @@ PODS:
     - AFNetworking/NSURLSession
   - GZIP (1.3.0)
   - libbase58 (0.1.4)
-  - MatrixSDKCrypto (0.1.4)
+  - MatrixSDKCrypto (0.1.5)
   - OHHTTPStubs (9.1.0):
     - OHHTTPStubs/Default (= 9.1.0)
   - OHHTTPStubs/Core (9.1.0)
@@ -44,7 +44,7 @@ DEPENDENCIES:
   - AFNetworking (~> 4.0.0)
   - GZIP (~> 1.3.0)
   - libbase58 (~> 0.1.4)
-  - MatrixSDKCrypto (= 0.1.4)
+  - MatrixSDKCrypto (= 0.1.5)
   - OHHTTPStubs (~> 9.1.0)
   - OLMKit (~> 3.2.5)
   - Realm (= 10.27.0)
@@ -65,12 +65,12 @@ SPEC CHECKSUMS:
   AFNetworking: 7864c38297c79aaca1500c33288e429c3451fdce
   GZIP: 416858efbe66b41b206895ac6dfd5493200d95b3
   libbase58: 7c040313537b8c44b6e2d15586af8e21f7354efd
-  MatrixSDKCrypto: 2cefddf230a2388fef10cb3249070cc2dc9b1688
+  MatrixSDKCrypto: dcab554bc7157cad31c01fc1137cf5acb01959a4
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   OLMKit: da115f16582e47626616874e20f7bb92222c7a51
   Realm: 9ca328bd7e700cc19703799785e37f77d1a130f2
   SwiftyBeaver: 84069991dd5dca07d7069100985badaca7f0ce82
 
-PODFILE CHECKSUM: 6d6b363a8a51d2a0ecce801a900d2d2e506f93c8
+PODFILE CHECKSUM: 7805b1fe65269b6ac6667a7f347f324e8970c050
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.11.3


### PR DESCRIPTION
A number of changes to [rust-based Crypto V2](https://github.com/matrix-org/matrix-ios-sdk/pull/1620) after extensive testing with polyjuice:

- expose `VerificationState` on decryption result to display trusted / untrusted sessions
- ensure CryptoV2 gets initialized on the main queue
- move event observers from key verification manager to crypto v2 to gain access to downloading user keys and processing outgoing requests
- always download keys for new senders before processing to-device events
- restore room keys from backup after recieving recovery key