### PR TITLE
Add keys query scheduler

### DIFF
--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -1995,6 +1995,10 @@
 		EDBCF33A281A8D3D00ED5044 /* MXSharedHistoryKeyService.m in Sources */ = {isa = PBXBuildFile; fileRef = EDBCF338281A8D3D00ED5044 /* MXSharedHistoryKeyService.m */; };
 		EDC2A0E628369E740039F3D6 /* CryptoTests.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = EDC2A0E528369E740039F3D6 /* CryptoTests.xctestplan */; };
 		EDC2A0E728369E740039F3D6 /* CryptoTests.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = EDC2A0E528369E740039F3D6 /* CryptoTests.xctestplan */; };
+		EDC8C4082968A993003792C5 /* MXKeysQueryScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC8C4072968A993003792C5 /* MXKeysQueryScheduler.swift */; };
+		EDC8C4092968A993003792C5 /* MXKeysQueryScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC8C4072968A993003792C5 /* MXKeysQueryScheduler.swift */; };
+		EDC8C40D2968C37E003792C5 /* MXKeysQuerySchedulerUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC8C40A2968A9F7003792C5 /* MXKeysQuerySchedulerUnitTests.swift */; };
+		EDC8C40E2968C37F003792C5 /* MXKeysQuerySchedulerUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC8C40A2968A9F7003792C5 /* MXKeysQuerySchedulerUnitTests.swift */; };
 		EDCB65E22912AB0C00F55D4D /* MXRoomEventDecryption.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDCB65E12912AB0C00F55D4D /* MXRoomEventDecryption.swift */; };
 		EDCB65E32912AB0C00F55D4D /* MXRoomEventDecryption.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDCB65E12912AB0C00F55D4D /* MXRoomEventDecryption.swift */; };
 		EDD4197E28DCAA5F007F3757 /* MXNativeKeyBackupEngine.h in Headers */ = {isa = PBXBuildFile; fileRef = EDD4197D28DCAA5F007F3757 /* MXNativeKeyBackupEngine.h */; };
@@ -3120,6 +3124,8 @@
 		EDBCF335281A8AB900ED5044 /* MXSharedHistoryKeyService.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXSharedHistoryKeyService.h; sourceTree = "<group>"; };
 		EDBCF338281A8D3D00ED5044 /* MXSharedHistoryKeyService.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXSharedHistoryKeyService.m; sourceTree = "<group>"; };
 		EDC2A0E528369E740039F3D6 /* CryptoTests.xctestplan */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CryptoTests.xctestplan; sourceTree = "<group>"; };
+		EDC8C4072968A993003792C5 /* MXKeysQueryScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXKeysQueryScheduler.swift; sourceTree = "<group>"; };
+		EDC8C40A2968A9F7003792C5 /* MXKeysQuerySchedulerUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXKeysQuerySchedulerUnitTests.swift; sourceTree = "<group>"; };
 		EDCB65E12912AB0C00F55D4D /* MXRoomEventDecryption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXRoomEventDecryption.swift; sourceTree = "<group>"; };
 		EDD4197D28DCAA5F007F3757 /* MXNativeKeyBackupEngine.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXNativeKeyBackupEngine.h; sourceTree = "<group>"; };
 		EDD4198028DCAA7B007F3757 /* MXNativeKeyBackupEngine.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXNativeKeyBackupEngine.m; sourceTree = "<group>"; };
@@ -5395,6 +5401,7 @@
 				ED8F1D3A2885BB2D00F897E7 /* MXCryptoProtocols.swift */,
 				ED2DD112286C450600F06731 /* MXEventDecryptionResult+DecryptedEvent.swift */,
 				ED2DD113286C450600F06731 /* MXCryptoRequests.swift */,
+				EDC8C4072968A993003792C5 /* MXKeysQueryScheduler.swift */,
 			);
 			path = CryptoMachine;
 			sourceTree = "<group>";
@@ -5407,6 +5414,7 @@
 				ED2DD11B286C4F3E00F06731 /* MXCryptoRequestsUnitTests.swift */,
 				ED8F1D312885AC5700F897E7 /* Device+Stub.swift */,
 				ED1FE90A2912E13A0046F722 /* DecryptedEvent+Stub.swift */,
+				EDC8C40A2968A9F7003792C5 /* MXKeysQuerySchedulerUnitTests.swift */,
 			);
 			path = CryptoMachine;
 			sourceTree = "<group>";
@@ -7001,6 +7009,7 @@
 				ECD2897D26E8F06F00F268CF /* MXStoreRoomListDataFetcher.swift in Sources */,
 				32D2CC0323422462002BD8CA /* MX3PidAddSession.m in Sources */,
 				3283F7791EAF30F700C1688C /* MXBugReportRestClient.m in Sources */,
+				EDC8C4082968A993003792C5 /* MXKeysQueryScheduler.swift in Sources */,
 				32B0E33B23A2989A0054FF1A /* MXEventReferenceChunk.m in Sources */,
 				A780625027B2CE74005780C0 /* FileManager+AppGroupContainer.swift in Sources */,
 				9274AFE91EE580240009BEB6 /* MXCallKitAdapter.m in Sources */,
@@ -7253,6 +7262,7 @@
 				322A51D81D9E846800C8536D /* MXCryptoTests.m in Sources */,
 				B146D4FF21A5C0BD00D8C2C6 /* MXMediaScanStoreUnitTests.m in Sources */,
 				32BD34BE1E84134A006EDC0D /* MatrixSDKTestsE2EData.m in Sources */,
+				EDC8C40E2968C37F003792C5 /* MXKeysQuerySchedulerUnitTests.swift in Sources */,
 				ED751DAE28EDEC7E003748C3 /* MXKeyVerificationStateResolverUnitTests.swift in Sources */,
 				ED6E87A9294B3BAB00100D9C /* MXAnalyticsDestinationUnitTests.swift in Sources */,
 				B146D4FE21A5C0BD00D8C2C6 /* MXEventScanStoreUnitTests.m in Sources */,
@@ -7650,6 +7660,7 @@
 				EC1165B727107E330089FA56 /* MXStoreRoomListDataCounts.swift in Sources */,
 				B14EF2392397E90400758AF0 /* MXMediaManager.m in Sources */,
 				B14EF23A2397E90400758AF0 /* MXHTTPOperation.m in Sources */,
+				EDC8C4092968A993003792C5 /* MXKeysQueryScheduler.swift in Sources */,
 				A780625127B2CE74005780C0 /* FileManager+AppGroupContainer.swift in Sources */,
 				B14EF23B2397E90400758AF0 /* MXKeyBackupData.m in Sources */,
 				B14EF23C2397E90400758AF0 /* MXJSONModels.m in Sources */,
@@ -7902,6 +7913,7 @@
 				32B090FE26201C8D002924AA /* MXAsyncTaskQueueUnitTests.swift in Sources */,
 				B1E09A242397FCE90057C069 /* MXPeekingRoomTests.m in Sources */,
 				B1E09A452397FD990057C069 /* MXLazyLoadingTests.m in Sources */,
+				EDC8C40D2968C37E003792C5 /* MXKeysQuerySchedulerUnitTests.swift in Sources */,
 				ED751DAF28EDEC7E003748C3 /* MXKeyVerificationStateResolverUnitTests.swift in Sources */,
 				ED6E87AA294B3BAB00100D9C /* MXAnalyticsDestinationUnitTests.swift in Sources */,
 				B1E09A1C2397FCE90057C069 /* MXEventAnnotationUnitTests.swift in Sources */,

--- a/MatrixSDK/Crypto/CrossSigning/MXCrossSigningV2.swift
+++ b/MatrixSDK/Crypto/CrossSigning/MXCrossSigningV2.swift
@@ -121,7 +121,7 @@ class MXCrossSigningV2: NSObject, MXCrossSigning {
         
         Task {
             do {
-                try await crossSigning.downloadKeys(users: [crossSigning.userId])
+                try await crossSigning.refreshCrossSigningStatus()
                 myUserCrossSigningKeys = infoSource.crossSigningInfo(userId: crossSigning.userId)
                 
                 log.debug("Cross signing state refreshed")

--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoMachine.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoMachine.swift
@@ -58,6 +58,7 @@ class MXCryptoMachine {
     
     private let machine: OlmMachine
     private let requests: MXCryptoRequests
+    private let queryScheduler: MXKeysQueryScheduler<MXKeysQueryResponse>
     private let getRoomAction: GetRoomAction
     
     private let sessionsQueue = MXTaskQueue()
@@ -72,7 +73,12 @@ class MXCryptoMachine {
     
     private let log = MXNamedLog(name: "MXCryptoMachine")
 
-    init(userId: String, deviceId: String, restClient: MXRestClient, getRoomAction: @escaping GetRoomAction) throws {
+    init(
+        userId: String,
+        deviceId: String,
+        restClient: MXRestClient,
+        getRoomAction: @escaping GetRoomAction
+    ) throws {
         let url = try Self.storeURL(for: userId)
         machine = try OlmMachine(
             userId: userId,
@@ -80,7 +86,12 @@ class MXCryptoMachine {
             path: url.path,
             passphrase: nil
         )
-        requests = MXCryptoRequests(restClient: restClient)
+        let requests = MXCryptoRequests(restClient: restClient)
+        self.requests = requests
+        
+        queryScheduler = MXKeysQueryScheduler { users in
+            try await requests.queryKeys(users: users)
+        }
         self.getRoomAction = getRoomAction
         
         setLogger(logger: self)
@@ -211,6 +222,31 @@ extension MXCryptoMachine: MXCryptoSyncing {
         return toDevice
     }
     
+    func downloadKeysIfNecessary(users: [String]) async throws {
+        machine.updateTrackedUsers(users: users)
+        try await withThrowingTaskGroup(of: Void.self) { [weak self] group in
+            guard let self = self else { return }
+
+            for request in try machine.outgoingRequests() {
+                if case .keysQuery(_, let requestUsers) = request {
+                    let usersInCommon = Set(requestUsers).intersection(users)
+                    if !usersInCommon.isEmpty {
+                        try await self.handleRequest(request)
+                        return
+                    }
+                }
+            }
+        }
+    }
+    
+    @available(*, deprecated, message: "The application should not manually force reload keys, use `downloadKeysIfNecessary` instead")
+    func reloadKeys(users: [String]) async throws {
+        machine.updateTrackedUsers(users: users)
+        try await handleRequest(
+            .keysQuery(requestId: UUID().uuidString, users: users)
+        )
+    }
+    
     func processOutgoingRequests() async throws {
         try await syncQueue.sync { [weak self] in
             try await self?.handleOutgoingRequests()
@@ -234,7 +270,8 @@ extension MXCryptoMachine: MXCryptoSyncing {
             try markRequestAsSent(requestId: requestId, requestType: .keysUpload, response: response.jsonString())
             
         case .keysQuery(let requestId, let users):
-            let response = try await requests.queryKeys(users: users)
+            // Key queries go through a scheduler layer instead of directly through the rest client
+            let response = try await queryScheduler.query(users: Set(users))
             try markRequestAsSent(requestId: requestId, requestType: .keysQuery, response: response.jsonString())
             
         case .keysClaim(let requestId, let oneTimeKeys):
@@ -341,21 +378,6 @@ extension MXCryptoMachine: MXCryptoUserIdentitySource {
         }
     }
     
-    func isUserTracked(userId: String) -> Bool {
-        do {
-            return try machine.isUserTracked(userId: userId)
-        } catch {
-            log.error("Failed checking user tracking")
-            return false
-        }
-    }
-    
-    func downloadKeys(users: [String]) async throws {
-        try await handleRequest(
-            .keysQuery(requestId: UUID().uuidString, users: users)
-        )
-    }
-    
     func verifyUser(userId: String) async throws {
         let request = try machine.verifyIdentity(userId: userId)
         try await requests.uploadSignatures(request: request)
@@ -378,7 +400,7 @@ extension MXCryptoMachine: MXCryptoRoomEventEncrypting {
         settings: EncryptionSettings
     ) async throws {
         try await sessionsQueue.sync { [weak self] in
-            try await self?.updateTrackedUsers(users: users)
+            try await self?.downloadKeysIfNecessary(users: users)
             try await self?.getMissingSessions(users: users)
         }
         
@@ -410,25 +432,6 @@ extension MXCryptoMachine: MXCryptoRoomEventEncrypting {
     }
     
     // MARK: - Private
-    
-    private func updateTrackedUsers(users: [String]) async throws {
-        machine.updateTrackedUsers(users: users)
-        try await withThrowingTaskGroup(of: Void.self) { [weak self] group in
-            guard let self = self else { return }
-
-            for request in try machine.outgoingRequests() {
-                guard case .keysQuery = request else {
-                    continue
-                }
-
-                group.addTask {
-                    try await self.handleRequest(request)
-                }
-            }
-
-            try await group.waitForAll()
-        }
-    }
     
     private func getMissingSessions(users: [String]) async throws {
         guard
@@ -484,6 +487,10 @@ extension MXCryptoMachine: MXCryptoRoomEventDecrypting {
 }
 
 extension MXCryptoMachine: MXCryptoCrossSigning {
+    func refreshCrossSigningStatus() async throws {
+        try await reloadKeys(users: [userId])
+    }
+    
     func crossSigningStatus() -> CrossSigningStatus {
         return machine.crossSigningStatus()
     }

--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoProtocols.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoProtocols.swift
@@ -40,6 +40,11 @@ protocol MXCryptoSyncing: MXCryptoIdentity {
     ) throws -> MXToDeviceSyncResponse
     
     func processOutgoingRequests() async throws
+    
+    func downloadKeysIfNecessary(users: [String]) async throws
+    
+    @available(*, deprecated, message: "The application should not manually force reload keys, use `downloadKeysIfNecessary` instead")
+    func reloadKeys(users: [String]) async throws
 }
 
 /// Source of user devices and their cryptographic trust status
@@ -52,8 +57,6 @@ protocol MXCryptoDevicesSource: MXCryptoIdentity {
 protocol MXCryptoUserIdentitySource: MXCryptoIdentity {
     func userIdentity(userId: String) -> UserIdentity?
     func isUserVerified(userId: String) -> Bool
-    func isUserTracked(userId: String) -> Bool
-    func downloadKeys(users: [String]) async throws
     func verifyUser(userId: String) async throws
     func verifyDevice(userId: String, deviceId: String) async throws
     func setLocalTrust(userId: String, deviceId: String, trust: LocalTrust) throws
@@ -74,6 +77,7 @@ protocol MXCryptoRoomEventDecrypting: MXCryptoIdentity {
 
 /// Cross-signing functionality
 protocol MXCryptoCrossSigning: MXCryptoUserIdentitySource {
+    func refreshCrossSigningStatus() async throws
     func crossSigningStatus() -> CrossSigningStatus
     func bootstrapCrossSigning(authParams: [AnyHashable: Any]) async throws
     func exportCrossSigningKeys() -> CrossSigningKeyExport?

--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoRequests.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoRequests.swift
@@ -86,8 +86,15 @@ struct MXCryptoRequests {
     }
     
     func queryKeys(users: [String]) async throws -> MXKeysQueryResponse {
-        return try await performCallbackRequest {
-            restClient.downloadKeys(forUsers: users, completion: $0)
+        return try await performCallbackRequest { completion in
+            _ = restClient.downloadKeysByChunk(
+                forUsers: users,
+                token: nil,
+                success: {
+                    completion(.success($0))
+                }, failure: {
+                    completion(.failure($0 ?? Error.unknownError))
+                })
         }
     }
     

--- a/MatrixSDK/Crypto/CryptoMachine/MXKeysQueryScheduler.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXKeysQueryScheduler.swift
@@ -47,7 +47,7 @@ public actor MXKeysQueryScheduler<Response> {
     /// If there is no ongoing query, it will be executed right away,
     /// otherwise it will be scheduled for the next available run.
     public func query(users: Set<String>) async throws -> Response {
-        log("Querying \(users.count) user(s) ...")
+        log("Querying \(users.count) user(s): \(users) ...")
         
         let task = currentOrNextQuery(users: users)
         return try await task.value

--- a/MatrixSDK/Crypto/CryptoMachine/MXKeysQueryScheduler.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXKeysQueryScheduler.swift
@@ -1,0 +1,112 @@
+// 
+// Copyright 2023 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+/// A schedule of `keys/query` requests that will ensure only one request
+/// is in-flight at any given point in time, and all future queries aggregate
+/// requested user ids into a single query.
+public actor MXKeysQueryScheduler<Response> {
+    typealias QueryAction = ([String]) async throws -> Response
+    
+    struct Query {
+        let users: Set<String>
+        let task: Task<Response, Error>
+        
+        func contains(users: Set<String>) -> Bool {
+            users.subtracting(self.users).isEmpty
+        }
+    }
+    
+    private let queryAction: QueryAction
+    private var nextUsers: Set<String>
+    
+    private var currentQuery: Query?
+    private var nextTask: Task<Response, Error>?
+
+    init(queryAction: @escaping QueryAction) {
+        self.queryAction = queryAction
+        self.nextUsers = []
+    }
+
+    /// Query a list of user ids
+    ///
+    /// If there is no ongoing query, it will be executed right away,
+    /// otherwise it will be scheduled for the next available run.
+    public func query(users: Set<String>) async throws -> Response {
+        log("Querying \(users.count) user(s) ...")
+        
+        let task = currentOrNextQuery(users: users)
+        return try await task.value
+    }
+
+    private func currentOrNextQuery(users: Set<String>) -> Task<Response, Error> {
+        if let currentQuery = currentQuery {
+            if currentQuery.contains(users: users) {
+                log("... query already running")
+                
+                return currentQuery.task
+                
+            } else {
+                log("... queueing users for the next query")
+                
+                nextUsers = nextUsers.union(users)
+
+                let task = nextTask ?? Task {
+                    // Next task needs to await to completion of the currently running task
+                    let _ = await currentQuery.task.result
+
+                    // Extract and reset next users
+                    let users = nextUsers
+                    nextUsers = []
+
+                    // Only then we can execute the actual work
+                    return try await executeQuery(users: users)
+                }
+                nextTask = task
+                return task
+            }
+
+        } else {
+            log("... query starting")
+            
+            let task = Task {
+                // Since we do not have any task running we can execute work right away
+                try await executeQuery(users: users)
+            }
+            currentQuery = .init(users: users, task: task)
+            return task
+        }
+    }
+
+    private func executeQuery(users: Set<String>) async throws -> Response {
+        defer {
+            if let next = nextTask {
+                log("... query completed, starting next pending query.")
+                currentQuery = .init(users: users, task: next)
+            } else {
+                log("... query completed, no other queries scheduled.")
+                currentQuery = nil
+            }
+            nextTask = nil
+        }
+        return try await queryAction(Array(users))
+    }
+    
+    private func log(_ message: String) {
+        MXLog.debug("[MXKeysQueryScheduler]: \(message)")
+    }
+}

--- a/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoProtocolStubs.swift
+++ b/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoProtocolStubs.swift
@@ -80,6 +80,10 @@ class CryptoCrossSigningStub: CryptoIdentityStub, MXCryptoCrossSigning {
         hasSelfSigning: false,
         hasUserSigning: false
     )
+    
+    func refreshCrossSigningStatus() async throws {
+    }
+    
     func crossSigningStatus() -> CrossSigningStatus {
         return stubbedStatus
     }

--- a/MatrixSDKTests/Crypto/CryptoMachine/MXKeysQuerySchedulerUnitTests.swift
+++ b/MatrixSDKTests/Crypto/CryptoMachine/MXKeysQuerySchedulerUnitTests.swift
@@ -1,0 +1,433 @@
+// 
+// Copyright 2023 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import XCTest
+@testable import MatrixSDK
+
+class MXKeysQuerySchedulerUnitTests: XCTestCase {
+    enum Error: Swift.Error, Equatable {
+        case dummy
+    }
+    
+    typealias UserId = String
+    typealias DeviceId = String
+    typealias Response = [UserId: [DeviceId]]
+    
+    var queryCounter: Int!
+    var queryStartSpy: (() -> Void)?
+    var stubbedResponse: Response!
+    var stubbedResult: Result<Response, Error>!
+    var scheduler: MXKeysQueryScheduler<Response>!
+    
+    override func setUp() {
+        queryCounter = 0
+        stubbedResponse = [
+            "alice": ["A"],
+            "bob": ["B"],
+            "carol": ["C"],
+            "david": ["D"],
+        ]
+        stubbedResult = .success(stubbedResponse)
+        
+        scheduler = MXKeysQueryScheduler(queryAction: queryAction(users:))
+    }
+    
+    private func queryAction(users: [String]) async throws -> Response {
+        queryCounter += 1
+        
+        switch stubbedResult! {
+        case .success(let response):
+            let res = response.filter {
+                users.contains($0.key)
+            }
+            
+            queryStartSpy?()
+            try await Task.sleep(nanoseconds: 1_000_000)
+            
+            return res
+            
+        case .failure(let error):
+            queryStartSpy?()
+            try await Task.sleep(nanoseconds: 1_000_000)
+            throw error
+        }
+    }
+    
+    private func query(
+        users: Set<String>,
+        completion: @escaping (Response) -> Void,
+        failure: ((Swift.Error) -> Void)? = nil
+    ) {
+        Task.detached {
+            do {
+                let result = try await self.scheduler.query(users: users)
+                completion(result)
+            } catch {
+                failure?(error)
+            }
+        }
+    }
+    
+    // MARK: - Tests
+    
+    func test_queryAlice() {
+        let exp = expectation(description: "exp")
+        
+        query(users: ["alice"]) { response in
+            XCTAssertEqual(response, [
+                "alice": ["A"]
+            ])
+            exp.fulfill()
+        }
+
+        waitForExpectations(timeout: 1)
+        XCTAssertQueriesCount(1)
+    }
+    
+    func test_queryAliceAndBob() {
+        let exp = expectation(description: "exp")
+        
+        query(users: ["alice", "bob"]) { response in
+            XCTAssertEqual(response, [
+                "alice": ["A"],
+                "bob": ["B"],
+            ])
+            exp.fulfill()
+        }
+
+        waitForExpectations(timeout: 1)
+        XCTAssertQueriesCount(1)
+    }
+
+    func test_queryBobAfterAlice() {
+        let exp = expectation(description: "exp")
+        exp.expectedFulfillmentCount = 2
+
+        query(users: ["alice"]) { response in
+            XCTAssertEqual(response, [
+                "alice": ["A"],
+            ])
+            exp.fulfill()
+        }
+
+        query(users: ["bob"]) { response in
+            XCTAssertEqual(response, [
+                "bob": ["B"],
+            ])
+            exp.fulfill()
+        }
+
+        waitForExpectations(timeout: 1)
+        XCTAssertQueriesCount(2)
+    }
+
+    func test_executeMultipleAliceQueriesOnce() {
+        queryStartSpy = {
+            self.stubbedResponse = [
+                "alice": ["A1", "A2"]
+            ]
+        }
+
+        let exp = expectation(description: "exp")
+        exp.expectedFulfillmentCount = 3
+
+        query(users: ["alice"]) { response in
+            XCTAssertEqual(response, [
+                "alice": ["A"],
+            ])
+            exp.fulfill()
+        }
+
+        query(users: ["alice"]) { response in
+            XCTAssertEqual(response, [
+                "alice": ["A"],
+            ])
+            exp.fulfill()
+        }
+
+        query(users: ["alice"]) { response in
+            XCTAssertEqual(response, [
+                "alice": ["A"],
+            ])
+            exp.fulfill()
+        }
+
+        waitForExpectations(timeout: 1)
+        
+        // Three queries are made but since they query the same user,
+        // second and third query will simply await the results of
+        // the first query
+        XCTAssertQueriesCount(1)
+    }
+
+    func test_executeEachAliceQuerySeparately() {
+        queryStartSpy = {
+            self.stubbedResponse = [
+                "alice": ["A1", "A2"]
+            ]
+        }
+
+        var exp = expectation(description: "exp")
+        query(users: ["alice"]) { response in
+            XCTAssertEqual(response, [
+                "alice": ["A"],
+            ])
+            exp.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+
+        exp = expectation(description: "exp")
+        query(users: ["alice"]) { response in
+            XCTAssertEqual(response, [
+                "alice": ["A1", "A2"],
+            ])
+            exp.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+
+        exp = expectation(description: "exp")
+        query(users: ["alice"]) { response in
+            XCTAssertEqual(response, [
+                "alice": ["A1", "A2"],
+            ])
+            exp.fulfill()
+        }
+        
+        waitForExpectations(timeout: 1)
+        
+        // Each of the three queries is made when no other query
+        // is ongoing, meaning they will all execute
+        XCTAssertQueriesCount(3)
+    }
+
+    func test_executeMultipleBobQueriesOnce() {
+        queryStartSpy = {
+            self.stubbedResponse = [
+                "bob": ["B1", "B2"]
+            ]
+        }
+
+        let exp = expectation(description: "exp")
+        exp.expectedFulfillmentCount = 2
+
+        query(users: ["alice", "bob"]) { response in
+            XCTAssertEqual(response, [
+                "alice": ["A"],
+                "bob": ["B"],
+            ])
+            exp.fulfill()
+        }
+
+        query(users: ["bob"]) { response in
+            XCTAssertEqual(response, [
+                "alice": ["A"],
+                "bob": ["B"],
+            ])
+            exp.fulfill()
+        }
+
+        waitForExpectations(timeout: 1)
+        
+        // The second query contains a different set of users,
+        // but since there is no user additional to the first
+        // query, we do not need to execute another query
+        XCTAssertQueriesCount(1)
+    }
+
+    func test_executeSecondBobQuerySeparately() {
+        queryStartSpy = {
+            self.stubbedResponse = [
+                "bob": ["B1", "B2"],
+                "carol": ["C"]
+            ]
+        }
+
+        let exp = expectation(description: "exp")
+        exp.expectedFulfillmentCount = 2
+
+        query(users: ["alice", "bob"]) { response in
+            XCTAssertEqual(response, [
+                "alice": ["A"],
+                "bob": ["B"],
+            ])
+            exp.fulfill()
+        }
+
+        query(users: ["bob", "carol"]) { response in
+            XCTAssertEqual(response, [
+                "bob": ["B1", "B2"],
+                "carol": ["C"],
+            ])
+            exp.fulfill()
+        }
+
+        waitForExpectations(timeout: 1)
+
+        // The second query contains one user shared with the first,
+        // but also one new user, meaning the second query cannot be
+        // satisfied by the first one, and a new query has to be made
+        XCTAssertQueriesCount(2)
+    }
+
+    func test_nextQueryAggregatesPendingUsers() {
+        let exp = expectation(description: "exp")
+        exp.expectedFulfillmentCount = 4
+
+        query(users: ["alice"]) { response in
+            XCTAssertEqual(response, [
+                "alice": ["A"],
+            ])
+            exp.fulfill()
+        }
+
+        // Making three future / pending queries has the same outcome
+        // as making a single query with all users aggregated.
+        query(users: ["bob"]) { response in
+            XCTAssertEqual(response, [
+                "bob": ["B"],
+                "carol": ["C"],
+                "david": ["D"],
+            ])
+            exp.fulfill()
+        }
+
+        query(users: ["carol"]) { response in
+            XCTAssertEqual(response, [
+                "bob": ["B"],
+                "carol": ["C"],
+                "david": ["D"],
+            ])
+            exp.fulfill()
+        }
+
+        query(users: ["david"]) { response in
+            XCTAssertEqual(response, [
+                "bob": ["B"],
+                "carol": ["C"],
+                "david": ["D"],
+            ])
+            exp.fulfill()
+        }
+
+        waitForExpectations(timeout: 1)
+        XCTAssertQueriesCount(2)
+    }
+    
+    func test_pendingUsersResetAfterQuery() {
+        var exp = expectation(description: "exp")
+        exp.expectedFulfillmentCount = 3
+
+        query(users: ["alice"]) { response in
+            XCTAssertEqual(response, [
+                "alice": ["A"],
+            ])
+            exp.fulfill()
+        }
+
+        query(users: ["bob"]) { response in
+            XCTAssertEqual(response, [
+                "bob": ["B"],
+                "carol": ["C"],
+            ])
+            exp.fulfill()
+        }
+
+        query(users: ["carol"]) { response in
+            XCTAssertEqual(response, [
+                "bob": ["B"],
+                "carol": ["C"],
+            ])
+            exp.fulfill()
+        }
+
+        waitForExpectations(timeout: 1)
+
+        exp = expectation(description: "exp")
+        exp.expectedFulfillmentCount = 2
+
+        query(users: ["alice"]) { response in
+            XCTAssertEqual(response, [
+                "alice": ["A"],
+            ])
+            exp.fulfill()
+        }
+
+        // Even though we have previously aggregated some users,
+        // once that query completed, all future queries will
+        // start with a clean list again
+        query(users: ["david"]) { response in
+            XCTAssertEqual(response, [
+                "david": ["D"],
+            ])
+            exp.fulfill()
+        }
+
+        waitForExpectations(timeout: 1)
+
+        XCTAssertQueriesCount(4)
+    }
+    
+    func test_queryFail() {
+        scheduler = MXKeysQueryScheduler { _ in
+            try! await Task.sleep(nanoseconds: 1_000_000)
+            throw Error.dummy
+        }
+        
+        let exp = expectation(description: "exp")
+        
+        query(users: ["alice"], completion: { _ in
+            XCTFail("Should not succeed")
+        }, failure: { error in
+            XCTAssertEqual(error as? Error, Error.dummy)
+            exp.fulfill()
+        })
+        
+        waitForExpectations(timeout: 1)
+    }
+    
+    func test_queryBobAfterFail() {
+        stubbedResult = .failure(Error.dummy)
+        queryStartSpy = {
+            self.stubbedResult = .success(self.stubbedResponse)
+        }
+        
+        let exp = expectation(description: "exp")
+        exp.expectedFulfillmentCount = 2
+        
+        query(users: ["alice"], completion: { _ in
+            XCTFail("Should not succeed")
+        }, failure: { error in
+            XCTAssertEqual(error as? Error, Error.dummy)
+            exp.fulfill()
+        })
+
+        query(users: ["bob"]) { response in
+            XCTAssertEqual(response, [
+                "bob": ["B"]
+            ])
+            exp.fulfill()
+        }
+        
+        waitForExpectations(timeout: 1)
+    }
+    
+    // MARK: - Helpers
+    
+    private func XCTAssertQueriesCount(_ count: Int, file: StaticString = #file, line: UInt = #line) {
+        XCTAssertEqual(count, queryCounter, file: file, line: line)
+    }
+}

--- a/MatrixSDKTests/Crypto/CryptoMachine/MXKeysQuerySchedulerUnitTests.swift
+++ b/MatrixSDKTests/Crypto/CryptoMachine/MXKeysQuerySchedulerUnitTests.swift
@@ -29,19 +29,19 @@ class MXKeysQuerySchedulerUnitTests: XCTestCase {
     
     var queryCounter: Int!
     var queryStartSpy: (() -> Void)?
-    var stubbedResponse: Response!
     var stubbedResult: Result<Response, Error>!
     var scheduler: MXKeysQueryScheduler<Response>!
     
     override func setUp() {
         queryCounter = 0
-        stubbedResponse = [
-            "alice": ["A"],
-            "bob": ["B"],
-            "carol": ["C"],
-            "david": ["D"],
-        ]
-        stubbedResult = .success(stubbedResponse)
+        stubbedResult = .success(
+            [
+                "alice": ["A"],
+                "bob": ["B"],
+                "carol": ["C"],
+                "david": ["D"],
+            ]
+        )
         
         scheduler = MXKeysQueryScheduler(queryAction: queryAction(users:))
     }
@@ -137,9 +137,9 @@ class MXKeysQuerySchedulerUnitTests: XCTestCase {
 
     func test_executeMultipleAliceQueriesOnce() {
         queryStartSpy = {
-            self.stubbedResponse = [
+            self.stubbedResult = .success([
                 "alice": ["A1", "A2"]
-            ]
+            ])
         }
 
         let exp = expectation(description: "exp")
@@ -176,9 +176,9 @@ class MXKeysQuerySchedulerUnitTests: XCTestCase {
 
     func test_executeEachAliceQuerySeparately() {
         queryStartSpy = {
-            self.stubbedResponse = [
+            self.stubbedResult = .success([
                 "alice": ["A1", "A2"]
-            ]
+            ])
         }
 
         var exp = expectation(description: "exp")
@@ -216,9 +216,9 @@ class MXKeysQuerySchedulerUnitTests: XCTestCase {
 
     func test_executeMultipleBobQueriesOnce() {
         queryStartSpy = {
-            self.stubbedResponse = [
+            self.stubbedResult = .success([
                 "bob": ["B1", "B2"]
-            ]
+            ])
         }
 
         let exp = expectation(description: "exp")
@@ -250,10 +250,10 @@ class MXKeysQuerySchedulerUnitTests: XCTestCase {
 
     func test_executeSecondBobQuerySeparately() {
         queryStartSpy = {
-            self.stubbedResponse = [
+            self.stubbedResult = .success([
                 "bob": ["B1", "B2"],
                 "carol": ["C"]
-            ]
+            ])
         }
 
         let exp = expectation(description: "exp")
@@ -402,7 +402,9 @@ class MXKeysQuerySchedulerUnitTests: XCTestCase {
     func test_queryBobAfterFail() {
         stubbedResult = .failure(Error.dummy)
         queryStartSpy = {
-            self.stubbedResult = .success(self.stubbedResponse)
+            self.stubbedResult = .success([
+                "bob": ["B"],
+            ])
         }
         
         let exp = expectation(description: "exp")

--- a/MatrixSDKTests/TestPlans/UnitTests.xctestplan
+++ b/MatrixSDKTests/TestPlans/UnitTests.xctestplan
@@ -65,6 +65,7 @@
         "MXKeyVerificationManagerV2UnitTests",
         "MXKeyVerificationRequestV2UnitTests",
         "MXKeyVerificationStateResolverUnitTests",
+        "MXKeysQuerySchedulerUnitTests",
         "MXMediaScanStoreUnitTests",
         "MXMegolmDecryptionUnitTests",
         "MXMegolmExportEncryptionUnitTests",

--- a/MatrixSDKTests/TestPlans/UnitTestsWithSanitizers.xctestplan
+++ b/MatrixSDKTests/TestPlans/UnitTestsWithSanitizers.xctestplan
@@ -73,6 +73,7 @@
         "MXKeyVerificationManagerV2UnitTests",
         "MXKeyVerificationRequestV2UnitTests",
         "MXKeyVerificationStateResolverUnitTests",
+        "MXKeysQuerySchedulerUnitTests",
         "MXMediaScanStoreUnitTests",
         "MXMegolmDecryptionUnitTests",
         "MXMegolmExportEncryptionUnitTests",

--- a/changelog.d/pr-1676.change
+++ b/changelog.d/pr-1676.change
@@ -1,0 +1,1 @@
+CryptoV2: Add keys query scheduler


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-ios-sdk/issues/1668 and partially resolves https://github.com/matrix-org/matrix-ios-sdk/issues/1670

Add `MXKeysQueryScheduler` used with crypto V2, which serves similar purpose as `MXDeviceList` serves in legacy crypto, albeit only focusing on optimizing `keys/query` requests.

Specifically it will:
- ensure that only one keys/query request is in-flight at any given time
- all further requests are aggregated, and if they contain any new users, will be executed right after the first one finishes

These optimizations should ensure that the application does not make unnecessary amout of queries, as we currently call the `downloadKeys` from far too many places. Note that I have [previously](https://github.com/matrix-org/matrix-ios-sdk/pull/1675) tried to solve the current/next task in more generic way, but was missing the additional need to aggregate further users. So for now I am adding a case specific `MXKeysQueryScheduler` which may later evolve to more generic `MXSerialTaskScheduler`

In general the application should never query keys directly, except for very few cases (starting new room, refreshing cross signing), but this is not unfortunatelly the case at the moment. To start moving in the right direction I split out `downloadKeysIfNecessary` and a deprecated `reloadKeys` instead of passing `forceDownload` parameter. This should make it clearer which API to use.
