### PR TITLE
Delete data for mismatched accounts

### DIFF
--- a/MatrixSDK/Crypto/MXCryptoV2.swift
+++ b/MatrixSDK/Crypto/MXCryptoV2.swift
@@ -197,7 +197,8 @@ class MXCryptoV2: NSObject, MXCrypto {
         }
         
         if deleteStore {
-            if let credentials = session?.credentials {
+            if let credentials = session?.credentials,
+               MXRealmCryptoStore.hasData(for: credentials) {
                 MXRealmCryptoStore.delete(with: credentials)
             } else {
                 log.failure("Missing credentials, cannot delete store")

--- a/changelog.d/pr-1763.bugfix
+++ b/changelog.d/pr-1763.bugfix
@@ -1,0 +1,1 @@
+Crypto: Delete data for mismatched accounts


### PR DESCRIPTION
Resolves https://github.com/vector-im/element-ios/issues/7488

When we recieve a "Mismatched account" error (meaning we have existing data for the current user but under a different device) we need to delete the previous data first before we can try to create the machine.

Note that this behaviour should not be happening as we delete data on logouts, but there are clearly edge-cases where this still occurs. In those cases we will log the error.