### PR TITLE
Log decryption errors separately with Crypto V2

### DIFF
--- a/MatrixSDK/Utils/Logs/MXAnalyticsDestination.swift
+++ b/MatrixSDK/Utils/Logs/MXAnalyticsDestination.swift
@@ -45,7 +45,7 @@ class MXAnalyticsDestination: BaseDestination {
             return dictionary
         } else if let error = context as? Error {
             return [
-                "error": error.localizedDescription
+                "error": error
             ]
         } else {
             return [

--- a/changelog.d/pr-1632.change
+++ b/changelog.d/pr-1632.change
@@ -1,0 +1,1 @@
+CryptoV2: Log decryption errors separately


### PR DESCRIPTION
Log separate errors based on the type of `DecryptionError` so that it is easier to distinguish and monitor unrelated failure reasons in sentry