### PR TITLE
Import legacy backup in batches with progress

### DIFF
--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -1942,6 +1942,8 @@
 		ED6DAC2228C7A51400ECDCB6 /* MXDateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED6DAC2028C7A4F000ECDCB6 /* MXDateProvider.swift */; };
 		ED6E87A9294B3BAB00100D9C /* MXAnalyticsDestinationUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED6E87A8294B3BAB00100D9C /* MXAnalyticsDestinationUnitTests.swift */; };
 		ED6E87AA294B3BAB00100D9C /* MXAnalyticsDestinationUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED6E87A8294B3BAB00100D9C /* MXAnalyticsDestinationUnitTests.swift */; };
+		ED6F4EFC2987F0FC007D1191 /* MXEncryptedKeyBackup.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED6F4EFB2987F0FC007D1191 /* MXEncryptedKeyBackup.swift */; };
+		ED6F4EFD2987F0FC007D1191 /* MXEncryptedKeyBackup.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED6F4EFB2987F0FC007D1191 /* MXEncryptedKeyBackup.swift */; };
 		ED7019DD2886C24100FC31B9 /* MXCrossSigningInfoSourceUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED8F1D242885A39800F897E7 /* MXCrossSigningInfoSourceUnitTests.swift */; };
 		ED7019DE2886C24A00FC31B9 /* MXTrustLevelSourceUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED8F1D2F2885AB0300F897E7 /* MXTrustLevelSourceUnitTests.swift */; };
 		ED7019DF2886C25600FC31B9 /* MXDeviceInfoUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED8F1D1B2885909E00F897E7 /* MXDeviceInfoUnitTests.swift */; };
@@ -3128,6 +3130,7 @@
 		ED6DAC1D28C79D2000ECDCB6 /* MXUnrequestedForwardedRoomKeyManagerUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXUnrequestedForwardedRoomKeyManagerUnitTests.swift; sourceTree = "<group>"; };
 		ED6DAC2028C7A4F000ECDCB6 /* MXDateProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXDateProvider.swift; sourceTree = "<group>"; };
 		ED6E87A8294B3BAB00100D9C /* MXAnalyticsDestinationUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXAnalyticsDestinationUnitTests.swift; sourceTree = "<group>"; };
+		ED6F4EFB2987F0FC007D1191 /* MXEncryptedKeyBackup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXEncryptedKeyBackup.swift; sourceTree = "<group>"; };
 		ED7019E42886C32900FC31B9 /* MXSASTransactionV2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXSASTransactionV2.swift; sourceTree = "<group>"; };
 		ED7019E72886C33100FC31B9 /* MXKeyVerificationRequestV2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXKeyVerificationRequestV2.swift; sourceTree = "<group>"; };
 		ED7019EA2886C33A00FC31B9 /* MXKeyVerificationManagerV2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXKeyVerificationManagerV2.swift; sourceTree = "<group>"; };
@@ -5790,6 +5793,7 @@
 				EDD4197D28DCAA5F007F3757 /* MXNativeKeyBackupEngine.h */,
 				EDD4198028DCAA7B007F3757 /* MXNativeKeyBackupEngine.m */,
 				ED36ED8528DD9E2100C86416 /* MXCryptoKeyBackupEngine.swift */,
+				ED6F4EFB2987F0FC007D1191 /* MXEncryptedKeyBackup.swift */,
 			);
 			path = Engine;
 			sourceTree = "<group>";
@@ -7162,6 +7166,7 @@
 				ECDA764E27BA963D000C48CF /* MXBooleanCapability.m in Sources */,
 				321CFDEB22525DEE004D31DF /* MXIncomingSASTransaction.m in Sources */,
 				EC1165C427107E330089FA56 /* MXRoomListDataFilterOptions.swift in Sources */,
+				ED6F4EFC2987F0FC007D1191 /* MXEncryptedKeyBackup.swift in Sources */,
 				3A108A8025810C96005EEBE9 /* MXKeyData.m in Sources */,
 				3A59A52B25A7B1B000DDA1FC /* MXOutboundSessionInfo.m in Sources */,
 				32A1515C1DB525DA00400192 /* NSObject+sortedKeys.m in Sources */,
@@ -7827,6 +7832,7 @@
 				3A858DE227528EEB006322C1 /* MXHomeserverCapabilitiesService.swift in Sources */,
 				ECDA764F27BA963D000C48CF /* MXBooleanCapability.m in Sources */,
 				B14EF24C2397E90400758AF0 /* MXCredentials.m in Sources */,
+				ED6F4EFD2987F0FC007D1191 /* MXEncryptedKeyBackup.swift in Sources */,
 				EC116590270F3ABF0089FA56 /* RLMRealm+MatrixSDK.m in Sources */,
 				B14EF24D2397E90400758AF0 /* MXOutgoingRoomKeyRequest.m in Sources */,
 				B14EF24E2397E90400758AF0 /* MXAllowedCertificates.m in Sources */,

--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoMachine.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoMachine.swift
@@ -362,6 +362,15 @@ extension MXCryptoMachine: MXCryptoUserIdentitySource {
 }
 
 extension MXCryptoMachine: MXCryptoRoomEventEncrypting {
+    func isUserTracked(userId: String) -> Bool {
+        do {
+            return try machine.isUserTracked(userId: userId)
+        } catch {
+            log.error("Failed getting tracked status", context: error)
+            return false
+        }
+    }
+    
     func addTrackedUsers(_ users: [String]) {
         do {
             try machine.updateTrackedUsers(users: users)

--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoProtocols.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoProtocols.swift
@@ -66,6 +66,7 @@ protocol MXCryptoUserIdentitySource: MXCryptoIdentity {
 
 /// Room event encryption
 protocol MXCryptoRoomEventEncrypting: MXCryptoIdentity {
+    func isUserTracked(userId: String) -> Bool
     func addTrackedUsers(_ users: [String])
     func shareRoomKeysIfNecessary(roomId: String, users: [String], settings: EncryptionSettings) async throws
     func encryptRoomEvent(content: [AnyHashable: Any], roomId: String, eventType: String) throws -> [String: Any]

--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoSDKLogger.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoSDKLogger.swift
@@ -31,8 +31,15 @@ class MXCryptoSDKLogger: Logger {
     func log(logLine: String) {
         // Excluding some auto-generated logs that are not useful
         // This will be changed in rust-sdk directly
-        guard !logLine.contains("::uniffi_api:") else {
-            return
+        let ignored = [
+            "::uniffi_api:",
+            "::backup_recovery_key: decrypt_v1"
+        ]
+        
+        for ignore in ignored {
+            if logLine.contains(ignore) {
+                return
+            }
         }
         
         MXLog.debug("[MXCryptoSDK] \(logLine)")

--- a/MatrixSDK/Crypto/Data/MXCryptoConstants.h
+++ b/MatrixSDK/Crypto/Data/MXCryptoConstants.h
@@ -89,6 +89,7 @@ typedef enum : NSUInteger
     MXKeyBackupErrorMissingPrivateKeySaltCode,
     MXKeyBackupErrorMissingAuthDataCode,
     MXKeyBackupErrorInvalidOrMissingLocalPrivateKey,
-    MXKeyBackupErrorUnknownAlgorithm
+    MXKeyBackupErrorUnknownAlgorithm,
+    MXKeyBackupErrorAlreadyInProgress,
 
 } MXKeyBackupErrorCode;

--- a/MatrixSDK/Crypto/KeyBackup/Engine/MXEncryptedKeyBackup.swift
+++ b/MatrixSDK/Crypto/KeyBackup/Engine/MXEncryptedKeyBackup.swift
@@ -1,0 +1,30 @@
+// 
+// Copyright 2023 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+/// Helper class for batch importing key backups
+@objcMembers public class MXEncryptedKeyBackup: NSObject {
+    public let roomId: String
+    public let sessionId: String
+    public let keyBackup: MXKeyBackupData
+    
+    public init(roomId: String, sessionId: String, keyBackup: MXKeyBackupData) {
+        self.roomId = roomId
+        self.sessionId = sessionId
+        self.keyBackup = keyBackup
+    }
+}

--- a/MatrixSDK/Crypto/MXCryptoV2.swift
+++ b/MatrixSDK/Crypto/MXCryptoV2.swift
@@ -656,7 +656,7 @@ class MXCryptoV2: NSObject, MXCrypto {
     
     private func handleRoomMemberEvent(_ event: MXEvent, roomState: MXRoomState?) async {
         guard
-            let userId = event.stateKey,
+            let userId = event.stateKey, !machine.isUserTracked(userId: userId),
             let state = roomState,
             let member = state.members?.member(withUserId: userId)
         else {

--- a/MatrixSDKTests/Crypto/Algorithms/RoomEvents/MXRoomEventEncryptionUnitTests.swift
+++ b/MatrixSDKTests/Crypto/Algorithms/RoomEvents/MXRoomEventEncryptionUnitTests.swift
@@ -86,6 +86,10 @@ class MXRoomEventEncryptionUnitTests: XCTestCase {
     
     class EncryptorStub: CryptoIdentityStub, MXCryptoRoomEventEncrypting {
         var trackedUsers: Set<String> = []
+        func isUserTracked(userId: String) -> Bool {
+            return trackedUsers.contains(userId)
+        }
+        
         func addTrackedUsers(_ users: [String]) {
             trackedUsers = trackedUsers.union(users)
         }

--- a/changelog.d/pr-1701.change
+++ b/changelog.d/pr-1701.change
@@ -1,0 +1,1 @@
+Backup: Import legacy backup in batches


### PR DESCRIPTION
Import room backups in batches and report progress continuously.

Note that even with this change memory growns linearly during import (albeit with a smaller slope), which means we are either leaking some memory or filling up in-memory cache somewhere in the crypto layer. Either way this should make imports slightly less memory hungry, and compute the progress regardless.

This PR also contains some small fixes for crypto v2 (logs + tracked users optimization)