### PR TITLE
Add support for MatrixRTC m.call.notify events.

### DIFF
--- a/MatrixSDK.xcodeproj/project.pbxproj
+++ b/MatrixSDK.xcodeproj/project.pbxproj
@@ -647,6 +647,14 @@
 		8EC5110D256822B400EC4E5B /* MXTaggedEvents.m in Sources */ = {isa = PBXBuildFile; fileRef = 8EC51109256822B400EC4E5B /* MXTaggedEvents.m */; };
 		918D30B7273951F400A16405 /* MXStoreService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918D30B6273951F400A16405 /* MXStoreService.swift */; };
 		918D30B8273951F400A16405 /* MXStoreService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918D30B6273951F400A16405 /* MXStoreService.swift */; };
+		918E431C2CDB8C0700F70790 /* MXCallNotify.h in Headers */ = {isa = PBXBuildFile; fileRef = 918E431A2CDB8C0700F70790 /* MXCallNotify.h */; };
+		918E431D2CDB8C0700F70790 /* MXCallNotify.m in Sources */ = {isa = PBXBuildFile; fileRef = 918E431B2CDB8C0700F70790 /* MXCallNotify.m */; };
+		918E431E2CDB8C0700F70790 /* MXCallNotify.m in Sources */ = {isa = PBXBuildFile; fileRef = 918E431B2CDB8C0700F70790 /* MXCallNotify.m */; };
+		918E431F2CDB8C0700F70790 /* MXCallNotify.h in Headers */ = {isa = PBXBuildFile; fileRef = 918E431A2CDB8C0700F70790 /* MXCallNotify.h */; };
+		918E43222CDB8D6000F70790 /* MXMentions.m in Sources */ = {isa = PBXBuildFile; fileRef = 918E43212CDB8D6000F70790 /* MXMentions.m */; };
+		918E43232CDB8D6000F70790 /* MXMentions.h in Headers */ = {isa = PBXBuildFile; fileRef = 918E43202CDB8D6000F70790 /* MXMentions.h */; };
+		918E43242CDB8D6000F70790 /* MXMentions.h in Headers */ = {isa = PBXBuildFile; fileRef = 918E43202CDB8D6000F70790 /* MXMentions.h */; };
+		918E43252CDB8D6000F70790 /* MXMentions.m in Sources */ = {isa = PBXBuildFile; fileRef = 918E43212CDB8D6000F70790 /* MXMentions.m */; };
 		91CC0FCA26A033AE00C2A387 /* MXURLPreview.h in Headers */ = {isa = PBXBuildFile; fileRef = 91CC0FC826A033AE00C2A387 /* MXURLPreview.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		91CC0FCB26A033AE00C2A387 /* MXURLPreview.h in Headers */ = {isa = PBXBuildFile; fileRef = 91CC0FC826A033AE00C2A387 /* MXURLPreview.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		91CC0FCC26A033AE00C2A387 /* MXURLPreview.m in Sources */ = {isa = PBXBuildFile; fileRef = 91CC0FC926A033AE00C2A387 /* MXURLPreview.m */; };
@@ -2477,6 +2485,10 @@
 		8EC51108256822B400EC4E5B /* MXTaggedEvents.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXTaggedEvents.h; sourceTree = "<group>"; };
 		8EC51109256822B400EC4E5B /* MXTaggedEvents.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXTaggedEvents.m; sourceTree = "<group>"; };
 		918D30B6273951F400A16405 /* MXStoreService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXStoreService.swift; sourceTree = "<group>"; };
+		918E431A2CDB8C0700F70790 /* MXCallNotify.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXCallNotify.h; sourceTree = "<group>"; };
+		918E431B2CDB8C0700F70790 /* MXCallNotify.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXCallNotify.m; sourceTree = "<group>"; };
+		918E43202CDB8D6000F70790 /* MXMentions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXMentions.h; sourceTree = "<group>"; };
+		918E43212CDB8D6000F70790 /* MXMentions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXMentions.m; sourceTree = "<group>"; };
 		91CC0FC826A033AE00C2A387 /* MXURLPreview.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXURLPreview.h; sourceTree = "<group>"; };
 		91CC0FC926A033AE00C2A387 /* MXURLPreview.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MXURLPreview.m; sourceTree = "<group>"; };
 		91F0685C2767C9FF0079F8FA /* MXTaskProfileName.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MXTaskProfileName.h; sourceTree = "<group>"; };
@@ -3660,6 +3672,8 @@
 				EC5C562727A36EDB0014CBE9 /* MXInReplyTo.m */,
 				327E9ABA2284521C00A98BC1 /* MXEventUnsignedData.h */,
 				327E9ABB2284521C00A98BC1 /* MXEventUnsignedData.m */,
+				918E43202CDB8D6000F70790 /* MXMentions.h */,
+				918E43212CDB8D6000F70790 /* MXMentions.m */,
 			);
 			path = Event;
 			sourceTree = "<group>";
@@ -4366,6 +4380,15 @@
 			path = Pods;
 			sourceTree = "<group>";
 		};
+		918E43192CDB8BD900F70790 /* MatrixRTC */ = {
+			isa = PBXGroup;
+			children = (
+				918E431A2CDB8C0700F70790 /* MXCallNotify.h */,
+				918E431B2CDB8C0700F70790 /* MXCallNotify.m */,
+			);
+			path = MatrixRTC;
+			sourceTree = "<group>";
+		};
 		91CC0FC426A0330900C2A387 /* Media */ = {
 			isa = PBXGroup;
 			children = (
@@ -4946,6 +4969,7 @@
 				EC8A536E25B1BC77004E0802 /* MXTurnServerResponse.h */,
 				EC8A538A25B1BC77004E0802 /* MXTurnServerResponse.m */,
 				EC8A537125B1BC77004E0802 /* Events */,
+				918E43192CDB8BD900F70790 /* MatrixRTC */,
 			);
 			path = Call;
 			sourceTree = "<group>";
@@ -5699,6 +5723,7 @@
 				EC6D007928E1F15400152144 /* MXDevice.h in Headers */,
 				EC619D9324DD834B00663A80 /* MXPushGatewayRestClient.h in Headers */,
 				EDE70DC528DA1B7F00099736 /* MXCryptoTools.h in Headers */,
+				918E431F2CDB8C0700F70790 /* MXCallNotify.h in Headers */,
 				EC60EDE8265CFF3100B39A4E /* MXRoomInviteState.h in Headers */,
 				324DD2A6246AE81300377005 /* MXSecretStorageKeyContent.h in Headers */,
 				EC60ED8F265CFD3B00B39A4E /* MXRoomSync.h in Headers */,
@@ -5773,6 +5798,7 @@
 				323F879625554FF2009E9E67 /* MXTaskProfile_Private.h in Headers */,
 				32618E7B20EFA45B00E1D2EA /* MXRoomMembers.h in Headers */,
 				B146D4D521A5A44E00D8C2C6 /* MXScanRealmProvider.h in Headers */,
+				918E43232CDB8D6000F70790 /* MXMentions.h in Headers */,
 				EC60EDD0265CFECC00B39A4E /* MXRoomSyncSummary.h in Headers */,
 				EC60EDBC265CFE8600B39A4E /* MXRoomSyncAccountData.h in Headers */,
 				32CEEF4323AD2A6C0039BA98 /* MXCrossSigningKey.h in Headers */,
@@ -5893,6 +5919,7 @@
 			files = (
 				B14EF2D62397E90400758AF0 /* MXMegolmSessionData.h in Headers */,
 				EC8A53BA25B1BC77004E0802 /* MXCallEventContent.h in Headers */,
+				918E43242CDB8D6000F70790 /* MXMentions.h in Headers */,
 				B14EF2BA2397E90400758AF0 /* MXOutgoingRoomKeyRequest.h in Headers */,
 				B14EF2FB2397E90400758AF0 /* MXOlmSession.h in Headers */,
 				B14EF2DF2397E90400758AF0 /* MXDecryptionResult.h in Headers */,
@@ -6193,6 +6220,7 @@
 				B19A30AB2404257700FB6F35 /* MXQRCodeKeyVerificationStart.h in Headers */,
 				B14EF34A2397E90400758AF0 /* MXAntivirusScanStatusFormatter.h in Headers */,
 				B14EF34B2397E90400758AF0 /* MXEventListener.h in Headers */,
+				918E431C2CDB8C0700F70790 /* MXCallNotify.h in Headers */,
 				EC60EDE9265CFF3100B39A4E /* MXRoomInviteState.h in Headers */,
 				B14EF34C2397E90400758AF0 /* MXMediaScan.h in Headers */,
 				B14EF34D2397E90400758AF0 /* MXRoomOperation.h in Headers */,
@@ -6634,6 +6662,7 @@
 				EC1165BA27107E330089FA56 /* MXRoomListDataFetcherDelegate.swift in Sources */,
 				3275FD9421A6B46600B9C13D /* MXLoginTerms.m in Sources */,
 				EC05478425FF99450047ECD7 /* MXRoomAccountDataUpdater.m in Sources */,
+				918E431E2CDB8C0700F70790 /* MXCallNotify.m in Sources */,
 				ED4114EB292E498100728459 /* MXBackgroundCryptoV2.swift in Sources */,
 				B11BD44D22CB56E80064D8B0 /* MXReplyEventParts.m in Sources */,
 				32B94E02228EDEBC00716A26 /* MXReactionRelation.m in Sources */,
@@ -6870,6 +6899,7 @@
 				C602B58E1F22A8D700B67D87 /* MXImage.swift in Sources */,
 				B105CD9D261E0B70006EB204 /* MXSpaceChildrenSummary.swift in Sources */,
 				32A9F8E0244720B10069C65B /* MXThrottler.m in Sources */,
+				918E43222CDB8D6000F70790 /* MXMentions.m in Sources */,
 				EC8A53E425B1BCC6004E0802 /* MXThirdPartyUsersResponse.m in Sources */,
 				ED4114E8292E496C00728459 /* MXBackgroundCrypto.swift in Sources */,
 				3295401A216385F100E300FC /* MXServerNoticeContent.m in Sources */,
@@ -7260,6 +7290,7 @@
 				ECDA762D27B28F3B000C48CF /* MXEventRelationThread.m in Sources */,
 				322AB592260CDBC10017E964 /* MXSyncResponseStoreManager.swift in Sources */,
 				324AAC7B2399140D00380A66 /* MXKeyVerificationRequestByDMJSONModel.m in Sources */,
+				918E431D2CDB8C0700F70790 /* MXCallNotify.m in Sources */,
 				B14EF1FD2397E90400758AF0 /* MXReactionOperation.m in Sources */,
 				ED4114EC292E498100728459 /* MXBackgroundCryptoV2.swift in Sources */,
 				B14EF1FE2397E90400758AF0 /* MXCryptoConstants.m in Sources */,
@@ -7496,6 +7527,7 @@
 				ED36ED8728DD9E2200C86416 /* MXCryptoKeyBackupEngine.swift in Sources */,
 				B14EF2632397E90400758AF0 /* MXReactionCountChange.m in Sources */,
 				324AAC762399140D00380A66 /* MXKeyVerificationCancel.m in Sources */,
+				918E43252CDB8D6000F70790 /* MXMentions.m in Sources */,
 				32AF928D240EA3880008A0FD /* MXSecretShareSend.m in Sources */,
 				B14EF2642397E90400758AF0 /* MXKey.m in Sources */,
 				EC8A53B825B1BC77004E0802 /* MXCallCandidatesEventContent.m in Sources */,

--- a/MatrixSDK/JSONModels/Call/MatrixRTC/MXCallNotify.h
+++ b/MatrixSDK/JSONModels/Call/MatrixRTC/MXCallNotify.h
@@ -1,0 +1,51 @@
+// 
+// Copyright 2024 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+#import "MXJSONModel.h"
+#import "MXMentions.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ `MXCallNotify` represents a push notification for a MatrixRTC call,
+ describing how the user should be notified about the call.
+ */
+@interface MXCallNotify : MXJSONModel
+
+/**
+ The application that is running the MatrixRTC session. `m.call` represents a VoIP call.
+ */
+@property (nonatomic) NSString *application;
+
+/**
+ Information about who should be notified in the room.
+ */
+@property (nonatomic) MXMentions *mentions;
+
+/**
+ Whether the call should ring or deliver a notification.
+ */
+@property (nonatomic) NSString *notifyType;
+
+/**
+ A unique identifier for the call that is running. Present for an application type of `m.call`.
+ */
+@property (nonatomic, nullable) NSString *callID;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixSDK/JSONModels/Call/MatrixRTC/MXCallNotify.m
+++ b/MatrixSDK/JSONModels/Call/MatrixRTC/MXCallNotify.m
@@ -1,0 +1,49 @@
+// 
+// Copyright 2024 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import "MXCallNotify.h"
+#import "MXMentions.h"
+
+@implementation MXCallNotify
+
++ (id)modelFromJSON:(NSDictionary *)JSONDictionary
+{
+    MXCallNotify *callNotify = [[MXCallNotify alloc] init];
+    if (callNotify)
+    {
+        MXJSONModelSetString(callNotify.application, JSONDictionary[@"application"]);
+        MXJSONModelSetMXJSONModel(callNotify.mentions, MXMentions, JSONDictionary[@"m.mentions"]);
+        MXJSONModelSetString(callNotify.notifyType, JSONDictionary[@"notify_type"]);
+        MXJSONModelSetString(callNotify.callID, JSONDictionary[@"call_id"]);
+    }
+
+    return callNotify;
+}
+
+- (NSDictionary *)JSONDictionary
+{
+    NSMutableDictionary *JSONDictionary = [NSMutableDictionary dictionary];
+    
+    JSONDictionary[@"application"] = _application;
+    JSONDictionary[@"m.mentions"] = _mentions.JSONDictionary;
+    JSONDictionary[@"notify_type"] = _notifyType;
+    JSONDictionary[@"call_id"] = _callID;
+    
+    return JSONDictionary;
+}
+
+@end
+

--- a/MatrixSDK/JSONModels/Event/MXMentions.h
+++ b/MatrixSDK/JSONModels/Event/MXMentions.h
@@ -1,0 +1,38 @@
+// 
+// Copyright 2024 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import <MatrixSDK/MatrixSDK.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ Describes whether an event mentions other users or the room
+ */
+@interface MXMentions : MXJSONModel
+
+/**
+ The user IDs of room members who should be notified about this event.
+ */
+@property (nonatomic, nullable) NSArray *userIDs;
+
+/**
+ Whether or not this event contains an @room mention.
+ */
+@property (nonatomic) BOOL room;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MatrixSDK/JSONModels/Event/MXMentions.m
+++ b/MatrixSDK/JSONModels/Event/MXMentions.m
@@ -1,0 +1,43 @@
+// 
+// Copyright 2024 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import "MXMentions.h"
+
+@implementation MXMentions
+
++ (instancetype)modelFromJSON:(NSDictionary *)JSONDictionary
+{
+    MXMentions *intentionalMentions = [[MXMentions alloc] init];
+    if (intentionalMentions)
+    {
+        MXJSONModelSetString(intentionalMentions.userIDs, JSONDictionary[@"user_ids"]);
+        MXJSONModelSetBoolean(intentionalMentions.room, JSONDictionary[@"room"]);
+    }
+
+    return intentionalMentions;
+}
+
+- (NSDictionary *)JSONDictionary
+{
+    NSMutableDictionary *JSONDictionary = [NSMutableDictionary dictionary];
+    
+    JSONDictionary[@"user_ids"] = _userIDs;
+    JSONDictionary[@"room"] = @(_room);
+    
+    return JSONDictionary;
+}
+
+@end

--- a/MatrixSDK/JSONModels/MXEvent.h
+++ b/MatrixSDK/JSONModels/MXEvent.h
@@ -104,6 +104,7 @@ typedef NS_ENUM(NSInteger, MXEventType)
     MXEventTypeBeaconInfo,
     MXEventTypeBeacon,
     MXEventTypeRoomRetention,
+    MXEventTypeCallNotify,
 
     // The event is a custom event. Refer to its `MXEventTypeString` version
     MXEventTypeCustom = 1000
@@ -316,6 +317,11 @@ FOUNDATION_EXPORT NSString *const kMXJoinRulesContentKeyRoomId;
 
 FOUNDATION_EXPORT NSString *const kMXEventTimelineMain;
 FOUNDATION_EXPORT NSString *const kMXEventUnthreaded;
+
+// MatrixRTC support
+
+FOUNDATION_EXPORT NSString *const kMXEventTypeStringCallNotify;
+FOUNDATION_EXPORT NSString *const kMXEventTypeStringCallNotifyUnstable;
 
 /**
  The internal event state used to handle the different steps of the event sending.

--- a/MatrixSDK/JSONModels/MXEvent.m
+++ b/MatrixSDK/JSONModels/MXEvent.m
@@ -212,6 +212,11 @@ NSString *const kMXJoinRulesContentKeyRoomId = @"room_id";
 NSString *const kMXEventTimelineMain = @"main";
 NSString *const kMXEventUnthreaded = @"unthreaded";
 
+// Matrix RTC support
+
+NSString *const kMXEventTypeStringCallNotify = @"m.call.notify";
+NSString *const kMXEventTypeStringCallNotifyUnstable = @"org.matrix.msc4075.call.notify";
+
 #pragma mark - MXEvent
 @interface MXEvent ()
 {

--- a/MatrixSDK/Utils/MXTools.m
+++ b/MatrixSDK/Utils/MXTools.m
@@ -122,6 +122,8 @@ NSCharacterSet *uriComponentCharset;
             @(MXEventTypeCallRejectReplacement) : kMXEventTypeStringCallRejectReplacement,
             @(MXEventTypeCallAssertedIdentity) : kMXEventTypeStringCallAssertedIdentity,
             @(MXEventTypeCallAssertedIdentityUnstable) : kMXEventTypeStringCallAssertedIdentityUnstable,
+            // MatrixRTC call events
+            @(MXEventTypeCallNotify) : kMXEventTypeStringCallNotifyUnstable,
             
             @(MXEventTypeKeyVerificationRequest) : kMXEventTypeStringKeyVerificationRequest,
             @(MXEventTypeKeyVerificationReady) : kMXEventTypeStringKeyVerificationReady,
@@ -194,6 +196,9 @@ NSCharacterSet *uriComponentCharset;
             kMXEventTypeStringCallRejectReplacement : @(MXEventTypeCallRejectReplacement),
             kMXEventTypeStringCallAssertedIdentity : @(MXEventTypeCallAssertedIdentity),
             kMXEventTypeStringCallAssertedIdentityUnstable : @(MXEventTypeCallAssertedIdentityUnstable),
+            // MatrixRTC call events
+            kMXEventTypeStringCallNotify : @(MXEventTypeCallNotify),
+            kMXEventTypeStringCallNotifyUnstable : @(MXEventTypeCallNotify),
             
             kMXEventTypeStringKeyVerificationRequest : @(MXEventTypeKeyVerificationRequest),
             kMXEventTypeStringKeyVerificationReady : @(MXEventTypeKeyVerificationReady),


### PR DESCRIPTION
This PR adds support for [MSC4075](https://github.com/matrix-org/matrix-spec-proposals/pull/4075) to detect call ringing for MatrixRTC calls (not supported in any other way in this SDK).

Part of https://github.com/element-hq/element-ios/issues/7861