### PR TITLE
Fail launch when unavailable crypto

### DIFF
--- a/MatrixSDK/Crypto/MXCrypto.h
+++ b/MatrixSDK/Crypto/MXCrypto.h
@@ -43,12 +43,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-FOUNDATION_EXPORT NSString *const MXCryptoErrorDomain;
-typedef NS_ENUM(NSInteger, MXCryptoErrorCode)
-{
-    MXCryptoUnavailableErrorCode,
-};
-
 /**
  Fires when we receive a room key request.
 
@@ -402,9 +396,11 @@ MX_ASSUME_MISSING_NULLABILITY_BEGIN
  Create a new crypto instance and data for the given user.
  
  @param mxSession the session on which to enable crypto.
+ @param error pointer to error that is non-nil if crypto failed to be created
  @return the fresh crypto instance.
  */
-+ (id<MXCrypto>)createCryptoWithMatrixSession:(MXSession*)mxSession;
++ (id<MXCrypto>)createCryptoWithMatrixSession:(MXSession*)mxSession
+                                        error:(NSError **)error;
 
 /**
  Check if the user has previously enabled crypto.
@@ -412,7 +408,8 @@ MX_ASSUME_MISSING_NULLABILITY_BEGIN
 
  @param complete a block called in any case when the operation completes.
  */
-+ (void)checkCryptoWithMatrixSession:(MXSession*)mxSession complete:(void (^)(id<MXCrypto> crypto))complete;
++ (void)checkCryptoWithMatrixSession:(MXSession*)mxSession
+                            complete:(void (^)(id<MXCrypto> crypto, NSError *error))complete;
 
 /**
  Stores the exportedOlmDevice related to the credentials into the store.

--- a/MatrixSDK/Crypto/MXCrypto.h
+++ b/MatrixSDK/Crypto/MXCrypto.h
@@ -43,6 +43,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+FOUNDATION_EXPORT NSString *const MXCryptoErrorDomain;
+typedef NS_ENUM(NSInteger, MXCryptoErrorCode)
+{
+    MXCryptoUnavailableErrorCode,
+};
+
 /**
  Fires when we receive a room key request.
 

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -62,6 +62,8 @@
  */
 #define MXCryptoStoreClass MXRealmCryptoStore
 
+NSString *const MXCryptoErrorDomain = @"org.matrix.sdk.crypto";
+
 NSString *const kMXCryptoRoomKeyRequestNotification = @"kMXCryptoRoomKeyRequestNotification";
 NSString *const kMXCryptoRoomKeyRequestNotificationRequestKey = @"kMXCryptoRoomKeyRequestNotificationRequestKey";
 NSString *const kMXCryptoRoomKeyRequestCancellationNotification = @"kMXCryptoRoomKeyRequestCancellationNotification";
@@ -157,9 +159,9 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 #ifdef MX_CRYPTO
     
     #if DEBUG
-    id<MXCrypto> cryptoV2 = [self createCryptoV2IfAvailableWithSession:mxSession];
-    if (cryptoV2) {
-        return cryptoV2;
+    if (MXSDKOptions.sharedInstance.enableCryptoV2)
+    {
+        return [self createCryptoV2WithSession:mxSession];
     }
     #endif
     
@@ -180,10 +182,9 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 {
 #ifdef MX_CRYPTO
     #if DEBUG
-    id<MXCrypto> cryptoV2 = [self createCryptoV2IfAvailableWithSession:mxSession];
-    if (cryptoV2)
+    if (MXSDKOptions.sharedInstance.enableCryptoV2)
     {
-        complete(cryptoV2);
+        complete([self createCryptoV2WithSession:mxSession]);
         return;
     }
     #endif

--- a/MatrixSDK/Crypto/MXCryptoV2.swift
+++ b/MatrixSDK/Crypto/MXCryptoV2.swift
@@ -19,17 +19,9 @@ import Foundation
 #if DEBUG
 public extension MXLegacyCrypto {
     /// Create a Rust-based work-in-progress implementation of `MXCrypto`
-    ///
-    /// The experimental crypto module is created only if:
-    /// - using DEBUG build
-    /// - enabling `enableCryptoV2` feature flag
-    @objc static func createCryptoV2IfAvailable(session: MXSession!) -> MXCrypto? {
+    @objc static func createCryptoV2(session: MXSession!) -> MXCrypto? {
         let log = MXNamedLog(name: "MXCryptoV2")
-        
-        guard MXSDKOptions.sharedInstance().enableCryptoV2 else {
-            return nil
-        }
-        
+                
         guard let session = session else {
             log.failure("Cannot create crypto V2, missing session")
             return nil

--- a/MatrixSDK/Crypto/MXCryptoV2.swift
+++ b/MatrixSDK/Crypto/MXCryptoV2.swift
@@ -18,20 +18,28 @@ import Foundation
 
 #if DEBUG
 public extension MXLegacyCrypto {
+    enum CryptoError: Swift.Error, LocalizedError {
+        case cryptoNotAvailable
+        
+        public var errorDescription: String? {
+            return "Encryption not available, please restart the app"
+        }
+    }
+    
     /// Create a Rust-based work-in-progress implementation of `MXCrypto`
-    @objc static func createCryptoV2(session: MXSession!) -> MXCrypto? {
+    @objc static func createCryptoV2(session: MXSession!) throws -> MXCrypto {
         let log = MXNamedLog(name: "MXCryptoV2")
-                
+
         guard let session = session else {
             log.failure("Cannot create crypto V2, missing session")
-            return nil
+            throw CryptoError.cryptoNotAvailable
         }
-        
+
         do {
             return try MXCryptoV2(session: session)
         } catch {
             log.failure("Error creating crypto V2", context: error)
-            return nil
+            throw CryptoError.cryptoNotAvailable
         }
     }
 }

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -398,16 +398,13 @@ typedef void (^MXOnResumeDone)(void);
 
         // Check if the user has enabled crypto
         MXWeakify(self);
-        [MXLegacyCrypto checkCryptoWithMatrixSession:self complete:^(id<MXCrypto> crypto) {
+        [MXLegacyCrypto checkCryptoWithMatrixSession:self complete:^(id<MXCrypto> crypto, NSError *error) {
             MXStrongifyAndReturnIfNil(self);
             
-            if (!crypto)
+            if (!crypto && error)
             {
                 if (failure)
                 {
-                    NSError *error = [NSError errorWithDomain:MXCryptoErrorDomain code:MXCryptoUnavailableErrorCode userInfo:@{
-                        NSLocalizedDescriptionKey: @"Encryption not available, please restart the app",
-                    }];
                     failure(error);
                 }
                 return;
@@ -2280,14 +2277,12 @@ typedef void (^MXOnResumeDone)(void);
 
     if (enableCrypto && !_crypto)
     {
-        _crypto = [MXLegacyCrypto createCryptoWithMatrixSession:self];
-        if (!_crypto)
+        NSError *error;
+        _crypto = [MXLegacyCrypto createCryptoWithMatrixSession:self error:&error];
+        if (!_crypto && error)
         {
             if (failure)
             {
-                NSError *error = [NSError errorWithDomain:MXCryptoErrorDomain code:MXCryptoUnavailableErrorCode userInfo:@{
-                    NSLocalizedDescriptionKey: @"Encryption not available, please restart the app",
-                }];
                 failure(error);
             }
             return;

--- a/changelog.d/pr-1646.change
+++ b/changelog.d/pr-1646.change
@@ -1,0 +1,1 @@
+Crypto: Fail launch when unavailable crypto


### PR DESCRIPTION
Fail sync / session init when `crypto` module is required but unavailable. This can happen for instance when we fail to open the underlying database.

Previously this would just silently fail and continue syncing forever, now we propagate the error upwards and can display an error.