### PR TITLE
Remove legacy crypto store after migration

### DIFF
--- a/MatrixSDK/Crypto/MXCryptoV2.swift
+++ b/MatrixSDK/Crypto/MXCryptoV2.swift
@@ -197,13 +197,6 @@ class MXCryptoV2: NSObject, MXCrypto {
         }
         
         if deleteStore {
-            if let credentials = session?.credentials,
-               MXRealmCryptoStore.hasData(for: credentials) {
-                MXRealmCryptoStore.delete(with: credentials)
-            } else {
-                log.failure("Missing credentials, cannot delete store")
-            }
-            
             do {
                 try machine.deleteAllData()
             } catch {

--- a/MatrixSDK/Crypto/MXCryptoV2Factory.swift
+++ b/MatrixSDK/Crypto/MXCryptoV2Factory.swift
@@ -91,6 +91,9 @@ import Foundation
         
         log.debug("Legacy crypto store exists")
         try migrateIfNecessary(legacyStore: legacyStore, updateProgress: updateProgress)
+        
+        log.debug("Removing legacy crypto store entirely")
+        MXRealmCryptoStore.delete(with: credentials)
     }
     
     private func migrateIfNecessary(
@@ -123,8 +126,5 @@ import Foundation
             log.debug("Needs verification upgrade")
             MXSDKOptions.sharedInstance().cryptoSDKFeature?.needsVerificationUpgrade = true
         }
-        
-        log.debug("Setting the latest deprecated version of legacy store")
-        legacyStore.cryptoVersion = lastDeprecatedVersion
     }
 }

--- a/MatrixSDKTests/Crypto/MXCryptoV2FactoryTests.swift
+++ b/MatrixSDKTests/Crypto/MXCryptoV2FactoryTests.swift
@@ -82,7 +82,7 @@ class MXCryptoV2FactoryTests: XCTestCase {
     func test_fullyMigratesLegacyUser() async throws {
         let env = try await e2eData.startE2ETest()
         let session = env.session
-        let legacyStore = session.legacyCrypto?.store
+        var legacyStore = session.legacyCrypto?.store
         
         // Assert that we have a legacy store that has not yet been deprecated
         XCTAssertNotNil(legacyStore)
@@ -93,9 +93,9 @@ class MXCryptoV2FactoryTests: XCTestCase {
         XCTAssertNotNil(crypto)
         XCTAssertTrue(hasMigrated)
         
-        // Assert we still have legacy store but it is now marked as deprecated
-        XCTAssertNotNil(legacyStore)
-        XCTAssertEqual(legacyStore?.cryptoVersion, .deprecated3)
+        // Assert that we no longer have a legacy store for this user
+        legacyStore = MXRealmCryptoStore(credentials: session.credentials)
+        XCTAssertNil(legacyStore)
         
         await env.close()
     }
@@ -105,7 +105,7 @@ class MXCryptoV2FactoryTests: XCTestCase {
         let session = env.session
         
         // We set the legacy store as partially deprecated
-        let legacyStore = session.legacyCrypto?.store
+        var legacyStore = session.legacyCrypto?.store
         XCTAssertNotNil(legacyStore)
         legacyStore?.cryptoVersion = .deprecated1
         
@@ -114,9 +114,9 @@ class MXCryptoV2FactoryTests: XCTestCase {
         XCTAssertNotNil(crypto)
         XCTAssertTrue(hasMigrated)
         
-        // Assert we still have legacy store but it is now marked as deprecated
-        XCTAssertNotNil(legacyStore)
-        XCTAssertEqual(legacyStore?.cryptoVersion, .deprecated3)
+        // Assert that we no longer have a legacy store for this user
+        legacyStore = MXRealmCryptoStore(credentials: session.credentials)
+        XCTAssertNil(legacyStore)
         
         await env.close()
     }
@@ -126,7 +126,7 @@ class MXCryptoV2FactoryTests: XCTestCase {
         let session = env.session
         
         // We set the legacy store as fully deprecated
-        let legacyStore = session.legacyCrypto?.store
+        var legacyStore = session.legacyCrypto?.store
         XCTAssertNotNil(legacyStore)
         legacyStore?.cryptoVersion = .deprecated3
         
@@ -135,9 +135,9 @@ class MXCryptoV2FactoryTests: XCTestCase {
         XCTAssertNotNil(crypto)
         XCTAssertFalse(hasMigrated)
         
-        // Assert we still have legacy store which is still marked as deprecated
-        XCTAssertNotNil(legacyStore)
-        XCTAssertEqual(legacyStore?.cryptoVersion, .deprecated3)
+        // Assert that we no longer have a legacy store for this user
+        legacyStore = MXRealmCryptoStore(credentials: session.credentials)
+        XCTAssertNil(legacyStore)
         
         await env.close()
     }

--- a/changelog.d/pr-1769.change
+++ b/changelog.d/pr-1769.change
@@ -1,0 +1,1 @@
+Crypto: Remove legacy crypto store


### PR DESCRIPTION
Now that rust crypto is fully rolled out, and all relevant data from realm database migrated, there is no need to keep it around. The database will be deleted after successfull migration