### PR TITLE
Set passphrase for the crypto store

### DIFF
--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoMachine.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoMachine.swift
@@ -76,13 +76,14 @@ class MXCryptoMachine {
         MXCryptoSDKLogger.shared.log(logLine: "Starting logs")
         
         let url = try MXCryptoMachineStore.createStoreURLIfNecessary(for: userId)
+        let passphrase = try MXCryptoMachineStore.storePassphrase()
         log.debug("Opening crypto store at \(url.path)/matrix-sdk-crypto.sqlite3") // Hardcoding path to db for debugging purpose
         
         machine = try OlmMachine(
             userId: userId,
             deviceId: deviceId,
             path: url.path,
-            passphrase: nil
+            passphrase: passphrase
         )
         
         self.requests = MXCryptoRequests(restClient: restClient)

--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoMachineStore.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoMachineStore.swift
@@ -19,6 +19,7 @@ import Foundation
 struct MXCryptoMachineStore {
     enum Error: Swift.Error {
         case invalidStorage
+        case invalidPassphrase
     }
     
     private static let storeFolder = "MXCryptoStore"
@@ -34,6 +35,21 @@ struct MXCryptoMachineStore {
     static func storeURL(for userId: String) throws -> URL {
         return try storeContainerURL()
             .appendingPathComponent(userId)
+    }
+    
+    static func storePassphrase() throws -> String {
+        let key = MXKeyProvider.sharedInstance()
+            .keyDataForData(
+                ofType: MXCryptoSDKStoreKeyDataType,
+                isMandatory: true,
+                expectedKeyType: .rawData
+            )
+        
+        guard let key = key as? MXRawDataKey else {
+            throw Error.invalidPassphrase
+        }
+        
+        return MXBase64Tools.base64(from: key.key)
     }
     
     private static func storeContainerURL() throws -> URL {

--- a/MatrixSDK/Crypto/Data/MXCryptoConstants.h
+++ b/MatrixSDK/Crypto/Data/MXCryptoConstants.h
@@ -50,6 +50,10 @@ FOUNDATION_EXPORT NSString *const kMXCryptoAes256KeyBackupAlgorithm;
  */
 FOUNDATION_EXPORT NSString *const MXCryptoOlmPickleKeyDataType;
 
+/**
+ MXKeyProvider identifier for a 32 bytes long key to a store managed by the Crypto SDK.
+ */
+FOUNDATION_EXPORT NSString *const MXCryptoSDKStoreKeyDataType;
 
 #pragma mark - Encrypting error
 

--- a/MatrixSDK/Crypto/Data/MXCryptoConstants.m
+++ b/MatrixSDK/Crypto/Data/MXCryptoConstants.m
@@ -26,6 +26,7 @@ NSString *const kMXCryptoMegolmAlgorithm                = @"m.megolm.v1.aes-sha2
 NSString *const kMXCryptoCurve25519KeyBackupAlgorithm   = @"m.megolm_backup.v1.curve25519-aes-sha2";
 NSString *const kMXCryptoAes256KeyBackupAlgorithm       = @"org.matrix.msc3270.v1.aes-hmac-sha2";
 NSString *const MXCryptoOlmPickleKeyDataType            = @"org.matrix.sdk.olm.pickle.key";
+NSString *const MXCryptoSDKStoreKeyDataType             = @"org.matrix.sdk.crypto.store.key";
 
 
 #pragma mark - Encrypting error

--- a/MatrixSDK/Crypto/Migration/MXCryptoMigrationV2.swift
+++ b/MatrixSDK/Crypto/Migration/MXCryptoMigrationV2.swift
@@ -22,27 +22,38 @@ import OLMKit
 import MatrixSDKCrypto
 
 class MXCryptoMigrationV2: NSObject {
+    enum Error: Swift.Error {
+        case unknownPickleKey
+        case missingStorePassphrase
+    }
+    
     private static let SessionBatchSize = 1000
     
+    private let legacyDevice: MXOlmDevice
     private let store: MXCryptoMigrationStore
     private let log = MXNamedLog(name: "MXCryptoMachineMigration")
     
     init(legacyStore: MXCryptoStore) {
+        MXCryptoSDKLogger.shared.log(logLine: "Starting logs")
+        
+        // We need to create legacy OlmDevice which sets itself internally as pickle key delegate
+        // Once established we can get the pickleKey from OLMKit which is used to decrypt and migrate
+        // the legacy store data
+        legacyDevice = MXOlmDevice(store: legacyStore)
         store = .init(legacyStore: legacyStore)
-        super.init()
-        OLMKit.sharedInstance().pickleKeyDelegate = self
     }
     
     func migrateCrypto(updateProgress: @escaping (Double) -> Void) throws {
         log.debug("Starting migration")
-        MXCryptoSDKLogger.shared.log(logLine: "Starting logs")
         
         let startDate = Date()
         updateProgress(0)
         
-        let key = pickleKey()
-        let data = try store.extractData(with: key)
+        let pickleKey = try legacyPickleKey()
+        let data = try store.extractData(with: pickleKey)
+        
         let url = try MXCryptoMachineStore.storeURL(for: data.account.userId)
+        let passphrase = try MXCryptoMachineStore.storePassphrase()
         
         if FileManager.default.fileExists(atPath: url.path) {
             try FileManager.default.removeItem(at: url)
@@ -63,7 +74,7 @@ class MXCryptoMigrationV2: NSObject {
         try migrate(
             data: data,
             path: url.path,
-            passphrase: nil,
+            passphrase: passphrase,
             progressListener: self
         )
         
@@ -73,14 +84,15 @@ class MXCryptoMigrationV2: NSObject {
         let totalSessions = store.olmSessionCount + store.megolmSessionCount
         let olmToMegolmRatio = totalSessions > 0 ? Double(store.olmSessionCount)/Double(totalSessions) : 0
         
-        store.extractSessions(with: key, batchSize: Self.SessionBatchSize) { [weak self] batch, progress in
+        store.extractSessions(with: pickleKey, batchSize: Self.SessionBatchSize) { [weak self] batch, progress in
             updateProgress(progress * olmToMegolmRatio)
             
             do {
                 try self?.migrateSessions(
                     data: data,
                     sessions: batch,
-                    url: url
+                    url: url,
+                    passphrase: passphrase
                 )
             } catch {
                 self?.log.error("Error migrating some sessions", context: error)
@@ -89,14 +101,15 @@ class MXCryptoMigrationV2: NSObject {
         
         log.debug("Migrating megolm sessions in batches")
         
-        store.extractGroupSessions(with: key, batchSize: Self.SessionBatchSize) { [weak self] batch, progress in
+        store.extractGroupSessions(with: pickleKey, batchSize: Self.SessionBatchSize) { [weak self] batch, progress in
             updateProgress(olmToMegolmRatio + progress * (1 - olmToMegolmRatio))
             
             do {
                 try self?.migrateSessions(
                     data: data,
                     inboundGroupSessions: batch,
-                    url: url
+                    url: url,
+                    passphrase: passphrase
                 )
             } catch {
                 self?.log.error("Error migrating some sessions", context: error)
@@ -108,6 +121,13 @@ class MXCryptoMigrationV2: NSObject {
         updateProgress(1)
     }
     
+    private func legacyPickleKey() throws -> Data {
+        guard let key = OLMKit.sharedInstance().pickleKeyDelegate?.pickleKey() else {
+            throw Error.unknownPickleKey
+        }
+        return key
+    }
+    
     // To migrate sessions in batches and keep memory under control we are repeatedly calling `migrate`
     // function whilst only passing data for sessions and account, keeping the rest empty.
     // This API will be improved in `MatrixCryptoSDK` in the future.
@@ -115,7 +135,8 @@ class MXCryptoMigrationV2: NSObject {
         data: MigrationData,
         sessions: [PickledSession] = [],
         inboundGroupSessions: [PickledInboundGroupSession] = [],
-        url: URL
+        url: URL,
+        passphrase: String
     ) throws {
         try migrate(
             data: .init(
@@ -129,27 +150,9 @@ class MXCryptoMigrationV2: NSObject {
                 trackedUsers: data.trackedUsers
             ),
             path: url.path,
-            passphrase: nil,
+            passphrase: passphrase,
             progressListener: self
         )
-    }
-}
-
-extension MXCryptoMigrationV2: OLMKitPickleKeyDelegate {
-    public func pickleKey() -> Data {
-        let key = MXKeyProvider.sharedInstance()
-            .keyDataForData(
-                ofType: MXCryptoOlmPickleKeyDataType,
-                isMandatory: true,
-                expectedKeyType: .rawData
-            )
-        
-        guard let key = key as? MXRawDataKey else {
-            log.failure("Wrong key")
-            return Data()
-        }
-        
-        return key.key
     }
 }
 

--- a/MatrixSDK/Crypto/Migration/MXCryptoMigrationV2.swift
+++ b/MatrixSDK/Crypto/Migration/MXCryptoMigrationV2.swift
@@ -24,7 +24,6 @@ import MatrixSDKCrypto
 class MXCryptoMigrationV2: NSObject {
     enum Error: Swift.Error {
         case unknownPickleKey
-        case missingStorePassphrase
     }
     
     private static let SessionBatchSize = 1000

--- a/MatrixSDK/Crypto/Trust/MXTrustLevelSource.swift
+++ b/MatrixSDK/Crypto/Trust/MXTrustLevelSource.swift
@@ -50,14 +50,10 @@ struct MXTrustLevelSource {
         )
     }
     
-    func trustLevelSummary(userIds: [String]) -> MXUsersTrustLevelSummary? {
-        guard let devices = trustedDevices(userIds: userIds) else {
-            return nil
-        }
-        
+    func trustLevelSummary(userIds: [String]) -> MXUsersTrustLevelSummary {
         return .init(
             trustedUsersProgress: trustedUsers(userIds: userIds),
-            andTrustedDevicesProgress: devices
+            andTrustedDevicesProgress: trustedDevices(userIds: userIds)
         )
     }
     
@@ -71,7 +67,7 @@ struct MXTrustLevelSource {
         return progress
     }
     
-    private func trustedDevices(userIds: [String]) -> Progress? {
+    private func trustedDevices(userIds: [String]) -> Progress {
         let devices = userIds.flatMap {
             devicesSource.devices(userId: $0)
         }

--- a/MatrixSDK/Crypto/Verification/MXKeyVerificationManagerV2.swift
+++ b/MatrixSDK/Crypto/Verification/MXKeyVerificationManagerV2.swift
@@ -268,7 +268,7 @@ class MXKeyVerificationManagerV2: NSObject, MXKeyVerificationManager {
     }
     
     func handleRoomEvent(_ event: MXEvent) async throws {
-        guard isRoomVerificationEvent(event) else {
+        guard isIncomingRoomVerificationEvent(event) else {
             return
         }
         
@@ -465,7 +465,13 @@ class MXKeyVerificationManagerV2: NSObject, MXKeyVerificationManager {
         return roomId
     }
     
-    private func isRoomVerificationEvent(_ event: MXEvent) -> Bool {
+    private func isIncomingRoomVerificationEvent(_ event: MXEvent) -> Bool {
+        // Only consider events not coming from our own user, because verification events
+        // for the same user are sent as encrypted to-device messages
+        guard event.sender != session?.myUserId else {
+            return false
+        }
+        
         // Filter incoming events by allowed list of event types
         guard Self.dmEventTypes.contains(where: { $0.identifier == event.type }) else {
             return false

--- a/MatrixSDKTests/Crypto/Trust/MXTrustLevelSourceUnitTests.swift
+++ b/MatrixSDKTests/Crypto/Trust/MXTrustLevelSourceUnitTests.swift
@@ -72,11 +72,11 @@ class MXTrustLevelSourceUnitTests: XCTestCase {
         
         let summary = source.trustLevelSummary(userIds: ["Alice", "Bob"])
         
-        XCTAssertEqual(summary?.trustedUsersProgress.totalUnitCount, 2)
-        XCTAssertEqual(summary?.trustedUsersProgress.completedUnitCount, 1)
+        XCTAssertEqual(summary.trustedUsersProgress.totalUnitCount, 2)
+        XCTAssertEqual(summary.trustedUsersProgress.completedUnitCount, 1)
         
-        XCTAssertEqual(summary?.trustedDevicesProgress.totalUnitCount, 3)
-        XCTAssertEqual(summary?.trustedDevicesProgress.completedUnitCount, 2)
+        XCTAssertEqual(summary.trustedDevicesProgress.totalUnitCount, 3)
+        XCTAssertEqual(summary.trustedDevicesProgress.completedUnitCount, 2)
     }
 }
 

--- a/changelog.d/pr-1699.change
+++ b/changelog.d/pr-1699.change
@@ -1,0 +1,1 @@
+CryptoV2: Set passphrase for the crypto store


### PR DESCRIPTION
Use existing `MXKeyProvider` mechanism to get a new key that is used as base64-encoded passphrase when migrating or creating `OlmMachine` in crypto V2. This means all data stored in the underlying sqlite db will be encrypted.

Additionally:
- listen to room membership changes and track new users
- listen to room encryption events and set encryption if necessary