### PR TITLE
Add event decryption decoration

### DIFF
--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -45,7 +45,7 @@ Pod::Spec.new do |s|
       ss.dependency 'OLMKit', '~> 3.2.5'
       ss.dependency 'Realm', '10.27.0'
       ss.dependency 'libbase58', '~> 0.1.4'
-      ss.dependency 'MatrixSDKCrypto', '0.3.0', :configurations => ["DEBUG", "RELEASE"], :inhibit_warnings => true
+      ss.dependency 'MatrixSDKCrypto', '0.3.1', :configurations => ["DEBUG", "RELEASE"], :inhibit_warnings => true
   end
 
   s.subspec 'JingleCallStack' do |ss|

--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -876,7 +876,7 @@
 		B14EF1E32397E90400758AF0 /* MXCall.m in Sources */ = {isa = PBXBuildFile; fileRef = 3245A74D1AF7B2930001D8A7 /* MXCall.m */; };
 		B14EF1E42397E90400758AF0 /* MXWellknownIntegrations.m in Sources */ = {isa = PBXBuildFile; fileRef = 32CF439C2371AF9500907C56 /* MXWellknownIntegrations.m */; };
 		B14EF1E52397E90400758AF0 /* MXLoginPolicy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3275FD9B21A6B60B00B9C13D /* MXLoginPolicy.m */; };
-		B14EF1E62397E90400758AF0 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		B14EF1E62397E90400758AF0 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
 		B14EF1E72397E90400758AF0 /* MXRoomThirdPartyInvite.m in Sources */ = {isa = PBXBuildFile; fileRef = 327F8DB11C6112BA00581CA3 /* MXRoomThirdPartyInvite.m */; };
 		B14EF1E82397E90400758AF0 /* MXRoomPowerLevels.m in Sources */ = {isa = PBXBuildFile; fileRef = B17982F42119E4A2001FD722 /* MXRoomPowerLevels.m */; };
 		B14EF1E92397E90400758AF0 /* MXRealmMediaScanMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = B146D4DE21A5AEF100D8C2C6 /* MXRealmMediaScanMapper.m */; };
@@ -933,7 +933,7 @@
 		B14EF21D2397E90400758AF0 /* MXEncryptedContentKey.m in Sources */ = {isa = PBXBuildFile; fileRef = 021AFBA12179E91800742B2C /* MXEncryptedContentKey.m */; };
 		B14EF21E2397E90400758AF0 /* MXEventDecryptionResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 32F634AA1FC5E3470054EF49 /* MXEventDecryptionResult.m */; };
 		B14EF21F2397E90400758AF0 /* MXMyUser.m in Sources */ = {isa = PBXBuildFile; fileRef = 327137261A24D50A00DB6757 /* MXMyUser.m */; };
-		B14EF2202397E90400758AF0 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		B14EF2202397E90400758AF0 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
 		B14EF2212397E90400758AF0 /* MX3PID.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6F935831E5B3BE600FC34BF /* MX3PID.swift */; };
 		B14EF2222397E90400758AF0 /* MXMediaScan.m in Sources */ = {isa = PBXBuildFile; fileRef = B146D47621A5950800D8C2C6 /* MXMediaScan.m */; };
 		B14EF2232397E90400758AF0 /* MXEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6F935861E5B3BE600FC34BF /* MXEvent.swift */; };
@@ -948,7 +948,7 @@
 		B14EF22C2397E90400758AF0 /* MXAccountData.m in Sources */ = {isa = PBXBuildFile; fileRef = 3264DB901CEC528D00B99881 /* MXAccountData.m */; };
 		B14EF22D2397E90400758AF0 /* MXRealmReactionCount.m in Sources */ = {isa = PBXBuildFile; fileRef = 32133018228B010C0070BA9B /* MXRealmReactionCount.m */; };
 		B14EF22E2397E90400758AF0 /* MXCryptoTools.m in Sources */ = {isa = PBXBuildFile; fileRef = 3250E7C9220C913900736CB5 /* MXCryptoTools.m */; };
-		B14EF22F2397E90400758AF0 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		B14EF22F2397E90400758AF0 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
 		B14EF2302397E90400758AF0 /* MXDeviceListOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 322691311E5EF77D00966A6E /* MXDeviceListOperation.m */; };
 		B14EF2312397E90400758AF0 /* MX3PidAddSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D2CBFF23422462002BD8CA /* MX3PidAddSession.m */; };
 		B14EF2322397E90400758AF0 /* MXBugReportRestClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 3283F7771EAF30F700C1688C /* MXBugReportRestClient.m */; };
@@ -992,7 +992,7 @@
 		B14EF25B2397E90400758AF0 /* MXSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 320DFDD119DD99B60068622A /* MXSession.m */; };
 		B14EF25C2397E90400758AF0 /* MXRoomTombStoneContent.m in Sources */ = {isa = PBXBuildFile; fileRef = B17982EE2119E49F001FD722 /* MXRoomTombStoneContent.m */; };
 		B14EF25D2397E90400758AF0 /* MXImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C602B58D1F22A8D700B67D87 /* MXImage.swift */; };
-		B14EF25E2397E90400758AF0 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		B14EF25E2397E90400758AF0 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
 		B14EF25F2397E90400758AF0 /* MXServerNoticeContent.m in Sources */ = {isa = PBXBuildFile; fileRef = 32954018216385F100E300FC /* MXServerNoticeContent.m */; };
 		B14EF2602397E90400758AF0 /* MXContentScanResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 02CAD434217DD12F0074700B /* MXContentScanResult.m */; };
 		B14EF2612397E90400758AF0 /* MXRealmAggregationsStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 32133014228AF4EF0070BA9B /* MXRealmAggregationsStore.m */; };
@@ -1030,7 +1030,7 @@
 		B14EF2822397E90400758AF0 /* MXDeviceList.m in Sources */ = {isa = PBXBuildFile; fileRef = 32637ED31E5B00400011E20D /* MXDeviceList.m */; };
 		B14EF2832397E90400758AF0 /* MXRoomCreateContent.m in Sources */ = {isa = PBXBuildFile; fileRef = B17982F22119E4A1001FD722 /* MXRoomCreateContent.m */; };
 		B14EF2842397E90400758AF0 /* MXUIKitBackgroundModeHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 32A9E8231EF4026E0081358A /* MXUIKitBackgroundModeHandler.m */; };
-		B14EF2852397E90400758AF0 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		B14EF2852397E90400758AF0 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
 		B14EF2862397E90400758AF0 /* MXRealmMediaScanStore.m in Sources */ = {isa = PBXBuildFile; fileRef = B146D4F521A5BB9F00D8C2C6 /* MXRealmMediaScanStore.m */; };
 		B14EF2872397E90400758AF0 /* MXPusherData.m in Sources */ = {isa = PBXBuildFile; fileRef = 32999DE222DCD1AD004FF987 /* MXPusherData.m */; };
 		B14EF2882397E90400758AF0 /* MXOlmDevice.m in Sources */ = {isa = PBXBuildFile; fileRef = 322A51C61D9BBD3C00C8536D /* MXOlmDevice.m */; };
@@ -1850,6 +1850,8 @@
 		ED356530281153480002BF6A /* MXMegolmSessionDataUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED35652E281153480002BF6A /* MXMegolmSessionDataUnitTests.swift */; };
 		ED36ED8628DD9E2200C86416 /* MXCryptoKeyBackupEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED36ED8528DD9E2100C86416 /* MXCryptoKeyBackupEngine.swift */; };
 		ED36ED8728DD9E2200C86416 /* MXCryptoKeyBackupEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED36ED8528DD9E2100C86416 /* MXCryptoKeyBackupEngine.swift */; };
+		ED37834929C9B6E700A449DA /* MXEventDecryptionDecoration.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED37834829C9B6E700A449DA /* MXEventDecryptionDecoration.swift */; };
+		ED37834A29C9B6E700A449DA /* MXEventDecryptionDecoration.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED37834829C9B6E700A449DA /* MXEventDecryptionDecoration.swift */; };
 		ED4114E8292E496C00728459 /* MXBackgroundCrypto.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED4114E7292E496C00728459 /* MXBackgroundCrypto.swift */; };
 		ED4114E9292E496C00728459 /* MXBackgroundCrypto.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED4114E7292E496C00728459 /* MXBackgroundCrypto.swift */; };
 		ED4114EB292E498100728459 /* MXBackgroundCryptoV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED4114EA292E498100728459 /* MXBackgroundCryptoV2.swift */; };
@@ -2005,10 +2007,10 @@
 		EDA69341290BA92E00223252 /* MXCryptoMachineUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDA6933F290BA92E00223252 /* MXCryptoMachineUnitTests.swift */; };
 		EDAAC41928E2FCFE00DD89B5 /* MXCryptoSecretStoreV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDAAC41828E2FCFE00DD89B5 /* MXCryptoSecretStoreV2.swift */; };
 		EDAAC41A28E2FCFE00DD89B5 /* MXCryptoSecretStoreV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDAAC41828E2FCFE00DD89B5 /* MXCryptoSecretStoreV2.swift */; };
-		EDAAC41C28E30F3C00DD89B5 /* (null) in Headers */ = {isa = PBXBuildFile; settings = {ATTRIBUTES = (Public, ); }; };
-		EDAAC41D28E30F3C00DD89B5 /* (null) in Headers */ = {isa = PBXBuildFile; settings = {ATTRIBUTES = (Public, ); }; };
-		EDAAC41F28E30F4C00DD89B5 /* (null) in Sources */ = {isa = PBXBuildFile; };
-		EDAAC42028E30F4C00DD89B5 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		EDAAC41C28E30F3C00DD89B5 /* BuildFile in Headers */ = {isa = PBXBuildFile; settings = {ATTRIBUTES = (Public, ); }; };
+		EDAAC41D28E30F3C00DD89B5 /* BuildFile in Headers */ = {isa = PBXBuildFile; settings = {ATTRIBUTES = (Public, ); }; };
+		EDAAC41F28E30F4C00DD89B5 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		EDAAC42028E30F4C00DD89B5 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
 		EDAAC42128E3174700DD89B5 /* MXCryptoSecretStore.h in Headers */ = {isa = PBXBuildFile; fileRef = EDAAC41228E2F86800DD89B5 /* MXCryptoSecretStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EDAAC42228E3174700DD89B5 /* MXCryptoSecretStore.h in Headers */ = {isa = PBXBuildFile; fileRef = EDAAC41228E2F86800DD89B5 /* MXCryptoSecretStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EDAAC42428E3177000DD89B5 /* MXRecoveryServiceDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDAAC42328E3177000DD89B5 /* MXRecoveryServiceDependencies.swift */; };
@@ -3096,6 +3098,7 @@
 		ED35652B281150310002BF6A /* MXOlmInboundGroupSessionUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXOlmInboundGroupSessionUnitTests.swift; sourceTree = "<group>"; };
 		ED35652E281153480002BF6A /* MXMegolmSessionDataUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXMegolmSessionDataUnitTests.swift; sourceTree = "<group>"; };
 		ED36ED8528DD9E2100C86416 /* MXCryptoKeyBackupEngine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXCryptoKeyBackupEngine.swift; sourceTree = "<group>"; };
+		ED37834829C9B6E700A449DA /* MXEventDecryptionDecoration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MXEventDecryptionDecoration.swift; sourceTree = "<group>"; };
 		ED4114E7292E496C00728459 /* MXBackgroundCrypto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXBackgroundCrypto.swift; sourceTree = "<group>"; };
 		ED4114EA292E498100728459 /* MXBackgroundCryptoV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXBackgroundCryptoV2.swift; sourceTree = "<group>"; };
 		ED4114ED292E49C000728459 /* MXLegacyBackgroundCrypto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXLegacyBackgroundCrypto.swift; sourceTree = "<group>"; };
@@ -3566,6 +3569,7 @@
 				32F9FA7C1DBA0CF0009D98A6 /* MXDecryptionResult.m */,
 				32F634A91FC5E3470054EF49 /* MXEventDecryptionResult.h */,
 				32F634AA1FC5E3470054EF49 /* MXEventDecryptionResult.m */,
+				ED37834829C9B6E700A449DA /* MXEventDecryptionDecoration.swift */,
 			);
 			path = Algorithms;
 			sourceTree = "<group>";
@@ -5928,7 +5932,7 @@
 				B146D47421A5945800D8C2C6 /* MXAntivirusScanStatus.h in Headers */,
 				322691361E5EFF8700966A6E /* MXDeviceListOperationsPool.h in Headers */,
 				3281E8B719E42DFE00976E1A /* MXJSONModel.h in Headers */,
-				EDAAC41C28E30F3C00DD89B5 /* (null) in Headers */,
+				EDAAC41C28E30F3C00DD89B5 /* BuildFile in Headers */,
 				B135066127E9CB6400BD3276 /* MXBeaconInfo.h in Headers */,
 				EC5C562827A36EDB0014CBE9 /* MXInReplyTo.h in Headers */,
 				EC8A539325B1BC77004E0802 /* MXCallSessionDescription.h in Headers */,
@@ -6552,7 +6556,7 @@
 				324AAC7E2399143400380A66 /* MXKeyVerificationCancel.h in Headers */,
 				ED01915528C64E0400ED3A69 /* MXRoomKeyEventContent.h in Headers */,
 				B14EF3372397E90400758AF0 /* MXRoomTombStoneContent.h in Headers */,
-				EDAAC41D28E30F3C00DD89B5 /* (null) in Headers */,
+				EDAAC41D28E30F3C00DD89B5 /* BuildFile in Headers */,
 				3274538B23FD918800438328 /* MXKeyVerificationByToDeviceRequest.h in Headers */,
 				B14EF3382397E90400758AF0 /* MXFilterObject.h in Headers */,
 				B14EF3392397E90400758AF0 /* MXRealmReactionCount.h in Headers */,
@@ -7044,6 +7048,7 @@
 				ED5C754428B3E80300D24E85 /* MXLogObjcWrapper.m in Sources */,
 				ED47CB6D28523995004FD755 /* MXCryptoV2.swift in Sources */,
 				ED463ECB29B0B75800957941 /* EventEncryptionAlgorithm+String.swift in Sources */,
+				ED37834929C9B6E700A449DA /* MXEventDecryptionDecoration.swift in Sources */,
 				EDF154E1296C203E004D7FFE /* MXCryptoMachineStore.swift in Sources */,
 				32A1513A1DAD292400400192 /* MXMegolmEncryption.m in Sources */,
 				EC60EDFE265CFFD200B39A4E /* MXInvitedGroupSync.m in Sources */,
@@ -7310,7 +7315,7 @@
 				ED6DABFC28C7542800ECDCB6 /* MXRoomKeyInfoFactory.swift in Sources */,
 				B11556EE230C45C600B2A2CF /* MXIdentityServerRestClient.swift in Sources */,
 				ED5EF145297AB1F200A5ADDA /* MXRoomEventEncryption.swift in Sources */,
-				EDAAC41F28E30F4C00DD89B5 /* (null) in Sources */,
+				EDAAC41F28E30F4C00DD89B5 /* BuildFile in Sources */,
 				321CFDE722525A49004D31DF /* MXSASTransaction.m in Sources */,
 				EDDBA7F0293F353900AD1480 /* MXToDevicePayload.swift in Sources */,
 				32720D9D222EAA6F0086FFF5 /* MXDiscoveredClientConfig.m in Sources */,
@@ -7621,7 +7626,7 @@
 				EC1165B527107E330089FA56 /* MXStoreRoomListDataManager.swift in Sources */,
 				66836ABA27CFA17200515780 /* MXLiveEventListener.swift in Sources */,
 				B14EF1E52397E90400758AF0 /* MXLoginPolicy.m in Sources */,
-				B14EF1E62397E90400758AF0 /* (null) in Sources */,
+				B14EF1E62397E90400758AF0 /* BuildFile in Sources */,
 				B18D23F727ECF199004C4277 /* MXLocationService.swift in Sources */,
 				EC60EDB5265CFE6200B39A4E /* MXRoomSyncEphemeral.m in Sources */,
 				B14EF1E72397E90400758AF0 /* MXRoomThirdPartyInvite.m in Sources */,
@@ -7716,6 +7721,7 @@
 				ED47CB6E28523995004FD755 /* MXCryptoV2.swift in Sources */,
 				ED463ECC29B0B75800957941 /* EventEncryptionAlgorithm+String.swift in Sources */,
 				EDF154E2296C203E004D7FFE /* MXCryptoMachineStore.swift in Sources */,
+				ED37834A29C9B6E700A449DA /* MXEventDecryptionDecoration.swift in Sources */,
 				B14EF2082397E90400758AF0 /* MX3PidAddManager.m in Sources */,
 				ECD2899026EB3B3400F268CF /* MXRoomListData.swift in Sources */,
 				B14EF2092397E90400758AF0 /* MXCallKitConfiguration.m in Sources */,
@@ -7762,7 +7768,7 @@
 				B14EF21F2397E90400758AF0 /* MXMyUser.m in Sources */,
 				EDAAC42528E3177300DD89B5 /* MXRecoveryServiceDependencies.swift in Sources */,
 				EC60EDAB265CFE3B00B39A4E /* MXRoomSyncTimeline.m in Sources */,
-				B14EF2202397E90400758AF0 /* (null) in Sources */,
+				B14EF2202397E90400758AF0 /* BuildFile in Sources */,
 				ED647E3F292CE64400A47519 /* MXSessionStartupProgress.swift in Sources */,
 				B14EF2212397E90400758AF0 /* MX3PID.swift in Sources */,
 				18121F79273E6E4100B68ADF /* PollBuilder.swift in Sources */,
@@ -7801,7 +7807,7 @@
 				B18B0E6825FBDC3000E32151 /* MXSpace.swift in Sources */,
 				B14EF22D2397E90400758AF0 /* MXRealmReactionCount.m in Sources */,
 				B14EF22E2397E90400758AF0 /* MXCryptoTools.m in Sources */,
-				B14EF22F2397E90400758AF0 /* (null) in Sources */,
+				B14EF22F2397E90400758AF0 /* BuildFile in Sources */,
 				B14EF2302397E90400758AF0 /* MXDeviceListOperation.m in Sources */,
 				32C78B6B256CFC4D008130B1 /* MXCryptoMigration.m in Sources */,
 				ECDA763027B292B5000C48CF /* MXThreadModel.swift in Sources */,
@@ -7919,7 +7925,7 @@
 				B14EF25C2397E90400758AF0 /* MXRoomTombStoneContent.m in Sources */,
 				B1432B52282AB29A00737CA6 /* MXBeaconInfoSummaryAllRoomListener.swift in Sources */,
 				B14EF25D2397E90400758AF0 /* MXImage.swift in Sources */,
-				B14EF25E2397E90400758AF0 /* (null) in Sources */,
+				B14EF25E2397E90400758AF0 /* BuildFile in Sources */,
 				32B090E3261F709B002924AA /* MXAsyncTaskQueue.swift in Sources */,
 				B14EF25F2397E90400758AF0 /* MXServerNoticeContent.m in Sources */,
 				B1F04B112811E7B600103EBE /* MXBeaconInfoSummaryMemoryStore.swift in Sources */,
@@ -7981,7 +7987,7 @@
 				ED6DABFD28C7542800ECDCB6 /* MXRoomKeyInfoFactory.swift in Sources */,
 				B14EF2782397E90400758AF0 /* MXTransactionCancelCode.m in Sources */,
 				ED5EF146297AB1F200A5ADDA /* MXRoomEventEncryption.swift in Sources */,
-				EDAAC42028E30F4C00DD89B5 /* (null) in Sources */,
+				EDAAC42028E30F4C00DD89B5 /* BuildFile in Sources */,
 				B14EF2792397E90400758AF0 /* MXEventListener.m in Sources */,
 				EDDBA7F1293F353900AD1480 /* MXToDevicePayload.swift in Sources */,
 				B1710B202613D01400A9B429 /* MXSpaceChildrenRequestParameters.swift in Sources */,
@@ -8018,7 +8024,7 @@
 				EC60ED7E265CFCD100B39A4E /* MXDeviceListResponse.m in Sources */,
 				323F879025553D84009E9E67 /* MXTaskProfile.m in Sources */,
 				B14EF2842397E90400758AF0 /* MXUIKitBackgroundModeHandler.m in Sources */,
-				B14EF2852397E90400758AF0 /* (null) in Sources */,
+				B14EF2852397E90400758AF0 /* BuildFile in Sources */,
 				32A9F8E1244720B10069C65B /* MXThrottler.m in Sources */,
 				3274538D23FD918800438328 /* MXKeyVerificationByToDeviceRequest.m in Sources */,
 				32CEEF5223B0AB030039BA98 /* MXCrossSigning.m in Sources */,

--- a/MatrixSDK/Background/Crypto/MXLegacyBackgroundCrypto.swift
+++ b/MatrixSDK/Background/Crypto/MXLegacyBackgroundCrypto.swift
@@ -73,7 +73,10 @@ class MXLegacyBackgroundCrypto: MXBackgroundCrypto {
             decryptionResult.senderCurve25519Key = olmResult.senderKey
             decryptionResult.claimedEd25519Key = olmResult.keysClaimed?["ed25519"] as? String
             decryptionResult.forwardingCurve25519KeyChain = olmResult.forwardingCurve25519KeyChain
-            decryptionResult.isUntrusted = olmResult.isUntrusted
+            decryptionResult.decoration = MXEventDecryptionDecoration(
+                color: olmResult.isUntrusted ? .grey : .none,
+                message: nil
+            )
             event.setClearData(decryptionResult)
         } else if decryptorClass == MXOlmDecryption.self {
             guard let ciphertextDict = event.content["ciphertext"] as? [AnyHashable: Any],

--- a/MatrixSDK/Crypto/Algorithms/MXDecryptionResult.h
+++ b/MatrixSDK/Crypto/Algorithms/MXDecryptionResult.h
@@ -85,7 +85,7 @@ FOUNDATION_EXPORT NSString* const MXDecryptingErrorMissingPropertyReason;
 @property NSArray<NSString *> *forwardingCurve25519KeyChain;
 
 /**
- Flag indicating the decrpytion was made with an untrusted session.
+ Flag indicating the decryption was made with an untrusted session.
  */
 @property (nonatomic, getter=isUntrusted) BOOL untrusted;
 

--- a/MatrixSDK/Crypto/Algorithms/MXEventDecryptionDecoration.swift
+++ b/MatrixSDK/Crypto/Algorithms/MXEventDecryptionDecoration.swift
@@ -1,0 +1,35 @@
+// 
+// Copyright 2023 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+/// Recommended color to represent message's authenticity properties
+@objc public enum MXEventDecryptionDecorationColor: Int {
+    case red
+    case grey
+    case none
+}
+
+/// Recommended visual decorations for decrypted messages, representing the message's authenticity properties
+@objcMembers public class MXEventDecryptionDecoration: NSObject {
+    public let color: MXEventDecryptionDecorationColor
+    public let message: String?
+    
+    public init(color: MXEventDecryptionDecorationColor, message: String?) {
+        self.color = color
+        self.message = message
+    }
+}

--- a/MatrixSDK/Crypto/Algorithms/MXEventDecryptionResult.h
+++ b/MatrixSDK/Crypto/Algorithms/MXEventDecryptionResult.h
@@ -17,6 +17,8 @@
 
 #import <Foundation/Foundation.h>
 
+@class MXEventDecryptionDecoration;
+
 /**
  The result of a (successful) call to decryptEvent.
  */
@@ -46,13 +48,13 @@
 @property NSArray<NSString *> *forwardingCurve25519KeyChain;
 
 /**
+ Decoration representing the authenticity of the decrypted message
+ */
+@property (nonatomic, strong) MXEventDecryptionDecoration *decoration;
+
+/**
  If any, the error that occured during decryption.
  */
 @property (nonatomic) NSError *error;
-
-/**
- Flag indicating the decryption was made with an untrusted session.
- */
-@property (nonatomic, getter=isUntrusted) BOOL untrusted;
 
 @end

--- a/MatrixSDK/Crypto/Algorithms/RoomEvent/MXRoomEventDecryption.swift
+++ b/MatrixSDK/Crypto/Algorithms/RoomEvent/MXRoomEventDecryption.swift
@@ -113,9 +113,7 @@ actor MXRoomEventDecryption: MXRoomEventDecrypting {
                 log.debug("Ignoring non-room event `\(eventId)`")
             }
             
-            let result = MXEventDecryptionResult()
-            result.clearEvent = event.clear?.jsonDictionary()
-            return result
+            return event.decryptionResult
         }
         
         do {

--- a/MatrixSDK/Crypto/CryptoMachine/Extensions/MXEventDecryptionResult+DecryptedEvent.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/Extensions/MXEventDecryptionResult+DecryptedEvent.swift
@@ -34,10 +34,28 @@ extension MXEventDecryptionResult {
         senderCurve25519Key = event.senderCurve25519Key
         claimedEd25519Key = event.claimedEd25519Key
         forwardingCurve25519KeyChain = event.forwardingCurve25519Chain
-        
-        // `Untrusted` state from rust is currently ignored as it lacks "undecided" option,
-        // will be changed in a future PR into:
-        // isUntrusted = event.verificationState == VerificationState.untrusted
-        isUntrusted = false
+        decoration = MXEventDecryptionDecoration(state: event.shieldState)
+    }
+}
+
+extension MXEventDecryptionDecoration {
+    convenience init(state: ShieldState) {
+        self.init(
+            color: MXEventDecryptionDecorationColor(color: state.color),
+            message: state.message
+        )
+    }
+}
+
+extension MXEventDecryptionDecorationColor {
+    init(color: ShieldColor) {
+        switch color {
+        case .red:
+            self = .red
+        case .grey:
+            self = .grey
+        case .none:
+            self = .none
+        }
     }
 }

--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoMachine.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoMachine.swift
@@ -513,7 +513,10 @@ extension MXCryptoMachine: MXCryptoRoomEventDecrypting {
             roomId: roomId,
             // Handling verification events automatically during event decryption is now a deprecated behavior,
             // all verification events are handled manually via `receiveVerificationEvent`
-            handleVerificationEvents: false
+            handleVerificationEvents: false,
+            // The app does not use strict shields by default, in the future this will become configurable
+            // per room.
+            strictShields: false
         )
     }
     

--- a/MatrixSDK/JSONModels/MXEvent.h
+++ b/MatrixSDK/JSONModels/MXEvent.h
@@ -24,6 +24,7 @@
 @class MXEventDecryptionResult;
 @class MXEncryptedContentFile;
 @class MXEventContentLocation;
+@class MXEventDecryptionDecoration;
 
 MX_ASSUME_MISSING_NULLABILITY_BEGIN
 
@@ -688,12 +689,6 @@ extern NSString *const kMXEventIdentifierKey;
 @property (nonatomic, readonly) MXEvent *clearEvent;
 
 /**
- Flag indicating the event was decrypted with an untrusted key.
- If the event cannot be decrypted yet or the event not encrypted at all, this flag would be NO.
- */
-@property (nonatomic, readonly, getter=isUntrusted) BOOL untrusted;
-
-/**
  The curve25519 key for the device that we think sent this event.
 
  For an Olm-encrypted event, this is inferred directly from the DH
@@ -744,6 +739,16 @@ extern NSString *const kMXEventIdentifierKey;
  @return base64-encoded curve25519 keys, from oldest to newest.
  */
 @property (nonatomic, readonly) NSArray<NSString *> *forwardingCurve25519KeyChain;
+
+/**
+ Extract the decryption result that allowed to decrypt the event
+ */
+@property (nonatomic, strong, readonly) MXEventDecryptionResult *decryptionResult;
+
+/**
+ Decoration representing the authenticity of the decrypted message
+ */
+@property (nonatomic, strong, readonly) MXEventDecryptionDecoration *decryptionDecoration;
 
 /**
  If any, the error that occured during decryption.

--- a/MatrixSDK/JSONModels/MXEvent.m
+++ b/MatrixSDK/JSONModels/MXEvent.m
@@ -233,12 +233,10 @@ NSString *const kMXEventUnthreaded = @"unthreaded";
      See `forwardingCurve25519KeyChain` property.
      */
     NSArray<NSString *> *forwardingCurve25519KeyChain;
-
-    /**
-     Untrusted flag for clear events.
-     */
-    BOOL untrusted;
 }
+
+@property (nonatomic, strong, readwrite) MXEventDecryptionDecoration *decryptionDecoration;
+
 @end
 
 @implementation MXEvent
@@ -254,7 +252,7 @@ NSString *const kMXEventUnthreaded = @"unthreaded";
     if (self)
     {
         _ageLocalTs = -1;
-        untrusted = NO;
+        _decryptionDecoration = nil;
     }
 
     return self;
@@ -1073,7 +1071,7 @@ NSString *const kMXEventUnthreaded = @"unthreaded";
         _clearEvent->senderCurve25519Key = decryptionResult.senderCurve25519Key;
         _clearEvent->claimedEd25519Key = decryptionResult.claimedEd25519Key;
         _clearEvent->forwardingCurve25519KeyChain = decryptionResult.forwardingCurve25519KeyChain ? decryptionResult.forwardingCurve25519KeyChain : @[];
-        _clearEvent->untrusted = decryptionResult.isUntrusted;
+        _clearEvent.decryptionDecoration = decryptionResult.decoration;
     }
 
     // Notify only for events that are lately decrypted
@@ -1182,7 +1180,6 @@ NSString *const kMXEventUnthreaded = @"unthreaded";
     return encryptedContentFiles;
 }
 
-// Extract the decryption result that allowed to decrypt the event.
 - (MXEventDecryptionResult*)decryptionResult
 {
     MXEventDecryptionResult *decryptionResult = [MXEventDecryptionResult new];
@@ -1193,7 +1190,7 @@ NSString *const kMXEventUnthreaded = @"unthreaded";
         decryptionResult.senderCurve25519Key = _clearEvent->senderCurve25519Key;
         decryptionResult.claimedEd25519Key = _clearEvent->claimedEd25519Key;
         decryptionResult.forwardingCurve25519KeyChain = _clearEvent->forwardingCurve25519KeyChain;
-        decryptionResult.untrusted = _clearEvent.isUntrusted;
+        decryptionResult.decoration = _clearEvent.decryptionDecoration;
     }
     
     decryptionResult.error = _decryptionError;
@@ -1201,13 +1198,13 @@ NSString *const kMXEventUnthreaded = @"unthreaded";
     return decryptionResult;
 }
 
-- (BOOL)isUntrusted
+- (MXEventDecryptionDecoration *)decryptionDecoration
 {
     if (self.isEncrypted && _clearEvent)
     {
-        return _clearEvent.isUntrusted;
+        return _clearEvent.decryptionDecoration;
     }
-    return untrusted;
+    return _decryptionDecoration;
 }
 
 #pragma mark - private

--- a/MatrixSDKTests/Crypto/CryptoMachine/DecryptedEvent+Stub.swift
+++ b/MatrixSDKTests/Crypto/CryptoMachine/DecryptedEvent+Stub.swift
@@ -26,7 +26,10 @@ extension DecryptedEvent {
             senderCurve25519Key: "",
             claimedEd25519Key: nil,
             forwardingCurve25519Chain: [],
-            verificationState: .trusted
+            shieldState: .init(
+                color: .none,
+                message: nil
+            )
         )
     }
 }

--- a/MatrixSDKTests/JSONModels/MXEventFixtures.swift
+++ b/MatrixSDKTests/JSONModels/MXEventFixtures.swift
@@ -122,14 +122,20 @@ extension MXEvent {
     
     static func encryptedFixture(
         id: String = "1",
-        sessionId: String = "123"
+        sender: String = "Alice",
+        sessionId: String = "123",
+        senderKey: String = "456",
+        ciphertext: String = "ABC"
     ) -> MXEvent {
         return MXEvent(fromJSON: [
             "type": "m.room.encrypted",
             "event_id": id,
+            "sender": sender,
             "content": [
                 "algorithm": kMXCryptoMegolmAlgorithm,
-                "session_id": sessionId
+                "session_id": sessionId,
+                "sender_key": senderKey,
+                "ciphertext": ciphertext
             ]
         ])!
     }

--- a/Podfile
+++ b/Podfile
@@ -16,7 +16,7 @@ abstract_target 'MatrixSDK' do
     
     pod 'Realm', '10.27.0'
     pod 'libbase58', '~> 0.1.4'
-    pod 'MatrixSDKCrypto', "0.3.0", :inhibit_warnings => true
+    pod 'MatrixSDKCrypto', "0.3.1", :inhibit_warnings => true
     
     target 'MatrixSDK-iOS' do
         platform :ios, '11.0'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -16,7 +16,7 @@ PODS:
     - AFNetworking/NSURLSession
   - GZIP (1.3.0)
   - libbase58 (0.1.4)
-  - MatrixSDKCrypto (0.3.0)
+  - MatrixSDKCrypto (0.3.1)
   - OHHTTPStubs (9.1.0):
     - OHHTTPStubs/Default (= 9.1.0)
   - OHHTTPStubs/Core (9.1.0)
@@ -44,7 +44,7 @@ DEPENDENCIES:
   - AFNetworking (~> 4.0.0)
   - GZIP (~> 1.3.0)
   - libbase58 (~> 0.1.4)
-  - MatrixSDKCrypto (= 0.3.0)
+  - MatrixSDKCrypto (= 0.3.1)
   - OHHTTPStubs (~> 9.1.0)
   - OLMKit (~> 3.2.5)
   - Realm (= 10.27.0)
@@ -65,12 +65,12 @@ SPEC CHECKSUMS:
   AFNetworking: 3bd23d814e976cd148d7d44c3ab78017b744cd58
   GZIP: 416858efbe66b41b206895ac6dfd5493200d95b3
   libbase58: 7c040313537b8c44b6e2d15586af8e21f7354efd
-  MatrixSDKCrypto: 05ebe373ccebf40f8a0cff37d8f8b24fd01b9883
+  MatrixSDKCrypto: c706ee43742bb2a0b6295bcf39d04bf804caf0aa
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   OLMKit: da115f16582e47626616874e20f7bb92222c7a51
   Realm: 9ca328bd7e700cc19703799785e37f77d1a130f2
   SwiftyBeaver: 84069991dd5dca07d7069100985badaca7f0ce82
 
-PODFILE CHECKSUM: 8bb882cb5f6c537792581a49410afe8c2f848364
+PODFILE CHECKSUM: aba72092ad54b55e762c5b015ba74766ae700538
 
 COCOAPODS: 1.11.3

--- a/changelog.d/pr-1743.api
+++ b/changelog.d/pr-1743.api
@@ -1,0 +1,1 @@
+Crypto: Add event decryption decoration instead of untrusted property


### PR DESCRIPTION
Previously the legacy SDK would expose `untrusted` property to mark events that were decrypted using an untrusted key (e.g. one downloaded from asymmetrical backup). On the app side, this untrusted property would be combined with other encryption properties, namely the trust of the sender and their device. Only then the combine result gets turned into a visual decoration (e.g. red or grey shield).

To improve this, and align with rust-sdk, expose the decoration color directly from the crypto SDK, alongside an explanation message if necessary. This moves some of the trust computation down to the crypto module and leaves the app with fewer decisions to make.