### PR TITLE
Add fallback text for m.poll.end events (PSG-1156)

### DIFF
--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -2583,9 +2583,11 @@ NSInteger const kMXRoomInvalidInviteSenderErrorCode = 9002;
     MXEventContentRelatesTo *relatesTo = [[MXEventContentRelatesTo alloc] initWithRelationType:MXEventRelationTypeReference
                                                                                        eventId:pollStartEvent.eventId];
     
+    MXSendReplyEventDefaultStringLocalizer* localizer = MXSendReplyEventDefaultStringLocalizer.new;
     NSDictionary *content = @{
         kMXEventRelationRelatesToKey: relatesTo.JSONDictionary,
-        kMXMessageContentKeyExtensiblePollEndMSC3381: @{}
+        kMXMessageContentKeyExtensiblePollEndMSC3381: @{},
+        kMXMessageContentKeyExtensibleTextMSC1767: localizer.replyToEndedPoll
     };
     
     return [self sendEventOfType:[MXTools eventTypeString:MXEventTypePollEnd] content:content threadId:threadId localEcho:localEcho success:success failure:failure];

--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -2220,7 +2220,7 @@ NSInteger const kMXRoomInvalidInviteSenderErrorCode = 9002;
     {
         // The "Ended poll" text is not meant to be localized from the sender side.
         // This is why here we use a "default localizer" providing the english version of it.
-        senderMessageBody = MXSendReplyEventDefaultStringLocalizer.new.replyToEndedPoll;
+        senderMessageBody = MXSendReplyEventDefaultStringLocalizer.new.endedPollMessage;
     }
     else if (eventToReply.eventType == MXEventTypeBeaconInfo)
     {
@@ -2587,7 +2587,7 @@ NSInteger const kMXRoomInvalidInviteSenderErrorCode = 9002;
     NSDictionary *content = @{
         kMXEventRelationRelatesToKey: relatesTo.JSONDictionary,
         kMXMessageContentKeyExtensiblePollEndMSC3381: @{},
-        kMXMessageContentKeyExtensibleTextMSC1767: localizer.replyToEndedPoll
+        kMXMessageContentKeyExtensibleTextMSC1767: localizer.endedPollMessage
     };
     
     return [self sendEventOfType:[MXTools eventTypeString:MXEventTypePollEnd] content:content threadId:threadId localEcho:localEcho success:success failure:failure];

--- a/MatrixSDK/Data/MXSendReplyEventDefaultStringLocalizer.m
+++ b/MatrixSDK/Data/MXSendReplyEventDefaultStringLocalizer.m
@@ -26,7 +26,7 @@
 @property (nonatomic, strong) NSString *senderSentTheirLocation;
 @property (nonatomic, strong) NSString *senderSentTheirLiveLocation;
 @property (nonatomic, strong) NSString *messageToReplyToPrefix;
-@property (nonatomic, strong) NSString *replyToEndedPoll;
+@property (nonatomic, strong) NSString *endedPollMessage;
 
 @end
 
@@ -44,7 +44,7 @@
         _senderSentTheirLocation = @"has shared their location.";
         _senderSentTheirLiveLocation = @"Live location.";
         _messageToReplyToPrefix = @"In reply to";
-        _replyToEndedPoll = @"Ended poll";
+        _endedPollMessage = @"Ended poll";
     }
     return self;
 }

--- a/MatrixSDK/Data/MXSendReplyEventStringLocalizerProtocol.h
+++ b/MatrixSDK/Data/MXSendReplyEventStringLocalizerProtocol.h
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSString *)senderSentTheirLocation;
 - (NSString *)senderSentTheirLiveLocation;
 - (NSString *)messageToReplyToPrefix;
-- (NSString *)replyToEndedPoll;
+- (NSString *)endedPollMessage;
 
 @end
 

--- a/MatrixSDKTests/MXPollRelationTests.m
+++ b/MatrixSDKTests/MXPollRelationTests.m
@@ -66,6 +66,8 @@
                             [mxSession.aggregations referenceEventsForEvent:pollStartEvent.eventId inRoom:room.roomId from:nil limit:-1 success:^(MXAggregationPaginatedResponse *paginatedResponse) {
                                 XCTAssertNil(paginatedResponse.nextBatch);
                                 XCTAssertEqual(paginatedResponse.chunk.count, 2);
+                                MXEvent* pollEndedEvent = paginatedResponse.chunk.lastObject;
+                                XCTAssertTrue([pollEndedEvent.content[kMXMessageContentKeyExtensibleTextMSC1767] isEqual:@"Ended poll"]);
                                 
                                 [expectation fulfill];
                             } failure:^(NSError *error) {
@@ -81,8 +83,6 @@
                     XCTFail(@"The operation should not fail - NSError: %@", error);
                     [expectation fulfill];
                 }];
-                
-                [expectation fulfill];
             } failure:^(NSError *error) {
                 XCTFail(@"The operation should not fail - NSError: %@", error);
                 [expectation fulfill];

--- a/changelog.d/pr-1713.change
+++ b/changelog.d/pr-1713.change
@@ -1,0 +1,1 @@
+Polls: add fallback text for poll ended events.


### PR DESCRIPTION
### Description

This PR adds a fallback text for `m.poll.end` events.
These fallbacks are useful for receivers when the associated `m.poll.start` event is unavailable.