### PR TITLE
More migration fixes for Crypto V2

### DIFF
--- a/MatrixSDK/Background/Crypto/MXBackgroundCrypto.swift
+++ b/MatrixSDK/Background/Crypto/MXBackgroundCrypto.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /// Light-weight crypto protocol to be used with background services
-/// that can recieve room keys and decrypt notification messages
+/// that can receive room keys and decrypt notification messages
 protocol MXBackgroundCrypto {
     func handleSyncResponse(_ syncResponse: MXSyncResponse) async
     func canDecryptEvent(_ event: MXEvent) -> Bool

--- a/MatrixSDK/Background/MXBackgroundCryptoStore.m
+++ b/MatrixSDK/Background/MXBackgroundCryptoStore.m
@@ -109,16 +109,6 @@ NSString *const MXBackgroundCryptoStoreUserIdSuffix = @":bgCryptoStore";
     }
 }
 
-- (void)open:(void (^)(void))onComplete failure:(void (^)(NSError *error))failure
-{
-    MXWeakify(self);
-    [cryptoStore open:^{
-        MXStrongifyAndReturnIfNil(self);
-        
-        [self->bgCryptoStore open:onComplete failure:failure];
-    } failure:failure];
-}
-
 - (instancetype)initWithCredentials:(MXCredentials *)theCredentials
 {
     NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
@@ -529,6 +519,12 @@ NSString *const MXBackgroundCryptoStoreUserIdSuffix = @":bgCryptoStore";
 - (void)storeSecret:(NSString*)secret withSecretId:(NSString*)secretId
 {
     NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+}
+
+- (BOOL)hasSecretWithSecretId:(NSString *)secretId
+{
+    NSAssert(NO, @"This method should be useless in the context of MXBackgroundCryptoStore");
+    return NO;
 }
 
 - (NSString*)secretWithSecretId:(NSString*)secretId

--- a/MatrixSDK/Crypto/Algorithms/RoomEvent/MXRoomEventDecryption.swift
+++ b/MatrixSDK/Crypto/Algorithms/RoomEvent/MXRoomEventDecryption.swift
@@ -81,7 +81,7 @@ actor MXRoomEventDecryption: MXRoomEventDecrypting {
             return
         }
         
-        log.debug("Recieved a new room key as `\(event.type ?? "")` for session \(sessionId)")
+        log.debug("Received a new room key as `\(event.type ?? "")` for session \(sessionId)")
         let events = undecryptedEvents[sessionId]?.map(\.value) ?? []
         retryDecryption(events: events)
     }

--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoMachine.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoMachine.swift
@@ -530,7 +530,7 @@ extension MXCryptoMachine: MXCryptoVerifying {
         try machine.receiveUnencryptedVerificationEvent(event: string, roomId: roomId)
         
         // Out-of-sync check if there are any verification events to sent out as a result of
-        // the event just recieved
+        // the event just received
         for request in try machine.outgoingRequests() {
             if case .roomMessage = request {
                 try await handleRequest(request)

--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoMachine.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoMachine.swift
@@ -226,16 +226,15 @@ extension MXCryptoMachine: MXCryptoSyncing {
     
     func downloadKeysIfNecessary(users: [String]) async throws {
         machine.updateTrackedUsers(users: users)
-        try await withThrowingTaskGroup(of: Void.self) { [weak self] group in
-            guard let self = self else { return }
 
-            for request in try machine.outgoingRequests() {
-                if case .keysQuery(_, let requestUsers) = request {
-                    let usersInCommon = Set(requestUsers).intersection(users)
-                    if !usersInCommon.isEmpty {
-                        try await self.handleRequest(request)
-                        return
-                    }
+        // Out-of-sync check if there is a pending outgoing request for some of these users
+        // (note that if a request is already in-flight, keys query scheduler will deduplicate them)
+        for request in try machine.outgoingRequests() {
+            if case .keysQuery(_, let requestUsers) = request {
+                let usersInCommon = Set(requestUsers).intersection(users)
+                if !usersInCommon.isEmpty {
+                    try await handleRequest(request)
+                    return
                 }
             }
         }
@@ -523,15 +522,20 @@ extension MXCryptoMachine: MXCryptoCrossSigning {
 }
 
 extension MXCryptoMachine: MXCryptoVerifying {
-    func receiveUnencryptedVerificationEvent(event: MXEvent, roomId: String) {
+    func receiveUnencryptedVerificationEvent(event: MXEvent, roomId: String) async throws {
         guard let string = event.jsonString() else {
-            log.failure("Invalid event")
-            return
+            throw Error.invalidEvent
         }
-        do {
-            try machine.receiveUnencryptedVerificationEvent(event: string, roomId: roomId)
-        } catch {
-            log.error("Error receiving unencrypted event", context: error)
+        
+        try machine.receiveUnencryptedVerificationEvent(event: string, roomId: roomId)
+        
+        // Out-of-sync check if there are any verification events to sent out as a result of
+        // the event just recieved
+        for request in try machine.outgoingRequests() {
+            if case .roomMessage = request {
+                try await handleRequest(request)
+                return
+            }
         }
     }
     

--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoProtocols.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoProtocols.swift
@@ -89,7 +89,8 @@ protocol MXCryptoCrossSigning: MXCryptoUserIdentitySource {
 
 /// Verification functionality
 protocol MXCryptoVerifying: MXCryptoIdentity {
-    func receiveUnencryptedVerificationEvent(event: MXEvent, roomId: String)
+    func downloadKeysIfNecessary(users: [String]) async throws
+    func receiveUnencryptedVerificationEvent(event: MXEvent, roomId: String) async throws
     func requestSelfVerification(methods: [String]) async throws -> VerificationRequestProtocol
     func requestVerification(userId: String, roomId: String, methods: [String]) async throws -> VerificationRequestProtocol
     func requestVerification(userId: String, deviceId: String, methods: [String]) async throws -> VerificationRequestProtocol

--- a/MatrixSDK/Crypto/Data/Store/MXCryptoSecretStore.h
+++ b/MatrixSDK/Crypto/Data/Store/MXCryptoSecretStore.h
@@ -34,6 +34,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)storeSecret:(NSString *)secret withSecretId:(NSString *)secretId;
 
 /**
+ Check if a given secret is stored
+ 
+ @param secretId the id of the secret.
+ @return YES if we have secret stored locally
+ */
+- (BOOL)hasSecretWithSecretId:(NSString *)secretId;
+
+/**
  Retrieve a secret.
  
  @param secretId the id of the secret.

--- a/MatrixSDK/Crypto/Data/Store/MXCryptoStore.h
+++ b/MatrixSDK/Crypto/Data/Store/MXCryptoStore.h
@@ -84,17 +84,6 @@
 - (instancetype)initWithCredentials:(MXCredentials *)credentials;
 
 /**
- Open the store corresponding to the passed account.
-
- The implementation can use a separated thread for loading data but the callback blocks
- must be called from the main thread.
-
- @param onComplete the callback called once the data has been loaded.
- @param failure the callback called in case of error.
- */
-- (void)open:(void (^)(void))onComplete failure:(void (^)(NSError *error))failure;
-
-/**
  The user id.
  */
 - (NSString*)userId;

--- a/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
+++ b/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
@@ -473,11 +473,6 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
     return [MXRealmOlmAccount objectInRealm:self.realm forPrimaryKey:userId];
 }
 
-- (void)open:(void (^)(void))onComplete failure:(void (^)(NSError *error))failure
-{
-    onComplete();
-}
-
 - (NSString *)userId
 {
     return self.accountInCurrentThread.userId;
@@ -1603,6 +1598,11 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
         
         [realm addOrUpdateObject:realmSecret];
     }];
+}
+
+- (BOOL)hasSecretWithSecretId:(NSString *)secretId
+{
+    return [self secretWithSecretId:secretId] != nil;
 }
 
 - (NSString*)secretWithSecretId:(NSString*)secretId

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -234,27 +234,16 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
         {
             MXLogDebug(@"[MXCrypto] checkCryptoWithMatrixSession: Crypto store exists");
 
-            // If it already exists, open and init crypto
+            // If it already exists, init store and crypto
             MXCryptoStoreClass *cryptoStore = [[MXCryptoStoreClass alloc] initWithCredentials:mxSession.matrixRestClient.credentials];
 
-            [cryptoStore open:^{
+            MXLogDebug(@"[MXCrypto] checkCryptoWithMatrixSession: Crypto store initialized");
 
-                MXLogDebug(@"[MXCrypto] checkCryptoWithMatrixSession: Crypto store opened");
+            id<MXCrypto> crypto = [[MXLegacyCrypto alloc] initWithMatrixSession:mxSession cryptoQueue:cryptoQueue andStore:cryptoStore];
 
-                id<MXCrypto> crypto = [[MXLegacyCrypto alloc] initWithMatrixSession:mxSession cryptoQueue:cryptoQueue andStore:cryptoStore];
-
-                dispatch_async(dispatch_get_main_queue(), ^{
-                    complete(crypto, nil);
-                });
-
-            } failure:^(NSError *error) {
-
-                MXLogDebug(@"[MXCrypto] checkCryptoWithMatrixSession: Crypto store failed to open. Error: %@", error);
-                
-                dispatch_async(dispatch_get_main_queue(), ^{
-                    complete(nil, error);
-                });
-            }];
+            dispatch_async(dispatch_get_main_queue(), ^{
+                complete(crypto, nil);
+            });
         }
         else if ([MXSDKOptions sharedInstance].enableCryptoWhenStartingMXSession
                  // Without the device id provided by the hs, the crypto does not work

--- a/MatrixSDK/Crypto/MXCryptoV2.swift
+++ b/MatrixSDK/Crypto/MXCryptoV2.swift
@@ -627,16 +627,10 @@ class MXCryptoV2: NSObject, MXCrypto {
             
             if direction == .forwards && event.sender != session.myUserId {
                 Task {
-                    if let userId = await self.keyVerification.handleRoomEvent(event) {
-                        // If we recieved a verification event from a new user we do not yet track
-                        // we need to download their keys to be able to proceed with the verification flow
-                        try await self.machine.downloadKeysIfNecessary(users: [userId])
-                    }
-                    
                     do {
-                        try await self.machine.processOutgoingRequests()
+                        try await self.keyVerification.handleRoomEvent(event)
                     } catch {
-                        self.log.error("Error processing requests", context: error)
+                        self.log.error("Error handling event", context: error)
                     }
                 }
             }

--- a/MatrixSDK/Crypto/MXCryptoV2Factory.swift
+++ b/MatrixSDK/Crypto/MXCryptoV2Factory.swift
@@ -79,8 +79,7 @@ import Foundation
         
         if
             MXRealmCryptoStore.hasData(for: credentials),
-            let legacyStore = MXRealmCryptoStore(credentials: credentials),
-            legacyStore.account() != nil
+            let legacyStore = MXRealmCryptoStore(credentials: credentials)
         {
             log.debug("Legacy crypto store exists")
             return legacyStore

--- a/MatrixSDK/Crypto/MXOlmDevice.m
+++ b/MatrixSDK/Crypto/MXOlmDevice.m
@@ -393,7 +393,7 @@ NSInteger const kMXInboundGroupSessionCacheSize = 100;
             }
             else
             {
-                MXLogWarning(@"[MXOlmDevice] addInboundGroupSession: Recieved a safer but disconnected key, which will override the existing unsafe key");
+                MXLogWarning(@"[MXOlmDevice] addInboundGroupSession: Received a safer but disconnected key, which will override the existing unsafe key");
                 existingSession = nil;
             }
         }

--- a/MatrixSDK/Crypto/Recovery/MXRecoveryService.m
+++ b/MatrixSDK/Crypto/Recovery/MXRecoveryService.m
@@ -218,7 +218,7 @@ NSString *const MXRecoveryServiceErrorDomain = @"org.matrix.sdk.recoveryService"
 
 - (BOOL)hasSecretLocally:(NSString*)secretId
 {
-    return ([self.dependencies.secretStore secretWithSecretId:secretId] != nil);
+    return ([self.dependencies.secretStore hasSecretWithSecretId:secretId]);
 }
 
 - (NSArray*)secretsStoredLocally

--- a/MatrixSDK/Crypto/SecretStorage/MXCryptoSecretStoreV2.swift
+++ b/MatrixSDK/Crypto/SecretStorage/MXCryptoSecretStoreV2.swift
@@ -74,6 +74,22 @@ class MXCryptoSecretStoreV2: NSObject, MXCryptoSecretStore {
         }
     }
     
+    func hasSecret(withSecretId secretId: String) -> Bool {
+        switch secretId as NSString {
+        case MXSecretId.crossSigningMaster.takeUnretainedValue():
+            return crossSigning.crossSigningStatus().hasMaster
+        case MXSecretId.crossSigningSelfSigning.takeUnretainedValue():
+            return crossSigning.crossSigningStatus().hasSelfSigning
+        case MXSecretId.crossSigningUserSigning.takeUnretainedValue():
+            return crossSigning.crossSigningStatus().hasUserSigning
+        case MXSecretId.keyBackup.takeUnretainedValue():
+            return backupEngine?.privateKey() != nil
+        default:
+            log.error("Unsupported type of secret", context: secretId)
+            return false
+        }
+    }
+    
     func secret(withSecretId secretId: String) -> String? {
         switch secretId as NSString {
         case MXSecretId.crossSigningMaster.takeUnretainedValue():

--- a/MatrixSDK/Crypto/Verification/MXKeyVerificationManagerV2.swift
+++ b/MatrixSDK/Crypto/Verification/MXKeyVerificationManagerV2.swift
@@ -287,7 +287,7 @@ class MXKeyVerificationManagerV2: NSObject, MXKeyVerificationManager {
             newUserId = nil
         }
 
-        // If we recieved a verification event from a new user we do not yet track
+        // If we received a verification event from a new user we do not yet track
         // we need to download their keys to be able to proceed with the verification flow
         if let userId = newUserId {
             try await self.handler.downloadKeysIfNecessary(users: [userId])

--- a/MatrixSDK/Crypto/Verification/MXKeyVerificationManagerV2.swift
+++ b/MatrixSDK/Crypto/Verification/MXKeyVerificationManagerV2.swift
@@ -267,25 +267,30 @@ class MXKeyVerificationManagerV2: NSObject, MXKeyVerificationManager {
         }
     }
     
-    @MainActor
-    func handleRoomEvent(_ event: MXEvent) -> String? {
+    func handleRoomEvent(_ event: MXEvent) async throws {
         guard isRoomVerificationEvent(event) else {
-            return nil
+            return
         }
         
         if !event.isEncrypted, let roomId = event.roomId {
-            handler.receiveUnencryptedVerificationEvent(event: event, roomId: roomId)
+            try await handler.receiveUnencryptedVerificationEvent(event: event, roomId: roomId)
         }
         
+        let newUserId: String?
         if event.type == kMXEventTypeStringRoomMessage && event.content?[kMXMessageTypeKey] as? String == kMXMessageTypeKeyVerificationRequest {
-            handleIncomingRequest(userId: event.sender, flowId: event.eventId)
-            return event.sender
-            
+            await handleIncomingRequest(userId: event.sender, flowId: event.eventId)
+            newUserId = event.sender
         } else if event.type == kMXEventTypeStringKeyVerificationStart, let flowId = event.relatesTo.eventId {
-            handleIncomingVerification(userId: event.sender, flowId: flowId)
-            return event.sender
+            await handleIncomingVerification(userId: event.sender, flowId: flowId)
+            newUserId = event.sender
         } else {
-            return nil
+            newUserId = nil
+        }
+
+        // If we recieved a verification event from a new user we do not yet track
+        // we need to download their keys to be able to proceed with the verification flow
+        if let userId = newUserId {
+            try await self.handler.downloadKeysIfNecessary(users: [userId])
         }
     }
     

--- a/MatrixSDK/MXSessionStartupProgress.swift
+++ b/MatrixSDK/MXSessionStartupProgress.swift
@@ -31,7 +31,7 @@ public enum MXSessionStartupStage {
     case processingResponse(progress: Double)
 }
 
-/// Delegate that recieves stage updates
+/// Delegate that receives stage updates
 public protocol MXSessionStartupProgressDelegate: AnyObject {
     func sessionDidUpdateStartupStage(_ stage: MXSessionStartupStage)
 }

--- a/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoProtocolStubs.swift
+++ b/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoProtocolStubs.swift
@@ -130,8 +130,10 @@ class CryptoVerificationStub: CryptoIdentityStub {
 }
 
 extension CryptoVerificationStub: MXCryptoVerifying {
+    func downloadKeysIfNecessary(users: [String]) async throws {
+    }
+    
     func receiveUnencryptedVerificationEvent(event: MXEvent, roomId: String) {
-        
     }
     
     func requestSelfVerification(methods: [String]) async throws -> VerificationRequestProtocol {

--- a/MatrixSDKTests/Crypto/Data/Store/MXMemoryCryptoStore.swift
+++ b/MatrixSDKTests/Crypto/Data/Store/MXMemoryCryptoStore.swift
@@ -71,10 +71,6 @@ public class MXMemoryCryptoStore: NSObject, MXCryptoStore {
     public static func deleteReadonlyStore(with credentials: MXCredentials!) {
         // no-op
     }
-
-    public func open(_ onComplete: (() -> Void)!, failure: ((Error?) -> Void)!) {
-        onComplete?()
-    }
     
     // MARK: - User ID
     
@@ -424,6 +420,10 @@ public class MXMemoryCryptoStore: NSObject, MXCryptoStore {
 
     public func storeSecret(_ secret: String, withSecretId secretId: String) {
         secrets[secretId] = secret
+    }
+    
+    public func hasSecret(withSecretId secretId: String) -> Bool {
+        return secrets[secretId] != nil
     }
 
     public func secret(withSecretId secretId: String) -> String? {


### PR DESCRIPTION
Some further changes when testing account migration from libolm to rust:
- remove `open` method from `MXCryptoStore` that is empty in all implementations of this protocol. This was probably used in the past but is clearly not doing anything, and removing it reduces objc callback nesting by one level
- add `hasSecretWithSecretId` on the `MXCryptoStore` protocol. For legacy store this is just a convenience API, but for crypto V2 it calls a different (and faster) rust API
- some changes in key verification management, where we only `processOutgoingRequests` and `downloadKeysIfNecessary` from within the manager, rather than `MXCryptoV2`, which makes for a better logic encapsuation