### PR TITLE
Fix backup performance with Crypto V2

### DIFF
--- a/MatrixSDK/Data/MXRoom.h
+++ b/MatrixSDK/Data/MXRoom.h
@@ -176,12 +176,18 @@ FOUNDATION_EXPORT NSInteger const kMXRoomInvalidInviteSenderErrorCode;
 
 /**
  Indicate if the room is tagged as a direct chat.
+ 
+ @warning: This is an O(n) computed property that iterates through all
+ direct rooms to determine whether any particular room is direct.
  */
 @property (nonatomic, readonly) BOOL isDirect;
 
 /**
  The user identifier for whom this room is tagged as direct (if any).
  nil if the room is not a direct chat.
+ 
+ @warning: This is an O(n) computed property that iterates through all
+ direct rooms to determine given direct user id.
  */
 @property (nonatomic, readonly) NSString *directUserId;
 

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -3537,12 +3537,14 @@ NSInteger const kMXRoomInvalidInviteSenderErrorCode = 9002;
 - (BOOL)isDirect
 {
     // Check whether this room is tagged as direct for one of the room members.
+    // This is an O(n) operation.
     return (self.directUserId != nil);
 }
 
 - (NSString *)directUserId
 {
     // Get the information from the user account data that is managed by MXSession
+    // This is an O(n) operation.
     return [self.mxSession directUserIdInRoom:_roomId];
 }
 

--- a/MatrixSDK/Space/MXSpaceService.swift
+++ b/MatrixSDK/Space/MXSpaceService.swift
@@ -498,13 +498,8 @@ public class MXSpaceService: NSObject {
         let startDate = Date()
         MXLog.debug("[MXSpaceService] buildGraph: started")
         
-        var directRoomIds = Set<String>()
-        let roomIds: [String] = self.session.rooms.compactMap { room in
-            if room.isDirect {
-                directRoomIds.insert(room.roomId)
-            }
-            return room.roomId
-        }
+        var directRoomIds = Set(session.directRooms?.flatMap(\.value) ?? [])
+        let roomIds = session.rooms.compactMap(\.roomId)
         
         let output = PrepareDataResult()
         MXLog.debug("[MXSpaceService] buildGraph: preparing data for \(roomIds.count) rooms")

--- a/changelog.d/pr-1641.change
+++ b/changelog.d/pr-1641.change
@@ -1,0 +1,1 @@
+CryptoV2: Fix backup performance


### PR DESCRIPTION
The check to see whether we have any keys to backup relies on getting the actual count of total vs backed-up keys. For large accounts this rust method is very compute intensive and blocks the main thread. This has to be improved on the rust side, but for the time being we will return a cached count synchronously and then compute the actual count on a separate thread asynchronously. This will free up the main thread.

Additionally and unrelatedly I noticed that space graph computation during sync also blocks the main thread (once again for large accounts). This is due to an innocent looking `MXRoom.isDirect` method that actually has O(n) performance. Instead of being a state property, it is a computed property that iterates through all direct rooms to determine if itself is direct or not. Changing the performance of this method is a rabbit hole I don't want to get into. Luckily the solution is quite simple, given that `MXSpaceService` can use an existing `MXSession.directRooms` method to get all of the ids at once, instead of doing essentially O(n^2) work (for every room, check every other direct room).