### PR TITLE
Upgrade verification if necessary

### DIFF
--- a/MatrixSDK/Crypto/CrossSigning/MXCrossSigningV2.swift
+++ b/MatrixSDK/Crypto/CrossSigning/MXCrossSigningV2.swift
@@ -123,6 +123,12 @@ class MXCrossSigningV2: NSObject, MXCrossSigning {
                 try await crossSigning.refreshCrossSigningStatus()
                 myUserCrossSigningKeys = infoSource.crossSigningInfo(userId: crossSigning.userId)
                 
+                // If we are considered verified, there is no need for a verification upgrade
+                // after migrating from legacy crypto
+                if myUserCrossSigningKeys?.trustLevel.isVerified == true {
+                    MXSDKOptions.sharedInstance().cryptoSDKFeature?.needsVerificationUpgrade = false
+                }
+                
                 log.debug("Cross signing state refreshed, new state: \(state)")
                 await MainActor.run {
                     success?(true)

--- a/MatrixSDK/Crypto/MXCryptoV2Feature.swift
+++ b/MatrixSDK/Crypto/MXCryptoV2Feature.swift
@@ -28,6 +28,12 @@ import Foundation
     /// as there is no way to migrate from from Crypto SDK back to legacy crypto.
     var isEnabled: Bool { get }
     
+    /// Flag indicating whether this account requires a re-verification after migrating to Crypto SDK
+    ///
+    /// This flag is set to true if the legacy account is considered verified but the rust account
+    /// does not consider the migrated data secure enough, as it applies stricter security conditions.
+    var needsVerificationUpgrade: Bool { get set }
+    
     /// Manually enable the feature
     ///
     /// This is typically triggered by some user settings / Labs as an experimental feature. Once called

--- a/MatrixSDK/Crypto/Migration/MXCryptoVersion.h
+++ b/MatrixSDK/Crypto/Migration/MXCryptoVersion.h
@@ -46,6 +46,10 @@ typedef NS_ENUM(NSInteger, MXCryptoVersion)
     // Deprecated version that migrates room settings from the legacy store, which were
     // not included in the deprecated v1
     MXCryptoDeprecated2,
+    
+    // Deprecated version that checks whether the verification state of the rust crypto
+    // needs to be upgraded after migrating from legacy crypto
+    MXCryptoDeprecated3,
 };
 
 // The current version of non-deprecated MXCrypto

--- a/MatrixSDKTests/Crypto/MXCryptoV2FactoryTests.swift
+++ b/MatrixSDKTests/Crypto/MXCryptoV2FactoryTests.swift
@@ -82,7 +82,7 @@ class MXCryptoV2FactoryTests: XCTestCase {
     func test_fullyMigratesLegacyUser() async throws {
         let env = try await e2eData.startE2ETest()
         let session = env.session
-        var legacyStore = session.legacyCrypto?.store
+        let legacyStore = session.legacyCrypto?.store
         
         // Assert that we have a legacy store that has not yet been deprecated
         XCTAssertNotNil(legacyStore)
@@ -93,9 +93,9 @@ class MXCryptoV2FactoryTests: XCTestCase {
         XCTAssertNotNil(crypto)
         XCTAssertTrue(hasMigrated)
         
-        // Assert that we no longer have a legacy store for this user
-        legacyStore = MXRealmCryptoStore.init(credentials: session.credentials)
-        XCTAssertNil(legacyStore)
+        // Assert we still have legacy store but it is now marked as deprecated
+        XCTAssertNotNil(legacyStore)
+        XCTAssertEqual(legacyStore?.cryptoVersion, .deprecated3)
         
         await env.close()
     }
@@ -105,7 +105,7 @@ class MXCryptoV2FactoryTests: XCTestCase {
         let session = env.session
         
         // We set the legacy store as partially deprecated
-        var legacyStore = session.legacyCrypto?.store
+        let legacyStore = session.legacyCrypto?.store
         XCTAssertNotNil(legacyStore)
         legacyStore?.cryptoVersion = .deprecated1
         
@@ -114,9 +114,9 @@ class MXCryptoV2FactoryTests: XCTestCase {
         XCTAssertNotNil(crypto)
         XCTAssertTrue(hasMigrated)
         
-        // Assert that we no longer have a legacy store for this user
-        legacyStore = MXRealmCryptoStore.init(credentials: session.credentials)
-        XCTAssertNil(legacyStore)
+        // Assert we still have legacy store but it is now marked as deprecated
+        XCTAssertNotNil(legacyStore)
+        XCTAssertEqual(legacyStore?.cryptoVersion, .deprecated3)
         
         await env.close()
     }
@@ -126,18 +126,18 @@ class MXCryptoV2FactoryTests: XCTestCase {
         let session = env.session
         
         // We set the legacy store as fully deprecated
-        var legacyStore = session.legacyCrypto?.store
+        let legacyStore = session.legacyCrypto?.store
         XCTAssertNotNil(legacyStore)
-        legacyStore?.cryptoVersion = .deprecated2
+        legacyStore?.cryptoVersion = .deprecated3
         
         // Build crypto and assert no migration has been performed
         let (crypto, hasMigrated) = try await buildCrypto(session: session)
         XCTAssertNotNil(crypto)
         XCTAssertFalse(hasMigrated)
         
-        // Assert that we no longer have a legacy store for this user
-        legacyStore = MXRealmCryptoStore.init(credentials: session.credentials)
-        XCTAssertNil(legacyStore)
+        // Assert we still have legacy store which is still marked as deprecated
+        XCTAssertNotNil(legacyStore)
+        XCTAssertEqual(legacyStore?.cryptoVersion, .deprecated3)
         
         await env.close()
     }

--- a/MatrixSDKTests/Crypto/Migration/MXCryptoMigrationV2Tests.swift
+++ b/MatrixSDKTests/Crypto/Migration/MXCryptoMigrationV2Tests.swift
@@ -233,7 +233,7 @@ class MXCryptoMigrationV2Tests: XCTestCase {
         await env2.close()
     }
     
-    func test_test_migratesGlobalSettingsInPartialMigration() async throws {
+    func test_migratesGlobalSettingsInPartialMigration() async throws {
         let env1 = try await e2eData.startE2ETest()
         env1.session.crypto.globalBlacklistUnverifiedDevices = true
         let machine1 = try partiallyMigratedOlmMachine(session: env1.session)

--- a/changelog.d/pr-1751.change
+++ b/changelog.d/pr-1751.change
@@ -1,0 +1,1 @@
+Crypto: Upgrade verification if necessary


### PR DESCRIPTION
Set `needsVerificationUpgrade` property when migrating from legacy to rust crypto, which will be used to display altered UX for "verify your session" modal. This is because sessions considered as verified in the legacy crypto should not always be considered as verified in rust crypto, as the latter imposes stricter rules on session verification. In case the rust *does* consider the session as verified the property is reset.

Note that this is not meant to be 100% reliable way to detect verification state change. For instance if legacy crypto was already unverified, migrating to rust would still display the "upgrade verification" dialoge. This is acceptable, given that the "upgrade verification" prompt will only be shown until either successful verification or ignoring of the alert.

Additionally keep the existing realm store around after migration instead of deleting it. It will be removed in a future PR.