### PR TITLE
Release 0.26.5

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## Changes in 0.26.5 (2023-03-28)
+
+🙌 Improvements
+
+- Crypto: Upgrade verification if necessary ([#1751](https://github.com/matrix-org/matrix-ios-sdk/pull/1751))
+
+
 ## Changes in 0.26.4 (2023-03-22)
 
 🐛 Bugfixes

--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "MatrixSDK"
-  s.version      = "0.26.4"
+  s.version      = "0.26.5"
   s.summary      = "The iOS SDK to build apps compatible with Matrix (https://www.matrix.org)"
 
   s.description  = <<-DESC

--- a/MatrixSDK/Crypto/CrossSigning/MXCrossSigningV2.swift
+++ b/MatrixSDK/Crypto/CrossSigning/MXCrossSigningV2.swift
@@ -123,6 +123,12 @@ class MXCrossSigningV2: NSObject, MXCrossSigning {
                 try await crossSigning.refreshCrossSigningStatus()
                 myUserCrossSigningKeys = infoSource.crossSigningInfo(userId: crossSigning.userId)
                 
+                // If we are considered verified, there is no need for a verification upgrade
+                // after migrating from legacy crypto
+                if myUserCrossSigningKeys?.trustLevel.isVerified == true {
+                    MXSDKOptions.sharedInstance().cryptoSDKFeature?.needsVerificationUpgrade = false
+                }
+                
                 log.debug("Cross signing state refreshed, new state: \(state)")
                 await MainActor.run {
                     success?(true)

--- a/MatrixSDK/Crypto/MXCryptoV2Feature.swift
+++ b/MatrixSDK/Crypto/MXCryptoV2Feature.swift
@@ -28,6 +28,12 @@ import Foundation
     /// as there is no way to migrate from from Crypto SDK back to legacy crypto.
     var isEnabled: Bool { get }
     
+    /// Flag indicating whether this account requires a re-verification after migrating to Crypto SDK
+    ///
+    /// This flag is set to true if the legacy account is considered verified but the rust account
+    /// does not consider the migrated data secure enough, as it applies stricter security conditions.
+    var needsVerificationUpgrade: Bool { get set }
+    
     /// Manually enable the feature
     ///
     /// This is typically triggered by some user settings / Labs as an experimental feature. Once called

--- a/MatrixSDK/Crypto/Migration/MXCryptoVersion.h
+++ b/MatrixSDK/Crypto/Migration/MXCryptoVersion.h
@@ -46,6 +46,10 @@ typedef NS_ENUM(NSInteger, MXCryptoVersion)
     // Deprecated version that migrates room settings from the legacy store, which were
     // not included in the deprecated v1
     MXCryptoDeprecated2,
+    
+    // Deprecated version that checks whether the verification state of the rust crypto
+    // needs to be upgraded after migrating from legacy crypto
+    MXCryptoDeprecated3,
 };
 
 // The current version of non-deprecated MXCrypto

--- a/MatrixSDK/MatrixSDKVersion.m
+++ b/MatrixSDK/MatrixSDKVersion.m
@@ -16,4 +16,4 @@
 
 #import <Foundation/Foundation.h>
 
-NSString *const MatrixSDKVersion = @"0.26.4";
+NSString *const MatrixSDKVersion = @"0.26.5";

--- a/MatrixSDKTests/Crypto/MXCryptoV2FactoryTests.swift
+++ b/MatrixSDKTests/Crypto/MXCryptoV2FactoryTests.swift
@@ -82,7 +82,7 @@ class MXCryptoV2FactoryTests: XCTestCase {
     func test_fullyMigratesLegacyUser() async throws {
         let env = try await e2eData.startE2ETest()
         let session = env.session
-        var legacyStore = session.legacyCrypto?.store
+        let legacyStore = session.legacyCrypto?.store
         
         // Assert that we have a legacy store that has not yet been deprecated
         XCTAssertNotNil(legacyStore)
@@ -93,9 +93,9 @@ class MXCryptoV2FactoryTests: XCTestCase {
         XCTAssertNotNil(crypto)
         XCTAssertTrue(hasMigrated)
         
-        // Assert that we no longer have a legacy store for this user
-        legacyStore = MXRealmCryptoStore.init(credentials: session.credentials)
-        XCTAssertNil(legacyStore)
+        // Assert we still have legacy store but it is now marked as deprecated
+        XCTAssertNotNil(legacyStore)
+        XCTAssertEqual(legacyStore?.cryptoVersion, .deprecated3)
         
         await env.close()
     }
@@ -105,7 +105,7 @@ class MXCryptoV2FactoryTests: XCTestCase {
         let session = env.session
         
         // We set the legacy store as partially deprecated
-        var legacyStore = session.legacyCrypto?.store
+        let legacyStore = session.legacyCrypto?.store
         XCTAssertNotNil(legacyStore)
         legacyStore?.cryptoVersion = .deprecated1
         
@@ -114,9 +114,9 @@ class MXCryptoV2FactoryTests: XCTestCase {
         XCTAssertNotNil(crypto)
         XCTAssertTrue(hasMigrated)
         
-        // Assert that we no longer have a legacy store for this user
-        legacyStore = MXRealmCryptoStore.init(credentials: session.credentials)
-        XCTAssertNil(legacyStore)
+        // Assert we still have legacy store but it is now marked as deprecated
+        XCTAssertNotNil(legacyStore)
+        XCTAssertEqual(legacyStore?.cryptoVersion, .deprecated3)
         
         await env.close()
     }
@@ -126,18 +126,18 @@ class MXCryptoV2FactoryTests: XCTestCase {
         let session = env.session
         
         // We set the legacy store as fully deprecated
-        var legacyStore = session.legacyCrypto?.store
+        let legacyStore = session.legacyCrypto?.store
         XCTAssertNotNil(legacyStore)
-        legacyStore?.cryptoVersion = .deprecated2
+        legacyStore?.cryptoVersion = .deprecated3
         
         // Build crypto and assert no migration has been performed
         let (crypto, hasMigrated) = try await buildCrypto(session: session)
         XCTAssertNotNil(crypto)
         XCTAssertFalse(hasMigrated)
         
-        // Assert that we no longer have a legacy store for this user
-        legacyStore = MXRealmCryptoStore.init(credentials: session.credentials)
-        XCTAssertNil(legacyStore)
+        // Assert we still have legacy store which is still marked as deprecated
+        XCTAssertNotNil(legacyStore)
+        XCTAssertEqual(legacyStore?.cryptoVersion, .deprecated3)
         
         await env.close()
     }

--- a/MatrixSDKTests/Crypto/Migration/MXCryptoMigrationV2Tests.swift
+++ b/MatrixSDKTests/Crypto/Migration/MXCryptoMigrationV2Tests.swift
@@ -233,7 +233,7 @@ class MXCryptoMigrationV2Tests: XCTestCase {
         await env2.close()
     }
     
-    func test_test_migratesGlobalSettingsInPartialMigration() async throws {
+    func test_migratesGlobalSettingsInPartialMigration() async throws {
         let env1 = try await e2eData.startE2ETest()
         env1.session.crypto.globalBlacklistUnverifiedDevices = true
         let machine1 = try partiallyMigratedOlmMachine(session: env1.session)

--- a/changelog.d/pr-1751.change
+++ b/changelog.d/pr-1751.change
@@ -1,1 +1,0 @@
-Crypto: Upgrade verification if necessary

--- a/changelog.d/pr-1751.change
+++ b/changelog.d/pr-1751.change
@@ -1,0 +1,1 @@
+Crypto: Upgrade verification if necessary


### PR DESCRIPTION
This PR prepares the release of MatrixSDK v0.26.5.

Notes:
- This PR targets `release/0.26.5/master`, which has been cut from `master`.
- It includes changes to the `Podfile`, but _not_ the corresponding changes to `Podfile.lock`, as `pod install` hasn't yet been run.
  This is because the `Podfile` targets future versions of dependencies yet to be released, so `pod install` wouldn't be able to find them yet.
- When the CI runs its checks, it will temporarily point to the pending release branches of those dependencies beforehand
- It is only during `release:finish` that `pod update` will be run -- updating the `Podfile.lock`
to use the now officially released dependencies -- before ultimately merging `release/0.26.5/master` into `master` to tag the release.

---

➡️  Once this PR is merged, you will need to first ensure that the products this one depends on are fully released,
   then run `bundle exec rake release:finish` to close this release.

💡 If you want to review _only_ the changes made since the release branch was cut from `develop`,
   you can [check those here](https://github.com/matrix-org/matrix-ios-sdk/compare/develop...release/0.26.5/release)
