### PR TITLE
Encrypt rooms' last messages

### DIFF
--- a/MatrixSDK/Data/MXRoomLastMessage.h
+++ b/MatrixSDK/Data/MXRoomLastMessage.h
@@ -69,7 +69,14 @@ FOUNDATION_EXPORT NSString *const MXRoomLastMessageDataType;
 
 - (instancetype)initWithEvent:(MXEvent *)event;
 
-- (nullable NSData*)encryptedAttributedString;
+/**
+ Returns an archived (possibly encrypted) version of MXRoomLastMessage data.
+ These include:
+ - `text`
+ - `attributedText`
+ - `others`
+ */
+- (nullable NSData*)sensitiveData;
 
 #pragma mark - CoreData Model
 

--- a/MatrixSDK/Data/MXRoomLastMessage.h
+++ b/MatrixSDK/Data/MXRoomLastMessage.h
@@ -70,7 +70,7 @@ FOUNDATION_EXPORT NSString *const MXRoomLastMessageDataType;
 - (instancetype)initWithEvent:(MXEvent *)event;
 
 /**
- Returns an archived (possibly encrypted) version of MXRoomLastMessage sensible data.
+ Returns an archived (possibly encrypted) version of MXRoomLastMessage sensitive data.
  These include:
  - `text`
  - `attributedText`

--- a/MatrixSDK/Data/MXRoomLastMessage.h
+++ b/MatrixSDK/Data/MXRoomLastMessage.h
@@ -69,6 +69,8 @@ FOUNDATION_EXPORT NSString *const MXRoomLastMessageDataType;
 
 - (instancetype)initWithEvent:(MXEvent *)event;
 
+- (nullable NSData*)encryptedAttributedString;
+
 #pragma mark - CoreData Model
 
 - (instancetype)initWithManagedObject:(MXRoomLastMessageMO *)model;

--- a/MatrixSDK/Data/MXRoomLastMessage.h
+++ b/MatrixSDK/Data/MXRoomLastMessage.h
@@ -70,7 +70,7 @@ FOUNDATION_EXPORT NSString *const MXRoomLastMessageDataType;
 - (instancetype)initWithEvent:(MXEvent *)event;
 
 /**
- Returns an archived (possibly encrypted) version of MXRoomLastMessage data.
+ Returns an archived (possibly encrypted) version of MXRoomLastMessage sensible data.
  These include:
  - `text`
  - `attributedText`

--- a/MatrixSDK/Data/MXRoomLastMessage.m
+++ b/MatrixSDK/Data/MXRoomLastMessage.m
@@ -174,20 +174,7 @@ NSString *const kCodingKeyOthers = @"others";
     [coder encodeObject:_sender forKey:kCodingKeySender];
     
     // Build last message sensitive data
-    NSMutableDictionary *lastMessageDictionary = [NSMutableDictionary dictionary];
-    if (_text)
-    {
-        lastMessageDictionary[kCodingKeyText] = _text;
-    }
-    if (_attributedText)
-    {
-        lastMessageDictionary[kCodingKeyAttributedText] = _attributedText;
-    }
-    if (_others)
-    {
-        lastMessageDictionary[kCodingKeyOthers] = _others;
-    }
-    
+    NSDictionary *lastMessageDictionary = [self sensitiveData];
     // And encrypt it if necessary
     if (_isEncrypted)
     {
@@ -203,6 +190,26 @@ NSString *const kCodingKeyOthers = @"others";
     {
         [coder encodeObject:lastMessageDictionary forKey:kCodingKeyData];
     }
+}
+
+-(NSDictionary*)sensitiveData
+{
+    NSMutableDictionary *lastMessageDictionary = [NSMutableDictionary dictionary];
+    
+    if (_text)
+    {
+        lastMessageDictionary[kCodingKeyText] = _text;
+    }
+    if (_attributedText)
+    {
+        lastMessageDictionary[kCodingKeyAttributedText] = _attributedText;
+    }
+    if (_others)
+    {
+        lastMessageDictionary[kCodingKeyOthers] = _others;
+    }
+    
+    return  lastMessageDictionary;
 }
 
 #pragma mark - Data encryption

--- a/MatrixSDK/Data/MXRoomLastMessage.m
+++ b/MatrixSDK/Data/MXRoomLastMessage.m
@@ -61,10 +61,10 @@ NSString *const kCodingKeyOthers = @"others";
 
 - (nullable NSData*)encryptedAttributedString
 {
-    if (_attributedText)
+    if (self.attributedText)
     {
-        NSData* archieved = [NSKeyedArchiver archivedDataWithRootObject:_attributedText];
-        return [self encrypt:archieved];
+        NSData* archived = [NSKeyedArchiver archivedDataWithRootObject:self.attributedText requiringSecureCoding:NO error:nil];
+        return [self encrypt:archived];
     }
     else
     {

--- a/MatrixSDK/Data/MXRoomLastMessage.m
+++ b/MatrixSDK/Data/MXRoomLastMessage.m
@@ -112,7 +112,7 @@ NSString *const kCodingKeyOthers = @"others";
         }
         else
         {
-            archivedSensitiveData = model.s_attributedText;
+            archivedSensitiveData = model.s_sensitiveData;
         }
         
         if (archivedSensitiveData)

--- a/MatrixSDK/Data/MXRoomLastMessage.m
+++ b/MatrixSDK/Data/MXRoomLastMessage.m
@@ -61,9 +61,14 @@ NSString *const kCodingKeyOthers = @"others";
 
 - (nullable NSData*)sensitiveData;
 {
+    NSError* error;
     NSData* archived = [NSKeyedArchiver archivedDataWithRootObject:[self sensitiveDataDictionary]
                                              requiringSecureCoding:NO
-                                                             error:nil];
+                                                             error:&error];
+    
+    if (error) {
+        MXLogDebug(@"[MXRoomLastMessage] did fail to archive sensitiveDataDictionary. Error: %@", error.description);
+    }
     
     if (archived && self.isEncrypted)
     {

--- a/MatrixSDK/Data/MXRoomLastMessage.m
+++ b/MatrixSDK/Data/MXRoomLastMessage.m
@@ -117,7 +117,7 @@ NSString *const kCodingKeyOthers = @"others";
         
         if (archivedSensitiveData)
         {
-            NSDictionary* sensitiveDataDictionary = [NSKeyedUnarchiver unarchivedObjectOfClass:NSMutableDictionary.class fromData:archivedSensitiveData error:nil];
+            NSDictionary* sensitiveDataDictionary = [NSKeyedUnarchiver unarchiveObjectWithData:archivedSensitiveData];
             
             _text = sensitiveDataDictionary[kCodingKeyText];
             _attributedText = sensitiveDataDictionary[kCodingKeyAttributedText];
@@ -128,11 +128,11 @@ NSString *const kCodingKeyOthers = @"others";
             _text = model.s_text;
             
             if (model.s_attributedText) {
-                _attributedText = [NSKeyedUnarchiver unarchivedObjectOfClass:NSAttributedString.class fromData:model.s_attributedText error:nil];
+                _attributedText = [NSKeyedUnarchiver unarchiveObjectWithData:model.s_attributedText];
             }
             
             if (model.s_others) {
-                _others = [NSKeyedUnarchiver unarchivedObjectOfClass:NSMutableDictionary.class fromData:model.s_others error:nil];
+                _others = [NSKeyedUnarchiver unarchiveObjectWithData:model.s_others];
             }
         }
     }

--- a/MatrixSDK/Data/MXRoomLastMessage.m
+++ b/MatrixSDK/Data/MXRoomLastMessage.m
@@ -128,18 +128,6 @@ NSString *const kCodingKeyOthers = @"others";
             _attributedText = sensitiveDataDictionary[kCodingKeyAttributedText];
             _others = sensitiveDataDictionary[kCodingKeyOthers];
         }
-        else // fallback logic for old database versions
-        {
-            _text = model.s_text;
-            
-            if (model.s_attributedText) {
-                _attributedText = [NSKeyedUnarchiver unarchiveObjectWithData:model.s_attributedText];
-            }
-            
-            if (model.s_others) {
-                _others = [NSKeyedUnarchiver unarchiveObjectWithData:model.s_others];
-            }
-        }
     }
     
     return self;

--- a/MatrixSDK/Data/RoomSummaryStore/CoreData/MXCoreDataRoomSummaryStore.xcdatamodeld/MXRoomSummaryCoreDataStore2.xcdatamodel/contents
+++ b/MatrixSDK/Data/RoomSummaryStore/CoreData/MXCoreDataRoomSummaryStore.xcdatamodeld/MXRoomSummaryCoreDataStore2.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="20086" systemVersion="21E258" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21513" systemVersion="22C65" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="MXRoomLastMessage" representedClassName="MXRoomLastMessageMO" syncable="YES">
         <attribute name="s_attributedText" optional="YES" attributeType="Binary" valueTransformerName=""/>
         <attribute name="s_eventId" attributeType="String"/>
@@ -7,6 +7,7 @@
         <attribute name="s_originServerTs" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="s_others" optional="YES" attributeType="Binary"/>
         <attribute name="s_sender" attributeType="String"/>
+        <attribute name="s_sensitiveData" optional="YES" attributeType="Binary"/>
         <attribute name="s_text" optional="YES" attributeType="String"/>
         <relationship name="s_ofRoom" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="MXRoomSummary" inverseName="s_lastMessage" inverseEntity="MXRoomSummary"/>
     </entity>
@@ -62,10 +63,4 @@
         <attribute name="s_usersCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <relationship name="s_ofRoom" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="MXRoomSummary" inverseName="s_trust" inverseEntity="MXRoomSummary"/>
     </entity>
-    <elements>
-        <element name="MXRoomLastMessage" positionX="117" positionY="90" width="128" height="149"/>
-        <element name="MXRoomMembersCount" positionX="297.1484375" positionY="-66.14453125" width="128" height="89"/>
-        <element name="MXRoomSummary" positionX="-63" positionY="-18" width="128" height="509"/>
-        <element name="MXUsersTrustLevelSummary" positionX="236.4921875" positionY="519.4296875" width="128" height="104"/>
-    </elements>
 </model>

--- a/MatrixSDK/Data/RoomSummaryStore/CoreData/MXCoreDataRoomSummaryStore.xcdatamodeld/MXRoomSummaryCoreDataStore2.xcdatamodel/contents
+++ b/MatrixSDK/Data/RoomSummaryStore/CoreData/MXCoreDataRoomSummaryStore.xcdatamodeld/MXRoomSummaryCoreDataStore2.xcdatamodel/contents
@@ -1,14 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21513" systemVersion="22C65" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="MXRoomLastMessage" representedClassName="MXRoomLastMessageMO" syncable="YES">
-        <attribute name="s_attributedText" optional="YES" attributeType="Binary" valueTransformerName=""/>
         <attribute name="s_eventId" attributeType="String"/>
         <attribute name="s_isEncrypted" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="s_originServerTs" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
-        <attribute name="s_others" optional="YES" attributeType="Binary"/>
         <attribute name="s_sender" attributeType="String"/>
         <attribute name="s_sensitiveData" optional="YES" attributeType="Binary"/>
-        <attribute name="s_text" optional="YES" attributeType="String"/>
         <relationship name="s_ofRoom" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="MXRoomSummary" inverseName="s_lastMessage" inverseEntity="MXRoomSummary"/>
     </entity>
     <entity name="MXRoomMembersCount" representedClassName="MXRoomMembersCountMO" syncable="YES">

--- a/MatrixSDK/Data/RoomSummaryStore/CoreData/Models/MXRoomLastMessageMO.swift
+++ b/MatrixSDK/Data/RoomSummaryStore/CoreData/Models/MXRoomLastMessageMO.swift
@@ -47,19 +47,18 @@ public class MXRoomLastMessageMO: NSManagedObject {
         s_originServerTs = lastMessage.originServerTs
         s_isEncrypted = lastMessage.isEncrypted
         s_sender = lastMessage.sender
-        s_text = lastMessage.text
         
-        if let attributedText = lastMessage.attributedText {
-            s_attributedText = NSKeyedArchiver.archivedData(withRootObject: attributedText)
-        } else {
-            s_attributedText = nil
+        s_text = lastMessage.isEncrypted ? nil : lastMessage.text
+        
+        if lastMessage.isEncrypted
+        {
+            s_attributedText = lastMessage.encryptedAttributedString()
+        }
+        else
+        {
+            s_attributedText = lastMessage.attributedText.map(NSKeyedArchiver.archivedData(withRootObject:))
         }
         
-        if let others = lastMessage.others {
-            s_others = NSKeyedArchiver.archivedData(withRootObject: others)
-        } else {
-            s_others = nil
-        }
+        s_others = lastMessage.others.map(NSKeyedArchiver.archivedData(withRootObject:))
     }
-    
 }

--- a/MatrixSDK/Data/RoomSummaryStore/CoreData/Models/MXRoomLastMessageMO.swift
+++ b/MatrixSDK/Data/RoomSummaryStore/CoreData/Models/MXRoomLastMessageMO.swift
@@ -31,6 +31,7 @@ public class MXRoomLastMessageMO: NSManagedObject {
     @NSManaged public var s_text: String?
     @NSManaged public var s_attributedText: Data?
     @NSManaged public var s_others: Data?
+    @NSManaged public var s_sensitiveData: Data?
     
     @discardableResult
     internal static func insert(roomLastMessage lastMessage: MXRoomLastMessage,
@@ -47,15 +48,9 @@ public class MXRoomLastMessageMO: NSManagedObject {
         s_originServerTs = lastMessage.originServerTs
         s_isEncrypted = lastMessage.isEncrypted
         s_sender = lastMessage.sender
-        
-        s_text = lastMessage.isEncrypted ? nil : lastMessage.text
-        
-        if lastMessage.isEncrypted {
-            s_attributedText = lastMessage.encryptedAttributedString()
-        } else {
-            s_attributedText = lastMessage.attributedText.map(NSKeyedArchiver.archivedData(withRootObject:))
-        }
-        
-        s_others = lastMessage.others.map(NSKeyedArchiver.archivedData(withRootObject:))
+        s_sensitiveData = lastMessage.sensitiveData()
+        s_text = nil;
+        s_attributedText = nil;
+        s_others = nil;
     }
 }

--- a/MatrixSDK/Data/RoomSummaryStore/CoreData/Models/MXRoomLastMessageMO.swift
+++ b/MatrixSDK/Data/RoomSummaryStore/CoreData/Models/MXRoomLastMessageMO.swift
@@ -50,12 +50,9 @@ public class MXRoomLastMessageMO: NSManagedObject {
         
         s_text = lastMessage.isEncrypted ? nil : lastMessage.text
         
-        if lastMessage.isEncrypted
-        {
+        if lastMessage.isEncrypted {
             s_attributedText = lastMessage.encryptedAttributedString()
-        }
-        else
-        {
+        } else {
             s_attributedText = lastMessage.attributedText.map(NSKeyedArchiver.archivedData(withRootObject:))
         }
         

--- a/MatrixSDK/Data/RoomSummaryStore/CoreData/Models/MXRoomLastMessageMO.swift
+++ b/MatrixSDK/Data/RoomSummaryStore/CoreData/Models/MXRoomLastMessageMO.swift
@@ -55,5 +55,10 @@ public class MXRoomLastMessageMO: NSManagedObject {
         s_isEncrypted = lastMessage.isEncrypted
         s_sender = lastMessage.sender
         s_sensitiveData = lastMessage.sensitiveData()
+        
+        // Cleaning up clear data in the database, in the future this property should be deleted from Core Data
+        s_text = nil;
+        s_others = nil;
+        s_attributedText = nil;
     }
 }

--- a/MatrixSDK/Data/RoomSummaryStore/CoreData/Models/MXRoomLastMessageMO.swift
+++ b/MatrixSDK/Data/RoomSummaryStore/CoreData/Models/MXRoomLastMessageMO.swift
@@ -28,10 +28,16 @@ public class MXRoomLastMessageMO: NSManagedObject {
     @NSManaged public var s_originServerTs: UInt64
     @NSManaged public var s_isEncrypted: Bool
     @NSManaged public var s_sender: String
-    @NSManaged public var s_text: String?
-    @NSManaged public var s_attributedText: Data?
-    @NSManaged public var s_others: Data?
     @NSManaged public var s_sensitiveData: Data?
+    
+    @available(*, deprecated, message: "Store sensitive information on s_sensitiveData instead")
+    @NSManaged public var s_text: String?
+    
+    @available(*, deprecated, message: "Store sensitive information on s_sensitiveData instead")
+    @NSManaged public var s_others: Data?
+    
+    @available(*, deprecated, message: "Store sensitive information on s_sensitiveData instead")
+    @NSManaged public var s_attributedText: Data?
     
     @discardableResult
     internal static func insert(roomLastMessage lastMessage: MXRoomLastMessage,
@@ -49,8 +55,5 @@ public class MXRoomLastMessageMO: NSManagedObject {
         s_isEncrypted = lastMessage.isEncrypted
         s_sender = lastMessage.sender
         s_sensitiveData = lastMessage.sensitiveData()
-        s_text = nil;
-        s_attributedText = nil;
-        s_others = nil;
     }
 }

--- a/MatrixSDK/Data/RoomSummaryStore/CoreData/Models/MXRoomLastMessageMO.swift
+++ b/MatrixSDK/Data/RoomSummaryStore/CoreData/Models/MXRoomLastMessageMO.swift
@@ -56,7 +56,7 @@ public class MXRoomLastMessageMO: NSManagedObject {
         s_sender = lastMessage.sender
         s_sensitiveData = lastMessage.sensitiveData()
         
-        // Cleaning up clear data in the database, in the future this property should be deleted from Core Data
+        // Cleaning up unencrypted data in the old database versions. In the future these properties should be deleted from Core Data.
         s_text = nil;
         s_others = nil;
         s_attributedText = nil;

--- a/MatrixSDK/Data/RoomSummaryStore/CoreData/Models/MXRoomLastMessageMO.swift
+++ b/MatrixSDK/Data/RoomSummaryStore/CoreData/Models/MXRoomLastMessageMO.swift
@@ -30,15 +30,6 @@ public class MXRoomLastMessageMO: NSManagedObject {
     @NSManaged public var s_sender: String
     @NSManaged public var s_sensitiveData: Data?
     
-    @available(*, deprecated, message: "Store sensitive information on s_sensitiveData instead")
-    @NSManaged public var s_text: String?
-    
-    @available(*, deprecated, message: "Store sensitive information on s_sensitiveData instead")
-    @NSManaged public var s_others: Data?
-    
-    @available(*, deprecated, message: "Store sensitive information on s_sensitiveData instead")
-    @NSManaged public var s_attributedText: Data?
-    
     @discardableResult
     internal static func insert(roomLastMessage lastMessage: MXRoomLastMessage,
                                 into moc: NSManagedObjectContext) -> MXRoomLastMessageMO {
@@ -55,10 +46,5 @@ public class MXRoomLastMessageMO: NSManagedObject {
         s_isEncrypted = lastMessage.isEncrypted
         s_sender = lastMessage.sender
         s_sensitiveData = lastMessage.sensitiveData()
-        
-        // Cleaning up unencrypted data in the old database versions. In the future these properties should be deleted from Core Data.
-        s_text = nil;
-        s_others = nil;
-        s_attributedText = nil;
     }
 }

--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
@@ -29,7 +29,7 @@
 #import "MatrixSDKSwiftHeader.h"
 #import "MXFileRoomSummaryStore.h"
 
-static NSUInteger const kMXFileVersion = 81;
+static NSUInteger const kMXFileVersion = 82;
 
 static NSString *const kMXFileStoreFolder = @"MXFileStore";
 static NSString *const kMXFileStoreMedaDataFile = @"MXFileStore";

--- a/changelog.d/pr-1718.change
+++ b/changelog.d/pr-1718.change
@@ -1,1 +1,2 @@
 Encryption: add encryption to rooms' last messages.
+WARNING: the migration to this database version will cause an initial full sync.

--- a/changelog.d/pr-1718.change
+++ b/changelog.d/pr-1718.change
@@ -1,0 +1,1 @@
+Encryption: add encryption to rooms' last messages.


### PR DESCRIPTION
### Description

This PR adds the AES encryption for rooms' last messages before they get stored into Core Data.

Fixes: https://github.com/vector-im/element-ios/issues/7358

| Before | After | 
| --- | ---|
| ![b](https://user-images.githubusercontent.com/19324622/220079479-af2d2137-251c-42e4-81dc-41e9063278a7.png)|![a](https://user-images.githubusercontent.com/19324622/220079527-e0b96897-c24f-4c00-aa26-59da76533f0f.png)|