### PR TITLE
Use correct next users with keys query

### DIFF
--- a/changelog.d/pr-1726.change
+++ b/changelog.d/pr-1726.change
@@ -1,0 +1,1 @@
+Use correct next users with keys query 


### PR DESCRIPTION
Fix a minor bug where starting the next pending `keys/query` would use the wrong list of users used to deduplicate requests. The consequence of this bug is that we may be executing slightly more requests than necessary