### PR TITLE
Enable Crypto SDK for production

### DIFF
--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -45,7 +45,7 @@ Pod::Spec.new do |s|
       ss.dependency 'OLMKit', '~> 3.2.5'
       ss.dependency 'Realm', '10.27.0'
       ss.dependency 'libbase58', '~> 0.1.4'
-      ss.dependency 'MatrixSDK/CryptoSDK'
+      ss.dependency 'MatrixSDKCrypto', '0.2.0', :configurations => ["DEBUG", "RELEASE"], :inhibit_warnings => true
   end
 
   s.subspec 'JingleCallStack' do |ss|
@@ -62,11 +62,6 @@ Pod::Spec.new do |s|
     
     # Use WebRTC framework included in Jitsi Meet SDK
     ss.ios.dependency 'JitsiMeetSDK', '5.0.2'
-  end
-  
-  # Experimental / NOT production-ready Rust-based crypto library
-  s.subspec 'CryptoSDK' do |ss|
-    ss.dependency 'MatrixSDKCrypto', '0.1.9', :configurations => ["DEBUG"], :inhibit_warnings => true
   end
 
 end

--- a/MatrixSDK/Background/Crypto/MXBackgroundCryptoV2.swift
+++ b/MatrixSDK/Background/Crypto/MXBackgroundCryptoV2.swift
@@ -16,8 +16,6 @@
 
 import Foundation
 
-#if DEBUG
-
 import MatrixSDKCrypto
 
 /// An implementation of `MXBackgroundCrypto` which uses [matrix-rust-sdk](https://github.com/matrix-org/matrix-rust-sdk/tree/main/crates/matrix-sdk-crypto)
@@ -139,5 +137,3 @@ class MXBackgroundCryptoV2: MXBackgroundCrypto {
         )
     }
 }
-
-#endif

--- a/MatrixSDK/Background/MXBackgroundSyncService.swift
+++ b/MatrixSDK/Background/MXBackgroundSyncService.swift
@@ -89,11 +89,11 @@ public enum MXBackgroundSyncServiceError: Error {
         let resetBackgroundCryptoStore = syncResponseStoreManager.syncToken() == nil
         
         crypto = {
-            #if DEBUG
             if MXSDKOptions.sharedInstance().isCryptoSDKAvailable && MXSDKOptions.sharedInstance().enableCryptoSDK {
                 return MXBackgroundCryptoV2(credentials: credentials, restClient: restClient)
             }
-            #endif
+            
+            MXLog.debug("[MXBackgroundSyncService] init: constructing legacy crypto \(MXSDKOptions.sharedInstance().isCryptoSDKAvailable) \(MXSDKOptions.sharedInstance().enableCryptoSDK)")
             return MXLegacyBackgroundCrypto(credentials: credentials, resetBackgroundCryptoStore: resetBackgroundCryptoStore)
         }()
         

--- a/MatrixSDK/Crypto/Algorithms/RoomEvent/MXRoomEventDecryption.swift
+++ b/MatrixSDK/Crypto/Algorithms/RoomEvent/MXRoomEventDecryption.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 The Matrix.org Foundation C.I.C
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,8 +15,6 @@
 //
 
 import Foundation
-
-#if DEBUG
 import MatrixSDKCrypto
 
 /// Object responsible for decrypting room events and dealing with undecryptable events
@@ -274,4 +272,3 @@ actor MXRoomEventDecryption: MXRoomEventDecrypting {
     }
 }
 
-#endif

--- a/MatrixSDK/Crypto/Algorithms/RoomEvent/MXRoomEventEncryption.swift
+++ b/MatrixSDK/Crypto/Algorithms/RoomEvent/MXRoomEventEncryption.swift
@@ -15,9 +15,6 @@
 //
 
 import Foundation
-
-#if DEBUG
-
 import MatrixSDKCrypto
 
 /// Object responsible for encrypting room events and ensuring that room keys are distributed to room members
@@ -85,8 +82,10 @@ struct MXRoomEventEncryption: MXRoomEventEncrypting {
         eventType: String,
         in room: MXRoom
     ) async throws -> [AnyHashable: Any] {
+        log.debug("Encrypting content of type `\(eventType)`")
         
         try await ensureEncryptionAndRoomKeys(in: room)
+        log.debug("Encryption and room keys ensured")
         
         let roomId = try roomId(for: room)
         return try handler.encryptRoomEvent(
@@ -219,5 +218,3 @@ struct MXRoomEventEncryption: MXRoomEventEncrypting {
         return roomId
     }
 }
-
-#endif

--- a/MatrixSDK/Crypto/CrossSigning/Data/MXCrossSigningInfo.h
+++ b/MatrixSDK/Crypto/CrossSigning/Data/MXCrossSigningInfo.h
@@ -33,12 +33,10 @@ extern NSString *const MXCrossSigningInfoTrustLevelDidChangeNotification;
  */
 @interface MXCrossSigningInfo : NSObject <NSCoding>
 
-#if DEBUG
 /**
  Initialize cross signing with MatrixSDKCrypto user identity
  */
 - (instancetype)initWithUserIdentity:(MXCryptoUserIdentityWrapper *)userIdentity;
-#endif
 
 /**
  The user's id.

--- a/MatrixSDK/Crypto/CrossSigning/Data/MXCrossSigningInfo.m
+++ b/MatrixSDK/Crypto/CrossSigning/Data/MXCrossSigningInfo.m
@@ -23,7 +23,6 @@ NSString *const MXCrossSigningInfoTrustLevelDidChangeNotification = @"MXCrossSig
 
 @implementation MXCrossSigningInfo
 
-#if DEBUG
 - (instancetype)initWithUserIdentity:(MXCryptoUserIdentityWrapper *)userIdentity
 {
     self = [self init];
@@ -48,7 +47,6 @@ NSString *const MXCrossSigningInfoTrustLevelDidChangeNotification = @"MXCrossSig
     }
     return self;
 }
-#endif
 
 - (MXCrossSigningKey *)masterKeys
 {

--- a/MatrixSDK/Crypto/CrossSigning/Data/MXCryptoUserIdentityWrapper.swift
+++ b/MatrixSDK/Crypto/CrossSigning/Data/MXCryptoUserIdentityWrapper.swift
@@ -15,9 +15,6 @@
 //
 
 import Foundation
-
-#if DEBUG
-
 import MatrixSDKCrypto
 
 /// Convenience wrapper around `MatrixSDKCrypto`'s `UserIdentity`
@@ -64,5 +61,3 @@ private extension MXCrossSigningKey {
         self.init(fromJSON: json)
     }
 }
-
-#endif

--- a/MatrixSDK/Crypto/CrossSigning/MXCrossSigningInfoSource.swift
+++ b/MatrixSDK/Crypto/CrossSigning/MXCrossSigningInfoSource.swift
@@ -16,8 +16,6 @@
 
 import Foundation
 
-#if DEBUG
-
 /// Convenience struct which transforms `MatrixSDKCrypto` cross signing info formats
 /// into `MatrixSDK` `MXCrossSigningInfo` formats.
 struct MXCrossSigningInfoSource {
@@ -40,5 +38,3 @@ struct MXCrossSigningInfoSource {
         )
     }
 }
-
-#endif

--- a/MatrixSDK/Crypto/CrossSigning/MXCrossSigningV2.swift
+++ b/MatrixSDK/Crypto/CrossSigning/MXCrossSigningV2.swift
@@ -16,8 +16,6 @@
 
 import Foundation
 
-#if DEBUG
-
 /// An implementation of `MXCrossSigning` compatible with `MXCryptoV2` and `MatrixSDKCrypto`
 class MXCrossSigningV2: NSObject, MXCrossSigning {
     enum Error: Swift.Error {
@@ -233,5 +231,3 @@ extension MXCrossSigningV2: MXRecoveryServiceDelegate {
         signUser(withUserId: userId, success: success, failure: failure)
     }
 }
-
-#endif

--- a/MatrixSDK/Crypto/CryptoMachine/Extensions/MXDeviceVerification+LocalTrust.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/Extensions/MXDeviceVerification+LocalTrust.swift
@@ -15,9 +15,6 @@
 //
 
 import Foundation
-
-#if DEBUG
-
 import MatrixSDKCrypto
 
 extension MXDeviceVerification {
@@ -37,5 +34,3 @@ extension MXDeviceVerification {
         }
     }
 }
-
-#endif

--- a/MatrixSDK/Crypto/CryptoMachine/Extensions/MXEventDecryptionResult+DecryptedEvent.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/Extensions/MXEventDecryptionResult+DecryptedEvent.swift
@@ -15,9 +15,6 @@
 //
 
 import Foundation
-
-#if DEBUG
-
 import MatrixSDKCrypto
 
 extension MXEventDecryptionResult {
@@ -44,5 +41,3 @@ extension MXEventDecryptionResult {
         isUntrusted = false
     }
 }
-
-#endif

--- a/MatrixSDK/Crypto/CryptoMachine/Extensions/MXRoomHistoryVisibility+HistoryVisibility.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/Extensions/MXRoomHistoryVisibility+HistoryVisibility.swift
@@ -15,9 +15,6 @@
 //
 
 import Foundation
-
-#if DEBUG
-
 import MatrixSDKCrypto
 
 extension MXRoomHistoryVisibility {
@@ -34,5 +31,3 @@ extension MXRoomHistoryVisibility {
         }
     }
 }
-
-#endif

--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoProtocols.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoProtocols.swift
@@ -15,9 +15,6 @@
 //
 
 import Foundation
-
-#if DEBUG
-
 import MatrixSDKCrypto
 
 /// A set of protocols defining the functionality in `MatrixSDKCrypto` and separating them into logical units
@@ -130,4 +127,3 @@ enum MXVerification {
     case qrCode(QrCodeProtocol)
 }
 
-#endif

--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoRequests.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoRequests.swift
@@ -15,9 +15,6 @@
 //
 
 import Foundation
-
-#if DEBUG
-
 import MatrixSDKCrypto
 
 /// Convenience class to delegate network requests originating in Rust crypto module
@@ -251,5 +248,3 @@ extension SignatureUploadRequest {
         return signatures
     }
 }
-
-#endif

--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoSDKLogger.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoSDKLogger.swift
@@ -15,9 +15,6 @@
 //
 
 import Foundation
-
-#if DEBUG
-
 import MatrixSDKCrypto
 
 /// Redirects logs originating in `MatrixSDKCrypto` into `MXLog`
@@ -45,5 +42,3 @@ class MXCryptoSDKLogger: Logger {
         MXLog.debug("[MXCryptoSDK] \(logLine)")
     }
 }
-
-#endif

--- a/MatrixSDK/Crypto/Devices/Data/MXCryptoDeviceWrapper.swift
+++ b/MatrixSDK/Crypto/Devices/Data/MXCryptoDeviceWrapper.swift
@@ -15,9 +15,6 @@
 //
 
 import Foundation
-
-#if DEBUG
-
 import MatrixSDKCrypto
 
 /// Convenience wrapper around `MatrixSDKCrypto`'s `Device`
@@ -62,5 +59,3 @@ import MatrixSDKCrypto
         )
     }
 }
-
-#endif

--- a/MatrixSDK/Crypto/Devices/Data/MXDeviceInfo.h
+++ b/MatrixSDK/Crypto/Devices/Data/MXDeviceInfo.h
@@ -34,12 +34,10 @@ extern NSString *const MXDeviceInfoTrustLevelDidChangeNotification;
 
 - (instancetype)initWithDeviceId:(NSString *)deviceId;
 
-#if DEBUG
 /**
  Initialize device info with MatrixSDKCrypto device
  */
 - (instancetype)initWithDevice:(MXCryptoDeviceWrapper *)device;
-#endif
 
 /**
  The id of this device.

--- a/MatrixSDK/Crypto/Devices/Data/MXDeviceInfo.m
+++ b/MatrixSDK/Crypto/Devices/Data/MXDeviceInfo.m
@@ -35,7 +35,6 @@ NSString *const MXDeviceInfoTrustLevelDidChangeNotification = @"MXDeviceInfoTrus
     return self;
 }
 
-#if DEBUG
 - (instancetype)initWithDevice:(MXCryptoDeviceWrapper *)device
 {
     self = [super init];
@@ -50,7 +49,6 @@ NSString *const MXDeviceInfoTrustLevelDidChangeNotification = @"MXDeviceInfoTrus
     }
     return self;
 }
-#endif
 
 - (NSString *)fingerprint
 {

--- a/MatrixSDK/Crypto/Devices/MXDeviceInfoSource.swift
+++ b/MatrixSDK/Crypto/Devices/MXDeviceInfoSource.swift
@@ -16,8 +16,6 @@
 
 import Foundation
 
-#if DEBUG
-
 /// Convenience struct which transforms `MatrixSDKCrypto` device formats
 /// into `MatrixSDK` `MXDeviceInfo` formats.
 struct MXDeviceInfoSource {
@@ -50,5 +48,3 @@ struct MXDeviceInfoSource {
         return map
     }
 }
-
-#endif

--- a/MatrixSDK/Crypto/KeyBackup/Engine/MXCryptoKeyBackupEngine.swift
+++ b/MatrixSDK/Crypto/KeyBackup/Engine/MXCryptoKeyBackupEngine.swift
@@ -15,9 +15,6 @@
 //
 
 import Foundation
-
-#if DEBUG
-
 import MatrixSDKCrypto
 
 class MXCryptoKeyBackupEngine: NSObject, MXKeyBackupEngine {
@@ -447,5 +444,3 @@ extension MegolmV1BackupKey {
         )
     }
 }
-
-#endif

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -150,8 +150,6 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
 @synthesize keyVerificationManager = _keyVerificationManager;
 @synthesize recoveryService = _recoveryService;
 
-#if DEBUG
-
 + (MXCryptoV2Factory *)sharedCryptoV2Factory
 {
     static MXCryptoV2Factory *factory = nil;
@@ -164,21 +162,17 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
     return factory;
 }
 
-#endif
-
 + (id<MXCrypto>)createCryptoWithMatrixSession:(MXSession *)mxSession
                                         error:(NSError **)error
 {
     __block id<MXCrypto> crypto;
 
 #ifdef MX_CRYPTO
-    #if DEBUG
     if (MXSDKOptions.sharedInstance.isCryptoSDKAvailable && MXSDKOptions.sharedInstance.enableCryptoSDK)
     {
         MXLogFailure(@"[MXCrypto] createCryptoWithMatrixSession: Crypto V2 should not be created directly, use initializeCryptoWithMatrixSession instead");
         return nil;
     }
-    #endif
     
     dispatch_queue_t cryptoQueue = [MXLegacyCrypto dispatchQueueForUser:mxSession.matrixRestClient.credentials.userId];
     dispatch_sync(cryptoQueue, ^{
@@ -198,7 +192,6 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
                                  complete:(void (^)(id<MXCrypto> crypto, NSError *error))complete
 {
 #ifdef MX_CRYPTO
-    #if DEBUG
     if (MXSDKOptions.sharedInstance.isCryptoSDKAvailable && MXSDKOptions.sharedInstance.enableCryptoSDK)
     {
         MXCryptoV2Factory *factory = [MXLegacyCrypto sharedCryptoV2Factory];
@@ -210,7 +203,6 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
                                 }];
         return;
     }
-    #endif
     
     [self initalizeLegacyCryptoWithMatrixSession:mxSession complete:complete];
 #else

--- a/MatrixSDK/Crypto/MXCryptoV2.swift
+++ b/MatrixSDK/Crypto/MXCryptoV2.swift
@@ -15,9 +15,6 @@
 //
 
 import Foundation
-
-#if DEBUG
-
 import MatrixSDKCrypto
 
 /// An implementation of `MXCrypto` which uses [matrix-rust-sdk](https://github.com/matrix-org/matrix-rust-sdk/tree/main/crates/matrix-sdk-crypto)
@@ -707,5 +704,3 @@ class MXCryptoV2: NSObject, MXCrypto {
             }
     }
 }
-
-#endif

--- a/MatrixSDK/Crypto/Migration/Data/MXCryptoMigrationStore.swift
+++ b/MatrixSDK/Crypto/Migration/Data/MXCryptoMigrationStore.swift
@@ -15,9 +15,6 @@
 //
 
 import Foundation
-
-#if DEBUG
-
 import OLMKit
 import MatrixSDKCrypto
 
@@ -200,5 +197,3 @@ private extension PickledInboundGroupSession {
         )
     }
 }
-
-#endif

--- a/MatrixSDK/Crypto/Migration/MXCryptoMigrationV2.swift
+++ b/MatrixSDK/Crypto/Migration/MXCryptoMigrationV2.swift
@@ -15,9 +15,6 @@
 //
 
 import Foundation
-
-#if DEBUG
-
 import OLMKit
 import MatrixSDKCrypto
 
@@ -160,5 +157,3 @@ extension MXCryptoMigrationV2: ProgressListener {
         // Progress loggged manually
     }
 }
-
-#endif

--- a/MatrixSDK/Crypto/SecretStorage/MXCryptoSecretStoreV2.swift
+++ b/MatrixSDK/Crypto/SecretStorage/MXCryptoSecretStoreV2.swift
@@ -16,8 +16,6 @@
 
 import Foundation
 
-#if DEBUG
-
 /// Secret store compatible with Rust-based Crypto V2, where
 /// backup secrets are stored internally in the Crypto machine
 /// and others have to be managed manually.
@@ -109,5 +107,3 @@ class MXCryptoSecretStoreV2: NSObject, MXCryptoSecretStore {
         }
     }
 }
-
-#endif

--- a/MatrixSDK/Crypto/Trust/MXTrustLevelSource.swift
+++ b/MatrixSDK/Crypto/Trust/MXTrustLevelSource.swift
@@ -16,8 +16,6 @@
 
 import Foundation
 
-#if DEBUG
-
 /// Convenience struct which transforms `MatrixSDKCrypto` trust levels
 /// into `MatrixSDK` `MXUserTrustLevel`, `MXDeviceTrustLevel` and `MXUsersTrustLevelSummary` formats.
 struct MXTrustLevelSource {
@@ -80,5 +78,3 @@ struct MXTrustLevelSource {
         return progress
     }
 }
-
-#endif

--- a/MatrixSDK/Crypto/Verification/MXKeyVerificationManagerV2.swift
+++ b/MatrixSDK/Crypto/Verification/MXKeyVerificationManagerV2.swift
@@ -6,9 +6,6 @@
 //
 
 import Foundation
-
-#if DEBUG
-
 import MatrixSDKCrypto
 
 class MXKeyVerificationManagerV2: NSObject, MXKeyVerificationManager {
@@ -491,5 +488,3 @@ class MXKeyVerificationManagerV2: NSObject, MXKeyVerificationManager {
         return messageType == kMXMessageTypeKeyVerificationRequest
     }
 }
-
-#endif

--- a/MatrixSDK/Crypto/Verification/Requests/MXKeyVerificationRequestV2.swift
+++ b/MatrixSDK/Crypto/Verification/Requests/MXKeyVerificationRequestV2.swift
@@ -15,9 +15,6 @@
 //
 
 import Foundation
-
-#if DEBUG
-
 import MatrixSDKCrypto
 
 /// Verification request originating from `MatrixSDKCrypto`
@@ -205,6 +202,4 @@ private extension MXKeyVerificationRequestState {
         }
     }
 }
-
-#endif
 

--- a/MatrixSDK/Crypto/Verification/Transactions/QRCode/MXQRCodeTransactionV2.swift
+++ b/MatrixSDK/Crypto/Verification/Transactions/QRCode/MXQRCodeTransactionV2.swift
@@ -15,9 +15,6 @@
 //
 
 import Foundation
-
-#if DEBUG
-
 import MatrixSDKCrypto
 
 /// QR transaction originating from `MatrixSDKCrypto`
@@ -236,5 +233,3 @@ private extension MXQRCodeTransactionState {
         }
     }
 }
-
-#endif

--- a/MatrixSDK/Crypto/Verification/Transactions/SAS/MXSASTransactionV2.swift
+++ b/MatrixSDK/Crypto/Verification/Transactions/SAS/MXSASTransactionV2.swift
@@ -15,9 +15,6 @@
 //
 
 import Foundation
-
-#if DEBUG
-
 import MatrixSDKCrypto
 
 /// SAS transaction originating from `MatrixSDKCrypto`
@@ -208,4 +205,3 @@ extension MXSASTransactionState {
     }
 }
 
-#endif

--- a/MatrixSDK/MXSDKOptions.h
+++ b/MatrixSDK/MXSDKOptions.h
@@ -203,8 +203,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic) BOOL enableRoomSharedHistoryOnInvite;
 
-#if DEBUG
-
 /**
  The state of the rust-based `MatrixCryptoSDK` which replaces `MatrixSDK`'s internal crypto module,
  and whether it is available to a user as an option.
@@ -223,8 +221,6 @@ NS_ASSUME_NONNULL_BEGIN
  @remark NO by default.
  */
 @property (nonatomic) BOOL enableCryptoSDK;
-
-#endif
 
 /**
  Enable symmetric room key backups

--- a/MatrixSDK/MXSDKOptions.m
+++ b/MatrixSDK/MXSDKOptions.m
@@ -55,10 +55,8 @@ static MXSDKOptions *sharedOnceInstance = nil;
         _enableThreads = NO;
         _enableRoomSharedHistoryOnInvite = NO;
         
-        #if DEBUG
-        _isCryptoSDKAvailable = NO;
+        _isCryptoSDKAvailable = YES;
         _enableCryptoSDK = NO;
-        #endif
         
         _enableSymmetricBackup = NO;
         _enableNewClientInformationFeature = NO;

--- a/MatrixSDKTests/Crypto/Algorithms/RoomEvents/MXRoomEventDecryptionUnitTests.swift
+++ b/MatrixSDKTests/Crypto/Algorithms/RoomEvents/MXRoomEventDecryptionUnitTests.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 The Matrix.org Foundation C.I.C
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,8 +16,6 @@
 
 import Foundation
 @testable import MatrixSDK
-
-#if DEBUG
 
 import MatrixSDKCrypto
 
@@ -197,5 +195,3 @@ class MXRoomEventDecryptionUnitTests: XCTestCase {
         try! await Task.sleep(nanoseconds: 1_000_000)
     }
 }
-
-#endif

--- a/MatrixSDKTests/Crypto/Algorithms/RoomEvents/MXRoomEventEncryptionUnitTests.swift
+++ b/MatrixSDKTests/Crypto/Algorithms/RoomEvents/MXRoomEventEncryptionUnitTests.swift
@@ -16,9 +16,6 @@
 
 import Foundation
 @testable import MatrixSDK
-
-#if DEBUG
-
 import MatrixSDKCrypto
 
 class MXRoomEventEncryptionUnitTests: XCTestCase {
@@ -285,5 +282,3 @@ class MXRoomEventEncryptionUnitTests: XCTestCase {
         XCTAssertEqual(result["ciphertext"] as? [String: String], ["body": "Hello"])
     }
 }
-
-#endif

--- a/MatrixSDKTests/Crypto/CrossSigning/Data/MXCrossSigningInfoUnitTests.swift
+++ b/MatrixSDKTests/Crypto/CrossSigning/Data/MXCrossSigningInfoUnitTests.swift
@@ -17,9 +17,6 @@
 import Foundation
 import XCTest
 @testable import MatrixSDK
-
-#if DEBUG
-
 import MatrixSDKCrypto
 
 class MXCrossSigningInfoUnitTests: XCTestCase {
@@ -92,5 +89,3 @@ class MXCrossSigningInfoUnitTests: XCTestCase {
         XCTAssertEqual(key1?.keys, key2?.keys, file: file, line: line)
     }
 }
-
-#endif

--- a/MatrixSDKTests/Crypto/CrossSigning/MXCrossSigningInfoSourceUnitTests.swift
+++ b/MatrixSDKTests/Crypto/CrossSigning/MXCrossSigningInfoSourceUnitTests.swift
@@ -17,9 +17,6 @@
 import Foundation
 import XCTest
 @testable import MatrixSDK
-
-#if DEBUG
-
 import MatrixSDKCrypto
 
 class MXCrossSigningInfoSourceUnitTests: XCTestCase {
@@ -56,5 +53,3 @@ class MXCrossSigningInfoSourceUnitTests: XCTestCase {
         XCTAssertEqual(info?.trustLevel.isVerified, true)
     }
 }
-
-#endif

--- a/MatrixSDKTests/Crypto/CrossSigning/MXCrossSigningV2UnitTests.swift
+++ b/MatrixSDKTests/Crypto/CrossSigning/MXCrossSigningV2UnitTests.swift
@@ -17,9 +17,6 @@
 import Foundation
 import XCTest
 @testable import MatrixSDK
-
-#if DEBUG
-
 import MatrixSDKCrypto
 
 class MXCrossSigningV2UnitTests: XCTestCase {
@@ -99,5 +96,3 @@ class MXCrossSigningV2UnitTests: XCTestCase {
         waitForExpectations(timeout: 1)
     }
 }
-
-#endif

--- a/MatrixSDKTests/Crypto/CryptoMachine/DecryptedEvent+Stub.swift
+++ b/MatrixSDKTests/Crypto/CryptoMachine/DecryptedEvent+Stub.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 The Matrix.org Foundation C.I.C
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,9 +15,6 @@
 //
 
 import Foundation
-
-#if DEBUG
-
 import MatrixSDKCrypto
 
 extension DecryptedEvent {
@@ -33,5 +30,3 @@ extension DecryptedEvent {
         )
     }
 }
-
-#endif

--- a/MatrixSDKTests/Crypto/CryptoMachine/Device+Stub.swift
+++ b/MatrixSDKTests/Crypto/CryptoMachine/Device+Stub.swift
@@ -15,9 +15,6 @@
 //
 
 import Foundation
-
-#if DEBUG
-
 import MatrixSDKCrypto
 
 extension Device {
@@ -47,5 +44,3 @@ extension Device {
         )
     }
 }
-
-#endif

--- a/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoMachineUnitTests.swift
+++ b/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoMachineUnitTests.swift
@@ -15,13 +15,23 @@
 //
 
 import Foundation
-
-#if DEBUG && os(iOS)
-
 import MatrixSDKCrypto
 @testable import MatrixSDK
 
 class MXCryptoMachineUnitTests: XCTestCase {
+    class KeyProvider: NSObject, MXKeyProviderDelegate {
+        func isEncryptionAvailableForData(ofType dataType: String) -> Bool {
+            return true
+        }
+        
+        func hasKeyForData(ofType dataType: String) -> Bool {
+            return true
+        }
+        
+        func keyDataForData(ofType dataType: String) -> MXKeyData? {
+            MXRawDataKey(key: "1234".data(using: .ascii)!)
+        }
+    }
     
     var userId = "@alice:matrix.org"
     var restClient: MXRestClient!
@@ -29,6 +39,7 @@ class MXCryptoMachineUnitTests: XCTestCase {
     
     override func setUp() {
         restClient = MXRestClientStub()
+        MXKeyProvider.sharedInstance().delegate = KeyProvider()
         machine = try! MXCryptoMachine(
             userId: userId,
             deviceId: "ABCD",
@@ -36,6 +47,7 @@ class MXCryptoMachineUnitTests: XCTestCase {
             getRoomAction: {
                 MXRoom(roomId: $0, andMatrixSession: nil)
             })
+        MXKeyProvider.sharedInstance().delegate = nil
     }
     
     override func tearDown() {
@@ -78,5 +90,3 @@ class MXCryptoMachineUnitTests: XCTestCase {
         XCTAssertEqual(result.events.count, 1)
     }
 }
-
-#endif

--- a/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoProtocolStubs.swift
+++ b/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoProtocolStubs.swift
@@ -16,9 +16,6 @@
 
 import Foundation
 @testable import MatrixSDK
-
-#if DEBUG
-
 @testable import MatrixSDKCrypto
 
 class CryptoIdentityStub: MXCryptoIdentity {
@@ -214,5 +211,3 @@ class CryptoBackupStub: MXCryptoBackup {
         return KeysImportResult(imported: 0, total: 0, keys: [:])
     }
 }
-
-#endif

--- a/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoRequestsUnitTests.swift
+++ b/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoRequestsUnitTests.swift
@@ -16,9 +16,6 @@
 
 import Foundation
 @testable import MatrixSDK
-
-#if DEBUG
-
 import MatrixSDKCrypto
 
 class MXCryptoRequestsUnitTests: XCTestCase {
@@ -134,5 +131,3 @@ class MXCryptoRequestsUnitTests: XCTestCase {
         XCTAssertEqual(keys["user_signing_key"] as? [String: String], ["key": "C"])
     }
 }
-
-#endif

--- a/MatrixSDKTests/Crypto/Devices/Data/MXDeviceInfoUnitTests.swift
+++ b/MatrixSDKTests/Crypto/Devices/Data/MXDeviceInfoUnitTests.swift
@@ -17,9 +17,6 @@
 import Foundation
 import XCTest
 @testable import MatrixSDK
-
-#if DEBUG
-
 import MatrixSDKCrypto
 
 class MXDeviceInfoUnitTests: XCTestCase {
@@ -89,5 +86,3 @@ class MXDeviceInfoUnitTests: XCTestCase {
         )
     }
 }
-
-#endif

--- a/MatrixSDKTests/Crypto/Devices/MXDeviceInfoSourceUnitTests.swift
+++ b/MatrixSDKTests/Crypto/Devices/MXDeviceInfoSourceUnitTests.swift
@@ -17,9 +17,6 @@
 import Foundation
 import XCTest
 @testable import MatrixSDK
-
-#if DEBUG
-
 import MatrixSDKCrypto
 
 class MXDeviceInfoSourceUnitTests: XCTestCase {
@@ -85,5 +82,3 @@ class MXDeviceInfoSourceUnitTests: XCTestCase {
         XCTAssertEqual(map.objects(forUser: "Bob").count, 1)
     }
 }
-
-#endif

--- a/MatrixSDKTests/Crypto/KeyBackup/Engine/MXCryptoKeyBackupEngineUnitTests.swift
+++ b/MatrixSDKTests/Crypto/KeyBackup/Engine/MXCryptoKeyBackupEngineUnitTests.swift
@@ -16,9 +16,6 @@
 
 import Foundation
 @testable import MatrixSDK
-
-#if DEBUG
-
 import MatrixSDKCrypto
 
 class MXCryptoKeyBackupEngineUnitTests: XCTestCase {
@@ -233,5 +230,3 @@ class MXCryptoKeyBackupEngineUnitTests: XCTestCase {
         waitForExpectations(timeout: 1)
     }
 }
-
-#endif

--- a/MatrixSDKTests/Crypto/Migration/Data/MXCryptoMigrationStoreUnitTests.swift
+++ b/MatrixSDKTests/Crypto/Migration/Data/MXCryptoMigrationStoreUnitTests.swift
@@ -16,11 +16,8 @@
 
 import Foundation
 import XCTest
-@testable import MatrixSDK
-
-#if DEBUG
-
 import MatrixSDKCrypto
+@testable import MatrixSDK
 
 class MXCryptoMigrationStoreUnitTests: XCTestCase {
     
@@ -254,5 +251,3 @@ class MXCryptoMigrationStoreUnitTests: XCTestCase {
         XCTAssertEqual(Set(trackedUsers), ["Bob", "Carol", "Dave"])
     }
 }
-
-#endif

--- a/MatrixSDKTests/Crypto/Migration/MXCryptoMigrationV2Tests.swift
+++ b/MatrixSDKTests/Crypto/Migration/MXCryptoMigrationV2Tests.swift
@@ -27,11 +27,11 @@ class MXCryptoMigrationV2Tests: XCTestCase {
         func isEncryptionAvailableForData(ofType dataType: String) -> Bool {
             return true
         }
-        
+
         func hasKeyForData(ofType dataType: String) -> Bool {
             return true
         }
-        
+
         func keyDataForData(ofType dataType: String) -> MXKeyData? {
             MXRawDataKey(key: "1234".data(using: .ascii)!)
         }
@@ -42,13 +42,7 @@ class MXCryptoMigrationV2Tests: XCTestCase {
     
     override func setUp() {
         data = MatrixSDKTestsData()
-        MXKeyProvider.sharedInstance().delegate = KeyProvider()
         e2eData = MatrixSDKTestsE2EData(matrixSDKTestsData: data)
-        setLogger(logger: self)
-    }
-    
-    override func tearDown() {
-        MXKeyProvider.sharedInstance().delegate = nil
     }
     
     // MARK: - Helpers
@@ -61,15 +55,18 @@ class MXCryptoMigrationV2Tests: XCTestCase {
             throw Error.missingDependencies
         }
         
+        MXKeyProvider.sharedInstance().delegate = KeyProvider()
         let migration = MXCryptoMigrationV2(legacyStore: store)
         try migration.migrateCrypto { _ in }
-        return try MXCryptoMachine(
+        let machine = try MXCryptoMachine(
             userId: store.userId(),
             deviceId: store.deviceId(),
             restClient: restClient,
             getRoomAction: { _ in
                 return nil
             })
+        MXKeyProvider.sharedInstance().delegate = nil
+        return machine
     }
     
     // MARK: - Tests
@@ -131,7 +128,26 @@ class MXCryptoMigrationV2Tests: XCTestCase {
         // As expected we cannot cross sign in v2 either
         XCTAssertFalse(crossSigningV2.canCrossSign)
         XCTAssertFalse(crossSigningV2.hasAllPrivateKeys)
-    }    
+    }
+    
+    func test_migratesCrossSigningStatus() async throws {
+        let env = try await e2eData.startE2ETest()
+        
+        // We start with user who setup cross-signing with password
+        let legacyCrossSigning = env.session.crypto.crossSigning
+        try await legacyCrossSigning.setup(withPassword: MXTESTS_ALICE_PWD)
+        XCTAssertTrue(legacyCrossSigning.canCrossSign)
+        XCTAssertTrue(legacyCrossSigning.hasAllPrivateKeys)
+        
+        // We now migrate the data into crypto v2
+        let machine = try migratedOlmMachine(session: env.session)
+        let crossSigningV2 = MXCrossSigningV2(crossSigning: machine, restClient: env.session.matrixRestClient)
+        try await crossSigningV2.refreshState()
+
+        // And confirm that cross signing is ready
+        XCTAssertTrue(crossSigningV2.canCrossSign)
+        XCTAssertTrue(crossSigningV2.hasAllPrivateKeys)
+    }
 }
 
 private extension MXCrypto {

--- a/MatrixSDKTests/Crypto/Migration/MXCryptoMigrationV2Tests.swift
+++ b/MatrixSDKTests/Crypto/Migration/MXCryptoMigrationV2Tests.swift
@@ -15,9 +15,6 @@
 //
 
 import Foundation
-
-#if DEBUG
-
 import MatrixSDKCrypto
 @testable import MatrixSDK
 
@@ -202,5 +199,3 @@ extension MXCryptoMigrationV2Tests: Logger {
         MXLog.debug("[MXCryptoMigrationV2Tests]: \(logLine)")
     }
 }
-
-#endif

--- a/MatrixSDKTests/Crypto/Trust/MXTrustLevelSourceUnitTests.swift
+++ b/MatrixSDKTests/Crypto/Trust/MXTrustLevelSourceUnitTests.swift
@@ -17,9 +17,6 @@
 import Foundation
 import XCTest
 @testable import MatrixSDK
-
-#if DEBUG
-
 import MatrixSDKCrypto
 
 class MXTrustLevelSourceUnitTests: XCTestCase {
@@ -79,5 +76,3 @@ class MXTrustLevelSourceUnitTests: XCTestCase {
         XCTAssertEqual(summary.trustedDevicesProgress.completedUnitCount, 2)
     }
 }
-
-#endif

--- a/MatrixSDKTests/Crypto/Verification/MXKeyVerificationManagerV2UnitTests.swift
+++ b/MatrixSDKTests/Crypto/Verification/MXKeyVerificationManagerV2UnitTests.swift
@@ -18,8 +18,6 @@ import Foundation
 import XCTest
 @testable import MatrixSDK
 
-#if DEBUG
-
 class MXKeyVerificationManagerV2UnitTests: XCTestCase {
     class MockSession: MXSession {
         override var myUserId: String! {
@@ -89,5 +87,3 @@ class MXKeyVerificationManagerV2UnitTests: XCTestCase {
         waitForExpectations(timeout: 1)
     }
 }
-
-#endif

--- a/MatrixSDKTests/Crypto/Verification/Requests/MXKeyVerificationRequestV2UnitTests.swift
+++ b/MatrixSDKTests/Crypto/Verification/Requests/MXKeyVerificationRequestV2UnitTests.swift
@@ -16,9 +16,6 @@
 
 import Foundation
 import XCTest
-
-#if DEBUG
-
 import MatrixSDKCrypto
 @testable import MatrixSDK
 
@@ -214,5 +211,3 @@ class MXKeyVerificationRequestV2UnitTests: XCTestCase {
         waitForExpectations(timeout: 1)
     }
 }
-
-#endif

--- a/MatrixSDKTests/Crypto/Verification/Requests/VerificationRequestStub.swift
+++ b/MatrixSDKTests/Crypto/Verification/Requests/VerificationRequestStub.swift
@@ -16,8 +16,6 @@
 
 import Foundation
 
-#if DEBUG
-
 import MatrixSDKCrypto
 
 class VerificationRequestStub: VerificationRequestProtocol {
@@ -142,5 +140,3 @@ class VerificationRequestStub: VerificationRequestProtocol {
         .requested
     }
 }
-
-#endif

--- a/MatrixSDKTests/Crypto/Verification/Transactions/QRCode/MXQRCodeTransactionV2UnitTests.swift
+++ b/MatrixSDKTests/Crypto/Verification/Transactions/QRCode/MXQRCodeTransactionV2UnitTests.swift
@@ -16,9 +16,6 @@
 
 import Foundation
 import XCTest
-
-#if DEBUG
-
 import MatrixSDKCrypto
 @testable import MatrixSDK
 
@@ -121,5 +118,3 @@ class MXQRCodeTransactionV2UnitTests: XCTestCase {
         XCTAssertEqual(transaction.state, .cancelled)
     }
 }
-
-#endif

--- a/MatrixSDKTests/Crypto/Verification/Transactions/QRCode/QrCodeStub.swift
+++ b/MatrixSDKTests/Crypto/Verification/Transactions/QRCode/QrCodeStub.swift
@@ -16,8 +16,6 @@
 
 import Foundation
 
-#if DEBUG
-
 import MatrixSDKCrypto
 
 struct QrCodeStub: QrCodeProtocol {
@@ -114,7 +112,5 @@ struct QrCodeStub: QrCodeProtocol {
     func state() -> QrCodeState {
         .started
     }
-    
 }
 
-#endif

--- a/MatrixSDKTests/Crypto/Verification/Transactions/SAS/MXSASTransactionV2UnitTests.swift
+++ b/MatrixSDKTests/Crypto/Verification/Transactions/SAS/MXSASTransactionV2UnitTests.swift
@@ -16,9 +16,6 @@
 
 import Foundation
 import XCTest
-
-#if DEBUG
-
 import MatrixSDKCrypto
 @testable import MatrixSDK
 
@@ -137,5 +134,3 @@ class MXSASTransactionV2UnitTests: XCTestCase {
         XCTAssertEqual(transaction.state, MXSASTransactionStateCancelled)
     }
 }
-
-#endif

--- a/MatrixSDKTests/Crypto/Verification/Transactions/SAS/SasStub.swift
+++ b/MatrixSDKTests/Crypto/Verification/Transactions/SAS/SasStub.swift
@@ -16,8 +16,6 @@
 
 import Foundation
 
-#if DEBUG
-
 import MatrixSDKCrypto
 
 struct SasStub: SasProtocol {
@@ -96,5 +94,3 @@ struct SasStub: SasProtocol {
         .started
     }
 }
-
-#endif

--- a/MatrixSDKTests/JSONModels/MXKeysQueryResponseUnitTests.swift
+++ b/MatrixSDKTests/JSONModels/MXKeysQueryResponseUnitTests.swift
@@ -17,8 +17,6 @@
 import Foundation
 @testable import MatrixSDK
 
-#if DEBUG
-
 class MXKeysQueryResponseUnitTests: XCTestCase {
     
     private func makeCrossSigningInfo(userId: String) -> MXCrossSigningInfo {
@@ -431,5 +429,3 @@ class MXKeysQueryResponseUnitTests: XCTestCase {
         ])
     }
 }
-
-#endif

--- a/Podfile
+++ b/Podfile
@@ -16,7 +16,7 @@ abstract_target 'MatrixSDK' do
     
     pod 'Realm', '10.27.0'
     pod 'libbase58', '~> 0.1.4'
-    pod 'MatrixSDKCrypto', "0.1.9", :configurations => ['DEBUG'], :inhibit_warnings => true
+    pod 'MatrixSDKCrypto', "0.2.0", :inhibit_warnings => true
     
     target 'MatrixSDK-iOS' do
         platform :ios, '11.0'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -16,7 +16,7 @@ PODS:
     - AFNetworking/NSURLSession
   - GZIP (1.3.0)
   - libbase58 (0.1.4)
-  - MatrixSDKCrypto (0.1.9)
+  - MatrixSDKCrypto (0.2.0)
   - OHHTTPStubs (9.1.0):
     - OHHTTPStubs/Default (= 9.1.0)
   - OHHTTPStubs/Core (9.1.0)
@@ -44,7 +44,7 @@ DEPENDENCIES:
   - AFNetworking (~> 4.0.0)
   - GZIP (~> 1.3.0)
   - libbase58 (~> 0.1.4)
-  - MatrixSDKCrypto (= 0.1.9)
+  - MatrixSDKCrypto (= 0.2.0)
   - OHHTTPStubs (~> 9.1.0)
   - OLMKit (~> 3.2.5)
   - Realm (= 10.27.0)
@@ -65,12 +65,12 @@ SPEC CHECKSUMS:
   AFNetworking: 3bd23d814e976cd148d7d44c3ab78017b744cd58
   GZIP: 416858efbe66b41b206895ac6dfd5493200d95b3
   libbase58: 7c040313537b8c44b6e2d15586af8e21f7354efd
-  MatrixSDKCrypto: e5ee6aa6b3680816d09929c5f362d116e70278ad
+  MatrixSDKCrypto: e1ef22aae76b5a6f030ace21a47be83864f4ff44
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   OLMKit: da115f16582e47626616874e20f7bb92222c7a51
   Realm: 9ca328bd7e700cc19703799785e37f77d1a130f2
   SwiftyBeaver: 84069991dd5dca07d7069100985badaca7f0ce82
 
-PODFILE CHECKSUM: ee29e7e375f643724ba4ab91b185d703c19b3939
+PODFILE CHECKSUM: 22dbe406b768ebe51e6de5fe02348d35a4d3d9f6
 
 COCOAPODS: 1.11.3

--- a/changelog.d/pr-1708.change
+++ b/changelog.d/pr-1708.change
@@ -1,0 +1,1 @@
+CryptoV2: Enable Crypto SDK for production


### PR DESCRIPTION
This is a big moment !

- update `MatrixSDKCrypto` pod to 0.2.0 which is now production ready (though still considered beta)
- remove all DEBUG compiler flags as we are ready to ship to production
- enable `isCryptoSDKAvailable`, which makes crypto 2.0 / SDK visible as a labs flag