### PR TITLE
Setup cross-signing even without auth session

### DIFF
--- a/MatrixSDK/Crypto/CrossSigning/MXCrossSigningV2.swift
+++ b/MatrixSDK/Crypto/CrossSigning/MXCrossSigningV2.swift
@@ -217,8 +217,9 @@ class MXCrossSigningV2: NSObject, MXCrossSigning {
             let session = authSession.session,
             let userId = restClient.credentials?.userId
         else {
-            log.error("Missing parameters")
-            throw Error.missingAuthSession
+            // Try to setup cross-signing without authentication parameters in case if a grace period is enabled
+            log.warning("Setting up cross-signing without authentication parameters")
+            return [:]
         }
 
         return [

--- a/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoProtocolStubs.swift
+++ b/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoProtocolStubs.swift
@@ -89,7 +89,9 @@ class CryptoCrossSigningStub: CryptoIdentityStub, MXCryptoCrossSigning {
         return stubbedStatus
     }
     
+    var spyAuthParams: [AnyHashable: Any]?
     func bootstrapCrossSigning(authParams: [AnyHashable : Any]) async throws {
+        self.spyAuthParams = authParams
     }
     
     func exportCrossSigningKeys() -> CrossSigningKeyExport? {

--- a/changelog.d/pr-1774.bugfix
+++ b/changelog.d/pr-1774.bugfix
@@ -1,0 +1,1 @@
+Cross-signing: Setup cross-signing with empty auth session


### PR DESCRIPTION
Calling `[MXRestClient authSessionForRequestWithMethod]` is supposed to return an auth session which is then passed to crypto machine to setup cross-singing keys. It is however valid for the auth session to be empty, which is already accounted for in `MXLegacyCrossSigning`, but not in `MXCrossSigningV2`. This PR fixes that issue by behaving in the same way as legacy cross-signing, namely returning empty auth session instead of throwing an error.