### PR TITLE
Implement MSC3987: Push actions clean-up

### DIFF
--- a/MatrixSDK/Background/MXBackgroundPushRulesManager.swift
+++ b/MatrixSDK/Background/MXBackgroundPushRulesManager.swift
@@ -82,6 +82,12 @@ import Foundation
             return false
         }
         
+        // Support for MSC3987: The dont_notify push rule action is deprecated.
+        if rule.actions.isEmpty {
+            return rule.enabled
+        }
+        
+        // Compatibility support.
         for ruleAction in rule.actions {
             guard let action = ruleAction as? MXPushRuleAction else { continue }
             if action.actionType == MXPushRuleActionTypeDontNotify {

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -1816,43 +1816,43 @@ andUnauthenticatedHandler: (MXRestClientUnauthenticatedHandler)unauthenticatedHa
     {
         case MXPushRuleKindOverride:
             kindString = @"override";
-            if (conditions.count && actions.count)
+            if (conditions.count && actions)
             {
                 content = @{@"conditions": conditions, @"actions": actions};
             }
-            else if (actions.count)
+            else if (actions)
             {
                 content = @{@"actions": actions};
             }
             break;
         case MXPushRuleKindContent:
             kindString = @"content";
-            if (pattern.length && actions.count)
+            if (pattern.length && actions)
             {
                 content = @{@"pattern": pattern, @"actions": actions};
             }
             break;
         case MXPushRuleKindRoom:
             kindString = @"room";
-            if (actions.count)
+            if (actions)
             {
                 content = @{@"actions": actions};
             }
             break;
         case MXPushRuleKindSender:
             kindString = @"sender";
-            if (actions.count)
+            if (actions)
             {
                 content = @{@"actions": actions};
             }
             break;
         case MXPushRuleKindUnderride:
             kindString = @"underride";
-            if (conditions.count && actions.count)
+            if (conditions.count && actions)
             {
                 content = @{@"conditions": conditions, @"actions": actions};
             }
-            else if (actions.count)
+            else if (actions)
             {
                 content = @{@"actions": actions};
             }

--- a/MatrixSDK/NotificationCenter/MXNotificationCenter.m
+++ b/MatrixSDK/NotificationCenter/MXNotificationCenter.m
@@ -579,6 +579,7 @@ NSString *const kMXNotificationCenterAllOtherRoomMessagesRuleID = @".m.rule.mess
                           highlight:(BOOL)highlight
 {
     NSMutableArray *actions = [NSMutableArray array];
+    // Support for MSC3987: The dont_notify push rule action is deprecated and replaced by an empty actions list.
     if (notify)
     {
         [actions addObject:@"notify"];
@@ -597,10 +598,6 @@ NSString *const kMXNotificationCenterAllOtherRoomMessagesRuleID = @".m.rule.mess
             [actions addObject:@{@"set_tweak": @"highlight", @"value": @NO}];
         }
     }
-    else
-    {
-        [actions addObject:@"dont_notify"];
-    }
     return actions;
 }
 
@@ -615,7 +612,8 @@ NSString *const kMXNotificationCenterAllOtherRoomMessagesRuleID = @".m.rule.mess
         if (rule)
         {
             // Make sure this is not a rule to prevent from generating a notification
-            BOOL actionNotify = YES;
+            // Support for MSC3987: The dont_notify push rule action is deprecated and replaced by an empty actions list.
+            BOOL actionNotify = (rule.actions.count > 0);
             if (1 == rule.actions.count)
             {
                 MXPushRuleAction *action = rule.actions[0];

--- a/MatrixSDK/Space/MXSpaceNotificationCounter.swift
+++ b/MatrixSDK/Space/MXSpaceNotificationCounter.swift
@@ -225,6 +225,12 @@ public class MXSpaceNotificationCounter: NSObject {
                 continue
             }
             
+            // Support for MSC3987: The dont_notify push rule action is deprecated.
+            if rule.actions.isEmpty {
+                return rule.enabled
+            }
+
+            // Compatibility support.
             for ruleAction in ruleActions where ruleAction.actionType == MXPushRuleActionTypeDontNotify {
                 return rule.enabled
             }

--- a/changelog.d/7576.change
+++ b/changelog.d/7576.change
@@ -1,0 +1,1 @@
+MSC3987 implementation: the 'dont_notify' action for a push_rule is now deprecated and replaced by an empty action list.


### PR DESCRIPTION
This PR add support for [MSC3987](https://github.com/matrix-org/matrix-spec-proposals/pull/3987) which deprecates the `dont_notify` action for a `push_rule`.  (linked to [Element-iOS #7576](https://github.com/vector-im/element-ios/issues/))