### PR TITLE
Direct room with a third party

### DIFF
--- a/MatrixSDK/Data/MXRoomSummaryUpdater.m
+++ b/MatrixSDK/Data/MXRoomSummaryUpdater.m
@@ -564,8 +564,14 @@
     switch (memberNames.count)
     {
         case 0:
+        {
             displayname = _roomNameStringLocalizer.emptyRoom;
-            if (roomState.thirdPartyInvites.firstObject.displayname != nil)
+            NSString *directUserId = [session roomWithRoomId: roomState.roomId].directUserId;
+            if (directUserId != nil && [MXTools isEmailAddress:directUserId])
+            {
+                displayname = directUserId;
+            }
+            else if (roomState.thirdPartyInvites.firstObject.displayname != nil)
             {
                 displayname = roomState.thirdPartyInvites.firstObject.displayname;
             }
@@ -574,7 +580,7 @@
                 MXLogDebug(@"[MXRoomSummaryUpdater] fixUnexpectedEmptyRoomDisplayname: No luck");
             }
             break;
-
+        }
         case 1:
             if (memberCount == 2)
             {

--- a/MatrixSDK/Data/MXRoomSummaryUpdater.m
+++ b/MatrixSDK/Data/MXRoomSummaryUpdater.m
@@ -516,8 +516,7 @@
             }
         }
 
-        if (memberCount > 1
-            && (!displayName || [displayName isEqualToString:_roomNameStringLocalizer.emptyRoom]))
+        if (!displayName || [displayName isEqualToString:_roomNameStringLocalizer.emptyRoom])
         {
             // Data are missing to compute the display name
             MXLogDebug(@"[MXRoomSummaryUpdater] updateSummaryDisplayname: Warning: Computed an unexpected \"Empty Room\" name. memberCount: %@", @(memberCount));
@@ -565,8 +564,15 @@
     switch (memberNames.count)
     {
         case 0:
-            MXLogDebug(@"[MXRoomSummaryUpdater] fixUnexpectedEmptyRoomDisplayname: No luck");
             displayname = _roomNameStringLocalizer.emptyRoom;
+            if (roomState.thirdPartyInvites.firstObject.displayname != nil)
+            {
+                displayname = roomState.thirdPartyInvites.firstObject.displayname;
+            }
+            else
+            {
+                MXLogDebug(@"[MXRoomSummaryUpdater] fixUnexpectedEmptyRoomDisplayname: No luck");
+            }
             break;
 
         case 1:

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -2509,8 +2509,12 @@ typedef void (^MXOnResumeDone)(void);
         {
             // When the flag isDirect is turned on, only one user id is expected in the inviteArray.
             // The room is considered as direct only for the first mentioned user in case of several user ids.
-            // Note: It is not possible FTM to mark as direct a room with an invited third party.
             NSString *directUserId = (parameters.inviteArray.count ? parameters.inviteArray.firstObject : nil);
+            // Fall back on the first invite3PID address.
+            if (!directUserId && parameters.invite3PIDArray != nil && parameters.invite3PIDArray.count > 0)
+            {
+                directUserId = parameters.invite3PIDArray.firstObject.address;
+            }
             [self onCreatedDirectChat:response withUserId:directUserId success:success];
         }
         else

--- a/changelog.d/pr-1727.change
+++ b/changelog.d/pr-1727.change
@@ -1,0 +1,1 @@
+Creating a direct room with a third party will now use their email as the m.direct ID and their obfuscated email as the room title.


### PR DESCRIPTION
This PR fixes part of [element-ios #6612](https://github.com/vector-im/element-ios/issues/6612)

When creating a direct chat with a 3rd party, use their email as the direct room id.
When updating the room summary, use the third party display name, if available, rather than empty room.