### PR TITLE
Fix invites count

### DIFF
--- a/MatrixSDK/Space/MXSpaceNotificationCounter.swift
+++ b/MatrixSDK/Space/MXSpaceNotificationCounter.swift
@@ -204,8 +204,10 @@ public class MXSpaceNotificationCounter: NSObject {
             }
         } else if roomInfo.membership == .invite {
             if roomInfo.isDirect {
+                notificationState.directMissedDiscussionsCount += 1
                 notificationState.directMissedDiscussionsHighlightedCount += 1
             } else {
+                notificationState.groupMissedDiscussionsCount += 1
                 notificationState.groupMissedDiscussionsHighlightedCount += 1
             }
         }

--- a/changelog.d/pr-1645.change
+++ b/changelog.d/pr-1645.change
@@ -1,0 +1,1 @@
+Change invites count logic.


### PR DESCRIPTION
### Description
This PR refactor the count logic for invites making it coherent with unread messages and mentions count.

Currently for mentions the same event is counted both in:
- `*count`
- `*HighlightedCount`

Conversely Invites are counted just in:
- `*HighlightedCount`

This break the invariant:
`*count >= *HighlightedCount` 
bringing inconsistencies in the client.

After this PR invites are counted **both as highlighted and in the general count as well**.

### Related PR
https://github.com/vector-im/element-ios/pull/7088