### PR TITLE
Crypto V2 fixes

### DIFF
--- a/MatrixSDK/Crypto/CrossSigning/MXCrossSigningV2.swift
+++ b/MatrixSDK/Crypto/CrossSigning/MXCrossSigningV2.swift
@@ -146,7 +146,7 @@ class MXCrossSigningV2: NSObject, MXCrossSigning {
         
         Task {
             do {
-                try await crossSigning.manuallyVerifyDevice(userId: crossSigning.userId, deviceId: deviceId)
+                try await crossSigning.verifyDevice(userId: crossSigning.userId, deviceId: deviceId)
                 
                 log.debug("Successfully cross-signed a device")
                 await MainActor.run {
@@ -170,7 +170,7 @@ class MXCrossSigningV2: NSObject, MXCrossSigning {
         
         Task {
             do {
-                try await crossSigning.manuallyVerifyUser(userId: userId)
+                try await crossSigning.verifyUser(userId: userId)
                 log.debug("Successfully cross-signed a user")
                 
                 await MainActor.run {

--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoProtocols.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoProtocols.swift
@@ -54,8 +54,8 @@ protocol MXCryptoUserIdentitySource: MXCryptoIdentity {
     func isUserVerified(userId: String) -> Bool
     func isUserTracked(userId: String) -> Bool
     func downloadKeys(users: [String]) async throws
-    func manuallyVerifyUser(userId: String) async throws
-    func manuallyVerifyDevice(userId: String, deviceId: String) async throws
+    func verifyUser(userId: String) async throws
+    func verifyDevice(userId: String, deviceId: String) async throws
     func setLocalTrust(userId: String, deviceId: String, trust: LocalTrust) throws
 }
 

--- a/MatrixSDK/Crypto/CryptoMachine/MXEventDecryptionResult+DecryptedEvent.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXEventDecryptionResult+DecryptedEvent.swift
@@ -37,11 +37,7 @@ extension MXEventDecryptionResult {
         senderCurve25519Key = event.senderCurve25519Key
         claimedEd25519Key = event.claimedEd25519Key
         forwardingCurve25519KeyChain = event.forwardingCurve25519Chain
-        
-        // Untrusted state not yet fully implemented, will equal to:
-        // `isUntrusted = event.verificationState == VerificationState.untrusted`
-        MXLog.warning("[MXEventDecryptionResult] trust not yet implemeneted")
-        isUntrusted = false
+        isUntrusted = event.verificationState == VerificationState.untrusted
     }
 }
 

--- a/MatrixSDK/Crypto/Data/MXMegolmSessionData.m
+++ b/MatrixSDK/Crypto/Data/MXMegolmSessionData.m
@@ -52,9 +52,21 @@
 
 - (NSDictionary *)JSONDictionary
 {
+    if (!_senderKey || !_roomId || !_sessionId || !_sessionKey || !_algorithm)
+    {
+        NSDictionary *details = @{
+            @"sender_key": _senderKey ?: @"unknown",
+            @"room_id": _roomId ?: @"unknown",
+            @"session_id": _sessionId ?: @"unknown",
+            @"algorithm": _algorithm ?: @"unknown",
+        };
+        MXLogErrorDetails(@"[MXMegolmSessionData] JSONDictionary: some properties are missing", details);
+        return nil;
+    }
+    
     return @{
       @"sender_key": _senderKey,
-      @"sender_claimed_keys": _senderClaimedKeys,
+      @"sender_claimed_keys": _senderClaimedKeys ?: @[],
       @"room_id": _roomId,
       @"session_id": _sessionId,
       @"session_key":_sessionKey,

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -2082,7 +2082,7 @@ typedef void (^MXOnResumeDone)(void);
 {
     BOOL isInValidState = _state == MXSessionStateStoreDataReady || _state == MXSessionStatePaused;
     if (!isInValidState) {
-        NSString *message = [NSString stringWithFormat:@"[MXSession] state %@ is not valid to handle background sync cache, investigate why the method was called", [MXTools readableSessionState:_state]];
+        NSString *message = [NSString stringWithFormat:@"[MXSession] handleBackgroundSyncCacheIfRequired: state %@ is not valid to handle background sync cache, investigate why the method was called", [MXTools readableSessionState:_state]];
         MXLogFailure(message);
         if (completion)
         {
@@ -4928,6 +4928,12 @@ typedef void (^MXOnResumeDone)(void);
     MXRoomSummary *summary = [self roomSummaryWithRoomId:event.roomId];
     if (summary)
     {
+        if (!summary.lastMessage)
+        {
+            [summary resetLastMessage:nil failure:nil commit:YES];
+            return;
+        }
+
         [self eventWithEventId:summary.lastMessage.eventId
                         inRoom:summary.roomId
                        success:^(MXEvent *lastEvent) {

--- a/MatrixSDKTests/Crypto/Algorithms/RoomEvents/MXRoomEventDecryptionUnitTests.swift
+++ b/MatrixSDKTests/Crypto/Algorithms/RoomEvents/MXRoomEventDecryptionUnitTests.swift
@@ -137,10 +137,10 @@ class MXRoomEventDecryptionUnitTests: XCTestCase {
     
     // MARK: - Retry all
     
-    func test_retryAllUndecryptedEvents() async {
+    func test_retryUndecryptedEvents() async {
         let events = await prepareEventsForRedecryption()
         
-        await roomDecryptor.retryAllUndecryptedEvents()
+        await roomDecryptor.retryUndecryptedEvents(sessionIds: ["123", "456"])
         await waitForDecryption()
         
         XCTAssertNotNil(events[0].clear)

--- a/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoMachineUnitTests.swift
+++ b/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoMachineUnitTests.swift
@@ -23,18 +23,31 @@ import MatrixSDKCrypto
 
 class MXCryptoMachineUnitTests: XCTestCase {
     
+    var userId = "@alice:matrix.org"
     var restClient: MXRestClient!
     var machine: MXCryptoMachine!
     
     override func setUp() {
         restClient = MXRestClientStub()
         machine = try! MXCryptoMachine(
-            userId: "@alice:matrix.org",
+            userId: userId,
             deviceId: "ABCD",
             restClient: restClient,
             getRoomAction: {
                 MXRoom(roomId: $0, andMatrixSession: nil)
             })
+    }
+    
+    override func tearDown() {
+        do {
+            let url = try MXCryptoMachine.storeURL(for: userId)
+            guard FileManager.default.fileExists(atPath: url.path) else {
+                return
+            }
+            try FileManager.default.removeItem(at: url)
+        } catch {
+            XCTFail("Cannot tear down test - \(error)")
+        }
     }
     
     func test_handleSyncResponse_canProcessEmptyResponse() throws {

--- a/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoProtocolStubs.swift
+++ b/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoProtocolStubs.swift
@@ -64,10 +64,10 @@ class UserIdentitySourceStub: CryptoIdentityStub, MXCryptoUserIdentitySource {
     func downloadKeys(users: [String]) async throws {
     }
     
-    func manuallyVerifyUser(userId: String) async throws {
+    func verifyUser(userId: String) async throws {
     }
     
-    func manuallyVerifyDevice(userId: String, deviceId: String) async throws {
+    func verifyDevice(userId: String, deviceId: String) async throws {
     }
     
     func setLocalTrust(userId: String, deviceId: String, trust: LocalTrust) throws {
@@ -111,10 +111,10 @@ class CryptoCrossSigningStub: CryptoIdentityStub, MXCryptoCrossSigning {
     func downloadKeys(users: [String]) async throws {
     }
     
-    func manuallyVerifyUser(userId: String) async throws {
+    func verifyUser(userId: String) async throws {
     }
     
-    func manuallyVerifyDevice(userId: String, deviceId: String) async throws {
+    func verifyDevice(userId: String, deviceId: String) async throws {
     }
     
     func setLocalTrust(userId: String, deviceId: String, trust: LocalTrust) throws {

--- a/MatrixSDKTests/Crypto/Data/MXMegolmSessionDataUnitTests.swift
+++ b/MatrixSDKTests/Crypto/Data/MXMegolmSessionDataUnitTests.swift
@@ -71,7 +71,7 @@ class MXMegolmSessionDataUnitTests: XCTestCase {
         data.algorithm = "G"
         data.forwardingCurve25519KeyChain = ["H", "I"]
         
-        let json = data.jsonDictionary() as NSDictionary
+        let json = data.jsonDictionary() as? NSDictionary
         
         XCTAssertEqual(json, [
             "sender_key": "A",
@@ -84,5 +84,20 @@ class MXMegolmSessionDataUnitTests: XCTestCase {
             "forwarding_curve25519_key_chain": ["H", "I"],
             "untrusted": false
         ])
+    }
+    
+    func testInvalidJsonDictionary() {
+        let data = MXMegolmSessionData()
+        data.senderKey = nil
+        data.senderClaimedKeys = nil
+        data.roomId = nil
+        data.sessionId = nil
+        data.sessionKey = nil
+        data.algorithm = nil
+        data.forwardingCurve25519KeyChain = nil
+        
+        let json = data.jsonDictionary() as? NSDictionary
+        
+        XCTAssertNil(json)
     }
 }

--- a/changelog.d/pr-1630.change
+++ b/changelog.d/pr-1630.change
@@ -1,0 +1,2 @@
+CryptoV2: Bugfixes
+


### PR DESCRIPTION
A number of changes / fixes for Crypto V2:

- re-decrypt events by specific sessionId after importing keys
- ensure we send room keys to our other devices
- better location for mac-specific crypto store (useful in integration tests)
- enable `isUntrusted` state for events
- fix a few nullability crashes