### PR TITLE
Resolve QR warnings

### DIFF
--- a/MatrixSDK/Crypto/Algorithms/MXEventDecryptionDecoration.swift
+++ b/MatrixSDK/Crypto/Algorithms/MXEventDecryptionDecoration.swift
@@ -18,9 +18,9 @@ import Foundation
 
 /// Recommended color to represent message's authenticity properties
 @objc public enum MXEventDecryptionDecorationColor: Int {
-    case red
-    case grey
     case none
+    case grey
+    case red
 }
 
 /// Recommended visual decorations for decrypted messages, representing the message's authenticity properties

--- a/MatrixSDK/Crypto/CryptoMachine/Extensions/MXEventDecryptionResult+DecryptedEvent.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/Extensions/MXEventDecryptionResult+DecryptedEvent.swift
@@ -50,12 +50,12 @@ extension MXEventDecryptionDecoration {
 extension MXEventDecryptionDecorationColor {
     init(color: ShieldColor) {
         switch color {
-        case .red:
-            self = .red
-        case .grey:
-            self = .grey
         case .none:
             self = .none
+        case .grey:
+            self = .grey
+        case .red:
+            self = .red
         }
     }
 }

--- a/MatrixSDK/Crypto/Verification/MXKeyVerificationManagerV2.swift
+++ b/MatrixSDK/Crypto/Verification/MXKeyVerificationManagerV2.swift
@@ -219,7 +219,7 @@ class MXKeyVerificationManagerV2: NSObject, MXKeyVerificationManager {
             do {
                 let qr = try activeRequest.startQrVerification()
                 log.debug("Starting new QR verification")
-                return addQrTransaction(for: request, qrCode: qr, isIncoming: false)
+                return addQrTransaction(for: request, qr: .code(qr), isIncoming: false)
             } catch {
                 log.error("Cannot start QR verification", context: error)
                 return nil
@@ -228,7 +228,7 @@ class MXKeyVerificationManagerV2: NSObject, MXKeyVerificationManager {
             /// Placehoder QR transaction generated in case we cannot start a QR verification flow
             /// (the other device cannot scan our code) but we may be able to scan theirs
             log.debug("Adding placeholder QR verification")
-            return addQrTransaction(for: request, qrCode: nil, isIncoming: false)
+            return addQrTransaction(for: request, qr: .placeholder, isIncoming: false)
         }
         
         log.debug("No support for QR verification flow")
@@ -438,7 +438,7 @@ class MXKeyVerificationManagerV2: NSObject, MXKeyVerificationManager {
                 log.debug("Updating existing QR verification transaction")
             } else {
                 log.debug("Tracking new QR verification transaction")
-                _ = addQrTransaction(for: request, qrCode: qrCode, isIncoming: true)
+                _ = addQrTransaction(for: request, qr: .code(qrCode), isIncoming: true)
             }
         }
     }
@@ -451,8 +451,8 @@ class MXKeyVerificationManagerV2: NSObject, MXKeyVerificationManager {
     }
     
     @MainActor
-    private func addQrTransaction(for request: VerificationRequestProtocol, qrCode: QrCodeProtocol?, isIncoming: Bool) -> MXQRCodeTransactionV2 {
-        let transaction = MXQRCodeTransactionV2(request: request, qrCode: qrCode, isIncoming: isIncoming, handler: handler)
+    private func addQrTransaction(for request: VerificationRequestProtocol, qr: MXQRCodeTransactionV2.QrKind, isIncoming: Bool) -> MXQRCodeTransactionV2 {
+        let transaction = MXQRCodeTransactionV2(request: request, qr: qr, isIncoming: isIncoming, handler: handler)
         activeTransactions[transaction.transactionId] = transaction
         return transaction
     }

--- a/MatrixSDKTests/Crypto/Verification/Transactions/QRCode/MXQRCodeTransactionV2UnitTests.swift
+++ b/MatrixSDKTests/Crypto/Verification/Transactions/QRCode/MXQRCodeTransactionV2UnitTests.swift
@@ -28,7 +28,7 @@ class MXQRCodeTransactionV2UnitTests: XCTestCase {
     func makeTransaction(for request: VerificationRequestStub = .init(), qrCode: QrCodeStub = .init(), isIncoming: Bool = true) -> MXQRCodeTransactionV2 {
         .init(
             request: request,
-            qrCode: qrCode,
+            qr: .code(qrCode),
             isIncoming: isIncoming,
             handler: verification
         )


### PR DESCRIPTION
Resolves https://github.com/vector-im/element-ios/issues/7470

We log several errors to Sentry regarding QR codes which should not really be errors, namely the inability to generate QR code data when the other side cannot scan (but we can scan theirs).

Improve this by creating a dedicated enum to capture these two variants as opposed to an optional that is more ambiguous