### PR TITLE
Expose MXRroomPowerLevels Swift wrappers to Element

### DIFF
--- a/MatrixSDK/Contrib/Swift/JSONModels/MXRoomPowerLevels.swift
+++ b/MatrixSDK/Contrib/Swift/JSONModels/MXRoomPowerLevels.swift
@@ -25,7 +25,7 @@ extension MXRoomPowerLevels {
      - parameter eventType: the type of event.
      - returns: the required minimum power level.
      */
-    @nonobjc func minimumPowerLevelForSendingMessageEvent(_ eventType: MXEventType) -> Int {
+    @nonobjc public func minimumPowerLevelForSendingMessageEvent(_ eventType: MXEventType) -> Int {
         return __minimumPowerLevelForSendingEvent(asMessage: eventType.identifier)
     }
     
@@ -36,7 +36,7 @@ extension MXRoomPowerLevels {
      - parameter eventType: the type of event.
      - returns: the required minimum power level.
      */
-    @nonobjc func minimumPowerLevelForSendingStateEvent(_ eventType: MXEventType) -> Int {
+    @nonobjc public func minimumPowerLevelForSendingStateEvent(_ eventType: MXEventType) -> Int {
         return __minimumPowerLevelForSendingEvent(asStateEvent: eventType.identifier)
     }
     

--- a/changelog.d/pr-1869.change
+++ b/changelog.d/pr-1869.change
@@ -1,0 +1,1 @@
+Expose MXRroomPowerLevels Swift wrappers to Element


### PR DESCRIPTION
Expose 2 methods from extension MXRoomPowerLevels to be available to client (like Element or Tchap).

Needed to check user room power level when live sharing location in room.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [X] Pull request is based on the develop branch
* [X] Pull request contains a changelog file in ./changelog.d. See https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog
* [X] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
