### PR TITLE
Fixing Race Condition on multiple commits to saveReceipts

### DIFF
--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
@@ -2192,41 +2192,48 @@ static NSUInteger preloadOptions;
             // Save rooms where there was changes
             for (NSString *roomId in roomsToCommit)
             {
-                RoomThreadedReceiptsStore *receiptsStore =  self->roomThreadedReceiptsStores[roomId];
-                if (receiptsStore)
+                RoomThreadedReceiptsStore *store = self->roomThreadedReceiptsStores[roomId];
+                if (!store) continue;
+                
+                NSDictionary<NSString*, RoomReceiptsStore*> *snapshot;
+                @synchronized (store) {
+                  NSMutableDictionary *outer = [NSMutableDictionary dictionaryWithCapacity:store.count];
+                  for (NSString *timelineId in store) {
+                    RoomReceiptsStore *inner = store[timelineId];
+                    // inner is itself an NSMutableDictionary, so copy it
+                    outer[timelineId] = [inner copy];
+                  }
+                  snapshot = [outer copy];
+                }
+              
+                NSString *file = [self threadedReadReceiptsFileForRoom:roomId forBackup:NO];
+                NSString *backupFile = [self threadedReadReceiptsFileForRoom:roomId forBackup:YES];
+                
+                // Backup the file
+                if (backupFile && [[NSFileManager defaultManager] fileExistsAtPath:file])
                 {
-                    @synchronized (receiptsStore)
-                    {
-                        NSString *file = [self threadedReadReceiptsFileForRoom:roomId forBackup:NO];
-                        NSString *backupFile = [self threadedReadReceiptsFileForRoom:roomId forBackup:YES];
-
-                        // Backup the file
-                        if (backupFile && [[NSFileManager defaultManager] fileExistsAtPath:file])
-                        {
-                            [self checkFolderExistenceForRoom:roomId forBackup:YES];
-                            [[NSFileManager defaultManager] moveItemAtPath:file toPath:backupFile error:nil];
-                        }
-
-                        // Store new data
-                        [self checkFolderExistenceForRoom:roomId forBackup:NO];
-                        
-                        NSError *error = nil;
-                        NSData *result = [NSKeyedArchiver archivedDataWithRootObject:receiptsStore requiringSecureCoding:false error:&error];
-                        
-                        if (error != nil)
-                        {
-                            MXLogErrorDetails(@"Failed archiving receipts store", error);
-                            continue;
-                        }
-                        
-                        [result writeToURL:[NSURL fileURLWithPath:file] options: NSDataWritingAtomic error: &error];
-                        
-                        if (error != nil)
-                        {
-                            MXLogErrorDetails(@"Failed writing receipts store to file", error);
-                            continue;
-                        }
-                    }
+                  [self checkFolderExistenceForRoom:roomId forBackup:YES];
+                  [[NSFileManager defaultManager] moveItemAtPath:file toPath:backupFile error:nil];
+                }
+                
+                // Store new data
+                [self checkFolderExistenceForRoom:roomId forBackup:NO];
+                
+                NSError *error = nil;
+                NSData *result = [NSKeyedArchiver archivedDataWithRootObject:receiptsStore requiringSecureCoding:false error:&error];
+                
+                if (error != nil)
+                {
+                  MXLogErrorDetails(@"Failed archiving receipts store", error);
+                  continue;
+                }
+                
+                [result writeToURL:[NSURL fileURLWithPath:file] options: NSDataWritingAtomic error: &error];
+                
+                if (error != nil)
+                {
+                  MXLogErrorDetails(@"Failed writing receipts store to file", error);
+                  continue;
                 }
             }
             

--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
@@ -2220,7 +2220,7 @@ static NSUInteger preloadOptions;
                 [self checkFolderExistenceForRoom:roomId forBackup:NO];
                 
                 NSError *error = nil;
-                NSData *result = [NSKeyedArchiver archivedDataWithRootObject:receiptsStore requiringSecureCoding:false error:&error];
+                NSData *result = [NSKeyedArchiver archivedDataWithRootObject:snapshot requiringSecureCoding:false error:&error];
                 
                 if (error != nil)
                 {

--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
@@ -2195,6 +2195,7 @@ static NSUInteger preloadOptions;
                 RoomThreadedReceiptsStore *store = self->roomThreadedReceiptsStores[roomId];
                 if (!store) continue;
                 
+                // Create a copy of the store at this point so other mutations can be done on it while we're saving it
                 NSDictionary<NSString*, RoomReceiptsStore*> *snapshot;
                 @synchronized (store) {
                   NSMutableDictionary *outer = [NSMutableDictionary dictionaryWithCapacity:store.count];

--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
@@ -2178,63 +2178,61 @@ static NSUInteger preloadOptions;
     {
         NSArray *roomsToCommit = [[NSArray alloc] initWithArray:roomsToCommitForReceipts copyItems:YES];
         [roomsToCommitForReceipts removeAllObjects];
-
+        
 #if DEBUG
         MXLogDebug(@"[MXFileStore commit] queuing saveReceipts for %tu rooms", roomsToCommit.count);
 #endif
         MXWeakify(self);
         dispatch_async(dispatchQueue, ^(void){
             MXStrongifyAndReturnIfNil(self);
-
+            
 #if DEBUG
             NSDate *startDate = [NSDate date];
 #endif
             // Save rooms where there was changes
             for (NSString *roomId in roomsToCommit)
             {
-                RoomThreadedReceiptsStore *store = self->roomThreadedReceiptsStores[roomId];
-                if (!store) continue;
-                
-                // Create a copy of the store at this point so other mutations can be done on it while we're saving it
-                NSDictionary<NSString*, RoomReceiptsStore*> *snapshot;
-                @synchronized (store) {
-                  NSMutableDictionary *outer = [NSMutableDictionary dictionaryWithCapacity:store.count];
-                  for (NSString *timelineId in store) {
-                    RoomReceiptsStore *inner = store[timelineId];
-                    // inner is itself an NSMutableDictionary, so copy it
-                    outer[timelineId] = [inner copy];
-                  }
-                  snapshot = [outer copy];
-                }
-              
-                NSString *file = [self threadedReadReceiptsFileForRoom:roomId forBackup:NO];
-                NSString *backupFile = [self threadedReadReceiptsFileForRoom:roomId forBackup:YES];
-                
-                // Backup the file
-                if (backupFile && [[NSFileManager defaultManager] fileExistsAtPath:file])
+                RoomThreadedReceiptsStore *receiptsStore =  self->roomThreadedReceiptsStores[roomId];
+                if (receiptsStore)
                 {
-                  [self checkFolderExistenceForRoom:roomId forBackup:YES];
-                  [[NSFileManager defaultManager] moveItemAtPath:file toPath:backupFile error:nil];
-                }
-                
-                // Store new data
-                [self checkFolderExistenceForRoom:roomId forBackup:NO];
-                
-                NSError *error = nil;
-                NSData *result = [NSKeyedArchiver archivedDataWithRootObject:snapshot requiringSecureCoding:false error:&error];
-                
-                if (error != nil)
-                {
-                  MXLogErrorDetails(@"Failed archiving receipts store", error);
-                  continue;
-                }
-                
-                [result writeToURL:[NSURL fileURLWithPath:file] options: NSDataWritingAtomic error: &error];
-                
-                if (error != nil)
-                {
-                  MXLogErrorDetails(@"Failed writing receipts store to file", error);
-                  continue;
+                    @synchronized (receiptsStore)
+                    {
+                        NSString *file = [self threadedReadReceiptsFileForRoom:roomId forBackup:NO];
+                        NSString *backupFile = [self threadedReadReceiptsFileForRoom:roomId forBackup:YES];
+                        
+                        // Backup the file
+                        if (backupFile && [[NSFileManager defaultManager] fileExistsAtPath:file])
+                        {
+                            [self checkFolderExistenceForRoom:roomId forBackup:YES];
+                            [[NSFileManager defaultManager] moveItemAtPath:file toPath:backupFile error:nil];
+                        }
+                        
+                        // Store new data
+                        [self checkFolderExistenceForRoom:roomId forBackup:NO];
+                        
+                        __block NSData *result = nil;
+                        __block NSError *archiveError = nil;
+                        
+                        dispatch_sync(dispatch_get_main_queue(), ^{
+                            result = [NSKeyedArchiver
+                                      archivedDataWithRootObject:receiptsStore
+                                      requiringSecureCoding:NO
+                                      error:&archiveError];
+                        });
+                        
+                        if (archiveError) {
+                            MXLogErrorDetails(@"Failed archiving receipts store", archiveError);
+                            continue;
+                        }
+                        
+                        [result writeToURL:[NSURL fileURLWithPath:file] options: NSDataWritingAtomic error: &archiveError];
+                        
+                        if (archiveError != nil)
+                        {
+                            MXLogErrorDetails(@"Failed writing receipts store to file", archiveError);
+                            continue;
+                        }
+                    }
                 }
             }
             

--- a/changelog.d/1810.bugfix
+++ b/changelog.d/1810.bugfix
@@ -1,0 +1,1 @@
+MXFileStore.saveReceipts: Fixed a race condition involving multiple saves to the RoomThreadedReceiptsStore while commiting more receipts. Contributed by the Connect v3 Team at @powerhome


### PR DESCRIPTION
This fix solves a relatively rare race condition that happens when multiple commits are made to MXFileStore in quick succession to readReceipts. It manifests in an error such as in #1810

To solve this, we copy the entire `RoomThreadedReceiptsStore` for a room, and it's sub-values. We then use that "copy" to actually write to the store, and passing it along to the `NSKeyedArchiver`.


If there is a better approach to solving this please let us know, we're more than happy to evaluate it and we understand that this may not be the most efficient way of solving this issue.

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request contains a changelog file in ./changelog.d. See https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)

Signed-off-by: Brandon Maul <brandon.maul@powerhrg.com>