### PR TITLE
Upload fallback keys with Crypto V2

### DIFF
--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -1880,8 +1880,8 @@
 		ED55806E296F0E3A003443E3 /* MXCryptoMigrationStoreUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED55806C296F0E3A003443E3 /* MXCryptoMigrationStoreUnitTests.swift */; };
 		ED558070296F1BEE003443E3 /* MXCryptoMigrationV2Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED55806F296F1BEE003443E3 /* MXCryptoMigrationV2Tests.swift */; };
 		ED558071296F1BEE003443E3 /* MXCryptoMigrationV2Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED55806F296F1BEE003443E3 /* MXCryptoMigrationV2Tests.swift */; };
-		ED5580732970265A003443E3 /* MXCryptoMachineLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED5580722970265A003443E3 /* MXCryptoMachineLogger.swift */; };
-		ED5580742970265A003443E3 /* MXCryptoMachineLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED5580722970265A003443E3 /* MXCryptoMachineLogger.swift */; };
+		ED5580732970265A003443E3 /* MXCryptoSDKLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED5580722970265A003443E3 /* MXCryptoSDKLogger.swift */; };
+		ED5580742970265A003443E3 /* MXCryptoSDKLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED5580722970265A003443E3 /* MXCryptoSDKLogger.swift */; };
 		ED55807629709943003443E3 /* MatrixSDKTestsE2EData.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED55807529709943003443E3 /* MatrixSDKTestsE2EData.swift */; };
 		ED55807729709943003443E3 /* MatrixSDKTestsE2EData.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED55807529709943003443E3 /* MatrixSDKTestsE2EData.swift */; };
 		ED5580792970A879003443E3 /* MatrixSDKTestsData.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED5580782970A879003443E3 /* MatrixSDKTestsData.swift */; };
@@ -3096,7 +3096,7 @@
 		ED558067296F0361003443E3 /* MXCryptoMigrationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXCryptoMigrationStore.swift; sourceTree = "<group>"; };
 		ED55806C296F0E3A003443E3 /* MXCryptoMigrationStoreUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXCryptoMigrationStoreUnitTests.swift; sourceTree = "<group>"; };
 		ED55806F296F1BEE003443E3 /* MXCryptoMigrationV2Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXCryptoMigrationV2Tests.swift; sourceTree = "<group>"; };
-		ED5580722970265A003443E3 /* MXCryptoMachineLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXCryptoMachineLogger.swift; sourceTree = "<group>"; };
+		ED5580722970265A003443E3 /* MXCryptoSDKLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXCryptoSDKLogger.swift; sourceTree = "<group>"; };
 		ED55807529709943003443E3 /* MatrixSDKTestsE2EData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatrixSDKTestsE2EData.swift; sourceTree = "<group>"; };
 		ED5580782970A879003443E3 /* MatrixSDKTestsData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatrixSDKTestsData.swift; sourceTree = "<group>"; };
 		ED5AE8C32816C8CF00105072 /* MXRoomSummaryCoreDataStore2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = MXRoomSummaryCoreDataStore2.xcdatamodel; sourceTree = "<group>"; };
@@ -5450,7 +5450,7 @@
 			children = (
 				ED5EF147297AB28600A5ADDA /* Extensions */,
 				ED2DD111286C450600F06731 /* MXCryptoMachine.swift */,
-				ED5580722970265A003443E3 /* MXCryptoMachineLogger.swift */,
+				ED5580722970265A003443E3 /* MXCryptoSDKLogger.swift */,
 				EDF154E0296C203E004D7FFE /* MXCryptoMachineStore.swift */,
 				ED8F1D3A2885BB2D00F897E7 /* MXCryptoProtocols.swift */,
 				ED2DD113286C450600F06731 /* MXCryptoRequests.swift */,
@@ -7335,7 +7335,7 @@
 				B1F04B132811E9D300103EBE /* MXBeaconInfoSummaryStoreProtocol.swift in Sources */,
 				183892802702F553003F0C4F /* MXRoomNameDefaultStringLocalizer.m in Sources */,
 				C6F9358B1E5B3BE600FC34BF /* MXJSONModels.swift in Sources */,
-				ED5580732970265A003443E3 /* MXCryptoMachineLogger.swift in Sources */,
+				ED5580732970265A003443E3 /* MXCryptoSDKLogger.swift in Sources */,
 				EC8A539725B1BC77004E0802 /* MXCallReplacesEventContent.m in Sources */,
 				B135066E27EA44C800BD3276 /* MXLocationServiceError.swift in Sources */,
 				32FA10C21FA1C9EE00E54233 /* MXOutgoingRoomKeyRequestManager.m in Sources */,
@@ -8000,7 +8000,7 @@
 				B1F04B142811E9D300103EBE /* MXBeaconInfoSummaryStoreProtocol.swift in Sources */,
 				EC8A53A225B1BC77004E0802 /* MXCallSelectAnswerEventContent.m in Sources */,
 				183892812702F553003F0C4F /* MXRoomNameDefaultStringLocalizer.m in Sources */,
-				ED5580742970265A003443E3 /* MXCryptoMachineLogger.swift in Sources */,
+				ED5580742970265A003443E3 /* MXCryptoSDKLogger.swift in Sources */,
 				B14EF2912397E90400758AF0 /* MXOutgoingRoomKeyRequestManager.m in Sources */,
 				B14EF2922397E90400758AF0 /* MXWellKnown.m in Sources */,
 				B1A026F926161EF5001AADFF /* MXSpaceChildSummaryResponse.m in Sources */,

--- a/MatrixSDK/Background/Crypto/MXBackgroundCryptoV2.swift
+++ b/MatrixSDK/Background/Crypto/MXBackgroundCryptoV2.swift
@@ -60,6 +60,8 @@ class MXBackgroundCryptoV2: MXBackgroundCrypto {
           - to-device events : \(syncResponse.toDevice?.events.count ?? 0)
           - devices changed  : \(syncResponse.deviceLists?.changed?.count ?? 0)
           - devices left     : \(syncResponse.deviceLists?.left?.count ?? 0)
+          - one time keys    : \(syncResponse.deviceOneTimeKeysCount?[kMXKeySignedCurve25519Type] ?? 0)
+          - fallback keys    : \(syncResponse.unusedFallbackKeys ?? [])
         """
         log.debug(details)
         

--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoRequests.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoRequests.swift
@@ -24,8 +24,22 @@ import MatrixSDKCrypto
 /// to the native REST API client
 struct MXCryptoRequests {
     private let restClient: MXRestClient
+    private let queryScheduler: MXKeysQueryScheduler<MXKeysQueryResponse>
+    
     init(restClient: MXRestClient) {
         self.restClient = restClient
+        self.queryScheduler = .init { users in
+            try await performCallbackRequest { completion in
+                _ = restClient.downloadKeysByChunk(
+                    forUsers: users,
+                    token: nil,
+                    success: {
+                        completion(.success($0))
+                    }, failure: {
+                        completion(.failure($0 ?? Error.unknownError))
+                    })
+            }
+        }
     }
     
     func sendToDevice(request: ToDeviceRequest) async throws {
@@ -47,7 +61,7 @@ struct MXCryptoRequests {
             restClient.uploadKeys(
                 request.deviceKeys,
                 oneTimeKeys: request.oneTimeKeys,
-                fallbackKeys: nil,
+                fallbackKeys: request.fallbackKeys,
                 forDevice: request.deviceId,
                 completion: $0
             )
@@ -86,16 +100,7 @@ struct MXCryptoRequests {
     }
     
     func queryKeys(users: [String]) async throws -> MXKeysQueryResponse {
-        return try await performCallbackRequest { completion in
-            _ = restClient.downloadKeysByChunk(
-                forUsers: users,
-                token: nil,
-                success: {
-                    completion(.success($0))
-                }, failure: {
-                    completion(.failure($0 ?? Error.unknownError))
-                })
-        }
+        try await queryScheduler.query(users: Set(users))
     }
     
     func claimKeys(request: ClaimKeysRequest) async throws -> MXKeysClaimResponse {
@@ -160,6 +165,7 @@ extension MXCryptoRequests {
     struct UploadKeysRequest {
         let deviceKeys: [String: Any]?
         let oneTimeKeys: [String: Any]?
+        let fallbackKeys: [String: Any]?
         let deviceId: String
         
         init(body: String, deviceId: String) throws {
@@ -169,6 +175,7 @@ extension MXCryptoRequests {
             
             self.deviceKeys = json["device_keys"] as? [String : Any]
             self.oneTimeKeys = json["one_time_keys"] as? [String : Any]
+            self.fallbackKeys = json["fallback_keys"] as? [String : Any]
             self.deviceId = deviceId
         }
     }

--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoSDKLogger.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoSDKLogger.swift
@@ -21,8 +21,8 @@ import Foundation
 import MatrixSDKCrypto
 
 /// Redirects logs originating in `MatrixSDKCrypto` into `MXLog`
-class MXCryptoMachineLogger: Logger {
-    static let shared = MXCryptoMachineLogger()
+class MXCryptoSDKLogger: Logger {
+    static let shared = MXCryptoSDKLogger()
     
     init() {
         setLogger(logger: self)
@@ -35,7 +35,7 @@ class MXCryptoMachineLogger: Logger {
             return
         }
         
-        MXLog.debug("[MXCryptoMachine] \(logLine)")
+        MXLog.debug("[MXCryptoSDK] \(logLine)")
     }
 }
 

--- a/MatrixSDK/Crypto/Migration/MXCryptoMigrationV2.swift
+++ b/MatrixSDK/Crypto/Migration/MXCryptoMigrationV2.swift
@@ -35,7 +35,7 @@ class MXCryptoMigrationV2: NSObject {
     
     func migrateCrypto(updateProgress: @escaping (Double) -> Void) throws {
         log.debug("Starting migration")
-        MXCryptoMachineLogger.shared.log(logLine: "Starting logs")
+        MXCryptoSDKLogger.shared.log(logLine: "Starting logs")
         
         let startDate = Date()
         updateProgress(0)

--- a/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoRequestsUnitTests.swift
+++ b/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoRequestsUnitTests.swift
@@ -52,6 +52,10 @@ class MXCryptoRequestsUnitTests: XCTestCase {
             "one_time_keys": [
                 "1": "C",
                 "2": "D",
+            ],
+            "fallback_keys": [
+                "3": "E",
+                "4": "F",
             ]
         ]
         
@@ -64,6 +68,10 @@ class MXCryptoRequestsUnitTests: XCTestCase {
             XCTAssertEqual(request.oneTimeKeys as? [String: String], [
                 "1": "C",
                 "2": "D",
+            ])
+            XCTAssertEqual(request.fallbackKeys as? [String: String], [
+                "3": "E",
+                "4": "F",
             ])
             XCTAssertEqual(request.deviceId, "A")
         } catch {

--- a/changelog.d/pr-1697.change
+++ b/changelog.d/pr-1697.change
@@ -1,0 +1,1 @@
+CryptoV2: Upload fallback keys


### PR DESCRIPTION
Upload fallback keys via `keys/upload` whenever present in the body of `UploadKeysRequest`.

Additionally:
- move `MXKeysQueryScheduler` into `MXCryptoRequests` (rather than the other way around), which hides away the details of making `keys/query` requests
- rename `MXCryptoSDKLogger`
- additional log messages