### PR TITLE
delegate OIDC compatibility flag added

### DIFF
--- a/MatrixSDK/JSONModels/Login/MXLoginSSOFlow.h
+++ b/MatrixSDK/JSONModels/Login/MXLoginSSOFlow.h
@@ -31,6 +31,7 @@ extern NSString *const MXLoginSSOFlowIdentityProvidersKey;
  List of all SSO Identity Providers supported
  */
 @property (nonatomic, readonly) NSArray<MXLoginSSOIdentityProvider*> *identityProviders;
+@property (atomic, readonly) BOOL isOIDC;
 
 @end
 

--- a/MatrixSDK/JSONModels/Login/MXLoginSSOFlow.h
+++ b/MatrixSDK/JSONModels/Login/MXLoginSSOFlow.h
@@ -31,7 +31,7 @@ extern NSString *const MXLoginSSOFlowIdentityProvidersKey;
  List of all SSO Identity Providers supported
  */
 @property (nonatomic, readonly) NSArray<MXLoginSSOIdentityProvider*> *identityProviders;
-@property (atomic, readonly) BOOL isOIDC;
+@property (atomic, readonly) BOOL delegatedOIDCCompatibility;
 
 @end
 

--- a/MatrixSDK/JSONModels/Login/MXLoginSSOFlow.m
+++ b/MatrixSDK/JSONModels/Login/MXLoginSSOFlow.m
@@ -22,7 +22,7 @@ NSString *const MXLoginSSOFlowDelegatedOIDCCompatibilityKey = @"org.matrix.msc38
 @interface MXLoginSSOFlow()
 
 @property (nonatomic, readwrite) NSArray<MXLoginSSOIdentityProvider*> *identityProviders;
-@property (atomic, readwrite) BOOL isOIDC;
+@property (atomic, readwrite) BOOL delegatedOIDCCompatibility;
 
 @end
 
@@ -52,7 +52,7 @@ NSString *const MXLoginSSOFlowDelegatedOIDCCompatibilityKey = @"org.matrix.msc38
         
         loginFlow.identityProviders = identityProviders;
         
-        MXJSONModelSetBoolean(loginFlow.isOIDC, JSONDictionary[MXLoginSSOFlowDelegatedOIDCCompatibilityKey]);
+        MXJSONModelSetBoolean(loginFlow.delegatedOIDCCompatibility, JSONDictionary[MXLoginSSOFlowDelegatedOIDCCompatibilityKey]);
     }
     
     return loginFlow;

--- a/MatrixSDK/JSONModels/Login/MXLoginSSOFlow.m
+++ b/MatrixSDK/JSONModels/Login/MXLoginSSOFlow.m
@@ -17,10 +17,12 @@
 #import "MXLoginSSOFlow.h"
 
 NSString *const MXLoginSSOFlowIdentityProvidersKey = @"identity_providers";
+NSString *const MXLoginSSOFlowDelegatedOIDCCompatibilityKey = @"org.matrix.msc3824.delegated_oidc_compatibility";
 
 @interface MXLoginSSOFlow()
 
 @property (nonatomic, readwrite) NSArray<MXLoginSSOIdentityProvider*> *identityProviders;
+@property (atomic, readwrite) BOOL isOIDC;
 
 @end
 
@@ -50,6 +52,7 @@ NSString *const MXLoginSSOFlowIdentityProvidersKey = @"identity_providers";
         
         loginFlow.identityProviders = identityProviders;
         
+        MXJSONModelSetBoolean(loginFlow.isOIDC, JSONDictionary[MXLoginSSOFlowDelegatedOIDCCompatibilityKey]);
     }
     
     return loginFlow;

--- a/changelog.d/pr-1811.feature
+++ b/changelog.d/pr-1811.feature
@@ -1,0 +1,1 @@
+Delegate OIDC compatibility flag added.


### PR DESCRIPTION
Now the `MXSSOSessionFlow` is able to parse the delegate OIDC compatibility flag.