### PR TITLE
Unify verification event processing in Crypto V2

### DIFF
--- a/MatrixSDK/Crypto/Algorithms/RoomEvent/MXRoomEventDecryption.swift
+++ b/MatrixSDK/Crypto/Algorithms/RoomEvent/MXRoomEventDecryption.swift
@@ -104,7 +104,13 @@ actor MXRoomEventDecryption: MXRoomEventDecrypting {
             event.content?["algorithm"] as? String == kMXCryptoMegolmAlgorithm,
             let sessionId = sessionId(for: event)
         else {
-            log.debug("Ignoring unencrypted or non-room event `\(eventId)`")
+            if !event.isEncrypted {
+                log.debug("Ignoring unencrypted event`\(eventId)`")
+            } else if event.clear != nil {
+                log.debug("Ignoring already decrypted event`\(eventId)`")
+            } else {
+                log.debug("Ignoring non-room event `\(eventId)`")
+            }
             
             let result = MXEventDecryptionResult()
             result.clearEvent = event.clear?.jsonDictionary()

--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoProtocols.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoProtocols.swift
@@ -88,7 +88,7 @@ protocol MXCryptoCrossSigning: MXCryptoUserIdentitySource {
 /// Verification functionality
 protocol MXCryptoVerifying: MXCryptoIdentity {
     func downloadKeysIfNecessary(users: [String]) async throws
-    func receiveUnencryptedVerificationEvent(event: MXEvent, roomId: String) async throws
+    func receiveVerificationEvent(event: MXEvent, roomId: String) async throws
     func requestSelfVerification(methods: [String]) async throws -> VerificationRequestProtocol
     func requestVerification(userId: String, roomId: String, methods: [String]) async throws -> VerificationRequestProtocol
     func requestVerification(userId: String, deviceId: String, methods: [String]) async throws -> VerificationRequestProtocol

--- a/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoMachineUnitTests.swift
+++ b/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoMachineUnitTests.swift
@@ -19,6 +19,10 @@ import MatrixSDKCrypto
 @testable import MatrixSDK
 
 class MXCryptoMachineUnitTests: XCTestCase {
+    enum Error: Swift.Error {
+        case invalidEvent
+    }
+    
     class KeyProvider: NSObject, MXKeyProviderDelegate {
         func isEncryptionAvailableForData(ofType dataType: String) -> Bool {
             return true
@@ -33,15 +37,18 @@ class MXCryptoMachineUnitTests: XCTestCase {
         }
     }
     
-    var userId = "@alice:matrix.org"
-    var restClient: MXRestClient!
+    var myUserId = "@alice:localhost"
+    var otherUserId = "@bob:localhost"
+    var roomId = "!1234:localhost"
+    var verificationRequestId = "$12345"
+    var restClient: MXRestClientStub!
     var machine: MXCryptoMachine!
     
     override func setUp() {
         restClient = MXRestClientStub()
         MXKeyProvider.sharedInstance().delegate = KeyProvider()
         machine = try! MXCryptoMachine(
-            userId: userId,
+            userId: myUserId,
             deviceId: "ABCD",
             restClient: restClient,
             getRoomAction: {
@@ -52,7 +59,7 @@ class MXCryptoMachineUnitTests: XCTestCase {
     
     override func tearDown() {
         do {
-            let url = try MXCryptoMachineStore.storeURL(for: userId)
+            let url = try MXCryptoMachineStore.storeURL(for: myUserId)
             guard FileManager.default.fileExists(atPath: url.path) else {
                 return
             }
@@ -61,6 +68,8 @@ class MXCryptoMachineUnitTests: XCTestCase {
             XCTFail("Cannot tear down test - \(error)")
         }
     }
+    
+    // MARK: - Sync response
     
     func test_handleSyncResponse_canProcessEmptyResponse() async throws {
         let result = try await machine.handleSyncResponse(
@@ -88,5 +97,93 @@ class MXCryptoMachineUnitTests: XCTestCase {
             unusedFallbackKeys: nil
         )
         XCTAssertEqual(result.events.count, 1)
+    }
+    
+    // MARK: - Verification events
+    
+    func test_receiveUnencryptedVerificationEvent() async throws {
+        let event = try makeUnencryptedRequestEvent()
+                
+        try await machine.receiveVerificationEvent(event: event, roomId: roomId)
+        
+        let requests = machine.verificationRequests(userId: otherUserId)
+        XCTAssertEqual(requests.count, 1)
+        XCTAssertEqual(requests.first?.state(), .requested)
+    }
+    
+    func test_receiveEncryptedVerificationEvent() async throws {
+        // Start verification by recieving `m.key.verifiaction.request` from the other user
+        let requestEvent = try makeUnencryptedRequestEvent()
+        try await machine.receiveVerificationEvent(event: requestEvent, roomId: roomId)
+        let request = machine.verificationRequests(userId: otherUserId).first
+        XCTAssertNotNil(request)
+        
+        let cancelEvent = try makeDecryptedCancelEvent()
+           
+        try await machine.receiveVerificationEvent(event: cancelEvent, roomId: roomId)
+        
+        XCTAssertEqual(request?.state(), .cancelled(
+            cancelInfo: .init(
+                cancelCode: "m.user",
+                reason: "The user cancelled the verification.",
+                cancelledByUs: false
+            )
+        ))
+    }
+    
+    // MARK: - Helpers
+    
+    private func makeUnencryptedRequestEvent() throws -> MXEvent {
+        guard let event = MXEvent(fromJSON: [
+            "origin_server_ts": Date().timeIntervalSince1970 * 1000,
+            "event_id": verificationRequestId,
+            "sender": otherUserId,
+            "type": "m.room.message",
+            "content": [
+                "msgtype": "m.key.verification.request",
+                "from_device": "ABC",
+                "to": myUserId,
+                "body": "",
+                "methods": ["m.sas.v1"]
+            ]
+        ]) else {
+            throw Error.invalidEvent
+        }
+        return event
+    }
+    
+    private func makeDecryptedCancelEvent() throws -> MXEvent {
+        guard let decrypted = MXEvent(fromJSON: [
+            "origin_server_ts": Date().timeIntervalSince1970 * 1000,
+            "event_id": verificationRequestId,
+            "sender": otherUserId,
+            "type": "m.room.encrypted",
+            "content": [
+                "algorithm": kMXCryptoMegolmAlgorithm,
+                "ciphertext": "ABCDEFGH",
+                "sender_key": "ABCD",
+                "device_id": "ABCD",
+                "session_id": "1234"
+            ]
+        ]) else {
+            throw Error.invalidEvent
+        }
+        
+        let result = try MXEventDecryptionResult(event: .stub(clearEvent: [
+            "event_id": "$6789",
+            "sender": otherUserId,
+            "type": "m.key.verification.cancel",
+            "content": [
+                "code": "m.user",
+                "reason": "User rejected the key verification request",
+                "transaction_id": verificationRequestId,
+                "m.relates_to": [
+                    "event_id": verificationRequestId,
+                    "rel_type": "m.reference"
+                ]
+            ]
+        ]))
+        decrypted.setClearData(result)
+        return decrypted
     }
 }

--- a/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoProtocolStubs.swift
+++ b/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoProtocolStubs.swift
@@ -130,7 +130,7 @@ extension CryptoVerificationStub: MXCryptoVerifying {
     func downloadKeysIfNecessary(users: [String]) async throws {
     }
     
-    func receiveUnencryptedVerificationEvent(event: MXEvent, roomId: String) {
+    func receiveVerificationEvent(event: MXEvent, roomId: String) {
     }
     
     func requestSelfVerification(methods: [String]) async throws -> VerificationRequestProtocol {

--- a/changelog.d/pr-1717.change
+++ b/changelog.d/pr-1717.change
@@ -1,0 +1,1 @@
+CryptoV2: Unify verification event processing


### PR DESCRIPTION
Previously the `CryptoSDK` would automatically handle encrypted verification events in rooms as soon as they are decrypted via `decryptRoomEvent` methods. Whilst this sounds convenient, there are a number of issues with this approach:
- we still need to manually pass in unencrypted verification events, not otherwise known to the crypto machine
- upon decrypting a verification event, we may have some new requests to sent out out of a sync loop

An improved approach is to prevent the machine from automatically processing verification events via a parameter, and then reuse existing event observers to pass in both encrypted and unencrypted verification events.