### PR TITLE
Fix: don’t send a verification cancel request if the session is closed

### DIFF
--- a/MatrixSDK/Crypto/KeyBackup/Engine/MXNativeKeyBackupEngine.m
+++ b/MatrixSDK/Crypto/KeyBackup/Engine/MXNativeKeyBackupEngine.m
@@ -101,7 +101,9 @@ static Class DefaultAlgorithmClass;
     self.crypto.store.backupVersion = keyBackupVersion.version;
     Class algorithmClass = AlgorithmClassesByName[keyBackupVersion.algorithm];
     //  store the desired backup algorithm
+    MXWeakify(self);
     self.keyBackupAlgorithm = [[algorithmClass alloc] initWithCrypto:self.crypto authData:authData keyGetterBlock:^NSData * _Nullable{
+        MXStrongifyAndReturnValueIfNil(self, nil);
         return self.privateKey;
     }];
     MXLogDebug(@"[MXNativeKeyBackupEngine] enableBackupWithVersion: Algorithm set to: %@", self.keyBackupAlgorithm);

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -2665,8 +2665,11 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onToDeviceEvent:) name:kMXSessionOnToDeviceEventNotification object:self.mxSession];
 
         // Observe membership changes
+        MXWeakify(self);
         self->roomMembershipEventsListener = [self.mxSession listenToEventsOfTypes:@[kMXEventTypeStringRoomEncryption, kMXEventTypeStringRoomMember] onEvent:^(MXEvent *event, MXTimelineDirection direction, id customObject) {
 
+            MXStrongifyAndReturnIfNil(self);
+            
             if (direction == MXTimelineDirectionForwards)
             {
                 if (event.eventType == MXEventTypeRoomEncryption)

--- a/MatrixSDK/Crypto/Verification/MXKeyVerificationManager.m
+++ b/MatrixSDK/Crypto/Verification/MXKeyVerificationManager.m
@@ -699,6 +699,17 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
                           success:(void(^)(void))success
                           failure:(void(^)(NSError *error))failure
 {
+    // If the session is closed, don't try to send a request
+    if (self.crypto.mxSession.state == MXSessionStateClosed)
+    {
+        // It's not an error, the associated session is simply not valid anymore
+        if (success)
+        {
+            success();
+        }
+        return;
+    }
+
     MXTransactionCancelCode *cancelCode = MXTransactionCancelCode.user;
 
     // If there is transaction in progress, cancel it
@@ -706,15 +717,6 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
     if (transaction)
     {
         [self cancelTransaction:transaction code:cancelCode success:success failure:failure];
-    }
-    // If the session is closed, don't try to send a request
-    else if (self.crypto.mxSession.state == MXSessionStateClosed)
-    {
-        // It's not an error, the associated session is simply not valid anymore
-        if (success)
-        {
-            success();
-        }
     }
     else
     {

--- a/MatrixSDK/Crypto/Verification/MXKeyVerificationManager.m
+++ b/MatrixSDK/Crypto/Verification/MXKeyVerificationManager.m
@@ -707,6 +707,15 @@ static NSArray<MXEventTypeString> *kMXKeyVerificationManagerVerificationEventTyp
     {
         [self cancelTransaction:transaction code:cancelCode success:success failure:failure];
     }
+    // If the session is closed, don't try to send a request
+    else if (self.crypto.mxSession.state == MXSessionStateClosed)
+    {
+        // It's not an error, the associated session is simply not valid anymore
+        if (success)
+        {
+            success();
+        }
+    }
     else
     {
         // Else only cancel the request

--- a/changelog.d/pr-1716.bugfix
+++ b/changelog.d/pr-1716.bugfix
@@ -1,0 +1,2 @@
+Avoid sending a verification cancel request while the session is closed
+Fix of some retain cycles


### PR DESCRIPTION
This PR fixes:
- a crash in DEBUG when the app tries to send a cancel verification request while the session is closed.
- 2 retain cycles preventing MXCrypto from being properly released
