### PR TITLE
MSC3912 implementation: stable property with_relations has been renamed with_rel_types

### DIFF
--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -3077,7 +3077,7 @@ andUnauthenticatedHandler: (MXRestClientUnauthenticatedHandler)unauthenticatedHa
     
     if (relations && [relations count] > 0)
     {
-        NSString* property = withRelationsIsStable ? @"with_relations" : @"org.matrix.msc3912.with_relations";
+        NSString* property = withRelationsIsStable ? @"with_rel_types" : @"org.matrix.msc3912.with_relations";
         parameters[property] = relations;
     }
 

--- a/changelog.d/7563.change
+++ b/changelog.d/7563.change
@@ -1,0 +1,1 @@
+MSC3912 implementation: the stable property with_relations has been renamed with_rel_types


### PR DESCRIPTION
This PR applies the change requested by [Element iOS - #7563](https://github.com/vector-im/element-ios/issues/7563)
