### PR TITLE
Bump rust crypto sdk version 0.4.1

### DIFF
--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -45,7 +45,7 @@ Pod::Spec.new do |s|
       ss.dependency 'OLMKit', '~> 3.2.5'
       ss.dependency 'Realm', '10.27.0'
       ss.dependency 'libbase58', '~> 0.1.4'
-      ss.dependency 'MatrixSDKCrypto', '0.3.13', :configurations => ["DEBUG", "RELEASE"], :inhibit_warnings => true
+      ss.dependency 'MatrixSDKCrypto', '0.4.1', :configurations => ["DEBUG", "RELEASE"], :inhibit_warnings => true
   end
 
   s.subspec 'JingleCallStack' do |ss|

--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoMachine.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoMachine.swift
@@ -591,9 +591,14 @@ extension MXCryptoMachine: MXCryptoCrossSigning {
     
     func bootstrapCrossSigning(authParams: [AnyHashable: Any]) async throws {
         let result = try machine.bootstrapCrossSigning()
+        // If this is called before the device keys have been uploaded there will be a
+        // request to upload them, do that first.
+        if let optionalKeyRequest = result.uploadKeysRequest {
+            try await handleRequest(optionalKeyRequest)
+        }
         let _ = try await [
             requests.uploadSigningKeys(request: result.uploadSigningKeysRequest, authParams: authParams),
-            requests.uploadSignatures(request: result.signatureRequest)
+            requests.uploadSignatures(request: result.uploadSignatureRequest)
         ]
     }
     
@@ -833,7 +838,7 @@ extension MXCryptoMachine: MXCryptoBackup {
         guard let message = MXCryptoTools.canonicalJSONString(forJSON: object) else {
             throw Error.cannotSerialize
         }
-        return machine.sign(message: message)
+        return try machine.sign(message: message)
     }
     
     func backupRoomKeys() async throws {

--- a/MatrixSDK/Crypto/Dehydration/DehydrationService.swift
+++ b/MatrixSDK/Crypto/Dehydration/DehydrationService.swift
@@ -68,7 +68,7 @@ public class DehydrationService: NSObject {
             // Convert it back to Data
             let pickleKeyData = MXBase64Tools.data(fromBase64: base64PickleKey)
             
-            let rehydrationResult = await rehydrateDevice(pickleKeyData: [UInt8](pickleKeyData))
+            let rehydrationResult = await rehydrateDevice(pickleKeyData: pickleKeyData)
             switch rehydrationResult {
             case .success((let deviceId, let rehydratedDevice)):
                 // Fetch and process the to device events available on the dehydrated device
@@ -86,14 +86,14 @@ public class DehydrationService: NSObject {
             }
             
             // Finally, create a new dehydrated device with the same pickle key
-            try await dehydrateDevice(pickleKeyData: [UInt8](pickleKeyData))
+            try await dehydrateDevice(pickleKeyData: pickleKeyData)
         } else { // Otherwise, generate a new dehydration pickle key, store it and dehydrate a device
             // Generate a new dehydration pickle key
-            var pickleKeyData = [UInt8](repeating: 0, count: 32)
+            var pickleKeyData = Data(count: 32)
             _ = SecRandomCopyBytes(kSecRandomDefault, 32, &pickleKeyData)
             
             // Convert it to unpadded base 64
-            let base64PickleKey = MXBase64Tools.unpaddedBase64(from: Data(bytes: pickleKeyData, count: 32))
+            let base64PickleKey = MXBase64Tools.unpaddedBase64(from: pickleKeyData)
             
             // Store it on the backend
             try await storeSecret(base64PickleKey, secretId: secretId, secretStorageKeys: [secretStorageKeyId: privateKeyData])
@@ -131,10 +131,10 @@ public class DehydrationService: NSObject {
     
     // MARK: - Device dehydration
     
-    private func dehydrateDevice(pickleKeyData: [UInt8]) async throws {
-        let dehydratedDevice = dehydratedDevices.create()
+    private func dehydrateDevice(pickleKeyData: Data) async throws {
+        let dehydratedDevice = try dehydratedDevices.create()
 
-        let requestDetails = try dehydratedDevice.keysForUpload(deviceDisplayName: deviceDisplayName, pickleKey: [UInt8](pickleKeyData))
+        let requestDetails = try dehydratedDevice.keysForUpload(deviceDisplayName: deviceDisplayName, pickleKey: pickleKeyData)
         
         let parameters = MXDehydratedDeviceCreationParameters()
         parameters.body = requestDetails.body
@@ -150,7 +150,7 @@ public class DehydrationService: NSObject {
         }
     }
     
-    private func rehydrateDevice(pickleKeyData: [UInt8]) async -> Result<(deviceId: String, rehydratedDevice: RehydratedDeviceProtocol), DehydrationServiceError>  {
+    private func rehydrateDevice(pickleKeyData: Data) async -> Result<(deviceId: String, rehydratedDevice: RehydratedDeviceProtocol), DehydrationServiceError>  {
         await withCheckedContinuation { continuation in
             self.restClient.retrieveDehydratedDevice { [weak self] dehydratedDevice in
                 guard let self else { return }
@@ -163,7 +163,7 @@ public class DehydrationService: NSObject {
                 }
                 
                 do {
-                    let rehydratedDevice = try self.dehydratedDevices.rehydrate(pickleKey: [UInt8](pickleKeyData), deviceId: dehydratedDevice.deviceId, deviceData: deviceDataJSON)
+                    let rehydratedDevice = try self.dehydratedDevices.rehydrate(pickleKey: pickleKeyData, deviceId: dehydratedDevice.deviceId, deviceData: deviceDataJSON)
                     continuation.resume(returning: .success((dehydratedDevice.deviceId, rehydratedDevice)))
                 } catch {
                     continuation.resume(returning: .failure(DehydrationServiceError.failedRehydration(error)))

--- a/MatrixSDK/Crypto/Migration/Data/MXCryptoMigrationStore.swift
+++ b/MatrixSDK/Crypto/Migration/Data/MXCryptoMigrationStore.swift
@@ -54,7 +54,7 @@ struct MXCryptoMigrationStore {
             account: try pickledAccount(pickleKey: pickleKey),
             sessions: [], // Sessions are extracted in batches separately
             inboundGroupSessions: [], // Group sessions are extracted in batches separately
-            pickleKey: [UInt8](pickleKey),
+            pickleKey: pickleKey,
             backupVersion: legacyStore.backupVersion,
             backupRecoveryKey: backupRecoveryKey(),
             crossSigning: crossSigning(),
@@ -194,7 +194,7 @@ private extension PickledAccount {
 private extension PickledSession {
     init(session: MXOlmSession, pickleKey: Data) throws {
         let pickle = try session.session.serializeData(withKey: pickleKey)
-        let time = "\(Int(session.lastReceivedMessageTs))"
+        let time = UInt64(session.lastReceivedMessageTs)
         
         self.init(
             pickle: pickle,

--- a/MatrixSDKTests/Crypto/CryptoMachine/Device+Stub.swift
+++ b/MatrixSDKTests/Crypto/CryptoMachine/Device+Stub.swift
@@ -41,7 +41,8 @@ extension Device {
             isBlocked: isBlocked,
             locallyTrusted: locallyTrusted,
             crossSigningTrusted: crossSigningTrusted,
-            firstTimeSeenTs: 0
+            firstTimeSeenTs: 0,
+            dehydrated: false
         )
     }
 }

--- a/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoProtocolStubs.swift
+++ b/MatrixSDKTests/Crypto/CryptoMachine/MXCryptoProtocolStubs.swift
@@ -143,7 +143,8 @@ class CryptoCrossSigningStub: CryptoIdentityStub, MXCryptoCrossSigning {
             locallyTrusted: device.locallyTrusted,
             // Modify cross signing trusted
             crossSigningTrusted: true,
-            firstTimeSeenTs: 0
+            firstTimeSeenTs: 0,
+            dehydrated: false
         )
     }
     

--- a/MatrixSDKTests/Crypto/Migration/Data/MXCryptoMigrationStoreUnitTests.swift
+++ b/MatrixSDKTests/Crypto/Migration/Data/MXCryptoMigrationStoreUnitTests.swift
@@ -141,8 +141,8 @@ class MXCryptoMigrationStoreUnitTests: XCTestCase {
         XCTAssertEqual(sessions[0].pickle, pickle)
         XCTAssertEqual(sessions[0].senderKey, "XYZ")
         XCTAssertFalse(sessions[0].createdUsingFallbackKey)
-        XCTAssertEqual(sessions[0].creationTime, "123")
-        XCTAssertEqual(sessions[0].lastUseTime, "123")
+        XCTAssertEqual(sessions[0].creationTime, 123)
+        XCTAssertEqual(sessions[0].lastUseTime, 123)
     }
     
     func test_extractsMultipleSessionsInBatches() throws {
@@ -235,7 +235,7 @@ class MXCryptoMigrationStoreUnitTests: XCTestCase {
     func test_extractsPickeKey() throws {
         let pickleKey = "some key".data(using: .ascii)!
         let key = try extractData(pickleKey: pickleKey).pickleKey
-        XCTAssertEqual(key, [UInt8](pickleKey))
+        XCTAssertEqual(key, pickleKey)
     }
     
     func test_extractsCrossSigning() throws {

--- a/MatrixSDKTests/Crypto/Verification/Transactions/QRCode/QrCodeStub.swift
+++ b/MatrixSDKTests/Crypto/Verification/Transactions/QRCode/QrCodeStub.swift
@@ -18,7 +18,7 @@ import Foundation
 
 import MatrixSDKCrypto
 
-struct QrCodeStub: QrCodeProtocol {
+class QrCodeStub: QrCodeProtocol {
     private let _otherUserId: String
     private let _otherDeviceId: String
     private let _flowId: String

--- a/MatrixSDKTests/Crypto/Verification/Transactions/SAS/SasStub.swift
+++ b/MatrixSDKTests/Crypto/Verification/Transactions/SAS/SasStub.swift
@@ -18,7 +18,7 @@ import Foundation
 
 import MatrixSDKCrypto
 
-struct SasStub: SasProtocol {
+class SasStub: SasProtocol {
     
     private let _otherUserId: String
     private let _otherDeviceId: String

--- a/Podfile
+++ b/Podfile
@@ -28,7 +28,7 @@ abstract_target 'MatrixSDK' do
     end
     
     target 'MatrixSDK-macOS' do
-        platform :osx, '10.10'
+        platform :osx, '10.15'
 
         target 'MatrixSDKTests-macOS' do
             inherit! :search_paths

--- a/Podfile
+++ b/Podfile
@@ -40,7 +40,7 @@ end
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     target.build_configurations.each do |config|
-      config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '11.0'
+      config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '13.0'
     end
   end
 end

--- a/Podfile
+++ b/Podfile
@@ -16,10 +16,10 @@ abstract_target 'MatrixSDK' do
     
     pod 'Realm', '10.27.0'
     pod 'libbase58', '~> 0.1.4'
-    pod 'MatrixSDKCrypto', "0.3.13", :inhibit_warnings => true
+    pod 'MatrixSDKCrypto', '0.4.1', :inhibit_warnings => true
     
     target 'MatrixSDK-iOS' do
-        platform :ios, '11.0'
+        platform :ios, '13.0'
         
         target 'MatrixSDKTests-iOS' do
             inherit! :search_paths

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -14,9 +14,9 @@ PODS:
   - AFNetworking/Serialization (4.0.1)
   - AFNetworking/UIKit (4.0.1):
     - AFNetworking/NSURLSession
-  - GZIP (1.3.0)
+  - GZIP (1.3.2)
   - libbase58 (0.1.4)
-  - MatrixSDKCrypto (0.3.13)
+  - MatrixSDKCrypto (0.4.1)
   - OHHTTPStubs (9.1.0):
     - OHHTTPStubs/Default (= 9.1.0)
   - OHHTTPStubs/Core (9.1.0)
@@ -44,7 +44,7 @@ DEPENDENCIES:
   - AFNetworking (~> 4.0.0)
   - GZIP (~> 1.3.0)
   - libbase58 (~> 0.1.4)
-  - MatrixSDKCrypto (= 0.3.13)
+  - MatrixSDKCrypto (= 0.4.1)
   - OHHTTPStubs (~> 9.1.0)
   - OLMKit (~> 3.2.5)
   - Realm (= 10.27.0)
@@ -63,14 +63,14 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   AFNetworking: 3bd23d814e976cd148d7d44c3ab78017b744cd58
-  GZIP: 416858efbe66b41b206895ac6dfd5493200d95b3
+  GZIP: 3c0abf794bfce8c7cb34ea05a1837752416c8868
   libbase58: 7c040313537b8c44b6e2d15586af8e21f7354efd
-  MatrixSDKCrypto: bf08b72f2cd015d8749420a2b8b92fc0536bedf4
+  MatrixSDKCrypto: da2b8a81f7e1989fc61ff85ed6aad92332beeb40
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   OLMKit: da115f16582e47626616874e20f7bb92222c7a51
   Realm: 9ca328bd7e700cc19703799785e37f77d1a130f2
   SwiftyBeaver: 84069991dd5dca07d7069100985badaca7f0ce82
 
-PODFILE CHECKSUM: 1bf28f5a19566c567d265232f60ee19a3ae86ed3
+PODFILE CHECKSUM: bce6f6e7af7aa0ac9a50d4f6594d923fc00ed168
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.15.2

--- a/build.sh
+++ b/build.sh
@@ -8,8 +8,8 @@ pod install
 if [ $1 == 'xcframework' ]	# optionally supports additional arguments for CFBundleShortVersionString and CFBundleVersion
 then
 	# archive the framework for iOS, macOS, Catalyst and the Simulator
-	xcodebuild archive -workspace MatrixSDK.xcworkspace -scheme MatrixSDK-iOS -destination "generic/platform=iOS" -archivePath build/MatrixSDK-iOS SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES IPHONEOS_DEPLOYMENT_TARGET=11.0 GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS=NO MARKETING_VERSION=$2 CURRENT_PROJECT_VERSION=$3
-	xcodebuild archive -workspace MatrixSDK.xcworkspace -scheme MatrixSDK-iOS -destination "generic/platform=iOS Simulator" -archivePath build/MatrixSDK-iOSSimulator SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES IPHONEOS_DEPLOYMENT_TARGET=11.0 GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS=NO MARKETING_VERSION=$2 CURRENT_PROJECT_VERSION=$3
+	xcodebuild archive -workspace MatrixSDK.xcworkspace -scheme MatrixSDK-iOS -destination "generic/platform=iOS" -archivePath build/MatrixSDK-iOS SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES IPHONEOS_DEPLOYMENT_TARGET=13.0 GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS=NO MARKETING_VERSION=$2 CURRENT_PROJECT_VERSION=$3
+	xcodebuild archive -workspace MatrixSDK.xcworkspace -scheme MatrixSDK-iOS -destination "generic/platform=iOS Simulator" -archivePath build/MatrixSDK-iOSSimulator SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES IPHONEOS_DEPLOYMENT_TARGET=13.0 GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS=NO MARKETING_VERSION=$2 CURRENT_PROJECT_VERSION=$3
 	xcodebuild archive -workspace MatrixSDK.xcworkspace -scheme MatrixSDK-macOS -destination "generic/platform=macOS" -archivePath build/MatrixSDK-macOS SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES MACOSX_DEPLOYMENT_TARGET=10.10 GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS=NO MARKETING_VERSION=$2 CURRENT_PROJECT_VERSION=$3
 	xcodebuild archive -workspace MatrixSDK.xcworkspace -scheme MatrixSDK-iOS -destination "generic/platform=macOS,variant=Mac Catalyst" -archivePath ./build/MatrixSDK-MacCatalyst SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES IPHONEOS_DEPLOYMENT_TARGET=13.0 GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS=NO MARKETING_VERSION=$2 CURRENT_PROJECT_VERSION=$3
 

--- a/changelog.d/pr-1853.change
+++ b/changelog.d/pr-1853.change
@@ -1,0 +1,1 @@
+Crypto: Update crypto SDK to 0.4.1


### PR DESCRIPTION
Updates crypto sdk version to [0.4.1](https://github.com/matrix-org/matrix-rust-sdk/releases/tag/matrix-sdk-crypto-ffi-0.4.1)

Some breaking changes:
- some key data can directly be passed as Data instead of UInt8 array. 
- Other changes on pickle format.
- `bootstrapCrossSigning` now returning an optional device key upload


**Updated the minimum ios version to 13, was previously 11.0 (to match the new pod min)**
**Updated the minimum osx version to 10.15, was previously 10.10**

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request contains a changelog file in ./changelog.d. See https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog
* [ ] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
