### PR TITLE
Fix JSONDictionary of keys query responses

### DIFF
--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -1874,6 +1874,8 @@
 		ED51943A28462D130006EEC6 /* MXRoomStateUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED51943828462D130006EEC6 /* MXRoomStateUnitTests.swift */; };
 		ED51943C284630090006EEC6 /* MXRestClientStub.m in Sources */ = {isa = PBXBuildFile; fileRef = ED51943B284630090006EEC6 /* MXRestClientStub.m */; };
 		ED51943D284630090006EEC6 /* MXRestClientStub.m in Sources */ = {isa = PBXBuildFile; fileRef = ED51943B284630090006EEC6 /* MXRestClientStub.m */; };
+		ED555F59298BB27200C5BD63 /* MXKeysQueryResponseUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED555F58298BB27200C5BD63 /* MXKeysQueryResponseUnitTests.swift */; };
+		ED555F5A298BB27200C5BD63 /* MXKeysQueryResponseUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED555F58298BB27200C5BD63 /* MXKeysQueryResponseUnitTests.swift */; };
 		ED558068296F0361003443E3 /* MXCryptoMigrationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED558067296F0361003443E3 /* MXCryptoMigrationStore.swift */; };
 		ED558069296F0361003443E3 /* MXCryptoMigrationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED558067296F0361003443E3 /* MXCryptoMigrationStore.swift */; };
 		ED55806D296F0E3A003443E3 /* MXCryptoMigrationStoreUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED55806C296F0E3A003443E3 /* MXCryptoMigrationStoreUnitTests.swift */; };
@@ -3095,6 +3097,7 @@
 		ED51943828462D130006EEC6 /* MXRoomStateUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXRoomStateUnitTests.swift; sourceTree = "<group>"; };
 		ED51943B284630090006EEC6 /* MXRestClientStub.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXRestClientStub.m; sourceTree = "<group>"; };
 		ED51943E284630100006EEC6 /* MXRestClientStub.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXRestClientStub.h; sourceTree = "<group>"; };
+		ED555F58298BB27200C5BD63 /* MXKeysQueryResponseUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXKeysQueryResponseUnitTests.swift; sourceTree = "<group>"; };
 		ED558067296F0361003443E3 /* MXCryptoMigrationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXCryptoMigrationStore.swift; sourceTree = "<group>"; };
 		ED55806C296F0E3A003443E3 /* MXCryptoMigrationStoreUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXCryptoMigrationStoreUnitTests.swift; sourceTree = "<group>"; };
 		ED55806F296F1BEE003443E3 /* MXCryptoMigrationV2Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXCryptoMigrationV2Tests.swift; sourceTree = "<group>"; };
@@ -5782,6 +5785,7 @@
 			children = (
 				321809B819EEBF3000377451 /* MXEventTests.m */,
 				EDB4209827DF842F0036AF39 /* MXEventFixtures.swift */,
+				ED555F58298BB27200C5BD63 /* MXKeysQueryResponseUnitTests.swift */,
 			);
 			path = JSONModels;
 			sourceTree = "<group>";
@@ -7369,6 +7373,7 @@
 				32B090FD26201C8D002924AA /* MXAsyncTaskQueueUnitTests.swift in Sources */,
 				322A51D81D9E846800C8536D /* MXCryptoTests.m in Sources */,
 				B146D4FF21A5C0BD00D8C2C6 /* MXMediaScanStoreUnitTests.m in Sources */,
+				ED555F59298BB27200C5BD63 /* MXKeysQueryResponseUnitTests.swift in Sources */,
 				32BD34BE1E84134A006EDC0D /* MatrixSDKTestsE2EData.m in Sources */,
 				EDC8C40E2968C37F003792C5 /* MXKeysQuerySchedulerUnitTests.swift in Sources */,
 				ED751DAE28EDEC7E003748C3 /* MXKeyVerificationStateResolverUnitTests.swift in Sources */,
@@ -8035,6 +8040,7 @@
 				32B4778E2638133D00EA5800 /* MXFilterUnitTests.m in Sources */,
 				32B090FE26201C8D002924AA /* MXAsyncTaskQueueUnitTests.swift in Sources */,
 				B1E09A242397FCE90057C069 /* MXPeekingRoomTests.m in Sources */,
+				ED555F5A298BB27200C5BD63 /* MXKeysQueryResponseUnitTests.swift in Sources */,
 				B1E09A452397FD990057C069 /* MXLazyLoadingTests.m in Sources */,
 				EDC8C40D2968C37E003792C5 /* MXKeysQuerySchedulerUnitTests.swift in Sources */,
 				ED751DAF28EDEC7E003748C3 /* MXKeyVerificationStateResolverUnitTests.swift in Sources */,

--- a/MatrixSDK/Categories/MXRestClient+Extensions.swift
+++ b/MatrixSDK/Categories/MXRestClient+Extensions.swift
@@ -35,7 +35,7 @@ public extension MXRestClient {
                              failure: @escaping (_ error: NSError?) -> Void) -> MXHTTPOperation {
         
         // Do not chunk if not needed
-        if users.count < chunkSize {
+        if users.count <= chunkSize {
             return self.downloadKeys(forUsers: users, token: token) { response in
                 switch response {
                     case .success(let keysQueryResponse):

--- a/MatrixSDK/Crypto/Algorithms/RoomEvent/MXRoomEventEncryption.swift
+++ b/MatrixSDK/Crypto/Algorithms/RoomEvent/MXRoomEventEncryption.swift
@@ -128,6 +128,7 @@ struct MXRoomEventEncryption: MXRoomEventEncrypting {
             for: room,
             historyVisibility: state.historyVisibility
         )
+        log.debug("Collected \(users.count) eligible users")
         
         let settings = try encryptionSettings(for: state)
         try await handler.shareRoomKeysIfNecessary(
@@ -135,6 +136,8 @@ struct MXRoomEventEncryption: MXRoomEventEncrypting {
             users: users,
             settings: settings
         )
+        
+        log.debug("Encryption and room keys up to date")
     }
     
     /// Make sure that we recognize (and store if necessary) the claimed room encryption algorithm

--- a/MatrixSDK/Crypto/Devices/Data/MXDeviceInfo.m
+++ b/MatrixSDK/Crypto/Devices/Data/MXDeviceInfo.m
@@ -144,7 +144,7 @@ NSString *const MXDeviceInfoTrustLevelDidChangeNotification = @"MXDeviceInfoTrus
         JSONDictionary[@"unsigned"] = _unsignedData;
     }
 
-    return JSONDictionary;
+    return JSONDictionary.copy;
 }
 
 - (NSDictionary *)signalableJSONDictionary
@@ -165,7 +165,7 @@ NSString *const MXDeviceInfoTrustLevelDidChangeNotification = @"MXDeviceInfoTrus
         signalableJSONDictionary[@"keys"] = _keys;
     }
 
-    return signalableJSONDictionary;
+    return signalableJSONDictionary.copy;
 }
 
 

--- a/MatrixSDKTests/JSONModels/MXKeysQueryResponseUnitTests.swift
+++ b/MatrixSDKTests/JSONModels/MXKeysQueryResponseUnitTests.swift
@@ -1,0 +1,435 @@
+// 
+// Copyright 2023 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+@testable import MatrixSDK
+
+#if DEBUG
+
+class MXKeysQueryResponseUnitTests: XCTestCase {
+    
+    private func makeCrossSigningInfo(userId: String) -> MXCrossSigningInfo {
+        .init(
+            userIdentity: .init(
+                identity: .other(
+                    userId: userId,
+                    masterKey: MXCrossSigningKey(
+                        userId: userId,
+                        usage: ["master"],
+                        keys: "\(userId)-MSK"
+                    ).jsonString(),
+                    selfSigningKey: MXCrossSigningKey(
+                        userId: userId,
+                        usage: ["self_signing"],
+                        keys: "\(userId)-SSK"
+                    ).jsonString()
+                ),
+                isVerified: true
+            )
+        )
+    }
+    
+    private func makeOwnCrossSigningInfo(userId: String) -> MXCrossSigningInfo {
+        .init(
+            userIdentity: .init(
+                identity: .own(
+                    userId: userId,
+                    trustsOurOwnDevice: true,
+                    masterKey: MXCrossSigningKey(
+                        userId: userId,
+                        usage: ["master"],
+                        keys: "\(userId)-MSK"
+                    ).jsonString(),
+                    selfSigningKey: MXCrossSigningKey(
+                        userId: userId,
+                        usage: ["self_signing"],
+                        keys: "\(userId)-SSK"
+                    ).jsonString(),
+                    userSigningKey: MXCrossSigningKey(
+                        userId: userId,
+                        usage: ["user_signing"],
+                        keys: "\(userId)-USK"
+                    ).jsonString()
+                ),
+                isVerified: true
+            )
+        )
+    }
+    
+    func test_emptyJSON() {
+        let response = MXKeysQueryResponse()
+        XCTAssertEqual(response.jsonDictionary() as NSDictionary, [
+            "device_keys": [:],
+            "failures": [:],
+            "master_keys": [:],
+            "self_signing_keys": [:],
+            "user_signing_keys": [:],
+        ])
+    }
+    
+    func test_deviceKeys() {
+        let response = MXKeysQueryResponse()
+        response.deviceKeys = MXUsersDevicesMap(map: [
+            "Alice": [
+                "DeviceA": MXDeviceInfo(deviceId: "DeviceA"),
+                "DeviceB": MXDeviceInfo(deviceId: "DeviceB"),
+            ],
+            "Bob": [
+                "DeviceC": MXDeviceInfo(deviceId: "DeviceC"),
+            ],
+        ])
+        
+        let keys = response.jsonDictionary()?["device_keys"] as? NSDictionary
+        
+        XCTAssertEqual(keys, [
+            "Alice": [
+                "DeviceA": [
+                    "device_id": "DeviceA"
+                ],
+                "DeviceB": [
+                    "device_id": "DeviceB"
+                ],
+            ],
+            "Bob": [
+                "DeviceC": [
+                    "device_id": "DeviceC"
+                ],
+            ],
+        ])
+    }
+    
+    func test_failures() {
+        let response = MXKeysQueryResponse()
+        response.failures = [
+            "matrix:org": "123",
+            "element.io": "456",
+        ]
+        
+        let failures = response.jsonDictionary()["failures"] as? NSDictionary
+        
+        XCTAssertEqual(failures, [
+            "matrix:org": "123",
+            "element.io": "456",
+        ])
+    }
+    
+    func test_masterKeys() {
+        let response = MXKeysQueryResponse()
+        response.crossSigningKeys = [
+            "Alice": makeCrossSigningInfo(userId: "Alice"),
+            "Bob": makeCrossSigningInfo(userId: "Bob")
+        ]
+        
+        let master = response.jsonDictionary()["master_keys"] as? NSDictionary
+        
+        XCTAssertEqual(master, [
+            "Alice": [
+                "user_id": "Alice",
+                "usage": ["master"],
+                "keys": [
+                    "ed25519:Alice-MSK": "Alice-MSK"
+                ],
+                "signatures": [:]
+            ],
+            "Bob": [
+                "user_id": "Bob",
+                "usage": ["master"],
+                "keys": [
+                    "ed25519:Bob-MSK": "Bob-MSK"
+                ],
+                "signatures": [:]
+            ],
+        ])
+    }
+    
+    func test_selfSigningKeys() {
+        let response = MXKeysQueryResponse()
+        response.crossSigningKeys = [
+            "Alice": makeCrossSigningInfo(userId: "Alice"),
+            "Bob": makeCrossSigningInfo(userId: "Bob")
+        ]
+        
+        let master = response.jsonDictionary()["self_signing_keys"] as? NSDictionary
+        
+        XCTAssertEqual(master, [
+            "Alice": [
+                "user_id": "Alice",
+                "usage": ["self_signing"],
+                "keys": [
+                    "ed25519:Alice-SSK": "Alice-SSK"
+                ],
+                "signatures": [:]
+            ],
+            "Bob": [
+                "user_id": "Bob",
+                "usage": ["self_signing"],
+                "keys": [
+                    "ed25519:Bob-SSK": "Bob-SSK"
+                ],
+                "signatures": [:]
+            ],
+        ])
+    }
+    
+    func test_userSigningKeys() {
+        let response = MXKeysQueryResponse()
+        response.crossSigningKeys = [
+            "Charlie": makeOwnCrossSigningInfo(userId: "Charlie")
+        ]
+        
+        let master = response.jsonDictionary()["user_signing_keys"] as? NSDictionary
+        
+        XCTAssertEqual(master, [
+            "Charlie": [
+                "user_id": "Charlie",
+                "usage": ["user_signing"],
+                "keys": [
+                    "ed25519:Charlie-USK": "Charlie-USK"
+                ],
+                "signatures": [:]
+            ],
+        ])
+    }
+    
+    func test_canCombineResponses() {
+        let empty = MXKeysQueryResponse()
+        let first = MXKeysQueryResponse()
+        first.deviceKeys = MXUsersDevicesMap(map: [
+            "Alice": [
+                "DeviceA": MXDeviceInfo(deviceId: "DeviceA"),
+                "DeviceB": MXDeviceInfo(deviceId: "DeviceB"),
+            ],
+            "Bob": [
+                "DeviceC": MXDeviceInfo(deviceId: "DeviceC"),
+            ],
+        ])
+        first.crossSigningKeys = [
+            "Alice": makeCrossSigningInfo(userId: "Alice"),
+            "Bob": makeCrossSigningInfo(userId: "Bob")
+        ]
+        
+        let second = MXKeysQueryResponse()
+        second.deviceKeys = MXUsersDevicesMap(map: [
+            "Charlie": [
+                "DeviceD": MXDeviceInfo(deviceId: "DeviceD"),
+            ],
+        ])
+        second.crossSigningKeys = [
+            "Charlie": makeOwnCrossSigningInfo(userId: "Charlie")
+        ]
+        
+        // Empty responses combine into empty json
+        let result1 = (empty + empty).jsonDictionary() as? NSDictionary
+        XCTAssertEqual(result1, [
+            "device_keys": [:],
+            "failures": [:],
+            "master_keys": [:],
+            "self_signing_keys": [:],
+            "user_signing_keys": [:],
+        ])
+        
+        // We combine empty and full response, result is equal to the second response
+        let result2 = (empty + first).jsonDictionary() as? NSDictionary
+        XCTAssertEqual(result2, [
+            "device_keys": [
+                "Alice": [
+                    "DeviceA": [
+                        "device_id": "DeviceA"
+                    ],
+                    "DeviceB": [
+                        "device_id": "DeviceB"
+                    ],
+                ],
+                "Bob": [
+                    "DeviceC": [
+                        "device_id": "DeviceC"
+                    ],
+                ],
+            ],
+            "failures": [:],
+            "master_keys": [
+                "Alice": [
+                    "user_id": "Alice",
+                    "usage": ["master"],
+                    "keys": [
+                        "ed25519:Alice-MSK": "Alice-MSK"
+                    ],
+                    "signatures": [:]
+                ],
+                "Bob": [
+                    "user_id": "Bob",
+                    "usage": ["master"],
+                    "keys": [
+                        "ed25519:Bob-MSK": "Bob-MSK"
+                    ],
+                    "signatures": [:]
+                ],
+            ],
+            "self_signing_keys": [
+                "Alice": [
+                    "user_id": "Alice",
+                    "usage": ["self_signing"],
+                    "keys": [
+                        "ed25519:Alice-SSK": "Alice-SSK"
+                    ],
+                    "signatures": [:]
+                ],
+                "Bob": [
+                    "user_id": "Bob",
+                    "usage": ["self_signing"],
+                    "keys": [
+                        "ed25519:Bob-SSK": "Bob-SSK"
+                    ],
+                    "signatures": [:]
+                ],
+            ],
+            "user_signing_keys": [:],
+        ])
+        
+        // We combine anoter empty and full response, result is equal to the second response
+        let result3 = (second + empty).jsonDictionary() as? NSDictionary
+        XCTAssertEqual(result3, [
+            "device_keys": [
+                "Charlie": [
+                    "DeviceD": [
+                        "device_id": "DeviceD"
+                    ],
+                ],
+            ],
+            "failures": [:],
+            "master_keys": [
+                "Charlie": [
+                    "user_id": "Charlie",
+                    "usage": ["master"],
+                    "keys": [
+                        "ed25519:Charlie-MSK": "Charlie-MSK"
+                    ],
+                    "signatures": [:]
+                ],
+            ],
+            "self_signing_keys": [
+                "Charlie": [
+                    "user_id": "Charlie",
+                    "usage": ["self_signing"],
+                    "keys": [
+                        "ed25519:Charlie-SSK": "Charlie-SSK"
+                    ],
+                    "signatures": [:]
+                ],
+            ],
+            "user_signing_keys": [
+                "Charlie": [
+                    "user_id": "Charlie",
+                    "usage": ["user_signing"],
+                    "keys": [
+                        "ed25519:Charlie-USK": "Charlie-USK"
+                    ],
+                    "signatures": [:]
+                ],
+            ],
+        ])
+
+        // We combine two non-empty responses, result has all the data of both
+        let result4 = (first + second).jsonDictionary() as? NSDictionary
+        XCTAssertEqual(result4, [
+            "device_keys": [
+                "Alice": [
+                    "DeviceA": [
+                        "device_id": "DeviceA"
+                    ],
+                    "DeviceB": [
+                        "device_id": "DeviceB"
+                    ],
+                ],
+                "Bob": [
+                    "DeviceC": [
+                        "device_id": "DeviceC"
+                    ],
+                ],
+                "Charlie": [
+                    "DeviceD": [
+                        "device_id": "DeviceD"
+                    ],
+                ],
+            ],
+            "failures": [:],
+            "master_keys": [
+                "Alice": [
+                    "user_id": "Alice",
+                    "usage": ["master"],
+                    "keys": [
+                        "ed25519:Alice-MSK": "Alice-MSK"
+                    ],
+                    "signatures": [:]
+                ],
+                "Bob": [
+                    "user_id": "Bob",
+                    "usage": ["master"],
+                    "keys": [
+                        "ed25519:Bob-MSK": "Bob-MSK"
+                    ],
+                    "signatures": [:]
+                ],
+                "Charlie": [
+                    "user_id": "Charlie",
+                    "usage": ["master"],
+                    "keys": [
+                        "ed25519:Charlie-MSK": "Charlie-MSK"
+                    ],
+                    "signatures": [:]
+                ],
+            ],
+            "self_signing_keys": [
+                "Alice": [
+                    "user_id": "Alice",
+                    "usage": ["self_signing"],
+                    "keys": [
+                        "ed25519:Alice-SSK": "Alice-SSK"
+                    ],
+                    "signatures": [:]
+                ],
+                "Bob": [
+                    "user_id": "Bob",
+                    "usage": ["self_signing"],
+                    "keys": [
+                        "ed25519:Bob-SSK": "Bob-SSK"
+                    ],
+                    "signatures": [:]
+                ],
+                "Charlie": [
+                    "user_id": "Charlie",
+                    "usage": ["self_signing"],
+                    "keys": [
+                        "ed25519:Charlie-SSK": "Charlie-SSK"
+                    ],
+                    "signatures": [:]
+                ],
+            ],
+            "user_signing_keys": [
+                "Charlie": [
+                    "user_id": "Charlie",
+                    "usage": ["user_signing"],
+                    "keys": [
+                        "ed25519:Charlie-USK": "Charlie-USK"
+                    ],
+                    "signatures": [:]
+                ],
+            ],
+        ])
+    }
+}
+
+#endif

--- a/MatrixSDKTests/TestPlans/UnitTests.xctestplan
+++ b/MatrixSDKTests/TestPlans/UnitTests.xctestplan
@@ -66,6 +66,7 @@
         "MXKeyVerificationManagerV2UnitTests",
         "MXKeyVerificationRequestV2UnitTests",
         "MXKeyVerificationStateResolverUnitTests",
+        "MXKeysQueryResponseUnitTest",
         "MXKeysQuerySchedulerUnitTests",
         "MXMediaScanStoreUnitTests",
         "MXMegolmDecryptionUnitTests",

--- a/MatrixSDKTests/TestPlans/UnitTestsWithSanitizers.xctestplan
+++ b/MatrixSDKTests/TestPlans/UnitTestsWithSanitizers.xctestplan
@@ -74,6 +74,7 @@
         "MXKeyVerificationManagerV2UnitTests",
         "MXKeyVerificationRequestV2UnitTests",
         "MXKeyVerificationStateResolverUnitTests",
+        "MXKeysQueryResponseUnitTests",
         "MXKeysQuerySchedulerUnitTests",
         "MXMediaScanStoreUnitTests",
         "MXMegolmDecryptionUnitTests",

--- a/changelog.d/pr-1707.change
+++ b/changelog.d/pr-1707.change
@@ -1,0 +1,1 @@
+CryptoV2: Fix JSONDictionary of keys query responses


### PR DESCRIPTION
When downloading user keys via `keys/query` we sometimes use `downloadByChunks` method that makes several HTTP requests and combines the result into a single `MXKeysQueryResponse`. The Crypto V2 relies on getting the value of this response via `JSONDictionary` property, however this property was previously just returning whatever initial value was used to create it, and is nil when combining multiple responses together.

To solve this we cannot rely on stored property but rather have to compute the `JSONDictionary` out of the current values of the response. Additionally there was a minor bug in `downloadByChunks` that would trigger this problem even if we are downloading exactly chunk-sized number of users