### PR TITLE
Remove trailing slash on identity server

### DIFF
--- a/MatrixSDK/Data/RoomList/Common/MXRoomListDataSortable.swift
+++ b/MatrixSDK/Data/RoomList/Common/MXRoomListDataSortable.swift
@@ -52,7 +52,7 @@ extension MXRoomListDataSortable {
 //        }
         
         if sortOptions.alphabetical {
-            result.append(NSSortDescriptor(keyPath: \MXRoomSummaryProtocol.displayName, ascending: true))
+            result.append(NSSortDescriptor(key: "displayName", ascending: true, selector: #selector(NSString.localizedCaseInsensitiveCompare(_:))))
         }
         
         if sortOptions.invitesFirst {

--- a/MatrixSDK/Data/RoomList/Common/MXRoomListDataSortable.swift
+++ b/MatrixSDK/Data/RoomList/Common/MXRoomListDataSortable.swift
@@ -52,7 +52,7 @@ extension MXRoomListDataSortable {
 //        }
         
         if sortOptions.alphabetical {
-            result.append(NSSortDescriptor(key: "displayName", ascending: true, selector: #selector(NSString.localizedCaseInsensitiveCompare(_:))))
+            result.append(NSSortDescriptor(key: "displayName", ascending: true, selector: #selector(NSString.localizedStandardCompare(_:))))
         }
         
         if sortOptions.invitesFirst {

--- a/MatrixSDK/Data/RoomList/CoreData/MXCoreDataRoomListDataFetcher.swift
+++ b/MatrixSDK/Data/RoomList/CoreData/MXCoreDataRoomListDataFetcher.swift
@@ -250,7 +250,7 @@ extension MXCoreDataRoomListDataFetcher: MXRoomListDataSortable {
         var result: [NSSortDescriptor] = []
         
         if sortOptions.alphabetical {
-            result.append(NSSortDescriptor(key: "s_displayName", ascending: true, selector: #selector(NSString.localizedCaseInsensitiveCompare(_:))))
+            result.append(NSSortDescriptor(key: "s_displayName", ascending: true, selector: #selector(NSString.localizedStandardCompare(_:))))
         }
         
         if sortOptions.invitesFirst {

--- a/MatrixSDK/Data/RoomList/CoreData/MXCoreDataRoomListDataFetcher.swift
+++ b/MatrixSDK/Data/RoomList/CoreData/MXCoreDataRoomListDataFetcher.swift
@@ -250,7 +250,7 @@ extension MXCoreDataRoomListDataFetcher: MXRoomListDataSortable {
         var result: [NSSortDescriptor] = []
         
         if sortOptions.alphabetical {
-            result.append(NSSortDescriptor(keyPath: \MXRoomSummaryMO.s_displayName, ascending: true))
+            result.append(NSSortDescriptor(key: "s_displayName", ascending: true, selector: #selector(NSString.localizedCaseInsensitiveCompare(_:))))
         }
         
         if sortOptions.invitesFirst {

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -832,6 +832,15 @@ typedef void (^MXOnResumeDone)(void);
 
 - (void)setIdentityServer:(NSString *)identityServer andAccessToken:(NSString *)accessToken
 {
+    // Old Account data can have a trailing slash at the end of their Identity Server.
+    // This can lead to unrecognized URL on the backend (like on 'invite to room') because the URL is then constructed
+    // with a double slash in its path.
+    // This leads to error 500 for these calls.
+    // So, fix this trailing slash as soon as we receive it.
+    if ([identityServer hasSuffix:@"/"]) {
+        identityServer = [identityServer substringToIndex:identityServer.length-1];
+    }
+    
     MXLogDebug(@"[MXSession] setIdentityServer: %@", identityServer);
     
     matrixRestClient.identityServer = identityServer;

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -832,6 +832,15 @@ typedef void (^MXOnResumeDone)(void);
 
 - (void)setIdentityServer:(NSString *)identityServer andAccessToken:(NSString *)accessToken
 {
+    // Old Account data can have a trailing slash at the end of their Identity Server.
+    // Ths can lead to unrecognized URL on the backend (like on 'invite to room') because the URL is then constructed
+    // with a double slash in its path.
+    // This lead to error 500 for these calls.
+    // Sp, fix this trailing slash as soon as we receive it.
+    if ([identityServer hasSuffix:@"/"]) {
+        identityServer = [identityServer substringToIndex:identityServer.length-1];
+    }
+    
     MXLogDebug(@"[MXSession] setIdentityServer: %@", identityServer);
     
     matrixRestClient.identityServer = identityServer;

--- a/changelog.d/pr-1851.change
+++ b/changelog.d/pr-1851.change
@@ -1,0 +1,1 @@
+When sorting room list alphabetically, sort it case-insensitive.

--- a/changelog.d/pr-1897.change
+++ b/changelog.d/pr-1897.change
@@ -1,0 +1,1 @@
+Remove trailing slash at the end of identity server.

--- a/changelog.d/sort-room-list-alphabetically-case-insensitive.change
+++ b/changelog.d/sort-room-list-alphabetically-case-insensitive.change
@@ -1,0 +1,1 @@
+Prevent crash when sending file with unrecognised file extension (no associated mime type)

--- a/changelog.d/sort-room-list-alphabetically-case-insensitive.change
+++ b/changelog.d/sort-room-list-alphabetically-case-insensitive.change
@@ -1,1 +1,0 @@
-Prevent crash when sending file with unrecognised file extension (no associated mime type)


### PR DESCRIPTION
Old Account data can have a trailing slash at the end of their Identity Server.
This can lead to unrecognized URL on the backend (like on 'invite to room') because the URL is then constructed with a double slash in its path.
This lead to error 500 for these calls.
So, fix this trailing slash as soon as we receive it.

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request contains a changelog file in ./changelog.d. See https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
