### PR TITLE
Add registration token flow type

### DIFF
--- a/MatrixSDK/Contrib/Swift/JSONModels/MXJSONModels.swift
+++ b/MatrixSDK/Contrib/Swift/JSONModels/MXJSONModels.swift
@@ -21,6 +21,7 @@ import Foundation
 public enum MXLoginFlowType: Equatable, Hashable {
     case password
     case recaptcha
+    case registrationToken
     case OAuth2
     case emailIdentity
     case msisdn
@@ -33,6 +34,7 @@ public enum MXLoginFlowType: Equatable, Hashable {
         switch self {
         case .password: return kMXLoginFlowTypePassword
         case .recaptcha: return kMXLoginFlowTypeRecaptcha
+        case .registrationToken: return kMXLoginFlowTypeRegistrationToken
         case .OAuth2: return kMXLoginFlowTypeOAuth2
         case .emailIdentity: return kMXLoginFlowTypeEmailIdentity
         case .msisdn: return kMXLoginFlowTypeMSISDN
@@ -44,7 +46,7 @@ public enum MXLoginFlowType: Equatable, Hashable {
     }
 
     public init(identifier: String) {
-        let flowTypes: [MXLoginFlowType] = [.password, .recaptcha, .OAuth2, .emailIdentity, .msisdn, .token, .dummy, .emailCode]
+        let flowTypes: [MXLoginFlowType] = [.password, .recaptcha, .registrationToken, .OAuth2, .emailIdentity, .msisdn, .token, .dummy, .emailCode]
         self = flowTypes.first(where: { $0.identifier == identifier }) ?? .other(identifier)
     }
 }

--- a/MatrixSDK/JSONModels/MXJSONModels.h
+++ b/MatrixSDK/JSONModels/MXJSONModels.h
@@ -137,6 +137,7 @@ FOUNDATION_EXPORT NSString *const kMX3PIDMediumMSISDN;
 typedef NSString* MXLoginFlowType NS_REFINED_FOR_SWIFT;
 FOUNDATION_EXPORT NSString *const kMXLoginFlowTypePassword;
 FOUNDATION_EXPORT NSString *const kMXLoginFlowTypeRecaptcha;
+FOUNDATION_EXPORT NSString *const kMXLoginFlowTypeRegistrationToken;
 FOUNDATION_EXPORT NSString *const kMXLoginFlowTypeOAuth2;
 FOUNDATION_EXPORT NSString *const kMXLoginFlowTypeCAS;
 FOUNDATION_EXPORT NSString *const kMXLoginFlowTypeSSO;

--- a/MatrixSDK/JSONModels/MXJSONModels.m
+++ b/MatrixSDK/JSONModels/MXJSONModels.m
@@ -122,6 +122,7 @@ static NSString* const kMXLoginFlowTypeKey = @"type";
 
 NSString *const kMXLoginFlowTypePassword = @"m.login.password";
 NSString *const kMXLoginFlowTypeRecaptcha = @"m.login.recaptcha";
+NSString *const kMXLoginFlowTypeRegistrationToken = @"m.login.registration_token";
 NSString *const kMXLoginFlowTypeOAuth2 = @"m.login.oauth2";
 NSString *const kMXLoginFlowTypeCAS = @"m.login.cas";
 NSString *const kMXLoginFlowTypeSSO = @"m.login.sso";

--- a/changelog.d/6507.feature
+++ b/changelog.d/6507.feature
@@ -1,0 +1,1 @@
+Added types for MSC3231: registration tokens.


### PR DESCRIPTION
## Why?
- I want the Element iOS app to support registration tokens which it currently does not
- https://github.com/element-hq/element-ios/issues/6507
- [MSC3231: Token Authenticated Registration](https://github.com/matrix-org/matrix-spec-proposals/blob/main/proposals/3231-token-authenticated-registration.md)

## :warning: Warnings:
- I do not yet have a way to run the tests or even compile this code so this change is COMPLETELY UNTESTED
- This is my first time writing Swift or Objective-C
- I probably missed some other places in the code that need to be changed

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request contains a changelog file in ./changelog.d. See https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
  * (see commit messages for sign-off)
