### PR TITLE
Do not track cancellation errors

### DIFF
--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -1912,6 +1912,8 @@
 		ED6DAC1F28C79D2000ECDCB6 /* MXUnrequestedForwardedRoomKeyManagerUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED6DAC1D28C79D2000ECDCB6 /* MXUnrequestedForwardedRoomKeyManagerUnitTests.swift */; };
 		ED6DAC2128C7A51400ECDCB6 /* MXDateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED6DAC2028C7A4F000ECDCB6 /* MXDateProvider.swift */; };
 		ED6DAC2228C7A51400ECDCB6 /* MXDateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED6DAC2028C7A4F000ECDCB6 /* MXDateProvider.swift */; };
+		ED6E87A9294B3BAB00100D9C /* MXAnalyticsDestinationUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED6E87A8294B3BAB00100D9C /* MXAnalyticsDestinationUnitTests.swift */; };
+		ED6E87AA294B3BAB00100D9C /* MXAnalyticsDestinationUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED6E87A8294B3BAB00100D9C /* MXAnalyticsDestinationUnitTests.swift */; };
 		ED7019DD2886C24100FC31B9 /* MXCrossSigningInfoSourceUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED8F1D242885A39800F897E7 /* MXCrossSigningInfoSourceUnitTests.swift */; };
 		ED7019DE2886C24A00FC31B9 /* MXTrustLevelSourceUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED8F1D2F2885AB0300F897E7 /* MXTrustLevelSourceUnitTests.swift */; };
 		ED7019DF2886C25600FC31B9 /* MXDeviceInfoUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED8F1D1B2885909E00F897E7 /* MXDeviceInfoUnitTests.swift */; };
@@ -3077,6 +3079,7 @@
 		ED6DAC1A28C79AA300ECDCB6 /* MXUnrequestedForwardedRoomKeyManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXUnrequestedForwardedRoomKeyManager.swift; sourceTree = "<group>"; };
 		ED6DAC1D28C79D2000ECDCB6 /* MXUnrequestedForwardedRoomKeyManagerUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXUnrequestedForwardedRoomKeyManagerUnitTests.swift; sourceTree = "<group>"; };
 		ED6DAC2028C7A4F000ECDCB6 /* MXDateProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXDateProvider.swift; sourceTree = "<group>"; };
+		ED6E87A8294B3BAB00100D9C /* MXAnalyticsDestinationUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXAnalyticsDestinationUnitTests.swift; sourceTree = "<group>"; };
 		ED7019E42886C32900FC31B9 /* MXSASTransactionV2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXSASTransactionV2.swift; sourceTree = "<group>"; };
 		ED7019E72886C33100FC31B9 /* MXKeyVerificationRequestV2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXKeyVerificationRequestV2.swift; sourceTree = "<group>"; };
 		ED7019EA2886C33A00FC31B9 /* MXKeyVerificationManagerV2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXKeyVerificationManagerV2.swift; sourceTree = "<group>"; };
@@ -3434,6 +3437,7 @@
 		322985C526FA66FD001890BC /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				ED6E87A7294B3B9900100D9C /* Logs */,
 				322985CA26FAF898001890BC /* MXSession.swift */,
 				322985CE26FBAE7B001890BC /* TestObserver.swift */,
 				322985D126FC9E61001890BC /* MXSessionTracker.swift */,
@@ -5508,6 +5512,14 @@
 			path = Store;
 			sourceTree = "<group>";
 		};
+		ED6E87A7294B3B9900100D9C /* Logs */ = {
+			isa = PBXGroup;
+			children = (
+				ED6E87A8294B3BAB00100D9C /* MXAnalyticsDestinationUnitTests.swift */,
+			);
+			path = Logs;
+			sourceTree = "<group>";
+		};
 		ED7019ED2886CA6C00FC31B9 /* Verification */ = {
 			isa = PBXGroup;
 			children = (
@@ -7238,6 +7250,7 @@
 				B146D4FF21A5C0BD00D8C2C6 /* MXMediaScanStoreUnitTests.m in Sources */,
 				32BD34BE1E84134A006EDC0D /* MatrixSDKTestsE2EData.m in Sources */,
 				ED751DAE28EDEC7E003748C3 /* MXKeyVerificationStateResolverUnitTests.swift in Sources */,
+				ED6E87A9294B3BAB00100D9C /* MXAnalyticsDestinationUnitTests.swift in Sources */,
 				B146D4FE21A5C0BD00D8C2C6 /* MXEventScanStoreUnitTests.m in Sources */,
 				EDF1B6932876CD8600BBBCEE /* MXTaskQueueUnitTests.swift in Sources */,
 				32684CB821085F770046D2F9 /* MXLazyLoadingTests.m in Sources */,
@@ -7885,6 +7898,7 @@
 				B1E09A242397FCE90057C069 /* MXPeekingRoomTests.m in Sources */,
 				B1E09A452397FD990057C069 /* MXLazyLoadingTests.m in Sources */,
 				ED751DAF28EDEC7E003748C3 /* MXKeyVerificationStateResolverUnitTests.swift in Sources */,
+				ED6E87AA294B3BAB00100D9C /* MXAnalyticsDestinationUnitTests.swift in Sources */,
 				B1E09A1C2397FCE90057C069 /* MXEventAnnotationUnitTests.swift in Sources */,
 				B1E09A262397FCE90057C069 /* MXPushRuleUnitTests.m in Sources */,
 				EDF1B6942876CD8600BBBCEE /* MXTaskQueueUnitTests.swift in Sources */,

--- a/MatrixSDK/Utils/Logs/MXLog.swift
+++ b/MatrixSDK/Utils/Logs/MXLog.swift
@@ -215,8 +215,11 @@ private var logger: SwiftyBeaver.Type = {
         }
         logger.addDestination(consoleDestination)
         
+        #if !DEBUG
+        // Non-debug builds will log fatal issues to analytics if tracking consent provided
         let analytics = MXAnalyticsDestination()
         logger.addDestination(analytics)
+        #endif
     }
 }
 

--- a/MatrixSDKTests/TestPlans/UnitTests.xctestplan
+++ b/MatrixSDKTests/TestPlans/UnitTests.xctestplan
@@ -32,6 +32,7 @@
         "MXAesUnitTests",
         "MXAggregatedEditsUnitTests",
         "MXAggregatedReferenceUnitTests",
+        "MXAnalyticsDestinationUnitTests",
         "MXAsyncTaskQueueUnitTests",
         "MXAuthenticationSessionUnitTests",
         "MXBackgroundTaskUnitTests",

--- a/MatrixSDKTests/TestPlans/UnitTestsWithSanitizers.xctestplan
+++ b/MatrixSDKTests/TestPlans/UnitTestsWithSanitizers.xctestplan
@@ -42,6 +42,7 @@
         "MXAesUnitTests",
         "MXAggregatedEditsUnitTests",
         "MXAggregatedReferenceUnitTests",
+        "MXAnalyticsDestinationUnitTests",
         "MXAsyncTaskQueueUnitTests",
         "MXAuthenticationSessionUnitTests",
         "MXBackgroundTaskUnitTests",

--- a/MatrixSDKTests/Utils/Logs/MXAnalyticsDestinationUnitTests.swift
+++ b/MatrixSDKTests/Utils/Logs/MXAnalyticsDestinationUnitTests.swift
@@ -1,0 +1,123 @@
+// 
+// Copyright 2022 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+@testable import MatrixSDK
+
+class MXAnalyticsDestinationUnitTests: XCTestCase {
+    enum Error: Swift.Error {
+        case sampleError
+    }
+    
+    class DelegateSpy: NSObject, MXAnalyticsDelegate {
+        func trackDuration(_ milliseconds: Int, name: MXTaskProfileName, units: UInt) {
+        }
+        
+        func startDurationTracking(forName name: String, operation: String) -> StopDurationTracking {
+            {}
+        }
+        
+        func trackCallStarted(withVideo isVideo: Bool, numberOfParticipants: Int, incoming isIncoming: Bool) {
+        }
+        
+        func trackCallEnded(withDuration duration: Int, video isVideo: Bool, numberOfParticipants: Int, incoming isIncoming: Bool) {
+        }
+        
+        func trackCallError(with reason: __MXCallHangupReason, video isVideo: Bool, numberOfParticipants: Int, incoming isIncoming: Bool) {
+        }
+        
+        func trackCreatedRoom(asDM isDM: Bool) {
+        }
+        
+        func trackJoinedRoom(asDM isDM: Bool, isSpace: Bool, memberCount: UInt) {
+        }
+        
+        func trackContactsAccessGranted(_ granted: Bool) {
+        }
+        
+        func trackComposerEvent(inThread: Bool, isEditing: Bool, isReply: Bool, startsThread: Bool) {
+        }
+        
+        var spyIssue: String?
+        var spyDetails: [String: Any]?
+        func trackNonFatalIssue(_ issue: String, details: [String: Any]?) {
+            spyIssue = issue
+            spyDetails = details
+        }
+    }
+    
+    var delegate: DelegateSpy!
+    var destination: MXAnalyticsDestination!
+    
+    override func setUp() {
+        delegate = DelegateSpy()
+        MXSDKOptions.sharedInstance().analyticsDelegate = delegate
+        destination = MXAnalyticsDestination()
+    }
+    
+    func track(msg: String, context: Any? = nil) {
+        _ = destination.send(.error, msg: msg, thread: "", file: "", function: "", line: 0, context: context)
+    }
+    
+    func test_tracksNoContext() {
+        track(msg: "Sample", context: nil)
+        
+        XCTAssertEqual(delegate.spyIssue, "Sample")
+        XCTAssertNil(delegate.spyDetails)
+    }
+    
+    func test_tracksDictionaryContext() {
+        track(msg: "ABC", context: [
+            "A": 1,
+            "B": 2
+        ])
+        
+        XCTAssertEqual(delegate.spyIssue, "ABC")
+        XCTAssertEqual(delegate.spyDetails as? NSDictionary, ["A": 1, "B": 2])
+    }
+    
+    func test_tracksErrorContext() {
+        track(msg: "ABC", context: Error.sampleError)
+        
+        XCTAssertEqual(delegate.spyIssue, "ABC")
+        XCTAssertEqual(delegate.spyDetails as? NSDictionary, ["error": Error.sampleError])
+    }
+    
+    func test_tracksNSErrorContext() {
+        let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorUnknown)
+        
+        track(msg: "ABC", context: error)
+        
+        XCTAssertEqual(delegate.spyIssue, "ABC")
+        XCTAssertEqual(delegate.spyDetails as? NSDictionary, ["error": error])
+    }
+    
+    func test_doesNotTrackCancellationError() {
+        let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled)
+        
+        track(msg: "XYZ", context: error)
+        
+        XCTAssertNil(delegate.spyIssue)
+        XCTAssertNil(delegate.spyDetails)
+    }
+    
+    func test_tracksOtherContext() {
+        track(msg: "XYZ", context: 1)
+        
+        XCTAssertEqual(delegate.spyIssue, "XYZ")
+        XCTAssertEqual(delegate.spyDetails as? NSDictionary, ["context": "1"])
+    }
+}

--- a/changelog.d/pr-1664.change
+++ b/changelog.d/pr-1664.change
@@ -1,0 +1,1 @@
+Analytics: Do not track cancellation errors


### PR DESCRIPTION
We log errors in a lot of places across the codebase via `MXLog.error(... error)` passing in any error that was returned from some api, incl rest clients that may return cancellation errors. These are not userful to track in analytics as they occur due to some user action. Instead of filtering them out in the many many places where we log errors, we will filter them out all at once in `MXAnalyticsDestination`