### PR TITLE
Fetch device info by sender key

### DIFF
--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -45,7 +45,7 @@ Pod::Spec.new do |s|
       ss.dependency 'OLMKit', '~> 3.2.5'
       ss.dependency 'Realm', '10.27.0'
       ss.dependency 'libbase58', '~> 0.1.4'
-      ss.dependency 'MatrixSDKCrypto', '0.3.2', :configurations => ["DEBUG", "RELEASE"], :inhibit_warnings => true
+      ss.dependency 'MatrixSDKCrypto', '0.3.3', :configurations => ["DEBUG", "RELEASE"], :inhibit_warnings => true
   end
 
   s.subspec 'JingleCallStack' do |ss|

--- a/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmDecryption.m
+++ b/MatrixSDK/Crypto/Algorithms/Megolm/MXMegolmDecryption.m
@@ -167,13 +167,14 @@
 {
     if (event.sender && [crypto trustLevelForUser:event.sender].isVerified)
     {
-        MXDeviceInfo *deviceInfo = [crypto eventDeviceInfo:event];
+        NSString *algorithm = event.wireContent[@"algorithm"];
+        MXDeviceInfo *deviceInfo = [crypto.deviceList deviceWithIdentityKey:decryptionResult.senderKey andAlgorithm:algorithm];
         if (!deviceInfo.trustLevel.isVerified)
         {
             return MXEventDecryptionDecorationColorRed;
         }
     }
-    
+
     return decryptionResult.isUntrusted ? MXEventDecryptionDecorationColorGrey : MXEventDecryptionDecorationColorNone;
 }
 

--- a/Podfile
+++ b/Podfile
@@ -16,7 +16,7 @@ abstract_target 'MatrixSDK' do
     
     pod 'Realm', '10.27.0'
     pod 'libbase58', '~> 0.1.4'
-    pod 'MatrixSDKCrypto', "0.3.2", :inhibit_warnings => true
+    pod 'MatrixSDKCrypto', "0.3.3", :inhibit_warnings => true
     
     target 'MatrixSDK-iOS' do
         platform :ios, '11.0'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -16,7 +16,7 @@ PODS:
     - AFNetworking/NSURLSession
   - GZIP (1.3.0)
   - libbase58 (0.1.4)
-  - MatrixSDKCrypto (0.3.2)
+  - MatrixSDKCrypto (0.3.3)
   - OHHTTPStubs (9.1.0):
     - OHHTTPStubs/Default (= 9.1.0)
   - OHHTTPStubs/Core (9.1.0)
@@ -44,7 +44,7 @@ DEPENDENCIES:
   - AFNetworking (~> 4.0.0)
   - GZIP (~> 1.3.0)
   - libbase58 (~> 0.1.4)
-  - MatrixSDKCrypto (= 0.3.2)
+  - MatrixSDKCrypto (= 0.3.3)
   - OHHTTPStubs (~> 9.1.0)
   - OLMKit (~> 3.2.5)
   - Realm (= 10.27.0)
@@ -65,12 +65,12 @@ SPEC CHECKSUMS:
   AFNetworking: 3bd23d814e976cd148d7d44c3ab78017b744cd58
   GZIP: 416858efbe66b41b206895ac6dfd5493200d95b3
   libbase58: 7c040313537b8c44b6e2d15586af8e21f7354efd
-  MatrixSDKCrypto: 7073c382c484cb8ba7dba0a83e112ead96d3bbfd
+  MatrixSDKCrypto: 427dbb126a3e3f97cadf9fc407abf17d365b4b39
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   OLMKit: da115f16582e47626616874e20f7bb92222c7a51
   Realm: 9ca328bd7e700cc19703799785e37f77d1a130f2
   SwiftyBeaver: 84069991dd5dca07d7069100985badaca7f0ce82
 
-PODFILE CHECKSUM: 2d9e98cd8d8a0371ca5e486c488e925fc0025f88
+PODFILE CHECKSUM: 174732d03c56adfa101fc7fcd2d573723820fcf4
 
 COCOAPODS: 1.11.3

--- a/changelog.d/pr-1765.change
+++ b/changelog.d/pr-1765.change
@@ -1,0 +1,1 @@
+Crypto: Upgrade Crypto SDK


### PR DESCRIPTION
When fetching device info, ensure that we retrieve it via its sender key, which may not be set on an event yet, but is a part of the decryption result.

Additionally upgrade crypto sdk version