### PR TITLE
New CryptoMachine on each background operation

### DIFF
--- a/MatrixSDK/Background/Crypto/MXBackgroundCryptoV2.swift
+++ b/MatrixSDK/Background/Crypto/MXBackgroundCryptoV2.swift
@@ -27,29 +27,13 @@ class MXBackgroundCryptoV2: MXBackgroundCrypto {
         case missingCredentials
     }
     
-    private let machine: MXCryptoMachine
+    private let credentials: MXCredentials
+    private let restClient: MXRestClient
     private let log = MXNamedLog(name: "MXBackgroundCryptoV2")
     
-    init(credentials: MXCredentials, restClient: MXRestClient) throws {
-        guard
-            let userId = credentials.userId,
-            let deviceId = credentials.deviceId
-        else {
-            throw Error.missingCredentials
-        }
-        
-        // `MXCryptoMachine` will load the same store as the main application meaning that background and foreground
-        // sync services have access to the same data / keys. Possible race conditions are handled internally.
-        machine = try MXCryptoMachine(
-            userId: userId,
-            deviceId: deviceId,
-            restClient: restClient,
-            getRoomAction: { [log] _ in
-                log.error("The background crypto should not be accessing rooms")
-                return nil
-            }
-        )
-        
+    init(credentials: MXCredentials, restClient: MXRestClient) {
+        self.credentials = credentials
+        self.restClient = restClient
         log.debug("Initialized background crypto module")
     }
     
@@ -66,6 +50,7 @@ class MXBackgroundCryptoV2: MXBackgroundCrypto {
         log.debug(details)
         
         do {
+            let machine = try createMachine()
             _ = try await machine.handleSyncResponse(
                 toDevice: syncResponse.toDevice,
                 deviceLists: syncResponse.deviceLists,
@@ -100,6 +85,7 @@ class MXBackgroundCryptoV2: MXBackgroundCrypto {
         do {
             // Rust-sdk does not expose api to see if we have a given session key yet (will be added in the future)
             // so for the time being to find out if we can decrypt we simply perform the (more expensive) decryption
+            let machine = try createMachine()
             _ = try machine.decryptRoomEvent(event)
             log.debug("Event `\(eventId)` can be decrypted with session `\(sessionId)`")
             return true
@@ -117,6 +103,7 @@ class MXBackgroundCryptoV2: MXBackgroundCrypto {
         log.debug("Decrypting event `\(eventId)`")
         
         do {
+            let machine = try createMachine()
             let decrypted = try machine.decryptRoomEvent(event)
             let result = try MXEventDecryptionResult(event: decrypted)
             event.setClearData(result)
@@ -126,6 +113,30 @@ class MXBackgroundCryptoV2: MXBackgroundCrypto {
             log.error("Failed to decrypt event", context: error)
             throw error
         }
+    }
+    
+    // `MXCryptoMachine` will load the same store as the main application meaning that background and foreground
+    // sync services have access to the same data / keys. The machine is not fully multi-thread and multi-process
+    // safe, and until this is resolved we open a new instance of `MXCryptoMachine` on each background operation
+    // to ensure we are always up-to-date with whatever has been written by the foreground process in the meanwhile.
+    // See https://github.com/matrix-org/matrix-rust-sdk/issues/1415 for more details.
+    private func createMachine() throws -> MXCryptoMachine {
+        guard
+            let userId = credentials.userId,
+            let deviceId = credentials.deviceId
+        else {
+            throw Error.missingCredentials
+        }
+         
+        return try MXCryptoMachine(
+            userId: userId,
+            deviceId: deviceId,
+            restClient: restClient,
+            getRoomAction: { [log] _ in
+                log.error("The background crypto should not be accessing rooms")
+                return nil
+            }
+        )
     }
 }
 

--- a/changelog.d/pr-1704.change
+++ b/changelog.d/pr-1704.change
@@ -1,0 +1,1 @@
+CryptoV2: New CryptoMachine on each background operation


### PR DESCRIPTION
The background crypto process (used to decrypt notifications) relies on several rust-crypto-sdk methods that are not multiprocess safe. In particular, since the background's `MXCryptoMachine` may live in memory for days, whereas foreground's will be recreated on each app launch, we may end up in a situation where foreground has written changes to disk that the background machine does not pick up. For more details see https://github.com/matrix-org/matrix-rust-sdk/issues/1415

This will be fixed in the future in the rust-sdk via a `proc_lock` or similar multiprocess lock, but in a meanwhile a relatively quick solution is to recreate `MXCryptoMachine` on each operation (recieve sync, decrypt event), ensuring that each time we have relatively fresh data taken straight from disk.

We could addionally add `NSFileCoordinator` to provide full mutual exclusion between the processes, but this adds some amount of complexity that will be eventually moved out to rust anyway. The chance of foreground and background processing sync at the same time is minimized by explicit `session.state` checks.