### PR TITLE
Fix | Share room keys with dehydrated devices with rust stack

### DIFF
--- a/MatrixSDK/Categories/MXKeysQueryResponse+Extensions.swift
+++ b/MatrixSDK/Categories/MXKeysQueryResponse+Extensions.swift
@@ -39,3 +39,27 @@ extension MXKeysQueryResponse : MXSummable {
         return keysQueryResponse as! Self
     }
 }
+
+
+extension MXKeysQueryResponseRaw : MXSummable {
+    
+    public static func +(lhs: MXKeysQueryResponseRaw, rhs: MXKeysQueryResponseRaw) -> Self {
+        let keysQueryResponse = MXKeysQueryResponseRaw()
+        
+        // Casts to original objc NSDictionary are annoying
+        // but we want to reuse our implementation of NSDictionary.+
+        let deviceKeysMap = (lhs.deviceKeys as NSDictionary? ?? NSDictionary())
+        + (rhs.deviceKeys as NSDictionary? ?? NSDictionary())
+        keysQueryResponse.deviceKeys = deviceKeysMap as? [String : Any]
+        
+        let crossSigningKeys = (lhs.crossSigningKeys as NSDictionary? ?? NSDictionary())
+            + (rhs.crossSigningKeys as NSDictionary? ?? NSDictionary())
+        keysQueryResponse.crossSigningKeys = crossSigningKeys as? [String: MXCrossSigningInfo]
+        
+        let failures = (lhs.failures as NSDictionary? ?? NSDictionary())
+            + (rhs.failures as NSDictionary? ?? NSDictionary())
+        keysQueryResponse.failures = failures as? [AnyHashable : Any]
+        
+        return keysQueryResponse as! Self
+    }
+}

--- a/MatrixSDK/Categories/MXRestClient+Extensions.swift
+++ b/MatrixSDK/Categories/MXRestClient+Extensions.swift
@@ -89,4 +89,75 @@ public extension MXRestClient {
         
         return operation
     }
+    
+    /// Download users keys by chunks.
+    ///
+    /// - Parameters:
+    ///   - users: list of users to get keys for.
+    ///   - token: sync token to pass in the query request, to help.
+    ///   - chunkSize: max number of users to ask for in one CS API request.
+    ///   - success: A block object called when the operation succeeds.
+    ///   - failure: A block object called when the operation fails.
+    /// - Returns: a MXHTTPOperation instance.
+    func downloadKeysByChunkRaw(forUsers users: [String],
+                             token: String?,
+                             chunkSize: Int = 250,
+                             success: @escaping (_ keysQueryResponse: MXKeysQueryResponseRaw) -> Void,
+                             failure: @escaping (_ error: NSError?) -> Void) -> MXHTTPOperation {
+        
+        // Do not chunk if not needed
+        if users.count <= chunkSize {
+            return self.downloadKeysRaw(forUsers: users, token: token) { response in
+                switch response {
+                    case .success(let keysQueryResponse):
+                        success(keysQueryResponse)
+                    case .failure(let error):
+                        failure(error as NSError)
+                }
+            }
+        }
+        
+        MXLog.debug("[MXRestClient+Extensions] downloadKeysByChunk: \(users.count) users with chunkSize:\(chunkSize)")
+        
+        // An arbitrary MXHTTPOperation. It will not cancel requests
+        // but it will avoid to call callbacks in case of a cancellation is requested
+        let operation = MXHTTPOperation()
+        
+        let group = DispatchGroup()
+        var responses = [MXResponse<MXKeysQueryResponseRaw>]()
+        users.chunked(into: chunkSize).forEach { chunkedUsers in
+            group.enter()
+            self.downloadKeysRaw(forUsers: chunkedUsers, token: token) { response in
+                switch response {
+                    case .success(let keysQueryResponse):
+                        MXLog.debug("[MXRestClient+Extensions] downloadKeysByChunk: Got intermediate response. Got device keys for %@ users. Got cross-signing keys for %@ users \(String(describing: keysQueryResponse.deviceKeys.keys.count)) \(String(describing: keysQueryResponse.crossSigningKeys.count))")
+                    case .failure(let error):
+                        MXLog.debug("[MXRestClient+Extensions] downloadKeysByChunk: Got intermediate error. Error: \(error)")
+                }
+
+                responses.append(response)
+                group.leave()
+            }
+        }
+        
+        group.notify(queue: self.completionQueue) {
+            MXLog.debug("[MXRestClient+Extensions] downloadKeysByChunk: Got all responses")
+                
+            guard operation.isCancelled == false else {
+                MXLog.debug("[MXRestClient+Extensions] downloadKeysByChunk: Request was cancelled")
+                return
+            }
+            
+            // Gather all responses in one
+            let response = responses.reduce(.success(MXKeysQueryResponseRaw()), +)
+            switch response {
+                case .success(let keysQueryResponse):
+                    success(keysQueryResponse)
+                case .failure(let error):
+                    failure(error as NSError)
+            }
+        }
+        
+        return operation
+    }
 }

--- a/MatrixSDK/Contrib/Swift/MXRestClient.swift
+++ b/MatrixSDK/Contrib/Swift/MXRestClient.swift
@@ -1848,6 +1848,10 @@ public extension MXRestClient {
         return __downloadKeys(forUsers: userIds, token: token, success: currySuccess(completion), failure: curryFailure(completion))
     }
     
+    @nonobjc @discardableResult func downloadKeysRaw(forUsers userIds: [String], token: String? = nil, completion: @escaping (_ response: MXResponse<MXKeysQueryResponseRaw>) -> Void) -> MXHTTPOperation {
+        return __downloadKeysRaw(forUsers: userIds, token: token, success: currySuccess(completion), failure: curryFailure(completion))
+    }
+    
     
     /**
      Claim one-time keys.

--- a/MatrixSDK/Crypto/CryptoMachine/MXCryptoRequests.swift
+++ b/MatrixSDK/Crypto/CryptoMachine/MXCryptoRequests.swift
@@ -21,13 +21,13 @@ import MatrixSDKCrypto
 /// to the native REST API client
 struct MXCryptoRequests {
     private let restClient: MXRestClient
-    private let queryScheduler: MXKeysQueryScheduler<MXKeysQueryResponse>
+    private let queryScheduler: MXKeysQueryScheduler<MXKeysQueryResponseRaw>
     
     init(restClient: MXRestClient) {
         self.restClient = restClient
         self.queryScheduler = .init { users in
             try await performCallbackRequest { completion in
-                _ = restClient.downloadKeysByChunk(
+                _ = restClient.downloadKeysByChunkRaw(
                     forUsers: users,
                     token: nil,
                     success: {
@@ -96,7 +96,7 @@ struct MXCryptoRequests {
         }
     }
     
-    func queryKeys(users: [String]) async throws -> MXKeysQueryResponse {
+    func queryKeys(users: [String]) async throws -> MXKeysQueryResponseRaw {
         try await queryScheduler.query(users: Set(users))
     }
     

--- a/MatrixSDK/JSONModels/MXJSONModels.h
+++ b/MatrixSDK/JSONModels/MXJSONModels.h
@@ -1125,6 +1125,25 @@ FOUNDATION_EXPORT NSString *const kMXPushRuleScopeStringGlobal;
 
 @end
 
+@interface MXKeysQueryResponseRaw : MXJSONModel
+
+    /**
+     The device keys per devices per users.
+     */
+    @property (nonatomic) NSDictionary<NSString *, id> *deviceKeys;
+
+    /**
+     Cross-signing keys per users.
+     */
+    @property (nonatomic) NSDictionary<NSString*, MXCrossSigningInfo*> *crossSigningKeys;
+
+    /**
+     The failures sorted by homeservers.
+    */
+    @property (nonatomic) NSDictionary *failures;
+
+@end
+
 /**
  `MXKeysClaimResponse` represents the response to /keys/claim request made by
  [MXRestClient claimOneTimeKeysForUsersDevices].

--- a/MatrixSDK/MXRestClient.h
+++ b/MatrixSDK/MXRestClient.h
@@ -2485,6 +2485,10 @@ Note: Clients should consider avoiding this endpoint for URLs posted in encrypte
                                  success:(void (^)(MXKeysQueryResponse *keysQueryResponse))success
                                  failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 
+- (MXHTTPOperation*)downloadKeysRawForUsers:(NSArray<NSString*>*)userIds
+                                   token:(NSString*)token
+                                 success:(void (^)(MXKeysQueryResponseRaw *keysQueryResponse))success
+                                 failure:(void (^)(NSError *error))failure NS_REFINED_FOR_SWIFT;
 /**
  * Claim one-time keys.
 


### PR DESCRIPTION
### Pull Request Checklist

Fixes https://github.com/element-hq/element-ios/issues/7795

The new [MSC3814](https://github.com/matrix-org/matrix-spec-proposals/pull/3814)https://github.com/matrix-org/matrix-spec-proposals/pull/3814 is introducing a new format for dehydrated devices (to get messages even if all your sessions are logged out). 
As per the new format, the DeviceKey payload from a keys/query call now contains a new boolean field `dehydrated`, that is used when computing the signature.
The problem is that the SDK converts the http response to a JSON Model `MXKeysQueryResponse` and this model was not aware of that field. As a consequence when passing back the response to rust via `markRequestAsSent` using `model.jsonString()`, the `dehydrated` field was dropped, thus the rust layer was refusing the device because the signature was invalid.


First approach would be to add the `dehydrated` field to the model, but this is not very future proof as any new future field would cause the same problem.
The rust crypto stack also just pass this payload and is not using it (the legacy stack neeeded the typed model).

Unfortunatly I cannot just modify the existing model to just use a generic Dictionnary because some parts of the sdk for the legacy crypto still needed it.
So I created a new `MXKeysQueryResponseRaw` almost similar to the existing `MXKeysQueryResponse`, but that is not trying to convert the device info to a typed model. This is now used by the rust layer to query and pass back to the olm machine.

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request contains a changelog file in ./changelog.d. See https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog
* [ ] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
