### PR TITLE
Always update tracked users when sharing keys

### DIFF
--- a/MatrixSDK/Crypto/Algorithms/RoomEvent/MXRoomEventEncryption.swift
+++ b/MatrixSDK/Crypto/Algorithms/RoomEvent/MXRoomEventEncryption.swift
@@ -108,7 +108,7 @@ struct MXRoomEventEncryption: MXRoomEventEncrypting {
             for: room,
             historyVisibility: state.historyVisibility
         )
-        handler.addTrackedUsers(users)
+        handler.updateTrackedUsers(users)
     }
     
     // MARK: - Private
@@ -127,6 +127,12 @@ struct MXRoomEventEncryption: MXRoomEventEncrypting {
             for: room,
             historyVisibility: state.historyVisibility
         )
+        
+        // Room membership events should ensure that we are always tracking users as soon as possible,
+        // but there are rare edge-cases where this does not always happen. To add a safety mechanism
+        // we will always update tracked users when sharing keys (which does nothing if a user is
+        // already tracked), triggering a key request for missing users in the next sync loop.
+        handler.updateTrackedUsers(users)
         
         let settings = try encryptionSettings(for: state)
         try await handler.shareRoomKeysIfNecessary(

--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoMachine.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoMachine.swift
@@ -373,7 +373,7 @@ extension MXCryptoMachine: MXCryptoRoomEventEncrypting {
         }
     }
     
-    func addTrackedUsers(_ users: [String]) {
+    func updateTrackedUsers(_ users: [String]) {
         do {
             try machine.updateTrackedUsers(users: users)
         } catch {

--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoProtocols.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoProtocols.swift
@@ -64,7 +64,7 @@ protocol MXCryptoUserIdentitySource: MXCryptoIdentity {
 /// Room event encryption
 protocol MXCryptoRoomEventEncrypting: MXCryptoIdentity {
     func isUserTracked(userId: String) -> Bool
-    func addTrackedUsers(_ users: [String])
+    func updateTrackedUsers(_ users: [String])
     func shareRoomKeysIfNecessary(roomId: String, users: [String], settings: EncryptionSettings) async throws
     func encryptRoomEvent(content: [AnyHashable: Any], roomId: String, eventType: String) throws -> [String: Any]
     func discardRoomKey(roomId: String)

--- a/MatrixSDK/Crypto/MXCryptoV2.swift
+++ b/MatrixSDK/Crypto/MXCryptoV2.swift
@@ -661,7 +661,7 @@ class MXCryptoV2: NSObject, MXCrypto {
         }
         
         log.debug("Tracking new user `\(userId)` due to \(member.membership) event")
-        machine.addTrackedUsers([userId])
+        machine.updateTrackedUsers([userId])
     }
     
     private func restoreBackupIfPossible(event: MXEvent) {

--- a/MatrixSDKTests/Crypto/Algorithms/RoomEvents/MXRoomEventEncryptionUnitTests.swift
+++ b/MatrixSDKTests/Crypto/Algorithms/RoomEvents/MXRoomEventEncryptionUnitTests.swift
@@ -87,7 +87,7 @@ class MXRoomEventEncryptionUnitTests: XCTestCase {
             return trackedUsers.contains(userId)
         }
         
-        func addTrackedUsers(_ users: [String]) {
+        func updateTrackedUsers(_ users: [String]) {
             trackedUsers = trackedUsers.union(users)
         }
         
@@ -254,7 +254,22 @@ class MXRoomEventEncryptionUnitTests: XCTestCase {
         members.eligibleUsers = ["Alice", "Carol"]
         
         try await encryptor.ensureRoomKeysShared(roomId: roomId)
+        
         XCTAssertEqual(handler.sharedUsers, ["Alice", "Carol"])
+    }
+    
+    func test_ensureRoomKeysShared_tracksMissingUsers() async throws {
+        members.stubbedMembers = [
+            .init(userId: "Alice"),
+            .init(userId: "Bob"),
+            .init(userId: "Carol"),
+        ]
+        members.eligibleUsers = ["Alice", "Bob", "Carol"]
+        handler.trackedUsers = ["Alice"]
+        
+        try await encryptor.ensureRoomKeysShared(roomId: roomId)
+        
+        XCTAssertEqual(handler.trackedUsers, ["Alice", "Bob", "Carol"])
     }
     
     // MARK: - Encrypt

--- a/changelog.d/pr-1733.change
+++ b/changelog.d/pr-1733.change
@@ -1,0 +1,1 @@
+Crypto: Always update tracked users when sharing keys


### PR DESCRIPTION
Resolves https://github.com/matrix-org/element-web-rageshakes/issues/19974

There are some rare cases when room members are not correctly tracked in `OlmMachine` (investigating separately), which is typically triggered by `m.room.membership` events. To solve the consequence (rather than the root cause), ensure that we always update tracked users when sharing keys, even if this does not trigger keys query for the current event, but will do so before the next one. In other words if we do indeed have users that are not yet tracked, they will be unable to decrypt at most the current message, but should recieve the key for the next message.