### PR TITLE
Use the stable endpoint when reporting rooms.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -275,7 +275,7 @@ GEM
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
     unicode-display_width (2.5.0)
-    webrick (1.8.1)
+    webrick (1.9.0)
     word_wrap (1.0.0)
     xcode-install (2.8.1)
       claide (>= 0.9.1)

--- a/MatrixSDK/MXRestClient.m
+++ b/MatrixSDK/MXRestClient.m
@@ -3103,7 +3103,7 @@ andUnauthenticatedHandler: (MXRestClientUnauthenticatedHandler)unauthenticatedHa
                        success:(void (^)(void))success
                        failure:(void (^)(NSError *))failure
 {
-    NSString *path = [NSString stringWithFormat:@"%@/org.matrix.msc4151/rooms/%@/report", kMXAPIPrefixPathUnstable, roomId];
+    NSString *path = [NSString stringWithFormat:@"%@/rooms/%@/report", kMXAPIPrefixPathV3, roomId];
 
     NSDictionary *parameters = @{ @"reason": reason.length > 0 ? reason : @"" };
 


### PR DESCRIPTION
As requested by @turt2live, Synapse and matrix.org support the stable endpoint now. I haven't added a fallback to the unstable endpoint for this as it doesn't seem worthwhile to me.