### PR TITLE
Import progress for room keys with Crypto V2

### DIFF
--- a/MatrixSDK/Crypto/KeyBackup/Engine/MXKeyBackupEngine.h
+++ b/MatrixSDK/Crypto/KeyBackup/Engine/MXKeyBackupEngine.h
@@ -125,7 +125,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)hasKeysToBackup;
 
 /**
- The ratio of total vs backed up keys
+ The ratio of backed up vs total keys
  */
 - (NSProgress *)backupProgress;
 
@@ -134,6 +134,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)backupKeysWithSuccess:(void (^)(void))success
                       failure:(void (^)(NSError *error))failure;
+
+/**
+ The ratio of imported vs total keys or nil if not actively importing keys
+ */
+- (nullable NSProgress *)importProgress;
 
 /**
  Import encypted backup keys

--- a/MatrixSDK/Crypto/KeyBackup/Engine/MXNativeKeyBackupEngine.m
+++ b/MatrixSDK/Crypto/KeyBackup/Engine/MXNativeKeyBackupEngine.m
@@ -531,6 +531,12 @@ static Class DefaultAlgorithmClass;
     } failure:failure];
 }
 
+- (NSProgress *)importProgress
+{
+    // Not implemented for legacy backup
+    return nil;
+}
+
 - (void)importKeysWithKeysBackupData:(MXKeysBackupData *)keysBackupData
                           privateKey:(NSData *)privateKey
                     keyBackupVersion:(MXKeyBackupVersion *)keyBackupVersion

--- a/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.h
+++ b/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.h
@@ -305,6 +305,10 @@ FOUNDATION_EXPORT NSString *const kMXKeyBackupDidStateChangeNotification;
 */
 @property (nonatomic, readonly) BOOL hasPrivateKeyInCryptoStore;
 
+/**
+ The ratio of imported vs total keys or nil if not actively importing keys
+ */
+@property (nullable, nonatomic, readonly) NSProgress *importProgress;
 
 #pragma mark - Backup trust
 

--- a/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.m
+++ b/MatrixSDK/Crypto/KeyBackup/MXKeyBackup.m
@@ -859,6 +859,11 @@ NSUInteger const kMXKeyBackupWaitingTimeToSendKeyBackup = 10000;
     return self.engine.privateKey != nil;
 }
 
+- (NSProgress *)importProgress
+{
+    return self.engine.importProgress;
+}
+
 #pragma mark - Backup trust
 
 - (void)trustForKeyBackupVersion:(MXKeyBackupVersion *)keyBackupVersion onComplete:(void (^)(MXKeyBackupVersionTrust * _Nonnull))onComplete

--- a/changelog.d/pr-1637.change
+++ b/changelog.d/pr-1637.change
@@ -1,0 +1,1 @@
+CryptoV2: Import progress for room keys


### PR DESCRIPTION
Split up room keys into batches of 1000 when importing, and ensure to decrypt + import within `autoreleasepool`. This ensures we do not run out of memory when importing large key backups.

Additionally expose `importProgress` property, analogous to existing `backupProgress`, that can be used by any UI.

Tested by importing 1,000,000 keys on a device, which does grow the memory footprint considerably, but still slower than without the `autoreleasepool` and batching. The initial spike seen below is the http request, roughly 800MB for all the keys.

<img width="1011" alt="Screenshot 2022-11-15 at 11 47 06" src="https://user-images.githubusercontent.com/3922159/201912110-9f2fb2e0-f281-4461-8d4b-ecbec404a421.png">

