### PR TITLE
🟢 Apply (polls) push rules client side for encrypted rooms

### DIFF
--- a/MatrixSDK/Background/MXBackgroundPushRulesManager.swift
+++ b/MatrixSDK/Background/MXBackgroundPushRulesManager.swift
@@ -101,9 +101,6 @@ import Foundation
     public func pushRule(matching event: MXEvent,
                          roomState: MXRoomState,
                          currentUserDisplayName: String?) -> MXPushRule? {
-        // getting the uncrypted event if present or fallback
-        let event = event.clear ?? event
-        
         //  return nil if current user's event
         if event.sender == credentials.userId {
             return nil
@@ -118,8 +115,8 @@ import Foundation
             .roomMemberCount: memberCountConditionChecker,
             .senderNotificationPermission: permissionConditionChecker
         ]
-        
-        let eventDictionary = event.jsonDictionary()
+        // getting the unencrypted event if present or fallback
+        let eventDictionary = (event.clear ?? event).jsonDictionary()
         let equivalentCondition = MXPushRuleCondition()
         
         for rule in flatRules.filter({ $0.enabled }) {

--- a/MatrixSDK/Background/MXBackgroundPushRulesManager.swift
+++ b/MatrixSDK/Background/MXBackgroundPushRulesManager.swift
@@ -101,6 +101,9 @@ import Foundation
     public func pushRule(matching event: MXEvent,
                          roomState: MXRoomState,
                          currentUserDisplayName: String?) -> MXPushRule? {
+        // getting the uncrypted event if present or fallback
+        let event = event.clear ?? event
+        
         //  return nil if current user's event
         if event.sender == credentials.userId {
             return nil

--- a/MatrixSDK/Background/MXBackgroundSyncService.swift
+++ b/MatrixSDK/Background/MXBackgroundSyncService.swift
@@ -500,5 +500,11 @@ public enum MXBackgroundSyncServiceError: Error {
             MXLog.debug("[MXBackgroundSyncService] updateBackgroundServiceStoresIfNeeded: Reset MXBackgroundCryptoStore")
             crypto.reset()
         }
+        
+        if let accountData = syncResponseStoreManager.syncResponseStore.accountData {
+            pushRulesManager.handleAccountData(accountData)
+        } else if let accountData = store.userAccountData ?? nil {
+            pushRulesManager.handleAccountData(accountData)
+        }
     }
 }

--- a/MatrixSDK/Background/MXBackgroundSyncService.swift
+++ b/MatrixSDK/Background/MXBackgroundSyncService.swift
@@ -98,13 +98,9 @@ public enum MXBackgroundSyncServiceError: Error {
         }()
         
         pushRulesManager = MXBackgroundPushRulesManager(withCredentials: credentials)
-        if let accountData = syncResponseStoreManager.syncResponseStore.accountData {
-            pushRulesManager.handleAccountData(accountData)
-        } else if let accountData = store.userAccountData ?? nil {
-            pushRulesManager.handleAccountData(accountData)
-        }
         MXLog.debug("[MXBackgroundSyncService] init complete")
         super.init()
+        syncPushRuleManagerWithAccountData()
     }
     
     /// Fetch event with given event and room identifiers. It performs a sync if the event not found in session store.
@@ -501,6 +497,10 @@ public enum MXBackgroundSyncServiceError: Error {
             crypto.reset()
         }
         
+        syncPushRuleManagerWithAccountData()
+    }
+    
+    private func syncPushRuleManagerWithAccountData() {
         if let accountData = syncResponseStoreManager.syncResponseStore.accountData {
             pushRulesManager.handleAccountData(accountData)
         } else if let accountData = store.userAccountData ?? nil {

--- a/changelog.d/pr-1714.change
+++ b/changelog.d/pr-1714.change
@@ -1,0 +1,1 @@
+Polls: Apply push rules client side for encrypted rooms

--- a/changelog.d/pr-1714.change
+++ b/changelog.d/pr-1714.change
@@ -1,1 +1,1 @@
-Polls: Apply push rules client side for encrypted rooms
+Push Rules: Apply push rules client side for encrypted rooms, including mentions and keywords.


### PR DESCRIPTION
push rules for an event was broken because it was reading the encrypted one.
Now if present the clear event, the proper rule id is matching properly.

It was also missing the pushRulesManager's handle account data in the updateBackgroundServiceStoresIfNeeded, that way it was not synchronised and a reboot of the app was needed in order to fetch the proper push rules