### PR TITLE
Unread rooms: Move the storage file to a better location

### DIFF
--- a/changelog.d/pr-1730.bugfix
+++ b/changelog.d/pr-1730.bugfix
@@ -1,0 +1,1 @@
+Unread rooms: Move the storage file to a better location.


### PR DESCRIPTION
It was previously stored alongside rooms:
```
├── rooms
│   ├── !TDpKIKrKaCXyncpKsH:localhost:8480
│   │   ├── messages
│   │   ├── state
│   │   └── threadedReadReceipts
│   └── unreadRooms
````

This created an unexpected behavior because the method `MXFileStore.countOfRooms()` is based on number of items in the `rooms` folder. The result was the app recomputing room summaries on each startup if there were unread rooms: https://github.com/matrix-org/matrix-ios-sdk/blob/v0.25.2/MatrixSDK/MXSession.m#L470

The file is not at an upper level.