### PR TITLE
Delete empty account_data events

### DIFF
--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -1921,6 +1921,10 @@ typedef void (^MXOnResumeDone)(void);
 
             // Update the corresponding part of account data
             if (event[@"content"] == nil || [event[@"content"] isEmpty]) {
+                /*
+                 MSC3391 returns an empty object in the sync after the user delete one account_data event using the associated DELETE endpoint.
+                 https://github.com/ShadowJonathan/matrix-doc/blob/account-data-delete/proposals/3391-account-data-delete.md#sync
+                 */
                 [_accountData deleteDataWithType:event[@"type"]];
             } else {
                 [_accountData updateWithEvent:event];

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -1920,7 +1920,11 @@ typedef void (^MXOnResumeDone)(void);
             }
 
             // Update the corresponding part of account data
-            [_accountData updateWithEvent:event];
+            if (event[@"content"] == nil || [event[@"content"] isEmpty]) {
+                [_accountData deleteDataWithType:event[@"type"]];
+            } else {
+                [_accountData updateWithEvent:event];
+            }
 
             if ([event[@"type"] isEqualToString:kMXAccountDataTypeIdentityServer])
             {


### PR DESCRIPTION
### Description
This PR removes empty `account_data` events in the sync.
They are coming back after someone calls `DELETE` on an `account_data` as described [here](https://github.com/ShadowJonathan/matrix-doc/blob/account-data-delete/proposals/3391-account-data-delete.md#sync).

### Dependency
https://github.com/matrix-org/matrix-ios-sdk/pull/1651