### PR TITLE
Run all Crypto tasks with default priority

### DIFF
--- a/MatrixSDK/Crypto/KeyBackup/Engine/MXCryptoKeyBackupEngine.swift
+++ b/MatrixSDK/Crypto/KeyBackup/Engine/MXCryptoKeyBackupEngine.swift
@@ -284,7 +284,7 @@ class MXCryptoKeyBackupEngine: NSObject, MXKeyBackupEngine {
             return
         }
         
-        Task(priority: .medium) {
+        Task {
             let encryptedSessions = keysBackupData.rooms.flatMap { roomId, room in
                 room.sessions.map { sessionId, keyBackup in
                     EncryptedSession(roomId: roomId, sessionId: sessionId, keyBackup: keyBackup)

--- a/changelog.d/pr-1639.change
+++ b/changelog.d/pr-1639.change
@@ -1,0 +1,1 @@
+CryptoV2: Run all tasks with default priority


### PR DESCRIPTION
- Run all crypto `Task`s with default priority rather than assigning `medium`
- Make sure `CryptoV2` does not get initialized more than once (which can happen during failing initial syncs)
- Remove unnecessary processing of outgoing requests