### PR TITLE
Fix unhandled callback when the session is nil.

### DIFF
--- a/changelog.d/pr-1833.bugfix
+++ b/changelog.d/pr-1833.bugfix
@@ -1,0 +1,1 @@
+Fix unhandled callback when the session is nil.


### PR DESCRIPTION
This fixes an issue in contexts such as a Notification Service where there might not be a session.

In the instance of Element, if an invite was sent and the app was in the background, it would send `[matrixSession.matrixRestClient stateOfRoom:success:failure:]` after calling this method with a nil session, so the notification would stall and then timeout.