### PR TITLE
Remove unnecessary error log

### DIFF
--- a/MatrixSDK/Crypto/Algorithms/RoomEvent/MXRoomEventDecryption.swift
+++ b/MatrixSDK/Crypto/Algorithms/RoomEvent/MXRoomEventDecryption.swift
@@ -60,10 +60,7 @@ actor MXRoomEventDecryption: MXRoomEventDecrypting {
         }
         
         if !undecrypted.isEmpty {
-            log.error("Unable to decrypt some event(s)", context: [
-                "total": events.count,
-                "undecrypted": undecrypted.count
-            ])
+            log.warning("Unable to decrypt \(undecrypted.count) out of \(events.count) event(s)")
         } else if events.count > 1 {
             log.debug("Decrypted all \(events.count) events")
         }


### PR DESCRIPTION
Convert an error log into a warning (which is not tracked to Sentry). This is an aggregate log that prints the number of undecrypted vs total events, after we have already logged (incl to Sentry) individual undecryptable events.