### PR TITLE
Upgrade to Jitsi pod to 7.0.1-lite

### DIFF
--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -61,7 +61,8 @@ Pod::Spec.new do |s|
     #ss.ios.dependency 'GoogleWebRTC', '~>1.1.21820'
     
     # Use WebRTC framework included in Jitsi Meet SDK
-    ss.ios.dependency 'JitsiMeetSDK', '5.0.2'
+    # Use the lite version so we don't add a dependency on Giphy.
+    ss.ios.dependency 'JitsiMeetSDKLite', '7.0.1-lite'
   end
 
 end

--- a/changelog.d/pr-1754.build
+++ b/changelog.d/pr-1754.build
@@ -1,0 +1,1 @@
+Upgrade JitsiMeetSDK to 7.0.1-lite.


### PR DESCRIPTION
I picked the Lite version as it excludes a dependency on Giphy which appears to be a 22MB binary for iOS and I'm not sure we really need that.

Closes https://github.com/vector-im/customer-retainer/issues/28 although discussed with @benparsons that this on its own isn't enough to enable screensharing. Extra info should be in Jira.
