### PR TITLE
Render m.poll.end event (PSG-196)

### DIFF
--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -2192,6 +2192,17 @@ NSInteger const kMXRoomInvalidInviteSenderErrorCode = 9002;
         
         senderMessageBody = question;
     }
+    if (eventToReply.eventType == MXEventTypePollEnd)
+    {
+        MXEvent* pollStartEvent = [mxSession.store eventWithEventId:eventToReply.relatesTo.eventId inRoom:self.roomId];
+        
+        if (pollStartEvent) {
+            NSString *question = [MXEventContentPollStart modelFromJSON:pollStartEvent.content].question;
+            senderMessageBody = question;
+        } else { // we need a fallback to avoid crashes. Now is the m.poll.start event id
+            senderMessageBody = eventToReply.relatesTo.eventId;
+        }
+    }
     else if (eventToReply.eventType == MXEventTypeBeaconInfo)
     {
         senderMessageBody = stringLocalizer.senderSentTheirLiveLocation;

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -2442,6 +2442,11 @@ NSInteger const kMXRoomInvalidInviteSenderErrorCode = 9002;
         return YES;
     }
     
+    if(eventToReply.eventType == MXEventTypePollEnd)
+    {
+        return YES;
+    }
+    
     if(eventToReply.eventType == MXEventTypeBeaconInfo)
     {
         return YES;

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -2199,7 +2199,8 @@ NSInteger const kMXRoomInvalidInviteSenderErrorCode = 9002;
         if (pollStartEvent) {
             NSString *question = [MXEventContentPollStart modelFromJSON:pollStartEvent.content].question;
             senderMessageBody = question;
-        } else { // we need a fallback to avoid crashes. Now is the m.poll.start event id
+        } else {
+            // we need a fallback to avoid crashes since the m.poll.start event may be missing.
             senderMessageBody = eventToReply.relatesTo.eventId;
         }
     }

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -2449,17 +2449,17 @@ NSInteger const kMXRoomInvalidInviteSenderErrorCode = 9002;
 
 - (BOOL)canReplyToEvent:(MXEvent *)eventToReply
 {
-    if(eventToReply.eventType == MXEventTypePollStart)
+    if (eventToReply.eventType == MXEventTypePollStart)
     {
         return YES;
     }
     
-    if(eventToReply.eventType == MXEventTypePollEnd)
+    if (eventToReply.eventType == MXEventTypePollEnd)
     {
         return YES;
     }
     
-    if(eventToReply.eventType == MXEventTypeBeaconInfo)
+    if (eventToReply.eventType == MXEventTypeBeaconInfo)
     {
         return YES;
     }

--- a/MatrixSDK/Room/Polls/PollAggregator.swift
+++ b/MatrixSDK/Room/Polls/PollAggregator.swift
@@ -71,6 +71,25 @@ public class PollAggregator {
         }
     }
     
+    public convenience init(session: MXSession, room: MXRoom, pollEvent: MXEvent) throws {
+        var pollStartEventId: String?
+        
+        switch pollEvent.eventType {
+        case .pollStart:
+            pollStartEventId = pollEvent.eventId
+        case .pollEnd:
+            pollStartEventId = pollEvent.relatesTo.eventId
+        default:
+            pollStartEventId = nil
+        }
+        
+        guard let pollStartEventId = pollStartEventId else {
+            throw PollAggregatorError.invalidPollStartEvent
+        }
+        
+        try self.init(session: session, room: room, pollStartEventId: pollStartEventId)
+    }
+    
     public init(session: MXSession, room: MXRoom, pollStartEventId: String) throws {
         self.session = session
         self.room = room

--- a/changelog.d/pr-1674.change
+++ b/changelog.d/pr-1674.change
@@ -1,0 +1,1 @@
+Polls: add support for rendering/replying to poll ended events.


### PR DESCRIPTION
This PR:
- Adds a new init for the `PollAggregator` so that it will be able to aggregate a poll starting from a `m.poll.end` event
- Enable replies for a `m.poll.end` event