### PR TITLE
Expose mxroompowerlevels swift wrappers to element

### DIFF
--- a/MatrixSDK/Contrib/Swift/JSONModels/MXRoomPowerLevels.swift
+++ b/MatrixSDK/Contrib/Swift/JSONModels/MXRoomPowerLevels.swift
@@ -25,7 +25,7 @@ extension MXRoomPowerLevels {
      - parameter eventType: the type of event.
      - returns: the required minimum power level.
      */
-    @nonobjc func minimumPowerLevelForSendingMessageEvent(_ eventType: MXEventType) -> Int {
+    @nonobjc public func minimumPowerLevelForSendingMessageEvent(_ eventType: MXEventType) -> Int {
         return __minimumPowerLevelForSendingEvent(asMessage: eventType.identifier)
     }
     
@@ -36,7 +36,7 @@ extension MXRoomPowerLevels {
      - parameter eventType: the type of event.
      - returns: the required minimum power level.
      */
-    @nonobjc func minimumPowerLevelForSendingStateEvent(_ eventType: MXEventType) -> Int {
+    @nonobjc public func minimumPowerLevelForSendingStateEvent(_ eventType: MXEventType) -> Int {
         return __minimumPowerLevelForSendingEvent(asStateEvent: eventType.identifier)
     }
     

--- a/MatrixSDK/Data/RoomList/Common/MXRoomListDataSortable.swift
+++ b/MatrixSDK/Data/RoomList/Common/MXRoomListDataSortable.swift
@@ -52,7 +52,7 @@ extension MXRoomListDataSortable {
 //        }
         
         if sortOptions.alphabetical {
-            result.append(NSSortDescriptor(keyPath: \MXRoomSummaryProtocol.displayName, ascending: true))
+            result.append(NSSortDescriptor(key: "displayName", ascending: true, selector: #selector(NSString.localizedCaseInsensitiveCompare(_:))))
         }
         
         if sortOptions.invitesFirst {

--- a/MatrixSDK/Data/RoomList/Common/MXRoomListDataSortable.swift
+++ b/MatrixSDK/Data/RoomList/Common/MXRoomListDataSortable.swift
@@ -52,7 +52,7 @@ extension MXRoomListDataSortable {
 //        }
         
         if sortOptions.alphabetical {
-            result.append(NSSortDescriptor(key: "displayName", ascending: true, selector: #selector(NSString.localizedCaseInsensitiveCompare(_:))))
+            result.append(NSSortDescriptor(key: "displayName", ascending: true, selector: #selector(NSString.localizedStandardCompare(_:))))
         }
         
         if sortOptions.invitesFirst {

--- a/MatrixSDK/Data/RoomList/CoreData/MXCoreDataRoomListDataFetcher.swift
+++ b/MatrixSDK/Data/RoomList/CoreData/MXCoreDataRoomListDataFetcher.swift
@@ -250,7 +250,7 @@ extension MXCoreDataRoomListDataFetcher: MXRoomListDataSortable {
         var result: [NSSortDescriptor] = []
         
         if sortOptions.alphabetical {
-            result.append(NSSortDescriptor(key: "s_displayName", ascending: true, selector: #selector(NSString.localizedCaseInsensitiveCompare(_:))))
+            result.append(NSSortDescriptor(key: "s_displayName", ascending: true, selector: #selector(NSString.localizedStandardCompare(_:))))
         }
         
         if sortOptions.invitesFirst {

--- a/MatrixSDK/Data/RoomList/CoreData/MXCoreDataRoomListDataFetcher.swift
+++ b/MatrixSDK/Data/RoomList/CoreData/MXCoreDataRoomListDataFetcher.swift
@@ -250,7 +250,7 @@ extension MXCoreDataRoomListDataFetcher: MXRoomListDataSortable {
         var result: [NSSortDescriptor] = []
         
         if sortOptions.alphabetical {
-            result.append(NSSortDescriptor(keyPath: \MXRoomSummaryMO.s_displayName, ascending: true))
+            result.append(NSSortDescriptor(key: "s_displayName", ascending: true, selector: #selector(NSString.localizedCaseInsensitiveCompare(_:))))
         }
         
         if sortOptions.invitesFirst {

--- a/changelog.d/pr-1851.change
+++ b/changelog.d/pr-1851.change
@@ -1,0 +1,1 @@
+When sorting room list alphabetically, sort it case-insensitive.

--- a/changelog.d/pr-1867.change
+++ b/changelog.d/pr-1867.change
@@ -1,0 +1,1 @@
+Expose MXRroomPowerLevels Swift wrappers to Element

--- a/changelog.d/sort-room-list-alphabetically-case-insensitive.change
+++ b/changelog.d/sort-room-list-alphabetically-case-insensitive.change
@@ -1,0 +1,1 @@
+Prevent crash when sending file with unrecognised file extension (no associated mime type)

--- a/changelog.d/sort-room-list-alphabetically-case-insensitive.change
+++ b/changelog.d/sort-room-list-alphabetically-case-insensitive.change
@@ -1,1 +1,0 @@
-Prevent crash when sending file with unrecognised file extension (no associated mime type)


### PR DESCRIPTION
Expose 2 methods from extension MXRoomPowerLevels to be available to client (like Element or Tchap).

Needed to check user room power level when live sharing location in room.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [X] Pull request is based on the develop branch
* [X] Pull request contains a changelog file in ./changelog.d. See https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog
* [X] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
