### PR TITLE
Remove commented device property from push rules.

### DIFF
--- a/MatrixSDK/JSONModels/MXJSONModels.h
+++ b/MatrixSDK/JSONModels/MXJSONModels.h
@@ -778,17 +778,11 @@ FOUNDATION_EXPORT NSString *const kMXPushRuleConditionStringSenderNotificationPe
  Push rule scope definitions - String version
  */
 FOUNDATION_EXPORT NSString *const kMXPushRuleScopeStringGlobal;
-FOUNDATION_EXPORT NSString *const kMXPushRuleScopeStringDevice;
 
 /**
  `MXPushRulesResponse` represents the response to the /pushRules/ request.
  */
 @interface MXPushRulesResponse : MXJSONModel
-
-    /**
-     Set of push rules specific per device.
-     */
-    // @property (nonatomic) NSDictionary *device;
 
     /**
      Set of global push rules.

--- a/MatrixSDK/JSONModels/MXJSONModels.m
+++ b/MatrixSDK/JSONModels/MXJSONModels.m
@@ -833,7 +833,6 @@ NSString *const kMXPushRuleConditionStringSenderNotificationPermission  = @"send
 @implementation MXPushRulesResponse
 
 NSString *const kMXPushRuleScopeStringGlobal = @"global";
-NSString *const kMXPushRuleScopeStringDevice = @"device";
 
 + (id)modelFromJSON:(NSDictionary *)JSONDictionary
 {
@@ -844,8 +843,6 @@ NSString *const kMXPushRuleScopeStringDevice = @"device";
         {
             pushRulesResponse.global = [MXPushRulesSet modelFromJSON:JSONDictionary[kMXPushRuleScopeStringGlobal] withScope:kMXPushRuleScopeStringGlobal];
         }
-
-        // TODO support device rules
 
         pushRulesResponse->JSONDictionary = JSONDictionary;
     }

--- a/changelog.d/pr-1677.change
+++ b/changelog.d/pr-1677.change
@@ -1,0 +1,1 @@
+Remove commented device property on MXPushRulesRespose.


### PR DESCRIPTION
It's an un-specced property and will be removed per https://github.com/matrix-org/synapse/issues/12482