### PR TITLE
Sync polls rules (PSG-77, PSG-1097)

### DIFF
--- a/MatrixSDK/NotificationCenter/MXNotificationCenter.h
+++ b/MatrixSDK/NotificationCenter/MXNotificationCenter.h
@@ -209,12 +209,14 @@ extern NSString *const kMXNotificationCenterAllOtherRoomMessagesRuleID;
  @param notify enable/disable notification.
  @param soundName the name of the sound to apply (`ring`, `default`, etc).
  @param highlight enable/disable highlight option.
+ @param completion an optional completion block for the operation.
  */
 - (void)updatePushRuleActions:(NSString*)ruleId
                          kind:(MXPushRuleKind)kind
                        notify:(BOOL)notify
                     soundName:(NSString*)soundName
-                    highlight:(BOOL)highlight;
+                    highlight:(BOOL)highlight
+                   completion: (void (^_Nullable)(NSError * _Nullable error))completion;
 
 /**
  Create a content push rule, see MXNotificationCenter notifications for operation result.

--- a/MatrixSDK/NotificationCenter/MXNotificationCenter.h
+++ b/MatrixSDK/NotificationCenter/MXNotificationCenter.h
@@ -197,8 +197,9 @@ extern NSString *const kMXNotificationCenterAllOtherRoomMessagesRuleID;
  
  @param pushRule the push rule to update
  @param enable YES to enable.
+ @param completion an optional completion block for the operation.
  */
-- (void)enableRule:(MXPushRule*)pushRule isEnabled:(BOOL)enable;
+- (void)enableRule:(MXPushRule*)pushRule isEnabled:(BOOL)enable completion:(void (^_Nullable)(NSError * _Nullable error))completion;
 
 /**
  Update the actions for an existing push rule.

--- a/MatrixSDK/NotificationCenter/MXNotificationCenter.h
+++ b/MatrixSDK/NotificationCenter/MXNotificationCenter.h
@@ -21,8 +21,9 @@
 #import "MXPushRuleConditionChecker.h"
 #import "MXHTTPOperation.h"
 
-
 @class MXSession;
+
+MX_ASSUME_MISSING_NULLABILITY_BEGIN
 
 /**
  Posted when an existing push rule will be modified (pause, resume, delete) or when a new rule will be added.
@@ -199,7 +200,7 @@ extern NSString *const kMXNotificationCenterAllOtherRoomMessagesRuleID;
  @param enable YES to enable.
  @param completion an optional completion block for the operation.
  */
-- (void)enableRule:(MXPushRule*)pushRule isEnabled:(BOOL)enable completion:(void (^_Nullable)(NSError * _Nullable error))completion;
+- (void)enableRule:(MXPushRule*)pushRule isEnabled:(BOOL)enable completion:(nullable void (^)(NSError * _Nullable error))completion;
 
 /**
  Update the actions for an existing push rule.
@@ -216,7 +217,7 @@ extern NSString *const kMXNotificationCenterAllOtherRoomMessagesRuleID;
                        notify:(BOOL)notify
                     soundName:(NSString*)soundName
                     highlight:(BOOL)highlight
-                   completion: (void (^_Nullable)(NSError * _Nullable error))completion;
+                   completion:(nullable void (^)(NSError * _Nullable error))completion;
 
 /**
  Create a content push rule, see MXNotificationCenter notifications for operation result.

--- a/MatrixSDK/NotificationCenter/MXNotificationCenter.m
+++ b/MatrixSDK/NotificationCenter/MXNotificationCenter.m
@@ -397,7 +397,7 @@ NSString *const kMXNotificationCenterAllOtherRoomMessagesRuleID = @".m.rule.mess
     }
 }
 
-- (void)enableRule:(MXPushRule*)pushRule isEnabled:(BOOL)enable completion:(void (^_Nullable)(NSError * _Nullable error))completion
+- (void)enableRule:(MXPushRule*)pushRule isEnabled:(BOOL)enable completion:(nullable void (^)(NSError * _Nullable error))completion;
 {
     if (pushRule)
     {
@@ -444,7 +444,7 @@ NSString *const kMXNotificationCenterAllOtherRoomMessagesRuleID = @".m.rule.mess
                        notify:(BOOL)notify
                     soundName:(NSString*)soundName
                     highlight:(BOOL)highlight
-                   completion:(void (^_Nullable)(NSError * _Nullable error))completion
+                   completion:(nullable void (^)(NSError * _Nullable error))completion
 {
     
     NSArray *actions = [self encodeActionsWithNotify:notify soundName:soundName highlight:highlight];

--- a/MatrixSDK/NotificationCenter/MXNotificationCenter.m
+++ b/MatrixSDK/NotificationCenter/MXNotificationCenter.m
@@ -465,8 +465,7 @@ NSString *const kMXNotificationCenterAllOtherRoomMessagesRuleID = @".m.rule.mess
                 completion(nil);
             }
         }];
-    }
-                                                 failure:^(NSError *error) {
+    }  failure:^(NSError *error) {
         [[NSNotificationCenter defaultCenter] postNotificationName:kMXNotificationCenterDidFailRulesUpdate object:self userInfo:@{kMXNotificationCenterErrorKey:error}];
         if (completion) {
             completion(error);

--- a/MatrixSDK/NotificationCenter/MXNotificationCenter.m
+++ b/MatrixSDK/NotificationCenter/MXNotificationCenter.m
@@ -397,7 +397,7 @@ NSString *const kMXNotificationCenterAllOtherRoomMessagesRuleID = @".m.rule.mess
     }
 }
 
-- (void)enableRule:(MXPushRule*)pushRule isEnabled:(BOOL)enable
+- (void)enableRule:(MXPushRule*)pushRule isEnabled:(BOOL)enable completion:(void (^_Nullable)(NSError * _Nullable error))completion
 {
     if (pushRule)
     {
@@ -426,10 +426,15 @@ NSString *const kMXNotificationCenterAllOtherRoomMessagesRuleID = @".m.rule.mess
             
             [[NSNotificationCenter defaultCenter] postNotificationName:kMXNotificationCenterDidUpdateRules object:self userInfo:nil];
             
+            if (completion) {
+                completion(nil);
+            }
         } failure:^(NSError *error) {
-            
             [[NSNotificationCenter defaultCenter] postNotificationName:kMXNotificationCenterDidFailRulesUpdate object:self userInfo:@{kMXNotificationCenterErrorKey:error}];
             
+            if (completion) {
+                completion(error);
+            }
         }];
     }
 }

--- a/MatrixSDK/NotificationCenter/MXNotificationCenter.m
+++ b/MatrixSDK/NotificationCenter/MXNotificationCenter.m
@@ -444,6 +444,7 @@ NSString *const kMXNotificationCenterAllOtherRoomMessagesRuleID = @".m.rule.mess
                        notify:(BOOL)notify
                     soundName:(NSString*)soundName
                     highlight:(BOOL)highlight
+                   completion:(void (^_Nullable)(NSError * _Nullable error))completion
 {
     
     NSArray *actions = [self encodeActionsWithNotify:notify soundName:soundName highlight:highlight];
@@ -455,12 +456,21 @@ NSString *const kMXNotificationCenterAllOtherRoomMessagesRuleID = @".m.rule.mess
         // Refresh locally rules
         [self refreshRules:^{
             [[NSNotificationCenter defaultCenter] postNotificationName:kMXNotificationCenterDidUpdateRules object:self userInfo:nil];
+            if (completion) {
+                completion(nil);
+            }
         } failure:^(NSError *error) {
             [[NSNotificationCenter defaultCenter] postNotificationName:kMXNotificationCenterDidFailRulesUpdate object:self userInfo:@{kMXNotificationCenterErrorKey:error}];
+            if (completion) {
+                completion(nil);
+            }
         }];
     }
                                                  failure:^(NSError *error) {
         [[NSNotificationCenter defaultCenter] postNotificationName:kMXNotificationCenterDidFailRulesUpdate object:self userInfo:@{kMXNotificationCenterErrorKey:error}];
+        if (completion) {
+            completion(error);
+        }
     }];
 }
 

--- a/changelog.d/pr-1702.change
+++ b/changelog.d/pr-1702.change
@@ -1,0 +1,1 @@
+Notifications: add completion blocks in the API.


### PR DESCRIPTION
### Description

This PR add completion blocks for updating push rules.
Completion blocks have been added for:
- Enabling/disabling a push rule
- Updated actions of a push rule

