### PR TITLE
Matrix sdk crypto update

### DIFF
--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -45,7 +45,7 @@ Pod::Spec.new do |s|
       ss.dependency 'OLMKit', '~> 3.2.5'
       ss.dependency 'Realm', '10.27.0'
       ss.dependency 'libbase58', '~> 0.1.4'
-      ss.dependency 'MatrixSDKCrypto', '0.3.4', :configurations => ["DEBUG", "RELEASE"], :inhibit_warnings => true
+      ss.dependency 'MatrixSDKCrypto', '0.3.11', :configurations => ["DEBUG", "RELEASE"], :inhibit_warnings => true
   end
 
   s.subspec 'JingleCallStack' do |ss|

--- a/MatrixSDK/Crypto/CrossSigning/Data/MXCryptoUserIdentityWrapper.swift
+++ b/MatrixSDK/Crypto/CrossSigning/Data/MXCryptoUserIdentityWrapper.swift
@@ -31,7 +31,7 @@ import MatrixSDKCrypto
     
     internal init(identity: UserIdentity, isVerified: Bool) {
         switch identity {
-        case .own(let userId, _, let masterKey, let selfSigningKey, let userSigningKey):
+        case .own(let userId, _, let masterKey, let userSigningKey, let selfSigningKey):
             self.userId = userId
             // Note: `trustsOurOwnDevice` is not currently used, instead using second `isVerified` parameter
             self.masterKeys = .init(jsonString: masterKey)

--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoMachine.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoMachine.swift
@@ -204,8 +204,9 @@ extension MXCryptoMachine: MXCryptoSyncing {
         )
         
         guard
-            let json = MXTools.deserialiseJSONString(result) as? [Any],
-            let toDevice = MXToDeviceSyncResponse(fromJSON: ["events": json])
+            let deserialisedResult = MXTools.deserialiseJSONString(result) as? [Any],
+            let deserialisedToDeviceEvents = deserialisedResult.first,
+            let toDevice = MXToDeviceSyncResponse(fromJSON: ["events": deserialisedToDeviceEvents])
         else {
             log.failure("Result cannot be serialized", context: [
                 "result": result

--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoMachine.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoMachine.swift
@@ -308,7 +308,7 @@ extension MXCryptoMachine: MXCryptoSyncing {
     }
     
     private func markRequestAsSent(requestId: String, requestType: RequestType, response: String? = nil) throws {
-        try self.machine.markRequestAsSent(requestId: requestId, requestType: requestType, response: response ?? "")
+        try self.machine.markRequestAsSent(requestId: requestId, requestType: requestType, responseBody: response ?? "")
     }
     
     private func handleOutgoingRequests() async throws {
@@ -583,7 +583,12 @@ extension MXCryptoMachine: MXCryptoCrossSigning {
     }
     
     func exportCrossSigningKeys() -> CrossSigningKeyExport? {
-        machine.exportCrossSigningKeys()
+        do {
+            return try machine.exportCrossSigningKeys()
+        } catch {
+            log.error("Failed exporting cross signing keys", context: error)
+            return nil
+        }
     }
     
     func importCrossSigningKeys(export: CrossSigningKeyExport) {
@@ -784,7 +789,7 @@ extension MXCryptoMachine: MXCryptoBackup {
         }
         
         do {
-            let verification = try machine.verifyBackup(authData: string)
+            let verification = try machine.verifyBackup(backupInfo: string)
             return verification.trusted
         } catch {
             log.error("Failed verifying backup", context: error)

--- a/MatrixSDK/Crypto/Migration/Data/MXCryptoMigrationStore.swift
+++ b/MatrixSDK/Crypto/Migration/Data/MXCryptoMigrationStore.swift
@@ -54,9 +54,9 @@ struct MXCryptoMigrationStore {
             account: try pickledAccount(pickleKey: pickleKey),
             sessions: [], // Sessions are extracted in batches separately
             inboundGroupSessions: [], // Group sessions are extracted in batches separately
+            pickleKey: [UInt8](pickleKey),
             backupVersion: legacyStore.backupVersion,
             backupRecoveryKey: backupRecoveryKey(),
-            pickleKey: [UInt8](pickleKey),
             crossSigning: crossSigning(),
             trackedUsers: trackedUsers(),
             roomSettings: extractRoomSettings()

--- a/MatrixSDKTests/Crypto/CrossSigning/Data/MXCrossSigningInfoUnitTests.swift
+++ b/MatrixSDKTests/Crypto/CrossSigning/Data/MXCrossSigningInfoUnitTests.swift
@@ -37,8 +37,8 @@ class MXCrossSigningInfoUnitTests: XCTestCase {
             userId: "Alice",
             trustsOurOwnDevice: false,
             masterKey: masterKeys.jsonString(),
-            selfSigningKey: selfSigningKeys.jsonString(),
-            userSigningKey: userSigningKeys.jsonString()
+            userSigningKey: userSigningKeys.jsonString(),
+            selfSigningKey: selfSigningKeys.jsonString()
         )
         let userIdentity = MXCryptoUserIdentityWrapper(
             identity: identity,

--- a/MatrixSDKTests/Crypto/CrossSigning/MXCrossSigningInfoSourceUnitTests.swift
+++ b/MatrixSDKTests/Crypto/CrossSigning/MXCrossSigningInfoSourceUnitTests.swift
@@ -39,8 +39,8 @@ class MXCrossSigningInfoSourceUnitTests: XCTestCase {
                 userId: "Alice",
                 trustsOurOwnDevice: true,
                 masterKey: "master",
-                selfSigningKey: "self",
-                userSigningKey: "user"
+                userSigningKey: "user",
+                selfSigningKey: "self"
             )
         ]
         cryptoSource.verification = [

--- a/MatrixSDKTests/Crypto/CrossSigning/MXCrossSigningV2UnitTests.swift
+++ b/MatrixSDKTests/Crypto/CrossSigning/MXCrossSigningV2UnitTests.swift
@@ -101,8 +101,8 @@ class MXCrossSigningV2UnitTests: XCTestCase {
                 userId: "Alice",
                 trustsOurOwnDevice: true,
                 masterKey: "",
-                selfSigningKey: "",
-                userSigningKey: ""
+                userSigningKey: "",
+                selfSigningKey: ""
             )
         ]
         crossSigning.refreshState { _ in
@@ -120,8 +120,8 @@ class MXCrossSigningV2UnitTests: XCTestCase {
                 userId: "Alice",
                 trustsOurOwnDevice: true,
                 masterKey: "",
-                selfSigningKey: "",
-                userSigningKey: ""
+                userSigningKey: "",
+                selfSigningKey: ""
             )
         ]
         crossSigning.refreshState { _ in
@@ -149,8 +149,8 @@ class MXCrossSigningV2UnitTests: XCTestCase {
                     userId: "Alice",
                     trustsOurOwnDevice: true,
                     masterKey: "",
-                    selfSigningKey: "",
-                    userSigningKey: ""
+                    userSigningKey: "",
+                    selfSigningKey: ""
                 )
             ]
             

--- a/MatrixSDKTests/Crypto/CryptoMachine/Device+Stub.swift
+++ b/MatrixSDKTests/Crypto/CryptoMachine/Device+Stub.swift
@@ -40,7 +40,8 @@ extension Device {
             displayName: displayName,
             isBlocked: isBlocked,
             locallyTrusted: locallyTrusted,
-            crossSigningTrusted: crossSigningTrusted
+            crossSigningTrusted: crossSigningTrusted,
+            firstTimeSeenTs: 0
         )
     }
 }

--- a/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoMachineUnitTests.swift
+++ b/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoMachineUnitTests.swift
@@ -204,8 +204,8 @@ class MXCryptoMachineUnitTests: XCTestCase {
         
         XCTAssertEqual(request?.state(), .cancelled(
             cancelInfo: .init(
-                cancelCode: "m.user",
                 reason: "The user cancelled the verification.",
+                cancelCode: "m.user",
                 cancelledByUs: false
             )
         ))

--- a/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoProtocolStubs.swift
+++ b/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoProtocolStubs.swift
@@ -138,7 +138,8 @@ class CryptoCrossSigningStub: CryptoIdentityStub, MXCryptoCrossSigning {
             isBlocked: device.isBlocked,
             locallyTrusted: device.locallyTrusted,
             // Modify cross signing trusted
-            crossSigningTrusted: true
+            crossSigningTrusted: true,
+            firstTimeSeenTs: 0
         )
     }
     

--- a/MatrixSDKTests/Crypto/Verification/Requests/MXKeyVerificationRequestV2UnitTests.swift
+++ b/MatrixSDKTests/Crypto/Verification/Requests/MXKeyVerificationRequestV2UnitTests.swift
@@ -128,7 +128,7 @@ class MXKeyVerificationRequestV2UnitTests: XCTestCase {
     func test_cancelledByMeState() {
         let request = makeRequest()
         
-        request.onChange(state: .cancelled(cancelInfo: .init(cancelCode: "123", reason: "Changed mind", cancelledByUs: true)))
+        request.onChange(state: .cancelled(cancelInfo: .init(reason: "Changed mind", cancelCode: "123", cancelledByUs: true)))
         
         XCTAssertEqual(request.reasonCancelCode?.value, "123")
         XCTAssertEqual(request.reasonCancelCode?.humanReadable, "Changed mind")
@@ -138,7 +138,7 @@ class MXKeyVerificationRequestV2UnitTests: XCTestCase {
     func test_cancelledByThemState() {
         let request = makeRequest()
         
-        request.onChange(state: .cancelled(cancelInfo: .init(cancelCode: "123", reason: "Changed mind", cancelledByUs: false)))
+        request.onChange(state: .cancelled(cancelInfo: .init(reason: "Changed mind", cancelCode: "123", cancelledByUs: false)))
         
         XCTAssertEqual(request.reasonCancelCode?.value, "123")
         XCTAssertEqual(request.reasonCancelCode?.humanReadable, "Changed mind")

--- a/MatrixSDKTests/Crypto/Verification/Transactions/QRCode/MXQRCodeTransactionV2UnitTests.swift
+++ b/MatrixSDKTests/Crypto/Verification/Transactions/QRCode/MXQRCodeTransactionV2UnitTests.swift
@@ -101,7 +101,7 @@ class MXQRCodeTransactionV2UnitTests: XCTestCase {
     func test_cancelledByMeState() {
         let transaction = makeTransaction()
 
-        transaction.onChange(state: .cancelled(cancelInfo: .init(cancelCode: "123", reason: "Changed mind", cancelledByUs: true)))
+        transaction.onChange(state: .cancelled(cancelInfo: .init(reason: "Changed mind", cancelCode: "123", cancelledByUs: true)))
 
         XCTAssertEqual(transaction.reasonCancelCode?.value, "123")
         XCTAssertEqual(transaction.reasonCancelCode?.humanReadable, "Changed mind")
@@ -111,7 +111,7 @@ class MXQRCodeTransactionV2UnitTests: XCTestCase {
     func test_cancelledByThemState() {
         let transaction = makeTransaction()
 
-        transaction.onChange(state: .cancelled(cancelInfo: .init(cancelCode: "123", reason: "Changed mind", cancelledByUs: false)))
+        transaction.onChange(state: .cancelled(cancelInfo: .init(reason: "Changed mind", cancelCode: "123", cancelledByUs: false)))
 
         XCTAssertEqual(transaction.reasonCancelCode?.value, "123")
         XCTAssertEqual(transaction.reasonCancelCode?.humanReadable, "Changed mind")

--- a/MatrixSDKTests/Crypto/Verification/Transactions/SAS/MXSASTransactionV2UnitTests.swift
+++ b/MatrixSDKTests/Crypto/Verification/Transactions/SAS/MXSASTransactionV2UnitTests.swift
@@ -117,7 +117,7 @@ class MXSASTransactionV2UnitTests: XCTestCase {
     func test_cancelledByMeState() {
         let transaction = makeTransaction()
         
-        transaction.onChange(state: .cancelled(cancelInfo: .init(cancelCode: "123", reason: "Changed mind", cancelledByUs: true)))
+        transaction.onChange(state: .cancelled(cancelInfo: .init(reason: "Changed mind", cancelCode: "123", cancelledByUs: true)))
         
         XCTAssertEqual(transaction.reasonCancelCode?.value, "123")
         XCTAssertEqual(transaction.reasonCancelCode?.humanReadable, "Changed mind")
@@ -127,7 +127,7 @@ class MXSASTransactionV2UnitTests: XCTestCase {
     func test_cancelledByThemState() {
         let transaction = makeTransaction()
         
-        transaction.onChange(state: .cancelled(cancelInfo: .init(cancelCode: "123", reason: "Changed mind", cancelledByUs: false)))
+        transaction.onChange(state: .cancelled(cancelInfo: .init(reason: "Changed mind", cancelCode: "123", cancelledByUs: false)))
         
         XCTAssertEqual(transaction.reasonCancelCode?.value, "123")
         XCTAssertEqual(transaction.reasonCancelCode?.humanReadable, "Changed mind")

--- a/MatrixSDKTests/JSONModels/MXKeysQueryResponseUnitTests.swift
+++ b/MatrixSDKTests/JSONModels/MXKeysQueryResponseUnitTests.swift
@@ -51,15 +51,15 @@ class MXKeysQueryResponseUnitTests: XCTestCase {
                         usage: ["master"],
                         keys: "\(userId)-MSK"
                     ).jsonString(),
-                    selfSigningKey: MXCrossSigningKey(
-                        userId: userId,
-                        usage: ["self_signing"],
-                        keys: "\(userId)-SSK"
-                    ).jsonString(),
                     userSigningKey: MXCrossSigningKey(
                         userId: userId,
                         usage: ["user_signing"],
                         keys: "\(userId)-USK"
+                    ).jsonString(),
+                    selfSigningKey: MXCrossSigningKey(
+                        userId: userId,
+                        usage: ["self_signing"],
+                        keys: "\(userId)-SSK"
                     ).jsonString()
                 ),
                 isVerified: true

--- a/Podfile
+++ b/Podfile
@@ -16,7 +16,7 @@ abstract_target 'MatrixSDK' do
     
     pod 'Realm', '10.27.0'
     pod 'libbase58', '~> 0.1.4'
-    pod 'MatrixSDKCrypto', "0.3.4", :inhibit_warnings => true
+    pod 'MatrixSDKCrypto', "0.3.11", :inhibit_warnings => true
     
     target 'MatrixSDK-iOS' do
         platform :ios, '11.0'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -16,7 +16,7 @@ PODS:
     - AFNetworking/NSURLSession
   - GZIP (1.3.0)
   - libbase58 (0.1.4)
-  - MatrixSDKCrypto (0.3.4)
+  - MatrixSDKCrypto (0.3.11)
   - OHHTTPStubs (9.1.0):
     - OHHTTPStubs/Default (= 9.1.0)
   - OHHTTPStubs/Core (9.1.0)
@@ -44,7 +44,7 @@ DEPENDENCIES:
   - AFNetworking (~> 4.0.0)
   - GZIP (~> 1.3.0)
   - libbase58 (~> 0.1.4)
-  - MatrixSDKCrypto (= 0.3.4)
+  - MatrixSDKCrypto (= 0.3.11)
   - OHHTTPStubs (~> 9.1.0)
   - OLMKit (~> 3.2.5)
   - Realm (= 10.27.0)
@@ -65,12 +65,12 @@ SPEC CHECKSUMS:
   AFNetworking: 3bd23d814e976cd148d7d44c3ab78017b744cd58
   GZIP: 416858efbe66b41b206895ac6dfd5493200d95b3
   libbase58: 7c040313537b8c44b6e2d15586af8e21f7354efd
-  MatrixSDKCrypto: ac805c22c24f79f349cdbfa065855c73a4c81b51
+  MatrixSDKCrypto: 475f3dd0058864839c80a464ce76dcdcc58e5c32
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   OLMKit: da115f16582e47626616874e20f7bb92222c7a51
   Realm: 9ca328bd7e700cc19703799785e37f77d1a130f2
   SwiftyBeaver: 84069991dd5dca07d7069100985badaca7f0ce82
 
-PODFILE CHECKSUM: 5c78f80c2f45525f29deaa0fc5455b81552ee632
+PODFILE CHECKSUM: 86a634fc24c104e3b913296f2d5e9eb4bf4202cc
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.12.1


### PR DESCRIPTION
This PR bumps the Matrix Crypto SDK version to 0.3.11 and fixes newly introduced problems:
* breaking api changes following uniffi udl->macro replacement
* toDevice sync response event processing after JSON format change + improved rust side API to avoid it in the future
* broken secret recovery following USK and SSK enum associtated value order change

Successful integration test run here https://github.com/matrix-org/matrix-ios-sdk/actions/runs/5609719049/jobs/10263800231