### PR TITLE
Remove trailing slash at the end of identity server

### DIFF
--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -832,6 +832,15 @@ typedef void (^MXOnResumeDone)(void);
 
 - (void)setIdentityServer:(NSString *)identityServer andAccessToken:(NSString *)accessToken
 {
+    // Old Account data can have a trailing slash at the end of their Identity Server.
+    // This can lead to unrecognized URL on the backend (like on 'invite to room') because the URL is then constructed
+    // with a double slash in its path.
+    // This leads to error 500 for these calls.
+    // So, fix this trailing slash as soon as we receive it.
+    if ([identityServer hasSuffix:@"/"]) {
+        identityServer = [identityServer substringToIndex:identityServer.length-1];
+    }
+    
     MXLogDebug(@"[MXSession] setIdentityServer: %@", identityServer);
     
     matrixRestClient.identityServer = identityServer;

--- a/changelog.d/pr-1898.change
+++ b/changelog.d/pr-1898.change
@@ -1,0 +1,1 @@
+Remove trailing slash at the end of identity server.


### PR DESCRIPTION
Old Account data can have a trailing slash at the end of their Identity Server.
This can lead to unrecognized URL on the backend (like on 'invite to room') because the URL is then constructed with a double slash in its path.
This leads to backend error 500 for these calls.
So, fix this trailing slash as soon as we receive i

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request contains a changelog file in ./changelog.d. See https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
