### PR TITLE
Migration improvements in Crypto V2

### DIFF
--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -2043,6 +2043,8 @@
 		EDD578EA2881C37C006739DD /* MXCryptoUserIdentityWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD578E02881C37C006739DD /* MXCryptoUserIdentityWrapper.swift */; };
 		EDD578EC2881C38C006739DD /* MXCrossSigningV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD578EB2881C38C006739DD /* MXCrossSigningV2.swift */; };
 		EDD578ED2881C38C006739DD /* MXCrossSigningV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD578EB2881C38C006739DD /* MXCrossSigningV2.swift */; };
+		EDDB07CA297EE0A7005249A6 /* MXCryptoV2FactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDDB07C9297EE0A7005249A6 /* MXCryptoV2FactoryTests.swift */; };
+		EDDB07CB297EE0A7005249A6 /* MXCryptoV2FactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDDB07C9297EE0A7005249A6 /* MXCryptoV2FactoryTests.swift */; };
 		EDDBA7F0293F353900AD1480 /* MXToDevicePayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDDBA7EF293F353900AD1480 /* MXToDevicePayload.swift */; };
 		EDDBA7F1293F353900AD1480 /* MXToDevicePayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDDBA7EF293F353900AD1480 /* MXToDevicePayload.swift */; };
 		EDDD90C82901611600B760E0 /* MXLegacyCrypto+LegacyCrossSigning.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDDD90C72901611600B760E0 /* MXLegacyCrypto+LegacyCrossSigning.swift */; };
@@ -3174,6 +3176,7 @@
 		EDD578DF2881C37C006739DD /* MXCryptoDeviceWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXCryptoDeviceWrapper.swift; sourceTree = "<group>"; };
 		EDD578E02881C37C006739DD /* MXCryptoUserIdentityWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXCryptoUserIdentityWrapper.swift; sourceTree = "<group>"; };
 		EDD578EB2881C38C006739DD /* MXCrossSigningV2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXCrossSigningV2.swift; sourceTree = "<group>"; };
+		EDDB07C9297EE0A7005249A6 /* MXCryptoV2FactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXCryptoV2FactoryTests.swift; sourceTree = "<group>"; };
 		EDDBA7EF293F353900AD1480 /* MXToDevicePayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXToDevicePayload.swift; sourceTree = "<group>"; };
 		EDDD90C72901611600B760E0 /* MXLegacyCrypto+LegacyCrossSigning.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MXLegacyCrypto+LegacyCrossSigning.swift"; sourceTree = "<group>"; };
 		EDE1B13A28B7BEAB000DEEE8 /* MXCrossSigningV2UnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXCrossSigningV2UnitTests.swift; sourceTree = "<group>"; };
@@ -5410,6 +5413,7 @@
 				ED5C95CD2833E85600843D82 /* MXOlmDeviceUnitTests.swift */,
 				ED825F8E29014EDA006A614E /* MXSession+LegacyCrypto.swift */,
 				EDDD90C72901611600B760E0 /* MXLegacyCrypto+LegacyCrossSigning.swift */,
+				EDDB07C9297EE0A7005249A6 /* MXCryptoV2FactoryTests.swift */,
 			);
 			path = Crypto;
 			sourceTree = "<group>";
@@ -7480,6 +7484,7 @@
 				18C26C4F273C0EB300805154 /* MXPollAggregatorTests.swift in Sources */,
 				ED35652F281153480002BF6A /* MXMegolmSessionDataUnitTests.swift in Sources */,
 				32EEA83F2603CA140041425B /* MXRestClientExtensionsTests.m in Sources */,
+				EDDB07CA297EE0A7005249A6 /* MXCryptoV2FactoryTests.swift in Sources */,
 				18121F7A273E6E4200B68ADF /* PollBuilder.swift in Sources */,
 				18121F7F273E837300B68ADF /* PollModels.swift in Sources */,
 				32C03CB62123076F00D92712 /* DirectRoomTests.m in Sources */,
@@ -8144,6 +8149,7 @@
 				ED7019E12886C26D00FC31B9 /* MXCryptoRequestsUnitTests.swift in Sources */,
 				18C26C50273C0EB400805154 /* MXPollAggregatorTests.swift in Sources */,
 				ED356530281153480002BF6A /* MXMegolmSessionDataUnitTests.swift in Sources */,
+				EDDB07CB297EE0A7005249A6 /* MXCryptoV2FactoryTests.swift in Sources */,
 				32C78BA8256D227D008130B1 /* MXCryptoMigrationTests.m in Sources */,
 				18121F7B273E6E4200B68ADF /* PollBuilder.swift in Sources */,
 				18121F80273E837400B68ADF /* PollModels.swift in Sources */,

--- a/MatrixSDK/Background/Crypto/MXBackgroundCrypto.swift
+++ b/MatrixSDK/Background/Crypto/MXBackgroundCrypto.swift
@@ -19,7 +19,7 @@ import Foundation
 /// Light-weight crypto protocol to be used with background services
 /// that can recieve room keys and decrypt notification messages
 protocol MXBackgroundCrypto {
-    func handleSyncResponse(_ syncResponse: MXSyncResponse)
+    func handleSyncResponse(_ syncResponse: MXSyncResponse) async
     func canDecryptEvent(_ event: MXEvent) -> Bool
     func decryptEvent(_ event: MXEvent) throws
 }

--- a/MatrixSDK/Background/Crypto/MXBackgroundCryptoV2.swift
+++ b/MatrixSDK/Background/Crypto/MXBackgroundCryptoV2.swift
@@ -51,13 +51,13 @@ class MXBackgroundCryptoV2: MXBackgroundCrypto {
         )
     }
     
-    func handleSyncResponse(_ syncResponse: MXSyncResponse) {
+    func handleSyncResponse(_ syncResponse: MXSyncResponse) async {
         let toDeviceCount = syncResponse.toDevice?.events.count ?? 0
         
         log.debug("Handling new sync response with \(toDeviceCount) to-device event(s)")
         
         do {
-            _ = try machine.handleSyncResponse(
+            _ = try await machine.handleSyncResponse(
                 toDevice: syncResponse.toDevice,
                 deviceLists: syncResponse.deviceLists,
                 deviceOneTimeKeysCounts: syncResponse.deviceOneTimeKeysCount ?? [:],

--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoMachine.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoMachine.swift
@@ -189,6 +189,8 @@ extension MXCryptoMachine: MXCryptoIdentity {
 }
 
 extension MXCryptoMachine: MXCryptoSyncing {
+    
+    @MainActor
     func handleSyncResponse(
         toDevice: MXToDeviceSyncResponse?,
         deviceLists: MXDeviceListResponse?,

--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoProtocols.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoProtocols.swift
@@ -32,6 +32,8 @@ protocol MXCryptoIdentity {
 
 /// Handler for cryptographic events in the sync loop
 protocol MXCryptoSyncing: MXCryptoIdentity {
+    
+    @MainActor
     func handleSyncResponse(
         toDevice: MXToDeviceSyncResponse?,
         deviceLists: MXDeviceListResponse?,

--- a/MatrixSDK/Crypto/Migration/MXCryptoMigrationV2.swift
+++ b/MatrixSDK/Crypto/Migration/MXCryptoMigrationV2.swift
@@ -67,10 +67,11 @@ class MXCryptoMigrationV2: NSObject {
         log.debug("Migrating olm sessions in batches")
         
         // How much does migration of olm vs megolm sessions contribute to the overall progress
-        let olmToMegolmProgressRatio = 0.25
+        let totalSessions = store.olmSessionCount + store.megolmSessionCount
+        let olmToMegolmRatio = totalSessions > 0 ? Double(store.olmSessionCount)/Double(totalSessions) : 0
         
         store.extractSessions(with: key, batchSize: Self.SessionBatchSize) { [weak self] batch, progress in
-            updateProgress(progress * olmToMegolmProgressRatio)
+            updateProgress(progress * olmToMegolmRatio)
             
             do {
                 try self?.migrateSessions(
@@ -86,7 +87,7 @@ class MXCryptoMigrationV2: NSObject {
         log.debug("Migrating megolm sessions in batches")
         
         store.extractGroupSessions(with: key, batchSize: Self.SessionBatchSize) { [weak self] batch, progress in
-            updateProgress(olmToMegolmProgressRatio + progress * (1 - olmToMegolmProgressRatio))
+            updateProgress(olmToMegolmRatio + progress * (1 - olmToMegolmRatio))
             
             do {
                 try self?.migrateSessions(

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -1457,7 +1457,9 @@ typedef void (^MXOnResumeDone)(void);
                       clientTimeout:(NSUInteger)clientTimeout
                         setPresence:(NSString*)setPresence
 {
-    if (MXSDKOptions.sharedInstance.enableStartupProgress)
+    // We only want to report sync progress when doing initial sync
+    BOOL shoulReportStartupProgress = MXSDKOptions.sharedInstance.enableStartupProgress && !self.isEventStreamInitialised;
+    if (shoulReportStartupProgress)
     {
         [self.startupProgress incrementSyncAttempt];
     }
@@ -1562,7 +1564,7 @@ typedef void (^MXOnResumeDone)(void);
         
         [self handleSyncResponse:syncResponse
                         progress:^(CGFloat progress) {
-            if (MXSDKOptions.sharedInstance.enableStartupProgress)
+            if (shoulReportStartupProgress)
             {
                 [self.startupProgress updateProcessingProgress:progress forPhase:MXSessionProcessingResponsePhaseSyncResponse];
             }
@@ -1577,7 +1579,7 @@ typedef void (^MXOnResumeDone)(void);
                 [self fixRoomsSummariesLastMessageWithMaxServerPaginationCount:MXRoomSummaryPaginationChunkSize
                                                                          force:YES
                                                                       progress:^(CGFloat progress) {
-                    if (MXSDKOptions.sharedInstance.enableStartupProgress)
+                    if (shoulReportStartupProgress)
                     {
                         [self.startupProgress updateProcessingProgress:progress forPhase:MXSessionProcessingResponsePhaseRoomSummaries];
                     }

--- a/MatrixSDK/MXSessionStartupProgress.swift
+++ b/MatrixSDK/MXSessionStartupProgress.swift
@@ -29,13 +29,6 @@ public enum MXSessionStartupStage {
     
     /// Processing server response
     case processingResponse(progress: Double)
-    
-    var isSyncing: Bool {
-        guard case .serverSyncing = self else {
-            return false
-        }
-        return true
-    }
 }
 
 /// Delegate that recieves stage updates
@@ -81,10 +74,6 @@ public protocol MXSessionStartupProgressDelegate: AnyObject {
     
     /// Increment the total number of sync attempts during the `serverSyncing` stage
     @objc public func incrementSyncAttempt() {
-        guard stage == nil || stage?.isSyncing == true else {
-            return
-        }
-        
         syncAttempts += 1
         stage = .serverSyncing(attempt: syncAttempts)
     }

--- a/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoMachineUnitTests.swift
+++ b/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoMachineUnitTests.swift
@@ -50,8 +50,8 @@ class MXCryptoMachineUnitTests: XCTestCase {
         }
     }
     
-    func test_handleSyncResponse_canProcessEmptyResponse() throws {
-        let result = try machine.handleSyncResponse(
+    func test_handleSyncResponse_canProcessEmptyResponse() async throws {
+        let result = try await machine.handleSyncResponse(
             toDevice: nil,
             deviceLists: nil,
             deviceOneTimeKeysCounts: [:],
@@ -69,7 +69,7 @@ class MXCryptoMachineUnitTests: XCTestCase {
         deviceList.changed = ["A", "B"]
         deviceList.left = ["C", "D"]
         
-        let result = try machine.handleSyncResponse(
+        let result = try await machine.handleSyncResponse(
             toDevice: toDevice,
             deviceLists: deviceList,
             deviceOneTimeKeysCounts: [:],

--- a/MatrixSDKTests/Crypto/MXCryptoV2FactoryTests.swift
+++ b/MatrixSDKTests/Crypto/MXCryptoV2FactoryTests.swift
@@ -1,0 +1,118 @@
+// 
+// Copyright 2023 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+class MXCryptoV2FactoryTests: XCTestCase {
+    class KeyProvider: NSObject, MXKeyProviderDelegate {
+        func isEncryptionAvailableForData(ofType dataType: String) -> Bool {
+            return true
+        }
+        
+        func hasKeyForData(ofType dataType: String) -> Bool {
+            return true
+        }
+        
+        func keyDataForData(ofType dataType: String) -> MXKeyData? {
+            MXRawDataKey(key: "1234".data(using: .ascii)!)
+        }
+    }
+    
+    var data: MatrixSDKTestsData!
+    var e2eData: MatrixSDKTestsE2EData!
+    var factory: MXCryptoV2Factory!
+    
+    override func setUp() {
+        data = .init()
+        e2eData = .init(matrixSDKTestsData: data)
+        factory = MXCryptoV2Factory()
+        MXKeyProvider.sharedInstance().delegate = KeyProvider()
+    }
+    
+    override func tearDown() {
+        MXKeyProvider.sharedInstance().delegate = nil
+    }
+    
+    private func buildCrypto(session: MXSession) async throws -> (MXCrypto?, Bool) {
+        try await withCheckedThrowingContinuation { cont in
+            var hasMigrated = false
+            factory.buildCrypto(
+                session: session) { _ in
+                    hasMigrated = true
+                } success: {
+                    cont.resume(returning: ($0, hasMigrated))
+                } failure: {
+                    cont.resume(throwing: $0)
+                }
+        }
+    }
+    
+    func test_doesNotMigrateNewUser() async throws {
+        let env = try await e2eData.startE2ETest()
+        let session = env.session
+        
+        // Simulating new user as one without a crypto database
+        MXRealmCryptoStore.delete(with: session.credentials)
+        
+        // Build crypto and assert no migration has been performed
+        let (crypto, hasMigrated) = try await buildCrypto(session: session)
+        XCTAssertNotNil(crypto)
+        XCTAssertFalse(hasMigrated)
+        
+        // Assert we have created legacy store (for remaining functionality) and marked it as deprecated
+        let legacyStore = MXRealmCryptoStore.init(credentials: session.credentials)
+        XCTAssertNotNil(legacyStore)
+        XCTAssertEqual(legacyStore?.cryptoVersion, .versionLegacyDeprecated)
+    }
+    
+    func test_migratesExistingUser() async throws {
+        let env = try await e2eData.startE2ETest()
+        let session = env.session
+        let legacyStore = session.legacyCrypto?.store
+        
+        // Assert that we have a legacy store that has not yet been depreacted
+        XCTAssertNotNil(legacyStore)
+        XCTAssertEqual(legacyStore?.cryptoVersion, .version2)
+        
+        // Build crypto and assert migration has been performed
+        let (crypto, hasMigrated) = try await buildCrypto(session: session)
+        XCTAssertNotNil(crypto)
+        XCTAssertTrue(hasMigrated)
+        
+        // Assert we still have legacy store but it is now marked as deprecated
+        XCTAssertNotNil(legacyStore)
+        XCTAssertEqual(legacyStore?.cryptoVersion, .versionLegacyDeprecated)
+    }
+
+    func test_doesNotMigrateDeprecatedStore() async throws {
+        let env = try await e2eData.startE2ETest()
+        let session = env.session
+        
+        // We set the legacy store as deprecated
+        let legacyStore = session.legacyCrypto?.store
+        XCTAssertNotNil(legacyStore)
+        legacyStore?.cryptoVersion = .versionLegacyDeprecated
+        
+        // Build crypto and assert no migration has been performed
+        let (crypto, hasMigrated) = try await buildCrypto(session: session)
+        XCTAssertNotNil(crypto)
+        XCTAssertFalse(hasMigrated)
+        
+        // Assert we still have legacy store which is still marked as deprecated
+        XCTAssertNotNil(legacyStore)
+        XCTAssertEqual(legacyStore?.cryptoVersion, .versionLegacyDeprecated)
+    }
+}

--- a/MatrixSDKTests/MXSessionStartupProgressUnitTests.swift
+++ b/MatrixSDKTests/MXSessionStartupProgressUnitTests.swift
@@ -33,6 +33,17 @@ class MXSessionStartupProgressUnitTests: XCTestCase {
         progress.delegate = delegate
     }
     
+    func testUpdatesMigrationProgress() {
+        XCTAssertNil(delegate.stage)
+        
+        progress.updateMigrationProgress(0)
+        XCTAssertMigratingProgress(0, stage: delegate.stage)
+        
+        progress.updateMigrationProgress(0.5)
+        XCTAssertMigratingProgress(0.5, stage: delegate.stage)
+    }
+    
+    
     func testIncrementsSyncAttempt() {
         XCTAssertNil(delegate.stage)
         
@@ -65,21 +76,20 @@ class MXSessionStartupProgressUnitTests: XCTestCase {
         XCTAssertProcessingProgress(1, stage: delegate.stage)
     }
     
-    func testIgnoresSyncAttemptWhenProcessing() {
-        progress.incrementSyncAttempt()
-        XCTAssertIsNthSyncingAttempt(1, stage: delegate.stage)
-        
-        progress.updateProcessingProgress(0, forPhase: .syncResponse)
-        XCTAssertProcessingProgress(0, stage: delegate.stage)
-        
-        progress.incrementSyncAttempt()
-        XCTAssertProcessingProgress(0, stage: delegate.stage)
-    }
-    
     // MARK: - Assertion helpers
     
+    private func XCTAssertMigratingProgress(_ expectedProgress: Double, stage: MXSessionStartupStage?, file: StaticString = #file, line: UInt = #line) {
+        if case .migratingData(let progress) = stage {
+            XCTAssertEqual(progress, expectedProgress, file: file, line: line)
+        } else if let stage = stage {
+            XCTFail("Unexpected stage \(stage)", file: file, line: line)
+        } else {
+            XCTFail("stage is nil", file: file, line: line)
+        }
+    }
+    
     private func XCTAssertIsNthSyncingAttempt(_ expectedAttempt: Int, stage: MXSessionStartupStage?, file: StaticString = #file, line: UInt = #line) {
-        if case .serverSyncing(attempt: let attempt) = stage {
+        if case .serverSyncing(let attempt) = stage {
             XCTAssertEqual(attempt, expectedAttempt, file: file, line: line)
         } else if let stage = stage {
             XCTFail("Unexpected stage \(stage)", file: file, line: line)
@@ -89,7 +99,7 @@ class MXSessionStartupProgressUnitTests: XCTestCase {
     }
     
     private func XCTAssertProcessingProgress(_ expectedProgress: Double, stage: MXSessionStartupStage?, file: StaticString = #file, line: UInt = #line) {
-        if case .processingResponse(progress: let progress) = stage {
+        if case .processingResponse(let progress) = stage {
             XCTAssertEqual(progress, expectedProgress, file: file, line: line)
         } else if let stage = stage {
             XCTFail("Unexpected stage \(stage)", file: file, line: line)

--- a/MatrixSDKTests/TestPlans/CryptoTests.xctestplan
+++ b/MatrixSDKTests/TestPlans/CryptoTests.xctestplan
@@ -37,6 +37,7 @@
         "MXCryptoSecretStorageTests",
         "MXCryptoShareTests",
         "MXCryptoTests",
+        "MXCryptoV2FactoryTests",
         "MXCurve25519KeyBackupTests",
         "MXMegolmEncryptionTests"
       ],

--- a/changelog.d/pr-1692.change
+++ b/changelog.d/pr-1692.change
@@ -1,0 +1,1 @@
+CryptoV2: Migration improvements


### PR DESCRIPTION
A set of unrelated improvements when testing crypto v2 migrations:
- ensure sync response is handled on the main thread for now (not entirely thread safe in rust atm)
- add integration tests for migration to ensure only existing users are migrated and only once
- do not force download keys when computing trust summary
- change the weight ratio of olm to megolm to be calculated dynamically from total amount of sessions
- ensure we report startup progress only during initial syncs