### PR TITLE
Fix CallKit audio session late init

### DIFF
--- a/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.m
+++ b/MatrixSDK/VoIP/CallKit/MXCallKitAdapter.m
@@ -226,6 +226,14 @@ NSString * const kMXCallKitAdapterAudioSessionDidActive = @"kMXCallKitAdapterAud
     update.supportsUngrouping = NO;
     update.supportsDTMF = NO;
     
+    // If the user tap the "Answer" button from Element's timeline, very often, he can't hear the other user.
+    // It's because the audio session is not configured at the beginiing of the call.
+    // It's a flaw in CallKit implementation.
+    // The audio session need to be configured earlier, like here.
+    //
+    // See https://developer.apple.com/forums/thread/64544 (7th post from Apple Engineer)
+    [self.audioSessionConfigurator configureAudioSessionForVideoCall:call.isVideoCall];
+    
     [self.provider reportNewIncomingCallWithUUID:callUUID update:update completion:^(NSError * _Nullable error) {
         if (error)
         {

--- a/changelog.d/pr-1866.bugfix
+++ b/changelog.d/pr-1866.bugfix
@@ -1,0 +1,1 @@
+Fix CallKit audio session late init in VoIP call.


### PR DESCRIPTION
Fix a bug in Element iOS : when the user answer a VoIP call from the "Answer" button in Element room timeline, very often, his correspondant can't hear him.

It's because the Audio Session is initialized too late. See https://developer.apple.com/forums/thread/64544 (7th post from Apple Engineer)

See this issue in Element Github: https://github.com/element-hq/element-ios/issues/7721

See this issue in Tchap: https://github.com/tchapgouv/tchap-ios/issues/1047

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request contains a changelog file in ./changelog.d. See https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)