### PR TITLE
Fix an issue where the media download would not start until the end of the scroll

### DIFF
--- a/MatrixSDK/Utils/Media/MXMediaLoader.m
+++ b/MatrixSDK/Utils/Media/MXMediaLoader.m
@@ -147,7 +147,12 @@ NSString *const kMXMediaUploadIdPrefix = @"upload-";
         request.HTTPBody = [NSJSONSerialization dataWithJSONObject:data options:0 error:nil];
     }
     
-    downloadConnection = [[NSURLConnection alloc] initWithRequest:request delegate:self];
+    // if we use the default settings the connection object will be scheduled in the NSDefaultRunLoopMode. That means that the connection is only executing the request when the app’s run loop is in NSDefaultRunLoopMode.
+    // Now, when a user touches the screen (e.g. to scroll a UIScrollView) the run loop’s mode will be switched to NSEventTrackingRunLoopMode. And now, that the run loop is not in NSDefaultRunMode anymore, the connection will not execute. The ugly effect of that is, that the download is blocked whenever the user touches the screen
+    // Setting the mode to NSRunLoopCommonModes allow the request to work in all modes (even NSEventTrackingRunLoopMode)
+    downloadConnection = [[NSURLConnection alloc] initWithRequest:request delegate:self startImmediately:NO];
+    [downloadConnection scheduleInRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
+    [downloadConnection start];
 }
 
 - (void)connection:(NSURLConnection *)connection didReceiveResponse:(NSURLResponse *)response

--- a/changelog.d/pr-1721.bugfix
+++ b/changelog.d/pr-1721.bugfix
@@ -1,0 +1,1 @@
+Fix an issue where MXMediaLoader would not start downloading until the end of the scroll.


### PR DESCRIPTION
This PR fixes an issue with the back pagination where images would not download until the end of the scroll.