### PR TITLE
Ensure device signed after restoring cross-signing keys

### DIFF
--- a/MatrixSDK/Crypto/CrossSigning/MXCrossSigning.h
+++ b/MatrixSDK/Crypto/CrossSigning/MXCrossSigning.h
@@ -137,11 +137,13 @@ typedef NS_ENUM(NSInteger, MXCrossSigningErrorCode)
  The operation requires to have the Self Signing Key in the local secret storage.
 
  @param deviceId the id of the device to cross-sign.
+ @param userId the user that owns the device.
 
  @param success A block object called when the operation succeeds.
  @param failure A block object called when the operation fails.
  */
 - (void)crossSignDeviceWithDeviceId:(NSString*)deviceId
+                             userId:(NSString*)userId
                             success:(void (^)(void))success
                             failure:(void (^)(NSError *error))failure;
 

--- a/MatrixSDK/Crypto/CrossSigning/MXCrossSigning.m
+++ b/MatrixSDK/Crypto/CrossSigning/MXCrossSigning.m
@@ -142,7 +142,7 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
             // Refresh our state so that we can cross-sign
             [self refreshStateWithSuccess:^(BOOL stateUpdated) {
                 // Expose this device to other users as signed by me
-                [self crossSignDeviceWithDeviceId:myCreds.deviceId success:^{
+                [self crossSignDeviceWithDeviceId:myCreds.deviceId userId:myCreds.userId success:^{
                     success();
                 } failure:failureBlock];
             } failure:failureBlock];
@@ -218,6 +218,7 @@ NSString *const MXCrossSigningErrorDomain = @"org.matrix.sdk.crosssigning";
 }
 
 - (void)crossSignDeviceWithDeviceId:(NSString*)deviceId
+                            userId:(NSString *)userId
                             success:(void (^)(void))success
                             failure:(void (^)(NSError *error))failure
 {

--- a/MatrixSDK/Crypto/CrossSigning/MXCrossSigningV2.swift
+++ b/MatrixSDK/Crypto/CrossSigning/MXCrossSigningV2.swift
@@ -144,10 +144,17 @@ class MXCrossSigningV2: NSObject, MXCrossSigning {
 
     func crossSignDevice(
         withDeviceId deviceId: String,
+        userId: String,
         success: @escaping () -> Void,
         failure: @escaping (Swift.Error) -> Void
     ) {
-        log.debug("->")
+        log.debug("Attempting to cross sign a device \(deviceId)")
+        
+        if let device = crossSigning.device(userId: userId, deviceId: deviceId), device.crossSigningTrusted {
+            log.debug("Device is already cross-signing trusted, no need to verify")
+            success()
+            return
+        }
         
         Task {
             do {

--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoProtocols.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoProtocols.swift
@@ -82,7 +82,7 @@ protocol MXCryptoRoomEventDecrypting: MXCryptoIdentity {
 }
 
 /// Cross-signing functionality
-protocol MXCryptoCrossSigning: MXCryptoUserIdentitySource {
+protocol MXCryptoCrossSigning: MXCryptoUserIdentitySource, MXCryptoDevicesSource {
     func refreshCrossSigningStatus() async throws
     func crossSigningStatus() -> CrossSigningStatus
     func bootstrapCrossSigning(authParams: [AnyHashable: Any]) async throws

--- a/MatrixSDK/Crypto/MXCrypto.m
+++ b/MatrixSDK/Crypto/MXCrypto.m
@@ -1092,7 +1092,7 @@ NSTimeInterval kMXCryptoMinForceSessionPeriod = 3600.0; // one hour
             {
                 // Cross-sign our own device
                 MXLogDebug(@"[MXCrypto] setDeviceVerificationForDevice: Mark device %@ as self verified", deviceId);
-                [self.crossSigning crossSignDeviceWithDeviceId:deviceId success:success failure:failure];
+                [self.crossSigning crossSignDeviceWithDeviceId:deviceId userId:userId success:success failure:failure];
                 
                 // Wait the end of cross-sign before returning
                 return;

--- a/MatrixSDK/Crypto/Recovery/MXRecoveryService.m
+++ b/MatrixSDK/Crypto/Recovery/MXRecoveryService.m
@@ -740,19 +740,14 @@ NSString *const MXRecoveryServiceErrorDomain = @"org.matrix.sdk.recoveryService"
     
     [self.dependencies.crossSigning refreshStateWithSuccess:^(BOOL stateUpdated) {
         
-        // Check if the service really needs to be started
-        if (self.dependencies.crossSigning.canCrossSign)
-        {
-            MXLogDebug(@"[MXRecoveryService] recoverCrossSigning: Cross-signing is already up");
-            success();
-            return;
-        }
+        NSString *userId = self.dependencies.credentials.userId;
+        NSString *deviceId = self.dependencies.credentials.deviceId;
 
         // Mark our user MSK as verified locally
-        [self.delegate setUserVerification:YES forUser:self.dependencies.credentials.userId success:^{
+        [self.delegate setUserVerification:YES forUser:userId success:^{
             
             // Cross sign our current device
-            [self.dependencies.crossSigning crossSignDeviceWithDeviceId:self.dependencies.credentials.deviceId success:^{
+            [self.dependencies.crossSigning crossSignDeviceWithDeviceId:deviceId userId:userId success:^{
                 
                 // And update the state
                 [self.dependencies.crossSigning refreshStateWithSuccess:^(BOOL stateUpdated) {

--- a/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoProtocolStubs.swift
+++ b/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoProtocolStubs.swift
@@ -72,6 +72,10 @@ class UserIdentitySourceStub: CryptoIdentityStub, MXCryptoUserIdentitySource {
 }
 
 class CryptoCrossSigningStub: CryptoIdentityStub, MXCryptoCrossSigning {
+    enum Error: Swift.Error {
+        case deviceMissing
+    }
+    
     var stubbedStatus = CrossSigningStatus(
         hasMaster: false,
         hasSelfSigning: false,
@@ -115,10 +119,38 @@ class CryptoCrossSigningStub: CryptoIdentityStub, MXCryptoCrossSigning {
     func verifyUser(userId: String) async throws {
     }
     
+    var verifiedDevicesSpy = Set<String>()
     func verifyDevice(userId: String, deviceId: String) async throws {
+        guard let device = devices[userId]?[deviceId] else {
+            throw Error.deviceMissing
+        }
+        
+        verifiedDevicesSpy.insert(deviceId)
+        
+        devices[userId]?[deviceId] = Device(
+            userId: device.userId,
+            deviceId: device.deviceId,
+            keys: device.keys,
+            algorithms: device.algorithms,
+            displayName: device.displayName,
+            isBlocked: device.isBlocked,
+            locallyTrusted: device.locallyTrusted,
+            // Modify cross signing trusted
+            crossSigningTrusted: true
+        )
     }
     
     func setLocalTrust(userId: String, deviceId: String, trust: LocalTrust) throws {
+    }
+    
+    var devices = [String: [String: Device]]()
+    
+    func device(userId: String, deviceId: String) -> Device? {
+        return devices[userId]?[deviceId]
+    }
+    
+    func devices(userId: String) -> [Device] {
+        return devices[userId]?.map { $0.value } ?? []
     }
 }
 

--- a/MatrixSDKTests/MXCrossSigningTests.m
+++ b/MatrixSDKTests/MXCrossSigningTests.m
@@ -1175,7 +1175,7 @@
             newDeviceId = newAliceSession.matrixRestClient.credentials.deviceId;
             
             // - Cross-sign this new device
-            [aliceSession.crypto.crossSigning crossSignDeviceWithDeviceId:newDeviceId success:^{
+            [aliceSession.crypto.crossSigning crossSignDeviceWithDeviceId:newDeviceId userId:newAliceSession.matrixRestClient.credentials.userId success:^{
                 
                 // Intermediate check
                 MXDeviceTrustLevel *aliceDevice2Trust = [aliceSession.crypto deviceTrustLevelForDevice:newDeviceId ofUser:aliceSession.myUserId];

--- a/changelog.d/pr-1768.change
+++ b/changelog.d/pr-1768.change
@@ -1,0 +1,1 @@
+Cross-signing: Ensure device signed after restoring cross-signing keys


### PR DESCRIPTION
`MXRecoveryService` responsible for restoring services after the import of cross-signing keys (e.g. when passphrase is entered) should verify the current user and device and upload relevant signature. However an early exit only checking current user trust and not the device trust will prevent this from happening ("canCrossSign" does not imply "device is signed").

To resolve this, remove the early exit in `MXRecoveryService` and always call `setUserVerification` and `crossSignDeviceWithDeviceId`. To avoid duplicate verifications of an already trusted device, add an early exit into `crossSignDeviceWithDeviceId` instead.