### PR TITLE
Fix room list last message when the key comes late

### DIFF
--- a/MatrixSDK/Data/MXRoomLastMessage.h
+++ b/MatrixSDK/Data/MXRoomLastMessage.h
@@ -52,6 +52,11 @@ FOUNDATION_EXPORT NSString *const MXRoomLastMessageDataType;
 @property (nonatomic, assign, readonly) BOOL isEncrypted;
 
 /**
+ Indicates if the last message failed to be decrypted.
+ */
+@property (nonatomic, assign, readonly) BOOL hasDecryptionError;
+
+/**
  Sender of the last message.
  */
 @property (nonatomic, copy, readonly) NSString *sender;

--- a/MatrixSDK/Data/MXRoomLastMessage.m
+++ b/MatrixSDK/Data/MXRoomLastMessage.m
@@ -30,6 +30,7 @@ NSString *const MXRoomLastMessageDataType = @"org.matrix.sdk.keychain.MXRoomLast
 NSString *const kCodingKeyEventId = @"eventId";
 NSString *const kCodingKeyOriginServerTs = @"originServerTs";
 NSString *const kCodingKeyIsEncrypted = @"isEncrypted";
+NSString *const kCodingKeyHasDecryptionError = @"hasDecryptionError";
 NSString *const kCodingKeySender = @"sender";
 NSString *const kCodingKeyData = @"data";
 NSString *const kCodingKeyEncryptedData = @"encryptedData";
@@ -54,6 +55,7 @@ NSString *const kCodingKeyOthers = @"others";
         _eventId = event.eventId;
         _originServerTs = event.originServerTs;
         _isEncrypted = event.isEncrypted;
+        _hasDecryptionError = event.decryptionError != nil;
         _sender = event.sender;
     }
     return self;
@@ -108,6 +110,7 @@ NSString *const kCodingKeyOthers = @"others";
         _eventId = model.s_eventId;
         _originServerTs = model.s_originServerTs;
         _isEncrypted = model.s_isEncrypted;
+        _hasDecryptionError = model.s_hasDecryptionError;
         _sender = model.s_sender;
         
         NSData* archivedSensitiveData;
@@ -142,6 +145,7 @@ NSString *const kCodingKeyOthers = @"others";
         _eventId = [coder decodeObjectForKey:kCodingKeyEventId];
         _originServerTs = [coder decodeInt64ForKey:kCodingKeyOriginServerTs];
         _isEncrypted = [coder decodeBoolForKey:kCodingKeyIsEncrypted];
+        _hasDecryptionError = [coder decodeBoolForKey:kCodingKeyHasDecryptionError];
         _sender = [coder decodeObjectForKey:kCodingKeySender];
 
         NSDictionary *lastMessageDictionary;
@@ -172,6 +176,7 @@ NSString *const kCodingKeyOthers = @"others";
     [coder encodeObject:_eventId forKey:kCodingKeyEventId];
     [coder encodeInt64:_originServerTs forKey:kCodingKeyOriginServerTs];
     [coder encodeBool:_isEncrypted forKey:kCodingKeyIsEncrypted];
+    [coder encodeBool:_hasDecryptionError forKey:kCodingKeyHasDecryptionError];
     [coder encodeObject:_sender forKey:kCodingKeySender];
     
     // Build last message sensitive data

--- a/MatrixSDK/Data/RoomSummaryStore/CoreData/MXCoreDataRoomSummaryStore.xcdatamodeld/MXRoomSummaryCoreDataStore.xcdatamodel/contents
+++ b/MatrixSDK/Data/RoomSummaryStore/CoreData/MXCoreDataRoomSummaryStore.xcdatamodeld/MXRoomSummaryCoreDataStore.xcdatamodel/contents
@@ -3,6 +3,7 @@
     <entity name="MXRoomLastMessage" representedClassName="MXRoomLastMessageMO" syncable="YES">
         <attribute name="s_attributedText" optional="YES" attributeType="Binary" valueTransformerName=""/>
         <attribute name="s_eventId" attributeType="String"/>
+        <attribute name="s_hasDecryptionError" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="s_isEncrypted" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="s_originServerTs" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="s_others" optional="YES" attributeType="Binary"/>

--- a/MatrixSDK/Data/RoomSummaryStore/CoreData/MXCoreDataRoomSummaryStore.xcdatamodeld/MXRoomSummaryCoreDataStore2.xcdatamodel/contents
+++ b/MatrixSDK/Data/RoomSummaryStore/CoreData/MXCoreDataRoomSummaryStore.xcdatamodeld/MXRoomSummaryCoreDataStore2.xcdatamodel/contents
@@ -2,6 +2,7 @@
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21513" systemVersion="22C65" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="MXRoomLastMessage" representedClassName="MXRoomLastMessageMO" syncable="YES">
         <attribute name="s_eventId" attributeType="String"/>
+        <attribute name="s_hasDecryptionError" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="s_isEncrypted" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="s_originServerTs" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="s_sender" attributeType="String"/>

--- a/MatrixSDK/Data/RoomSummaryStore/CoreData/Models/MXRoomLastMessageMO.swift
+++ b/MatrixSDK/Data/RoomSummaryStore/CoreData/Models/MXRoomLastMessageMO.swift
@@ -27,6 +27,7 @@ public class MXRoomLastMessageMO: NSManagedObject {
     @NSManaged public var s_eventId: String
     @NSManaged public var s_originServerTs: UInt64
     @NSManaged public var s_isEncrypted: Bool
+    @NSManaged public var s_hasDecryptionError: Bool
     @NSManaged public var s_sender: String
     @NSManaged public var s_sensitiveData: Data?
     
@@ -44,6 +45,7 @@ public class MXRoomLastMessageMO: NSManagedObject {
         s_eventId = lastMessage.eventId
         s_originServerTs = lastMessage.originServerTs
         s_isEncrypted = lastMessage.isEncrypted
+        s_hasDecryptionError = lastMessage.hasDecryptionError
         s_sender = lastMessage.sender
         s_sensitiveData = lastMessage.sensitiveData()
     }

--- a/changelog.d/6848.bugfix
+++ b/changelog.d/6848.bugfix
@@ -1,0 +1,1 @@
+Fix room list last message when the key comes late.


### PR DESCRIPTION
Fix https://github.com/vector-im/element-ios/issues/6848.

**TODO:** add dependency on another incoming PR.

This bug fix handles the case when the key arrives after an app restart.
