### PR TITLE
bring in line with foundation DCO

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,11 +155,6 @@ include the line in your commit or pull request comment:
 Signed-off-by: Your Name <your@email.example.org>
 ```
 
-We accept contributions under a legally identifiable name, such as
-your name on government documentation or common-law names (names
-claimed by legitimate usage or repute). Unfortunately, we cannot
-accept anonymous contributions at this time.
-
 Git allows you to add this signoff automatically when using the `-s`
 flag to `git commit`, which uses the name and email set in your
 `user.name` and `user.email` git configs.

--- a/changelog.d/pr-1875.doc
+++ b/changelog.d/pr-1875.doc
@@ -1,0 +1,1 @@
+Drop the requirement for "real" or "legally identifiable" name in order to contribute, in line with updated Foundation policy.


### PR DESCRIPTION
The Matrix.org Foundation is rolling out an updated DCO across all public repositories in its namespace. Of note, this DCO does not require the use of "real" or "legally identifiable" names.

(Meta: will add required changelog file as instructed in the next commit to this, opening PR first to get a reference number.)

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [X] Pull request is based on the develop branch
* [x] Pull request contains a changelog file in ./changelog.d. See https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog
* [X] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)

Signed-off-by: Josh Simmons <git@josh.tel>