### PR TITLE
Invalidate crypto store cache when entering foreground

### DIFF
--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -45,7 +45,7 @@ Pod::Spec.new do |s|
       ss.dependency 'OLMKit', '~> 3.2.5'
       ss.dependency 'Realm', '10.27.0'
       ss.dependency 'libbase58', '~> 0.1.4'
-      ss.dependency 'MatrixSDKCrypto', '0.4.1', :configurations => ["DEBUG", "RELEASE"], :inhibit_warnings => true
+      ss.dependency 'MatrixSDKCrypto', '0.4.2', :configurations => ["DEBUG", "RELEASE"], :inhibit_warnings => true
   end
 
   s.subspec 'JingleCallStack' do |ss|

--- a/MatrixSDK/Crypto/Algorithms/RoomEvent/MXRoomEventDecryption.swift
+++ b/MatrixSDK/Crypto/Algorithms/RoomEvent/MXRoomEventDecryption.swift
@@ -227,12 +227,13 @@ actor MXRoomEventDecryption: MXRoomEventDecrypting {
             ])
             return trackedDecryptionResult(for: event, error: error)
             
-        case .MissingRoomKey(let message):
+        case .MissingRoomKey(let message, let withheldCode):
             if undecryptedEvents[sessionId] == nil {
                 log.error("Failed to decrypt event(s) due to missing room keys", context: [
                     "session_id": sessionId,
                     "message": message,
                     "error": error,
+                    "withheldCode": withheldCode ?? "N/A",
                     "details": "further errors for the same key will be supressed",
                 ])
             }

--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoMachine.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoMachine.swift
@@ -116,6 +116,10 @@ class MXCryptoMachine {
         }
     }
     
+    func invalidateCache() async {
+        await machine.clearCryptoCache()
+    }
+    
     // MARK: - Private
     
     private static func createMachine(userId: String, deviceId: String, log: MXNamedLog) throws -> OlmMachine {

--- a/MatrixSDK/Crypto/Dehydration/DehydrationService.swift
+++ b/MatrixSDK/Crypto/Dehydration/DehydrationService.swift
@@ -89,8 +89,9 @@ public class DehydrationService: NSObject {
             try await dehydrateDevice(pickleKeyData: pickleKeyData)
         } else { // Otherwise, generate a new dehydration pickle key, store it and dehydrate a device
             // Generate a new dehydration pickle key
-            var pickleKeyData = Data(count: 32)
-            _ = SecRandomCopyBytes(kSecRandomDefault, 32, &pickleKeyData)
+            var pickleKeyRaw = [UInt8](repeating: 0, count: 32)
+            _ = SecRandomCopyBytes(kSecRandomDefault, 32, &pickleKeyRaw)
+            let pickleKeyData = Data(bytes: pickleKeyRaw, count: 32)
             
             // Convert it to unpadded base 64
             let base64PickleKey = MXBase64Tools.unpaddedBase64(from: pickleKeyData)

--- a/MatrixSDK/Crypto/MXCrypto.h
+++ b/MatrixSDK/Crypto/MXCrypto.h
@@ -378,6 +378,8 @@ extern NSString *const MXDeviceListDidUpdateUsersDevicesNotification;
  */
 - (void)setBlacklistUnverifiedDevicesInRoom:(NSString *)roomId blacklist:(BOOL)blacklist;
 
+- (void) invalidateCache:(void (^)(void))done;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/MatrixSDK/Crypto/MXCryptoV2.swift
+++ b/MatrixSDK/Crypto/MXCryptoV2.swift
@@ -20,6 +20,7 @@ import MatrixSDKCrypto
 /// An implementation of `MXCrypto` which uses [matrix-rust-sdk](https://github.com/matrix-org/matrix-rust-sdk/tree/main/crates/matrix-sdk-crypto)
 /// under the hood.
 class MXCryptoV2: NSObject, MXCrypto {
+
     enum Error: Swift.Error {
         case cannotUnsetTrust
         case backupNotEnabled
@@ -720,4 +721,13 @@ class MXCryptoV2: NSObject, MXCrypto {
                 return dict[info.userId] = info
             }
     }
-}
+    
+    func invalidateCache(_ done: @escaping () -> Void) {
+        Task {
+            log.debug("Invalidating Olm Machine crypto store cache.")
+            await machine.invalidateCache()
+            await MainActor.run {
+                done()
+            }
+        }
+    }}

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -1150,9 +1150,18 @@ typedef void (^MXOnResumeDone)(void);
 
 - (void)resume:(void (^)(void))resumeDone
 {
-    [self handleBackgroundSyncCacheIfRequiredWithCompletion:^{
-        [self _resume:resumeDone];
-    }];
+    // The app has resumed there might have been a NSE run that have invalidated the cache
+    if (self.crypto) {
+        [self.crypto invalidateCache:^{
+            [self handleBackgroundSyncCacheIfRequiredWithCompletion:^{
+                [self _resume:resumeDone];
+            }];
+        }];
+    } else {
+        [self handleBackgroundSyncCacheIfRequiredWithCompletion:^{
+            [self _resume:resumeDone];
+        }];
+    }
 }
 
 - (void)_resume:(void (^)(void))resumeDone

--- a/Podfile
+++ b/Podfile
@@ -16,7 +16,7 @@ abstract_target 'MatrixSDK' do
     
     pod 'Realm', '10.27.0'
     pod 'libbase58', '~> 0.1.4'
-    pod 'MatrixSDKCrypto', '0.4.1', :inhibit_warnings => true
+    pod 'MatrixSDKCrypto', '0.4.2', :inhibit_warnings => true
     
     target 'MatrixSDK-iOS' do
         platform :ios, '13.0'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -16,7 +16,7 @@ PODS:
     - AFNetworking/NSURLSession
   - GZIP (1.3.2)
   - libbase58 (0.1.4)
-  - MatrixSDKCrypto (0.4.1)
+  - MatrixSDKCrypto (0.4.2)
   - OHHTTPStubs (9.1.0):
     - OHHTTPStubs/Default (= 9.1.0)
   - OHHTTPStubs/Core (9.1.0)
@@ -44,7 +44,7 @@ DEPENDENCIES:
   - AFNetworking (~> 4.0.0)
   - GZIP (~> 1.3.0)
   - libbase58 (~> 0.1.4)
-  - MatrixSDKCrypto (= 0.4.1)
+  - MatrixSDKCrypto (= 0.4.2)
   - OHHTTPStubs (~> 9.1.0)
   - OLMKit (~> 3.2.5)
   - Realm (= 10.27.0)
@@ -65,12 +65,12 @@ SPEC CHECKSUMS:
   AFNetworking: 3bd23d814e976cd148d7d44c3ab78017b744cd58
   GZIP: 3c0abf794bfce8c7cb34ea05a1837752416c8868
   libbase58: 7c040313537b8c44b6e2d15586af8e21f7354efd
-  MatrixSDKCrypto: da2b8a81f7e1989fc61ff85ed6aad92332beeb40
+  MatrixSDKCrypto: 736069ee0a5ec12852ab3498bf2242acecc443fc
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   OLMKit: da115f16582e47626616874e20f7bb92222c7a51
   Realm: 9ca328bd7e700cc19703799785e37f77d1a130f2
   SwiftyBeaver: 84069991dd5dca07d7069100985badaca7f0ce82
 
-PODFILE CHECKSUM: bce6f6e7af7aa0ac9a50d4f6594d923fc00ed168
+PODFILE CHECKSUM: 37ab0de0200808bcd3335a637e31736df60fc62e
 
 COCOAPODS: 1.15.2


### PR DESCRIPTION
### Pull Request Checklist

depends on https://github.com/matrix-org/matrix-rust-sdk/pull/3462

Partial fix for the NSE process causing olm session wedging.
See element-x related issue https://github.com/matrix-org/matrix-rust-sdk/issues/3110.

The crypto store is keeping a cache of olm sessions for a given device. When using multiprocess this cache will get outdated and causing session wedging.
If the main app is inactive and the NSE do process a sync new olm sessions might be created (or mutated, like when replying to a key request). If the main process is then resumed it will use it's outdated cache instead of reloading from store.

The improvement here is that we will invalidate the cache when the main app enters foreground to limit the possible occurences of outdated caches.

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request contains a changelog file in ./changelog.d. See https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog
* [ ] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
