### PR TITLE
Fix fallback parsing logic for legacy location events

### DIFF
--- a/MatrixSDK/JSONModels/Event/Content/MXEventContentLocation.m
+++ b/MatrixSDK/JSONModels/Event/Content/MXEventContentLocation.m
@@ -111,7 +111,8 @@
         }
         
         finalLocationDictionary = @{
-            kMXMessageGeoURIKey: geoURIString
+            // The parsing logic inside `[MXLocation modelFromJSON:]` expects the geo URI to be at "uri" and not at "geo_uri"
+            kMXMessageContentKeyExtensibleLocationURI: geoURIString
         };
     }
     else


### PR DESCRIPTION
This PR fixes a problem causing the fallback parsing logic not working properly for "legacy" location events like this:

```
{
   "type": "m.room.message",
   "content": {
       "body: "Location was shared at geo:42.3431550455947,13.3939963489709 as of 2023-07-03 11:15:01 +0000",
       "geo_uri": "geo:42.3431550455947,13.3939963489709",
       "msgtype": "m.location"
    }
}
```
More context [here](https://github.com/matrix-org/matrix-spec-proposals/blob/matthew/location/proposals/3488-location.md)

| **Before** | **After** |
| --- | --- |
| ![b](https://github.com/matrix-org/matrix-ios-sdk/assets/19324622/3d2c2142-2833-480c-a0d2-afd93266c248)|![a](https://github.com/matrix-org/matrix-ios-sdk/assets/19324622/70af9e2d-e738-478e-8744-4dcd53af23cf)|

