### PR TITLE
Fix for removeReaction request parameters

### DIFF
--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -2041,7 +2041,15 @@ NSInteger const kMXRoomInvalidInviteSenderErrorCode = 9002;
                         success:(void (^)(void))success
                         failure:(void (^)(NSError *error))failure
 {
-    return [mxSession.matrixRestClient redactEvent:eventId inRoom:self.roomId reason:reason success:success failure:failure];
+    BOOL isFeatureWithRelationsStable = mxSession.store.supportedMatrixVersions.supportsRedactionWithRelations;
+    return [mxSession.matrixRestClient redactEvent:eventId
+                                            inRoom:self.roomId
+                                            reason:reason
+                                             txnId:nil
+                                     withRelations:nil
+                             withRelationsIsStable:isFeatureWithRelationsStable
+                                           success:success
+                                           failure:failure];
 }
 
 - (MXHTTPOperation*)redactEvent:(NSString*)eventId

--- a/changelog.d/pr-1838.bugfix
+++ b/changelog.d/pr-1838.bugfix
@@ -1,0 +1,1 @@
+SkiTles55: fix for removeReaction redactEvent request parameters


### PR DESCRIPTION
In MXAggregatedReactionsUpdater function for remove reaction call redactEvent request without required parameter txnId, because of this, the request returns an error and the reaction is not deleted

Signed-off-by: Dmitry Khudyakov [skitles55@gmail.com](mailto:skitles55@gmail.com)
