### PR TITLE
Improved session startup progress

### DIFF
--- a/MatrixSDK/MXSDKOptions.h
+++ b/MatrixSDK/MXSDKOptions.h
@@ -232,12 +232,12 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) BOOL enableNewClientInformationFeature;
 
 /**
- Enable the calculating of progress during session startup, incl counting the number
- of attempts to sync with the server and percentage of response data processed.
+ Enable the calculating and display of progress during session startup, incl store migration,
+ syncing and response processing.
  
- @remark the value currently depends on `enableCryptoSDK` being `YES`
+ @remark YES by default
  */
-@property (nonatomic, readonly) BOOL enableStartupProgress;
+@property (nonatomic) BOOL enableStartupProgress;
 
 @end
 

--- a/MatrixSDK/MXSDKOptions.m
+++ b/MatrixSDK/MXSDKOptions.m
@@ -56,6 +56,7 @@ static MXSDKOptions *sharedOnceInstance = nil;
         _enableRoomSharedHistoryOnInvite = NO;
         _enableSymmetricBackup = NO;
         _enableNewClientInformationFeature = NO;
+        _enableStartupProgress = YES;
     }
     
     return self;
@@ -69,14 +70,6 @@ static MXSDKOptions *sharedOnceInstance = nil;
         return NO;
     }
     return self.cryptoSDKFeature.isEnabled;
-}
-
-- (BOOL)enableStartupProgress
-{
-    // The value of `enableStartupProgress` depends on `enableCryptoSDK` as the latter provides some new UX elements
-    // such as initial data migration. It is a good opportunity to enable startup progress as well, before it becomes
-    // default to all.
-    return self.enableCryptoSDK;
 }
 
 - (void)setRoomListDataManagerClass:(Class)roomListDataManagerClass

--- a/changelog.d/7417.change
+++ b/changelog.d/7417.change
@@ -1,0 +1,1 @@
+Session: Improved session startup progress


### PR DESCRIPTION
Relates to https://github.com/vector-im/element-ios/issues/7417

Refactor `MXSessionStartupProgress` to align with current use case requirements, where we do not display sync attempts or copy for individual stages but rather calculate an overall progress.