### PR TITLE
Fully deprecate MXCryptoStore

### DIFF
--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -45,7 +45,7 @@ Pod::Spec.new do |s|
       ss.dependency 'OLMKit', '~> 3.2.5'
       ss.dependency 'Realm', '10.27.0'
       ss.dependency 'libbase58', '~> 0.1.4'
-      ss.dependency 'MatrixSDKCrypto', '0.2.1', :configurations => ["DEBUG", "RELEASE"], :inhibit_warnings => true
+      ss.dependency 'MatrixSDKCrypto', '0.3.0', :configurations => ["DEBUG", "RELEASE"], :inhibit_warnings => true
   end
 
   s.subspec 'JingleCallStack' do |ss|

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -876,7 +876,7 @@
 		B14EF1E32397E90400758AF0 /* MXCall.m in Sources */ = {isa = PBXBuildFile; fileRef = 3245A74D1AF7B2930001D8A7 /* MXCall.m */; };
 		B14EF1E42397E90400758AF0 /* MXWellknownIntegrations.m in Sources */ = {isa = PBXBuildFile; fileRef = 32CF439C2371AF9500907C56 /* MXWellknownIntegrations.m */; };
 		B14EF1E52397E90400758AF0 /* MXLoginPolicy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3275FD9B21A6B60B00B9C13D /* MXLoginPolicy.m */; };
-		B14EF1E62397E90400758AF0 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		B14EF1E62397E90400758AF0 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
 		B14EF1E72397E90400758AF0 /* MXRoomThirdPartyInvite.m in Sources */ = {isa = PBXBuildFile; fileRef = 327F8DB11C6112BA00581CA3 /* MXRoomThirdPartyInvite.m */; };
 		B14EF1E82397E90400758AF0 /* MXRoomPowerLevels.m in Sources */ = {isa = PBXBuildFile; fileRef = B17982F42119E4A2001FD722 /* MXRoomPowerLevels.m */; };
 		B14EF1E92397E90400758AF0 /* MXRealmMediaScanMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = B146D4DE21A5AEF100D8C2C6 /* MXRealmMediaScanMapper.m */; };
@@ -933,7 +933,7 @@
 		B14EF21D2397E90400758AF0 /* MXEncryptedContentKey.m in Sources */ = {isa = PBXBuildFile; fileRef = 021AFBA12179E91800742B2C /* MXEncryptedContentKey.m */; };
 		B14EF21E2397E90400758AF0 /* MXEventDecryptionResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 32F634AA1FC5E3470054EF49 /* MXEventDecryptionResult.m */; };
 		B14EF21F2397E90400758AF0 /* MXMyUser.m in Sources */ = {isa = PBXBuildFile; fileRef = 327137261A24D50A00DB6757 /* MXMyUser.m */; };
-		B14EF2202397E90400758AF0 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		B14EF2202397E90400758AF0 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
 		B14EF2212397E90400758AF0 /* MX3PID.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6F935831E5B3BE600FC34BF /* MX3PID.swift */; };
 		B14EF2222397E90400758AF0 /* MXMediaScan.m in Sources */ = {isa = PBXBuildFile; fileRef = B146D47621A5950800D8C2C6 /* MXMediaScan.m */; };
 		B14EF2232397E90400758AF0 /* MXEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6F935861E5B3BE600FC34BF /* MXEvent.swift */; };
@@ -948,7 +948,7 @@
 		B14EF22C2397E90400758AF0 /* MXAccountData.m in Sources */ = {isa = PBXBuildFile; fileRef = 3264DB901CEC528D00B99881 /* MXAccountData.m */; };
 		B14EF22D2397E90400758AF0 /* MXRealmReactionCount.m in Sources */ = {isa = PBXBuildFile; fileRef = 32133018228B010C0070BA9B /* MXRealmReactionCount.m */; };
 		B14EF22E2397E90400758AF0 /* MXCryptoTools.m in Sources */ = {isa = PBXBuildFile; fileRef = 3250E7C9220C913900736CB5 /* MXCryptoTools.m */; };
-		B14EF22F2397E90400758AF0 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		B14EF22F2397E90400758AF0 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
 		B14EF2302397E90400758AF0 /* MXDeviceListOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 322691311E5EF77D00966A6E /* MXDeviceListOperation.m */; };
 		B14EF2312397E90400758AF0 /* MX3PidAddSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D2CBFF23422462002BD8CA /* MX3PidAddSession.m */; };
 		B14EF2322397E90400758AF0 /* MXBugReportRestClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 3283F7771EAF30F700C1688C /* MXBugReportRestClient.m */; };
@@ -992,7 +992,7 @@
 		B14EF25B2397E90400758AF0 /* MXSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 320DFDD119DD99B60068622A /* MXSession.m */; };
 		B14EF25C2397E90400758AF0 /* MXRoomTombStoneContent.m in Sources */ = {isa = PBXBuildFile; fileRef = B17982EE2119E49F001FD722 /* MXRoomTombStoneContent.m */; };
 		B14EF25D2397E90400758AF0 /* MXImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C602B58D1F22A8D700B67D87 /* MXImage.swift */; };
-		B14EF25E2397E90400758AF0 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		B14EF25E2397E90400758AF0 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
 		B14EF25F2397E90400758AF0 /* MXServerNoticeContent.m in Sources */ = {isa = PBXBuildFile; fileRef = 32954018216385F100E300FC /* MXServerNoticeContent.m */; };
 		B14EF2602397E90400758AF0 /* MXContentScanResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 02CAD434217DD12F0074700B /* MXContentScanResult.m */; };
 		B14EF2612397E90400758AF0 /* MXRealmAggregationsStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 32133014228AF4EF0070BA9B /* MXRealmAggregationsStore.m */; };
@@ -1030,7 +1030,7 @@
 		B14EF2822397E90400758AF0 /* MXDeviceList.m in Sources */ = {isa = PBXBuildFile; fileRef = 32637ED31E5B00400011E20D /* MXDeviceList.m */; };
 		B14EF2832397E90400758AF0 /* MXRoomCreateContent.m in Sources */ = {isa = PBXBuildFile; fileRef = B17982F22119E4A1001FD722 /* MXRoomCreateContent.m */; };
 		B14EF2842397E90400758AF0 /* MXUIKitBackgroundModeHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 32A9E8231EF4026E0081358A /* MXUIKitBackgroundModeHandler.m */; };
-		B14EF2852397E90400758AF0 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		B14EF2852397E90400758AF0 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
 		B14EF2862397E90400758AF0 /* MXRealmMediaScanStore.m in Sources */ = {isa = PBXBuildFile; fileRef = B146D4F521A5BB9F00D8C2C6 /* MXRealmMediaScanStore.m */; };
 		B14EF2872397E90400758AF0 /* MXPusherData.m in Sources */ = {isa = PBXBuildFile; fileRef = 32999DE222DCD1AD004FF987 /* MXPusherData.m */; };
 		B14EF2882397E90400758AF0 /* MXOlmDevice.m in Sources */ = {isa = PBXBuildFile; fileRef = 322A51C61D9BBD3C00C8536D /* MXOlmDevice.m */; };
@@ -1864,6 +1864,10 @@
 		ED44F01528180EAB00452A5D /* MXSharedHistoryKeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED44F01328180EAB00452A5D /* MXSharedHistoryKeyManager.swift */; };
 		ED44F01A28180F4000452A5D /* MXSharedHistoryKeyManagerUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED44F01728180F1C00452A5D /* MXSharedHistoryKeyManagerUnitTests.swift */; };
 		ED44F01B28180F4000452A5D /* MXSharedHistoryKeyManagerUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED44F01728180F1C00452A5D /* MXSharedHistoryKeyManagerUnitTests.swift */; };
+		ED463ECB29B0B75800957941 /* EventEncryptionAlgorithm+String.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED463ECA29B0B75800957941 /* EventEncryptionAlgorithm+String.swift */; };
+		ED463ECC29B0B75800957941 /* EventEncryptionAlgorithm+String.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED463ECA29B0B75800957941 /* EventEncryptionAlgorithm+String.swift */; };
+		ED463ECE29B0B8E000957941 /* MXRoomSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED463ECD29B0B8E000957941 /* MXRoomSettings.swift */; };
+		ED463ECF29B0B8E000957941 /* MXRoomSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED463ECD29B0B8E000957941 /* MXRoomSettings.swift */; };
 		ED47CB6D28523995004FD755 /* MXCryptoV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED47CB6C28523995004FD755 /* MXCryptoV2.swift */; };
 		ED47CB6E28523995004FD755 /* MXCryptoV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED47CB6C28523995004FD755 /* MXCryptoV2.swift */; };
 		ED505DC028E1FD160079A3D3 /* MXCryptoKeyBackupEngineUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED505DBD28E1FD130079A3D3 /* MXCryptoKeyBackupEngineUnitTests.swift */; };
@@ -2001,10 +2005,10 @@
 		EDA69341290BA92E00223252 /* MXCryptoMachineUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDA6933F290BA92E00223252 /* MXCryptoMachineUnitTests.swift */; };
 		EDAAC41928E2FCFE00DD89B5 /* MXCryptoSecretStoreV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDAAC41828E2FCFE00DD89B5 /* MXCryptoSecretStoreV2.swift */; };
 		EDAAC41A28E2FCFE00DD89B5 /* MXCryptoSecretStoreV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDAAC41828E2FCFE00DD89B5 /* MXCryptoSecretStoreV2.swift */; };
-		EDAAC41C28E30F3C00DD89B5 /* (null) in Headers */ = {isa = PBXBuildFile; settings = {ATTRIBUTES = (Public, ); }; };
-		EDAAC41D28E30F3C00DD89B5 /* (null) in Headers */ = {isa = PBXBuildFile; settings = {ATTRIBUTES = (Public, ); }; };
-		EDAAC41F28E30F4C00DD89B5 /* (null) in Sources */ = {isa = PBXBuildFile; };
-		EDAAC42028E30F4C00DD89B5 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		EDAAC41C28E30F3C00DD89B5 /* BuildFile in Headers */ = {isa = PBXBuildFile; settings = {ATTRIBUTES = (Public, ); }; };
+		EDAAC41D28E30F3C00DD89B5 /* BuildFile in Headers */ = {isa = PBXBuildFile; settings = {ATTRIBUTES = (Public, ); }; };
+		EDAAC41F28E30F4C00DD89B5 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		EDAAC42028E30F4C00DD89B5 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
 		EDAAC42128E3174700DD89B5 /* MXCryptoSecretStore.h in Headers */ = {isa = PBXBuildFile; fileRef = EDAAC41228E2F86800DD89B5 /* MXCryptoSecretStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EDAAC42228E3174700DD89B5 /* MXCryptoSecretStore.h in Headers */ = {isa = PBXBuildFile; fileRef = EDAAC41228E2F86800DD89B5 /* MXCryptoSecretStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EDAAC42428E3177000DD89B5 /* MXRecoveryServiceDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDAAC42328E3177000DD89B5 /* MXRecoveryServiceDependencies.swift */; };
@@ -2066,6 +2070,8 @@
 		EDF1B6942876CD8600BBBCEE /* MXTaskQueueUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF1B6922876CD8600BBBCEE /* MXTaskQueueUnitTests.swift */; };
 		EDF4678727E3331D00435913 /* EventsEnumeratorDataSourceStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF4678627E3331D00435913 /* EventsEnumeratorDataSourceStub.swift */; };
 		EDF4678827E3331D00435913 /* EventsEnumeratorDataSourceStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF4678627E3331D00435913 /* EventsEnumeratorDataSourceStub.swift */; };
+		EDF9306A29BB488D0082A335 /* EventEncryptionAlgorithmUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF9306929BB488D0082A335 /* EventEncryptionAlgorithmUnitTests.swift */; };
+		EDF9306B29BB488D0082A335 /* EventEncryptionAlgorithmUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF9306929BB488D0082A335 /* EventEncryptionAlgorithmUnitTests.swift */; };
 		F0173EAC1FCF0E8900B5F6A3 /* MXGroup.h in Headers */ = {isa = PBXBuildFile; fileRef = F0173EAA1FCF0E8800B5F6A3 /* MXGroup.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F0173EAD1FCF0E8900B5F6A3 /* MXGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = F0173EAB1FCF0E8900B5F6A3 /* MXGroup.m */; };
 		F03EF4FE1DF014D9009DF592 /* MXMediaLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F03EF4FA1DF014D9009DF592 /* MXMediaLoader.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -3093,6 +3099,8 @@
 		ED44F01028180BCC00452A5D /* MXSharedHistoryKeyRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXSharedHistoryKeyRequest.swift; sourceTree = "<group>"; };
 		ED44F01328180EAB00452A5D /* MXSharedHistoryKeyManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXSharedHistoryKeyManager.swift; sourceTree = "<group>"; };
 		ED44F01728180F1C00452A5D /* MXSharedHistoryKeyManagerUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXSharedHistoryKeyManagerUnitTests.swift; sourceTree = "<group>"; };
+		ED463ECA29B0B75800957941 /* EventEncryptionAlgorithm+String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EventEncryptionAlgorithm+String.swift"; sourceTree = "<group>"; };
+		ED463ECD29B0B8E000957941 /* MXRoomSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXRoomSettings.swift; sourceTree = "<group>"; };
 		ED47CB6C28523995004FD755 /* MXCryptoV2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXCryptoV2.swift; sourceTree = "<group>"; };
 		ED505DBD28E1FD130079A3D3 /* MXCryptoKeyBackupEngineUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXCryptoKeyBackupEngineUnitTests.swift; sourceTree = "<group>"; };
 		ED505DC328E206FC0079A3D3 /* MXKeyBackupVersion+Stub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MXKeyBackupVersion+Stub.swift"; sourceTree = "<group>"; };
@@ -3193,6 +3201,7 @@
 		EDF1B68F2876CD2C00BBBCEE /* MXTaskQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXTaskQueue.swift; sourceTree = "<group>"; };
 		EDF1B6922876CD8600BBBCEE /* MXTaskQueueUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXTaskQueueUnitTests.swift; sourceTree = "<group>"; };
 		EDF4678627E3331D00435913 /* EventsEnumeratorDataSourceStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsEnumeratorDataSourceStub.swift; sourceTree = "<group>"; };
+		EDF9306929BB488D0082A335 /* EventEncryptionAlgorithmUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventEncryptionAlgorithmUnitTests.swift; sourceTree = "<group>"; };
 		F0173EAA1FCF0E8800B5F6A3 /* MXGroup.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXGroup.h; sourceTree = "<group>"; };
 		F0173EAB1FCF0E8900B5F6A3 /* MXGroup.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MXGroup.m; sourceTree = "<group>"; };
 		F03EF4FA1DF014D9009DF592 /* MXMediaLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MXMediaLoader.h; sourceTree = "<group>"; };
@@ -4163,6 +4172,7 @@
 				32E402B821C957D2004E87A6 /* MXOlmSession.m */,
 				3AC13800264482A100EE1E74 /* MXExportedOlmDevice.h */,
 				3AC13801264482A100EE1E74 /* MXExportedOlmDevice.m */,
+				ED463ECD29B0B8E000957941 /* MXRoomSettings.swift */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -5472,6 +5482,7 @@
 		ED2DD11A286C4F3100F06731 /* CryptoMachine */ = {
 			isa = PBXGroup;
 			children = (
+				EDF9306829BB48800082A335 /* Extensions */,
 				ED8F1D332885ADE200F897E7 /* MXCryptoProtocolStubs.swift */,
 				EDA6933F290BA92E00223252 /* MXCryptoMachineUnitTests.swift */,
 				ED2DD11B286C4F3E00F06731 /* MXCryptoRequestsUnitTests.swift */,
@@ -5590,6 +5601,7 @@
 				ED5EF148297AB29F00A5ADDA /* MXDeviceVerification+LocalTrust.swift */,
 				ED5EF14A297AB29F00A5ADDA /* MXEventDecryptionResult+DecryptedEvent.swift */,
 				ED5EF149297AB29F00A5ADDA /* MXRoomHistoryVisibility+HistoryVisibility.swift */,
+				ED463ECA29B0B75800957941 /* EventEncryptionAlgorithm+String.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -5806,6 +5818,14 @@
 			path = Engine;
 			sourceTree = "<group>";
 		};
+		EDF9306829BB48800082A335 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				EDF9306929BB488D0082A335 /* EventEncryptionAlgorithmUnitTests.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		F03EF4F91DF014D9009DF592 /* Media */ = {
 			isa = PBXGroup;
 			children = (
@@ -5900,7 +5920,7 @@
 				B146D47421A5945800D8C2C6 /* MXAntivirusScanStatus.h in Headers */,
 				322691361E5EFF8700966A6E /* MXDeviceListOperationsPool.h in Headers */,
 				3281E8B719E42DFE00976E1A /* MXJSONModel.h in Headers */,
-				EDAAC41C28E30F3C00DD89B5 /* (null) in Headers */,
+				EDAAC41C28E30F3C00DD89B5 /* BuildFile in Headers */,
 				B135066127E9CB6400BD3276 /* MXBeaconInfo.h in Headers */,
 				EC5C562827A36EDB0014CBE9 /* MXInReplyTo.h in Headers */,
 				EC8A539325B1BC77004E0802 /* MXCallSessionDescription.h in Headers */,
@@ -6524,7 +6544,7 @@
 				324AAC7E2399143400380A66 /* MXKeyVerificationCancel.h in Headers */,
 				ED01915528C64E0400ED3A69 /* MXRoomKeyEventContent.h in Headers */,
 				B14EF3372397E90400758AF0 /* MXRoomTombStoneContent.h in Headers */,
-				EDAAC41D28E30F3C00DD89B5 /* (null) in Headers */,
+				EDAAC41D28E30F3C00DD89B5 /* BuildFile in Headers */,
 				3274538B23FD918800438328 /* MXKeyVerificationByToDeviceRequest.h in Headers */,
 				B14EF3382397E90400758AF0 /* MXFilterObject.h in Headers */,
 				B14EF3392397E90400758AF0 /* MXRealmReactionCount.h in Headers */,
@@ -7011,6 +7031,7 @@
 				32AF9286240EA2430008A0FD /* MXSecretShareRequest.m in Sources */,
 				ED5C754428B3E80300D24E85 /* MXLogObjcWrapper.m in Sources */,
 				ED47CB6D28523995004FD755 /* MXCryptoV2.swift in Sources */,
+				ED463ECB29B0B75800957941 /* EventEncryptionAlgorithm+String.swift in Sources */,
 				EDF154E1296C203E004D7FFE /* MXCryptoMachineStore.swift in Sources */,
 				32A1513A1DAD292400400192 /* MXMegolmEncryption.m in Sources */,
 				EC60EDFE265CFFD200B39A4E /* MXInvitedGroupSync.m in Sources */,
@@ -7223,6 +7244,7 @@
 				3240969E1F9F751600DBA607 /* MXPushRuleSenderNotificationPermissionConditionChecker.m in Sources */,
 				71DE22E01BC7C51200284153 /* MXReceiptData.m in Sources */,
 				B14766B923D9D9420091F721 /* MXUsersTrustLevelSummary.m in Sources */,
+				ED463ECE29B0B8E000957941 /* MXRoomSettings.swift in Sources */,
 				323547D92226D5D600F15F94 /* MXWellKnownBaseConfig.m in Sources */,
 				EC0B94272718E64500B4D440 /* CoreDataContextable.swift in Sources */,
 				324BE4691E3FADB1008D99D4 /* MXMegolmExportEncryption.m in Sources */,
@@ -7276,7 +7298,7 @@
 				ED6DABFC28C7542800ECDCB6 /* MXRoomKeyInfoFactory.swift in Sources */,
 				B11556EE230C45C600B2A2CF /* MXIdentityServerRestClient.swift in Sources */,
 				ED5EF145297AB1F200A5ADDA /* MXRoomEventEncryption.swift in Sources */,
-				EDAAC41F28E30F4C00DD89B5 /* (null) in Sources */,
+				EDAAC41F28E30F4C00DD89B5 /* BuildFile in Sources */,
 				321CFDE722525A49004D31DF /* MXSASTransaction.m in Sources */,
 				EDDBA7F0293F353900AD1480 /* MXToDevicePayload.swift in Sources */,
 				32720D9D222EAA6F0086FFF5 /* MXDiscoveredClientConfig.m in Sources */,
@@ -7406,6 +7428,7 @@
 				323C5A081A70E53500FB0549 /* MXToolsUnitTests.m in Sources */,
 				3281E89E19E299C000976E1A /* MXErrorUnitTests.m in Sources */,
 				ED1FE9062912D2EB0046F722 /* MXRoomEventDecryptionUnitTests.swift in Sources */,
+				EDF9306A29BB488D0082A335 /* EventEncryptionAlgorithmUnitTests.swift in Sources */,
 				ED1FE90B2912E13A0046F722 /* DecryptedEvent+Stub.swift in Sources */,
 				EC51019D26C41981007D6D88 /* MXSyncResponseUnitTests.swift in Sources */,
 				EDB4209527DF822B0036AF39 /* MXEventsByTypesEnumeratorOnArrayTests.swift in Sources */,
@@ -7586,7 +7609,7 @@
 				EC1165B527107E330089FA56 /* MXStoreRoomListDataManager.swift in Sources */,
 				66836ABA27CFA17200515780 /* MXLiveEventListener.swift in Sources */,
 				B14EF1E52397E90400758AF0 /* MXLoginPolicy.m in Sources */,
-				B14EF1E62397E90400758AF0 /* (null) in Sources */,
+				B14EF1E62397E90400758AF0 /* BuildFile in Sources */,
 				B18D23F727ECF199004C4277 /* MXLocationService.swift in Sources */,
 				EC60EDB5265CFE6200B39A4E /* MXRoomSyncEphemeral.m in Sources */,
 				B14EF1E72397E90400758AF0 /* MXRoomThirdPartyInvite.m in Sources */,
@@ -7679,6 +7702,7 @@
 				3297913123AA126500F7BB9B /* MXKeyVerificationStatusResolver.m in Sources */,
 				ED5C754528B3E80300D24E85 /* MXLogObjcWrapper.m in Sources */,
 				ED47CB6E28523995004FD755 /* MXCryptoV2.swift in Sources */,
+				ED463ECC29B0B75800957941 /* EventEncryptionAlgorithm+String.swift in Sources */,
 				EDF154E2296C203E004D7FFE /* MXCryptoMachineStore.swift in Sources */,
 				B14EF2082397E90400758AF0 /* MX3PidAddManager.m in Sources */,
 				ECD2899026EB3B3400F268CF /* MXRoomListData.swift in Sources */,
@@ -7726,7 +7750,7 @@
 				B14EF21F2397E90400758AF0 /* MXMyUser.m in Sources */,
 				EDAAC42528E3177300DD89B5 /* MXRecoveryServiceDependencies.swift in Sources */,
 				EC60EDAB265CFE3B00B39A4E /* MXRoomSyncTimeline.m in Sources */,
-				B14EF2202397E90400758AF0 /* (null) in Sources */,
+				B14EF2202397E90400758AF0 /* BuildFile in Sources */,
 				ED647E3F292CE64400A47519 /* MXSessionStartupProgress.swift in Sources */,
 				B14EF2212397E90400758AF0 /* MX3PID.swift in Sources */,
 				18121F79273E6E4100B68ADF /* PollBuilder.swift in Sources */,
@@ -7765,7 +7789,7 @@
 				B18B0E6825FBDC3000E32151 /* MXSpace.swift in Sources */,
 				B14EF22D2397E90400758AF0 /* MXRealmReactionCount.m in Sources */,
 				B14EF22E2397E90400758AF0 /* MXCryptoTools.m in Sources */,
-				B14EF22F2397E90400758AF0 /* (null) in Sources */,
+				B14EF22F2397E90400758AF0 /* BuildFile in Sources */,
 				B14EF2302397E90400758AF0 /* MXDeviceListOperation.m in Sources */,
 				32C78B6B256CFC4D008130B1 /* MXCryptoMigration.m in Sources */,
 				ECDA763027B292B5000C48CF /* MXThreadModel.swift in Sources */,
@@ -7883,7 +7907,7 @@
 				B14EF25C2397E90400758AF0 /* MXRoomTombStoneContent.m in Sources */,
 				B1432B52282AB29A00737CA6 /* MXBeaconInfoSummaryAllRoomListener.swift in Sources */,
 				B14EF25D2397E90400758AF0 /* MXImage.swift in Sources */,
-				B14EF25E2397E90400758AF0 /* (null) in Sources */,
+				B14EF25E2397E90400758AF0 /* BuildFile in Sources */,
 				32B090E3261F709B002924AA /* MXAsyncTaskQueue.swift in Sources */,
 				B14EF25F2397E90400758AF0 /* MXServerNoticeContent.m in Sources */,
 				B1F04B112811E7B600103EBE /* MXBeaconInfoSummaryMemoryStore.swift in Sources */,
@@ -7891,6 +7915,7 @@
 				B14EF2612397E90400758AF0 /* MXRealmAggregationsStore.m in Sources */,
 				EC383BB72541C518002FBBE6 /* MXBackgroundPushRulesManager.swift in Sources */,
 				3259CFE726026A6F00C365DB /* MXRestClient+Extensions.swift in Sources */,
+				ED463ECF29B0B8E000957941 /* MXRoomSettings.swift in Sources */,
 				B105CDD9261F54C8006EB204 /* MXSpaceChildContent.m in Sources */,
 				B14EF2622397E90400758AF0 /* MXAntivirusScanStatusFormatter.m in Sources */,
 				EC0B94282718E64500B4D440 /* CoreDataContextable.swift in Sources */,
@@ -7944,7 +7969,7 @@
 				ED6DABFD28C7542800ECDCB6 /* MXRoomKeyInfoFactory.swift in Sources */,
 				B14EF2782397E90400758AF0 /* MXTransactionCancelCode.m in Sources */,
 				ED5EF146297AB1F200A5ADDA /* MXRoomEventEncryption.swift in Sources */,
-				EDAAC42028E30F4C00DD89B5 /* (null) in Sources */,
+				EDAAC42028E30F4C00DD89B5 /* BuildFile in Sources */,
 				B14EF2792397E90400758AF0 /* MXEventListener.m in Sources */,
 				EDDBA7F1293F353900AD1480 /* MXToDevicePayload.swift in Sources */,
 				B1710B202613D01400A9B429 /* MXSpaceChildrenRequestParameters.swift in Sources */,
@@ -7981,7 +8006,7 @@
 				EC60ED7E265CFCD100B39A4E /* MXDeviceListResponse.m in Sources */,
 				323F879025553D84009E9E67 /* MXTaskProfile.m in Sources */,
 				B14EF2842397E90400758AF0 /* MXUIKitBackgroundModeHandler.m in Sources */,
-				B14EF2852397E90400758AF0 /* (null) in Sources */,
+				B14EF2852397E90400758AF0 /* BuildFile in Sources */,
 				32A9F8E1244720B10069C65B /* MXThrottler.m in Sources */,
 				3274538D23FD918800438328 /* MXKeyVerificationByToDeviceRequest.m in Sources */,
 				32CEEF5223B0AB030039BA98 /* MXCrossSigning.m in Sources */,
@@ -8074,6 +8099,7 @@
 				32CEEF3E23AD134A0039BA98 /* MXCrossSigningTests.m in Sources */,
 				32EEA8402603CA140041425B /* MXRestClientExtensionsTests.m in Sources */,
 				ED1FE9072912D2EB0046F722 /* MXRoomEventDecryptionUnitTests.swift in Sources */,
+				EDF9306B29BB488D0082A335 /* EventEncryptionAlgorithmUnitTests.swift in Sources */,
 				ED1FE90C2912E13A0046F722 /* DecryptedEvent+Stub.swift in Sources */,
 				EC51019E26C41981007D6D88 /* MXSyncResponseUnitTests.swift in Sources */,
 				EDB4209627DF822B0036AF39 /* MXEventsByTypesEnumeratorOnArrayTests.swift in Sources */,

--- a/MatrixSDK/Crypto/CryptoMachine/Extensions/EventEncryptionAlgorithm+String.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/Extensions/EventEncryptionAlgorithm+String.swift
@@ -1,0 +1,40 @@
+// 
+// Copyright 2023 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import MatrixSDKCrypto
+
+extension EventEncryptionAlgorithm {
+    enum Error: Swift.Error {
+        case cannotResetEncryption
+        case invalidAlgorithm
+    }
+    
+    init(string: String?) throws {
+        guard let string = string else {
+            throw Error.cannotResetEncryption
+        }
+        
+        switch string {
+        case kMXCryptoOlmAlgorithm:
+            self = .olmV1Curve25519AesSha2
+        case kMXCryptoMegolmAlgorithm:
+            self = .megolmV1AesSha2
+        default:
+            throw Error.invalidAlgorithm
+        }
+    }
+}

--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoMachine.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoMachine.swift
@@ -364,6 +364,24 @@ extension MXCryptoMachine: MXCryptoUserIdentitySource {
 }
 
 extension MXCryptoMachine: MXCryptoRoomEventEncrypting {
+    var onlyAllowTrustedDevices: Bool {
+        get {
+            do {
+                return try machine.getOnlyAllowTrustedDevices()
+            } catch {
+                log.error("Failed getting value", context: error)
+                return false
+            }
+        }
+        set {
+            do {
+                try machine.setOnlyAllowTrustedDevices(onlyAllowTrustedDevices: newValue)
+            } catch {
+                log.error("Failed setting value", context: error)
+            }
+        }
+    }
+    
     func isUserTracked(userId: String) -> Bool {
         do {
             return try machine.isUserTracked(userId: userId)
@@ -379,6 +397,23 @@ extension MXCryptoMachine: MXCryptoRoomEventEncrypting {
         } catch {
             log.error("Failed updating tracked users", context: error)
         }
+    }
+    
+    func roomSettings(roomId: String) -> RoomSettings? {
+        do {
+            return try machine.getRoomSettings(roomId: roomId)
+        } catch {
+            log.error("Failed getting room settings", context: error)
+            return nil
+        }
+    }
+    
+    func setRoomAlgorithm(roomId: String, algorithm: EventEncryptionAlgorithm) throws {
+        try machine.setRoomAlgorithm(roomId: roomId, algorithm: algorithm)
+    }
+    
+    func setOnlyAllowTrustedDevices(for roomId: String, onlyAllowTrustedDevices: Bool) throws {
+        try machine.setRoomOnlyAllowTrustedDevices(roomId: roomId, onlyAllowTrustedDevices: onlyAllowTrustedDevices)
     }
     
     func shareRoomKeysIfNecessary(
@@ -478,7 +513,7 @@ extension MXCryptoMachine: MXCryptoRoomEventDecrypting {
             roomId: roomId,
             // Handling verification events automatically during event decryption is now a deprecated behavior,
             // all verification events are handled manually via `receiveVerificationEvent`
-            handleVerificatonEvents: false
+            handleVerificationEvents: false
         )
     }
     

--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoProtocols.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoProtocols.swift
@@ -63,8 +63,13 @@ protocol MXCryptoUserIdentitySource: MXCryptoIdentity {
 
 /// Room event encryption
 protocol MXCryptoRoomEventEncrypting: MXCryptoIdentity {
+    var onlyAllowTrustedDevices: Bool { get set }
+    
     func isUserTracked(userId: String) -> Bool
     func updateTrackedUsers(_ users: [String])
+    func roomSettings(roomId: String) -> RoomSettings?
+    func setRoomAlgorithm(roomId: String, algorithm: EventEncryptionAlgorithm) throws
+    func setOnlyAllowTrustedDevices(for roomId: String, onlyAllowTrustedDevices: Bool) throws
     func shareRoomKeysIfNecessary(roomId: String, users: [String], settings: EncryptionSettings) async throws
     func encryptRoomEvent(content: [AnyHashable: Any], roomId: String, eventType: String) throws -> [String: Any]
     func discardRoomKey(roomId: String)

--- a/MatrixSDK/Crypto/Data/MXRoomSettings.swift
+++ b/MatrixSDK/Crypto/Data/MXRoomSettings.swift
@@ -1,0 +1,46 @@
+// 
+// Copyright 2023 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+// Object containing stored room settings, such as algorithm used
+// and additional crypto options
+@objc public class MXRoomSettings: NSObject {
+    enum Error: Swift.Error {
+        case missingParameters
+    }
+    
+    public let roomId: String
+    public let algorithm: String
+    public let blacklistUnverifiedDevices: Bool
+    
+    @objc public init(
+        roomId: String!,
+        algorithm: String!,
+        blacklistUnverifiedDevices: Bool
+    ) throws {
+        guard
+            let roomId = roomId,
+            let algorithm = algorithm
+        else {
+            throw Error.missingParameters
+        }
+        
+        self.roomId = roomId
+        self.algorithm = algorithm
+        self.blacklistUnverifiedDevices = blacklistUnverifiedDevices
+    }
+}

--- a/MatrixSDK/Crypto/Data/Store/MXCryptoStore.h
+++ b/MatrixSDK/Crypto/Data/Store/MXCryptoStore.h
@@ -35,6 +35,7 @@
 
 @class OLMAccount;
 @class OLMOutboundGroupSession;
+@class MXRoomSettings;
 
 /**
  The `MXCryptoStore` protocol defines an interface that must be implemented in order to store
@@ -246,6 +247,11 @@
  nil if the room is not encrypted.
  */
 - (NSString*)algorithmForRoom:(NSString*)roomId;
+
+/**
+ Fetch all stored room settings, containing room algorithm and other crypto options
+ */
+- (NSArray <MXRoomSettings *> *)roomSettings;
 
 /**
  Store a session between this device and another device.

--- a/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
+++ b/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m
@@ -820,6 +820,23 @@ NSString *const MXRealmCryptoStoreReadonlySuffix = @"readonly";
     return [MXRealmRoomAlgorithm objectInRealm:realm forPrimaryKey:roomId];
 }
 
+- (NSArray<MXRealmRoomAlgorithm *> *)roomSettings
+{
+    NSMutableArray *objects = [NSMutableArray array];
+    for (MXRealmRoomAlgorithm *item in [MXRealmRoomAlgorithm allObjectsInRealm:self.realm]) {
+        NSError *error = nil;
+        MXRoomSettings *settings = [[MXRoomSettings alloc] initWithRoomId:item.roomId
+                                                                algorithm:item.algorithm
+                                               blacklistUnverifiedDevices:item.blacklistUnverifiedDevices
+                                                                    error:&error];
+        if (settings) {
+            [objects addObject:settings];
+        } else {
+            MXLogErrorDetails(@"[MXRealmCryptoStore] roomSettings: Cannot create settings", error);
+        }
+    }
+    return objects.copy;
+}
 
 - (void)storeSession:(MXOlmSession*)session
 {

--- a/MatrixSDK/Crypto/Migration/MXCryptoVersion.h
+++ b/MatrixSDK/Crypto/Migration/MXCryptoVersion.h
@@ -36,12 +36,19 @@ typedef NS_ENUM(NSInteger, MXCryptoVersion)
     // It is used to compute MXCryptoVersionLast.
     MXCryptoVersionCount,
     
+#pragma mark - Deprecated versions
+    
     // The internal crypto module has been deprecated in favour of `MatrixCryptoSDK`
-    // The value is set manually to leave room for intermediate version 3, 4 ...
-    MXCryptoVersionLegacyDeprecated = 1000,
+    // The value is set manually to a large number in order to leave room for possible
+    // intermediate valid version 3, 4 ... with bug fixes of the legacy store
+    MXCryptoDeprecated1 = 1000,
+    
+    // Deprecated version that migrates room settings from the legacy store, which were
+    // not included in the deprecated v1
+    MXCryptoDeprecated2,
 };
 
-// The current version of MXCrypto
+// The current version of non-deprecated MXCrypto
 #define MXCryptoVersionLast (MXCryptoVersionCount - 1)
 
 #endif /* MXCryptoVersion_h */

--- a/MatrixSDKTests/Crypto/Algorithms/RoomEvents/MXRoomEventEncryptionUnitTests.swift
+++ b/MatrixSDKTests/Crypto/Algorithms/RoomEvents/MXRoomEventEncryptionUnitTests.swift
@@ -82,6 +82,8 @@ class MXRoomEventEncryptionUnitTests: XCTestCase {
     }
     
     class EncryptorStub: CryptoIdentityStub, MXCryptoRoomEventEncrypting {
+        var onlyAllowTrustedDevices: Bool = false
+        
         var trackedUsers: Set<String> = []
         func isUserTracked(userId: String) -> Bool {
             return trackedUsers.contains(userId)
@@ -89,6 +91,25 @@ class MXRoomEventEncryptionUnitTests: XCTestCase {
         
         func updateTrackedUsers(_ users: [String]) {
             trackedUsers = trackedUsers.union(users)
+        }
+        
+        var stubbedRoomSettings: [String: RoomSettings] = [:]
+        func roomSettings(roomId: String) -> RoomSettings? {
+            return stubbedRoomSettings[roomId]
+        }
+        
+        func setRoomAlgorithm(roomId: String, algorithm: EventEncryptionAlgorithm) throws {
+            stubbedRoomSettings[roomId] = .init(
+                algorithm: algorithm,
+                onlyAllowTrustedDevices: stubbedRoomSettings[roomId]?.onlyAllowTrustedDevices ?? false
+            )
+        }
+        
+        func setOnlyAllowTrustedDevices(for roomId: String, onlyAllowTrustedDevices: Bool) throws {
+            stubbedRoomSettings[roomId] = .init(
+                algorithm: stubbedRoomSettings[roomId]?.algorithm ?? .megolmV1AesSha2,
+                onlyAllowTrustedDevices: onlyAllowTrustedDevices
+            )
         }
         
         var sharedUsers = [String]()
@@ -110,7 +131,6 @@ class MXRoomEventEncryptionUnitTests: XCTestCase {
     }
     
     var handler: EncryptorStub!
-    var store: MXMemoryCryptoStore!
     var encryptor: MXRoomEventEncryption!
     var roomId = "ABC"
     var room: RoomStub!
@@ -119,7 +139,6 @@ class MXRoomEventEncryptionUnitTests: XCTestCase {
     
     override func setUp() {
         handler = EncryptorStub()
-        store = MXMemoryCryptoStore(credentials: MXCredentials())
         room = .init(roomId: roomId, andMatrixSession: nil)
         state = .init(roomId: roomId, andMatrixSession: nil, andDirection: true)
         members = .init()
@@ -129,7 +148,6 @@ class MXRoomEventEncryptionUnitTests: XCTestCase {
         
         encryptor = MXRoomEventEncryption(
             handler: handler,
-            legacyStore: store,
             getRoomAction: { id in
                 id == self.room.roomId ? self.room : nil
             }
@@ -140,7 +158,12 @@ class MXRoomEventEncryptionUnitTests: XCTestCase {
     
     func test_isRoomEncrypted() {
         XCTAssertFalse(encryptor.isRoomEncrypted(roomId: roomId))
-        store.storeAlgorithm(forRoom: roomId, algorithm: "megolm")
+        
+        handler.stubbedRoomSettings[roomId] = .init(
+            algorithm: .megolmV1AesSha2,
+            onlyAllowTrustedDevices: false
+        )
+        
         XCTAssertTrue(encryptor.isRoomEncrypted(roomId: roomId))
     }
     
@@ -162,7 +185,7 @@ class MXRoomEventEncryptionUnitTests: XCTestCase {
     }
     
     func test_ensureRoomKeysShared_correctEncryptionAlgorithm() async throws {
-        XCTAssertNil(store.algorithm(forRoom: roomId))
+        XCTAssertNil(handler.roomSettings(roomId: roomId))
         
         // No algorithm -> throws + nothing stored
         state.stubbedAlgorithm = nil
@@ -170,7 +193,7 @@ class MXRoomEventEncryptionUnitTests: XCTestCase {
             try await encryptor.ensureRoomKeysShared(roomId: roomId)
             XCTFail("Should not succeed")
         } catch {
-            XCTAssertNil(store.algorithm(forRoom: roomId))
+            XCTAssertNil(handler.roomSettings(roomId: roomId))
         }
         
         // Invalid algorithm -> throws + nothing stored
@@ -179,27 +202,23 @@ class MXRoomEventEncryptionUnitTests: XCTestCase {
             try await encryptor.ensureRoomKeysShared(roomId: roomId)
             XCTFail("Should not succeed")
         } catch {
-            XCTAssertNil(store.algorithm(forRoom: roomId))
+            XCTAssertNil(handler.roomSettings(roomId: roomId))
         }
         
         // Valid -> algorithm stored
         state.stubbedAlgorithm = kMXCryptoMegolmAlgorithm
         try await encryptor.ensureRoomKeysShared(roomId: roomId)
-        XCTAssertEqual(store.algorithm(forRoom: roomId), kMXCryptoMegolmAlgorithm)
+        XCTAssertEqual(handler.roomSettings(roomId: roomId)?.algorithm, .megolmV1AesSha2)
         
-        // Another invalid algorithm -> throws + previous algorithm stored
+        // Another invalid algorithm -> previous algorithm kept without throwing
         state.stubbedAlgorithm = "blabla"
-        do {
-            try await encryptor.ensureRoomKeysShared(roomId: roomId)
-            XCTFail("Should not succeed")
-        } catch {
-            XCTAssertEqual(store.algorithm(forRoom: roomId), kMXCryptoMegolmAlgorithm)
-        }
+        try await encryptor.ensureRoomKeysShared(roomId: roomId)
+        XCTAssertEqual(handler.roomSettings(roomId: roomId)?.algorithm, .megolmV1AesSha2)
         
         // Another valid -> succeeds
-        state.stubbedAlgorithm = kMXCryptoMegolmAlgorithm
+        state.stubbedAlgorithm = kMXCryptoOlmAlgorithm
         try await encryptor.ensureRoomKeysShared(roomId: roomId)
-        XCTAssertEqual(store.algorithm(forRoom: roomId), kMXCryptoMegolmAlgorithm)
+        XCTAssertEqual(handler.roomSettings(roomId: roomId)?.algorithm, .olmV1Curve25519AesSha2)
     }
     
     func test_ensureRoomKeysShared_correctSettings() async throws {
@@ -236,8 +255,11 @@ class MXRoomEventEncryptionUnitTests: XCTestCase {
         ]
         
         for ((global, perRoom), settings) in storeToSettings {
-            store.globalBlacklistUnverifiedDevices = global
-            store.storeBlacklistUnverifiedDevices(inRoom: roomId, blacklist: perRoom)
+            handler.onlyAllowTrustedDevices = global
+            handler.stubbedRoomSettings[roomId] = .init(
+                algorithm: .megolmV1AesSha2,
+                onlyAllowTrustedDevices: perRoom
+            )
             
             try await encryptor.ensureRoomKeysShared(roomId: roomId)
             
@@ -284,7 +306,7 @@ class MXRoomEventEncryptionUnitTests: XCTestCase {
         )
         
         XCTAssertNotNil(handler.sharedSettings)
-        XCTAssertEqual(store.algorithm(forRoom: roomId), kMXCryptoMegolmAlgorithm)
+        XCTAssertEqual(handler.roomSettings(roomId: roomId)?.algorithm, .megolmV1AesSha2)
     }
     
     func test_encrypt_returnsEncryptedContent() async throws {

--- a/MatrixSDKTests/Crypto/CryptoMachine/Extensions/EventEncryptionAlgorithmUnitTests.swift
+++ b/MatrixSDKTests/Crypto/CryptoMachine/Extensions/EventEncryptionAlgorithmUnitTests.swift
@@ -1,0 +1,52 @@
+// 
+// Copyright 2023 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import XCTest
+import MatrixSDKCrypto
+@testable import MatrixSDK
+
+class EventEncryptionAlgorithmUnitTests: XCTestCase {
+    func test_nil() {
+        do {
+            _ = try EventEncryptionAlgorithm(string: nil)
+        } catch EventEncryptionAlgorithm.Error.cannotResetEncryption {
+            XCTAssertTrue(true)
+        } catch {
+            XCTFail("Unexpected error - \(error)")
+        }
+    }
+    
+    func test_invalidString() {
+        do {
+            _ = try EventEncryptionAlgorithm(string: "Blabla")
+        } catch EventEncryptionAlgorithm.Error.invalidAlgorithm {
+            XCTAssertTrue(true)
+        } catch {
+            XCTFail("Unexpected error - \(error)")
+        }
+    }
+    
+    func test_olm() throws {
+        let algorithm = try EventEncryptionAlgorithm(string: "m.olm.v1.curve25519-aes-sha2")
+        XCTAssertEqual(algorithm, .olmV1Curve25519AesSha2)
+    }
+    
+    func test_megolm() throws {
+        let algorithm = try EventEncryptionAlgorithm(string: "m.megolm.v1.aes-sha2")
+        XCTAssertEqual(algorithm, .megolmV1AesSha2)
+    }
+}

--- a/MatrixSDKTests/Crypto/Data/Store/MXMemoryCryptoStore.swift
+++ b/MatrixSDKTests/Crypto/Data/Store/MXMemoryCryptoStore.swift
@@ -183,6 +183,23 @@ public class MXMemoryCryptoStore: NSObject, MXCryptoStore {
     public func algorithm(forRoom roomId: String!) -> String! {
         algorithms[roomId]?.algorithm
     }
+    
+    // MARK: - Room Settings
+    
+    public func roomSettings() -> [MXRoomSettings]! {
+        return algorithms.compactMap { roomId, item in
+            do {
+                return try MXRoomSettings(
+                    roomId: roomId,
+                    algorithm: item.algorithm,
+                    blacklistUnverifiedDevices: item.blacklistUnverifiedDevices
+                )
+            } catch {
+                MXLog.debug("[MXMemoryCryptoStore] roomSettings: Failed creating algorithm", context: error)
+                return nil
+            }
+        }
+    }
 
     // MARK: - OLM Session
 

--- a/MatrixSDKTests/TestPlans/UnitTests.xctestplan
+++ b/MatrixSDKTests/TestPlans/UnitTests.xctestplan
@@ -29,6 +29,7 @@
   "testTargets" : [
     {
       "selectedTests" : [
+        "EventEncryptionAlgorithmUnitTests",
         "MXAesUnitTests",
         "MXAggregatedEditsUnitTests",
         "MXAggregatedReferenceUnitTests",

--- a/MatrixSDKTests/TestPlans/UnitTestsWithSanitizers.xctestplan
+++ b/MatrixSDKTests/TestPlans/UnitTestsWithSanitizers.xctestplan
@@ -39,6 +39,7 @@
   "testTargets" : [
     {
       "selectedTests" : [
+        "EventEncryptionAlgorithmUnitTests",
         "MXAesUnitTests",
         "MXAggregatedEditsUnitTests",
         "MXAggregatedReferenceUnitTests",

--- a/Podfile
+++ b/Podfile
@@ -16,7 +16,7 @@ abstract_target 'MatrixSDK' do
     
     pod 'Realm', '10.27.0'
     pod 'libbase58', '~> 0.1.4'
-    pod 'MatrixSDKCrypto', "0.2.1", :inhibit_warnings => true
+    pod 'MatrixSDKCrypto', "0.3.0", :inhibit_warnings => true
     
     target 'MatrixSDK-iOS' do
         platform :ios, '11.0'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -16,7 +16,7 @@ PODS:
     - AFNetworking/NSURLSession
   - GZIP (1.3.0)
   - libbase58 (0.1.4)
-  - MatrixSDKCrypto (0.2.1)
+  - MatrixSDKCrypto (0.3.0)
   - OHHTTPStubs (9.1.0):
     - OHHTTPStubs/Default (= 9.1.0)
   - OHHTTPStubs/Core (9.1.0)
@@ -44,7 +44,7 @@ DEPENDENCIES:
   - AFNetworking (~> 4.0.0)
   - GZIP (~> 1.3.0)
   - libbase58 (~> 0.1.4)
-  - MatrixSDKCrypto (= 0.2.1)
+  - MatrixSDKCrypto (= 0.3.0)
   - OHHTTPStubs (~> 9.1.0)
   - OLMKit (~> 3.2.5)
   - Realm (= 10.27.0)
@@ -65,12 +65,12 @@ SPEC CHECKSUMS:
   AFNetworking: 3bd23d814e976cd148d7d44c3ab78017b744cd58
   GZIP: 416858efbe66b41b206895ac6dfd5493200d95b3
   libbase58: 7c040313537b8c44b6e2d15586af8e21f7354efd
-  MatrixSDKCrypto: 477d818bf2cc37b6cf702a290eb647bc8cf3cb1b
+  MatrixSDKCrypto: 05ebe373ccebf40f8a0cff37d8f8b24fd01b9883
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   OLMKit: da115f16582e47626616874e20f7bb92222c7a51
   Realm: 9ca328bd7e700cc19703799785e37f77d1a130f2
   SwiftyBeaver: 84069991dd5dca07d7069100985badaca7f0ce82
 
-PODFILE CHECKSUM: e6ea6492ce460203d61def97cf6ceb27f8827d70
+PODFILE CHECKSUM: 8bb882cb5f6c537792581a49410afe8c2f848364
 
 COCOAPODS: 1.11.3

--- a/changelog.d/pr-1735.change
+++ b/changelog.d/pr-1735.change
@@ -1,0 +1,1 @@
+CryptoV2: Fully deprecate MXCryptoStore


### PR DESCRIPTION
Resolves https://github.com/vector-im/element-ios/issues/7419

Related rust-sdk change: https://github.com/matrix-org/matrix-rust-sdk/pull/1460

Until now the rust-based Crypto V2 still required access to the legacy Realm crypto database to store the following data:
- room algorithms
- whether to block untrusted devices per room
- whether to block untrusted devices globally

The rust-sdk can now store this data as well (after the above PR is merged) so we can fully deprecate the `MXCryptoStore` in the ios sdk.

Because there are already clients in production that have migrated from legacy to rust crypto we need to consider several use cases for migration of settings:
- new login => no realm store, so nothing to migrate
- user in legacy crypto => we can migrate settings via the existing migrate method
- user in rust crypto => we must only migrate room settings, but none of the other data (otherwise we could override changes in the account)

This is achieved by adding another `MXCryptoVersion` case and migrating in steps depending on the current version.