### PR TITLE
Reply to ended polls events (PSG-1131)

### DIFF
--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -2194,15 +2194,9 @@ NSInteger const kMXRoomInvalidInviteSenderErrorCode = 9002;
     }
     if (eventToReply.eventType == MXEventTypePollEnd)
     {
-        MXEvent* pollStartEvent = [mxSession.store eventWithEventId:eventToReply.relatesTo.eventId inRoom:self.roomId];
-        
-        if (pollStartEvent) {
-            NSString *question = [MXEventContentPollStart modelFromJSON:pollStartEvent.content].question;
-            senderMessageBody = question;
-        } else {
-            // we need a fallback to avoid crashes since the m.poll.start event may be missing.
-            senderMessageBody = eventToReply.relatesTo.eventId;
-        }
+        // The "Ended poll" text is not meant to be localized from the sender side.
+        // This is why here we use a "default localizer" providing the english version of it.
+        senderMessageBody = MXSendReplyEventDefaultStringLocalizer.new.replyToEndedPoll;
     }
     else if (eventToReply.eventType == MXEventTypeBeaconInfo)
     {

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -2278,8 +2278,7 @@ NSInteger const kMXRoomInvalidInviteSenderErrorCode = 9002;
         *replyContentFormattedBody = [self replyMessageFormattedBodyFromEventToReply:eventToReply
                                                           senderMessageFormattedBody:senderMessageFormattedBody
                                                               isSenderMessageAnEmote:isSenderMessageAnEmote
-                                                               replyFormattedMessage:finalFormattedTextMessage
-                                                                     stringLocalizer:stringLocalizer];
+                                                               replyFormattedMessage:finalFormattedTextMessage];
     }
 }
 
@@ -2369,7 +2368,6 @@ NSInteger const kMXRoomInvalidInviteSenderErrorCode = 9002;
  @param senderMessageFormattedBody The message body of the sender.
  @param isSenderMessageAnEmote Indicate if the sender message is an emote (/me).
  @param replyFormattedMessage The response for the sender message. HTML formatted string if any otherwise non formatted string as reply formatted body is mandatory.
- @param stringLocalizer string localizations used when building formatted body.
  
  @return reply message body.
  */
@@ -2377,7 +2375,6 @@ NSInteger const kMXRoomInvalidInviteSenderErrorCode = 9002;
                             senderMessageFormattedBody:(NSString*)senderMessageFormattedBody
                                 isSenderMessageAnEmote:(BOOL)isSenderMessageAnEmote
                                  replyFormattedMessage:(NSString*)replyFormattedMessage
-                                       stringLocalizer:(id<MXSendReplyEventStringLocalizerProtocol>)stringLocalizer
 {
     NSString *eventId = eventToReply.eventId;
     NSString *roomId = eventToReply.roomId;
@@ -2423,7 +2420,9 @@ NSInteger const kMXRoomInvalidInviteSenderErrorCode = 9002;
     [replyMessageFormattedBody appendString:@"<mx-reply><blockquote>"];
     
     // Add event link
-    [replyMessageFormattedBody appendFormat:@"<a href=\"%@\">%@</a> ", eventPermalink, stringLocalizer.messageToReplyToPrefix];
+    // The "In reply to" string is not meant to be localized from the sender side.
+    // This is how here we use the default string localizer to send the english version of it.
+    [replyMessageFormattedBody appendFormat:@"<a href=\"%@\">%@</a> ", eventPermalink, MXSendReplyEventDefaultStringLocalizer.new.messageToReplyToPrefix];
     
     if (isSenderMessageAnEmote)
     {

--- a/MatrixSDK/Data/MXSendReplyEventDefaultStringLocalizer.m
+++ b/MatrixSDK/Data/MXSendReplyEventDefaultStringLocalizer.m
@@ -26,6 +26,7 @@
 @property (nonatomic, strong) NSString *senderSentTheirLocation;
 @property (nonatomic, strong) NSString *senderSentTheirLiveLocation;
 @property (nonatomic, strong) NSString *messageToReplyToPrefix;
+@property (nonatomic, strong) NSString *replyToEndedPoll;
 
 @end
 
@@ -43,6 +44,7 @@
         _senderSentTheirLocation = @"has shared their location.";
         _senderSentTheirLiveLocation = @"Live location.";
         _messageToReplyToPrefix = @"In reply to";
+        _replyToEndedPoll = @"Ended poll";
     }
     return self;
 }

--- a/MatrixSDK/Data/MXSendReplyEventStringLocalizerProtocol.h
+++ b/MatrixSDK/Data/MXSendReplyEventStringLocalizerProtocol.h
@@ -32,6 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSString *)senderSentTheirLocation;
 - (NSString *)senderSentTheirLiveLocation;
 - (NSString *)messageToReplyToPrefix;
+- (NSString *)replyToEndedPoll;
 
 @end
 

--- a/changelog.d/pr-1685.bugfix
+++ b/changelog.d/pr-1685.bugfix
@@ -1,0 +1,1 @@
+Messages' replies: fix localizations issues.


### PR DESCRIPTION
### Description

This PR ensure that placeholders in reply events are always sent in the English version.
Matrix client receiving events containing this placeholder may chose to localize them or not.
It doesn't make sense localizing placeholders on the sender side since the receivers could prefer a different language.

Affected placeholders are:
- "In reply to"
- "Ended poll" (new one, it's used when replying to `m.poll.end` events)