### PR TITLE
Support for MSC 4289

### DIFF
--- a/MatrixSDK/Data/MXRoomState.h
+++ b/MatrixSDK/Data/MXRoomState.h
@@ -283,6 +283,11 @@ Use MXRoomSummary.displayname to get a computed room display name.
  */
 - (float)memberNormalizedPowerLevel:(NSString*)userId;
 
+/**
+ Returns the power level for a given user identifier, this checks also for the creator and additional creators
+ */
+- (NSInteger)powerLevelOfUserWithUserID:(NSString *)userId;
+
 
 # pragma mark - Conference call
 /**

--- a/MatrixSDK/Data/MXRoomState.m
+++ b/MatrixSDK/Data/MXRoomState.m
@@ -634,7 +634,7 @@
 {
     if ([userId isEqualToString: [self creatorUserId]] || [[self additionalCreators] containsObject: userId])
     {
-        return NSIntegerMax;
+        return maxPowerLevel ? maxPowerLevel + 1 : NSIntegerMax;
     }
     return [powerLevels powerLevelOfUserWithUserID:userId];
 }

--- a/MatrixSDK/Data/MXRoomState.m
+++ b/MatrixSDK/Data/MXRoomState.m
@@ -656,7 +656,18 @@
             return maxPowerLevel ? maxPowerLevel + 1 : NSIntegerMax;
         }
     }
-    return [powerLevels powerLevelOfUserWithUserID:userId];
+    
+    // By default, use usersDefault
+    NSInteger userPowerLevel = powerLevels.usersDefault;
+
+    NSNumber *powerLevel;
+    MXJSONModelSetNumber(powerLevel, powerLevels.users[userId]);
+    if (powerLevel)
+    {
+        userPowerLevel = [powerLevel integerValue];
+    }
+
+    return userPowerLevel;
 }
 
 - (BOOL)isMSC4289Supported {

--- a/MatrixSDK/Data/MXRoomState.m
+++ b/MatrixSDK/Data/MXRoomState.m
@@ -328,6 +328,23 @@
     return avatar;
 }
 
+- (NSString *)roomVersion
+{
+    NSString *roomVersion;
+    
+    // Check it from the state events
+    MXEvent *event = [stateEvents objectForKey:kMXEventTypeStringRoomCreate].lastObject;
+    NSDictionary<NSString *, id> *eventContent = [self contentOfEvent:event];
+    
+    if (event && eventContent)
+    {
+        MXJSONModelSetString(roomVersion, eventContent[@"room_version"]);
+        roomVersion = [roomVersion copy];
+
+    }
+    return roomVersion;
+}
+
 - (NSString *)creatorUserId
 {
     NSString *creatorUserId;
@@ -632,11 +649,23 @@
 
 - (NSInteger)powerLevelOfUserWithUserID:(NSString *)userId
 {
-    if ([userId isEqualToString: [self creatorUserId]] || [[self additionalCreators] containsObject: userId])
+    if ([self isMSC4289Supported])
     {
-        return maxPowerLevel ? maxPowerLevel + 1 : NSIntegerMax;
+        if ([userId isEqualToString: [self creatorUserId]] || [[self additionalCreators] containsObject: userId])
+        {
+            return maxPowerLevel ? maxPowerLevel + 1 : NSIntegerMax;
+        }
     }
     return [powerLevels powerLevelOfUserWithUserID:userId];
+}
+
+- (BOOL)isMSC4289Supported {
+    NSArray<NSString*> *supportedRoomVersions = @[@"org.matrix.hydra.11",@"12"];
+    if ([self roomVersion])
+    {
+        return [supportedRoomVersions containsObject:[self roomVersion]];
+    }
+    return NO;
 }
 
 # pragma mark - Conference call

--- a/MatrixSDK/Data/MXRoomState.m
+++ b/MatrixSDK/Data/MXRoomState.m
@@ -653,7 +653,7 @@
     {
         if ([userId isEqualToString: [self creatorUserId]] || [[self additionalCreators] containsObject: userId])
         {
-            return maxPowerLevel ? maxPowerLevel + 1 : NSIntegerMax;
+            return NSIntegerMax;
         }
     }
     

--- a/MatrixSDK/JSONModels/MXEvent.m
+++ b/MatrixSDK/JSONModels/MXEvent.m
@@ -683,8 +683,7 @@ NSString *const kMXEventTypeStringCallNotifyUnstable = @"org.matrix.msc4075.call
             
         case MXEventTypeRoomCreate:
         {
-            allowedKeys = @[@"creator",
-                            @"additional_creators"];
+            allowedKeys = @[@"creator"];
             break;
         }
             

--- a/MatrixSDK/JSONModels/MXEvent.m
+++ b/MatrixSDK/JSONModels/MXEvent.m
@@ -683,7 +683,8 @@ NSString *const kMXEventTypeStringCallNotifyUnstable = @"org.matrix.msc4075.call
             
         case MXEventTypeRoomCreate:
         {
-            allowedKeys = @[@"creator"];
+            allowedKeys = @[@"creator",
+                            @"additional_creators"];
             break;
         }
             

--- a/MatrixSDK/JSONModels/MXRoomCreateContent.h
+++ b/MatrixSDK/JSONModels/MXRoomCreateContent.h
@@ -33,6 +33,11 @@ extern NSString* _Nonnull const MXRoomCreateContentRoomTypeJSONKey;
 @property (nonatomic, copy, readonly, nullable) NSString *creatorUserId;
 
 /**
+ The array of `user_id` of the additional room creators.
+ */
+@property (nonatomic, copy, readonly, nullable) NSArray<NSString*> *additionalCreators;
+
+/**
  Room predecessor information if the current room is a new version of an old room (that has a state event `m.room.tombstone`).
  */
 @property (nonatomic, strong, readonly, nullable) MXRoomPredecessorInfo *roomPredecessorInfo;

--- a/MatrixSDK/JSONModels/MXRoomCreateContent.m
+++ b/MatrixSDK/JSONModels/MXRoomCreateContent.m
@@ -25,6 +25,7 @@ NSString* const MXRoomCreateContentRoomTypeJSONKey = @"type";
 // Private
 
 static NSString* const kRoomCreateContentUserIdJSONKey = @"creator";
+static NSString* const kRoomCreateContentAdditionalCreatorsJSONKey = @"additional_creators";
 static NSString* const kRoomCreateContentPredecessorInfoJSONKey = @"predecessor";
 static NSString* const kRoomCreateContentRoomVersionJSONKey = @"room_version";
 static NSString* const kRoomCreateContentFederateJSONKey = @"m.federate";
@@ -34,6 +35,7 @@ static NSString* const kRoomCreateContentFederateJSONKey = @"m.federate";
 @interface MXRoomCreateContent()
 
 @property (nonatomic, copy, readwrite, nullable) NSString *creatorUserId;
+@property (nonatomic, copy, readwrite, nullable) NSArray<NSString*> *additionalCreators;
 @property (nonatomic, strong, readwrite, nullable) MXRoomPredecessorInfo *roomPredecessorInfo;
 @property (nonatomic, copy, readwrite, nullable) NSString *roomVersion;
 @property (nonatomic, readwrite) BOOL isFederated;
@@ -53,6 +55,7 @@ static NSString* const kRoomCreateContentFederateJSONKey = @"m.federate";
         roomCreateContent.isFederated = YES;
         
         MXJSONModelSetString(roomCreateContent.creatorUserId, jsonDictionary[kRoomCreateContentUserIdJSONKey]);
+        MXJSONModelSetArray(roomCreateContent.additionalCreators, jsonDictionary[kRoomCreateContentAdditionalCreatorsJSONKey]);
         MXJSONModelSetMXJSONModel(roomCreateContent.roomPredecessorInfo, MXRoomPredecessorInfo, jsonDictionary[kRoomCreateContentPredecessorInfoJSONKey]);
         MXJSONModelSetString(roomCreateContent.roomVersion, jsonDictionary[kRoomCreateContentRoomVersionJSONKey]);
         MXJSONModelSetBoolean(roomCreateContent.isFederated, jsonDictionary[kRoomCreateContentFederateJSONKey]);
@@ -92,6 +95,11 @@ static NSString* const kRoomCreateContentFederateJSONKey = @"m.federate";
     if (self.roomType)
     {
         jsonDictionary[MXRoomCreateContentRoomTypeJSONKey] = self.roomType;
+    }
+    
+    if (self.additionalCreators)
+    {
+        jsonDictionary[kRoomCreateContentAdditionalCreatorsJSONKey] = self.additionalCreators;
     }
     
     return jsonDictionary;

--- a/MatrixSDK/JSONModels/MXRoomPowerLevels.h
+++ b/MatrixSDK/JSONModels/MXRoomPowerLevels.h
@@ -48,6 +48,7 @@ extern NSInteger const kMXRoomPowerLevelNotificationsRoomDefault;
 
 /**
  Helper to get the power level of a member of the room.
+ NOTE: Should not be used directly anymore prefer the MXRoomState implementation over this!
 
  @param userId the id of the user.
  @return his power level.

--- a/MatrixSDK/JSONModels/MXRoomPowerLevels.h
+++ b/MatrixSDK/JSONModels/MXRoomPowerLevels.h
@@ -46,15 +46,6 @@ extern NSInteger const kMXRoomPowerLevelNotificationsRoomDefault;
  */
 @property (nonatomic) NSInteger usersDefault;
 
-/**
- Helper to get the power level of a member of the room.
- NOTE: Should not be used directly anymore prefer the MXRoomState implementation over this!
-
- @param userId the id of the user.
- @return his power level.
- */
-- (NSInteger)powerLevelOfUserWithUserID:(NSString*)userId __attribute__((deprecated("Use the method in MXRoomState instead")));
-
 #pragma mark - Setup
 
 /**

--- a/MatrixSDK/JSONModels/MXRoomPowerLevels.h
+++ b/MatrixSDK/JSONModels/MXRoomPowerLevels.h
@@ -53,7 +53,7 @@ extern NSInteger const kMXRoomPowerLevelNotificationsRoomDefault;
  @param userId the id of the user.
  @return his power level.
  */
-- (NSInteger)powerLevelOfUserWithUserID:(NSString*)userId;
+- (NSInteger)powerLevelOfUserWithUserID:(NSString*)userId __attribute__((deprecated("Use the method in MXRoomState instead")));
 
 #pragma mark - Setup
 

--- a/MatrixSDK/JSONModels/MXRoomPowerLevels.m
+++ b/MatrixSDK/JSONModels/MXRoomPowerLevels.m
@@ -117,21 +117,6 @@ NSInteger const kMXRoomPowerLevelNotificationsRoomDefault = 50;
     return self;
 }
 
-- (NSInteger)powerLevelOfUserWithUserID:(NSString *)userId
-{
-    // By default, use usersDefault
-    NSInteger userPowerLevel = _usersDefault;
-
-    NSNumber *powerLevel;
-    MXJSONModelSetNumber(powerLevel, _users[userId]);
-    if (powerLevel)
-    {
-        userPowerLevel = [powerLevel integerValue];
-    }
-
-    return userPowerLevel;
-}
-
 - (NSInteger)minimumPowerLevelForSendingEventAsMessage:(MXEventTypeString)eventTypeString
 {
     NSInteger minimumPowerLevel;

--- a/MatrixSDK/NotificationCenter/Checker/MXPushRuleSenderNotificationPermissionConditionChecker.m
+++ b/MatrixSDK/NotificationCenter/Checker/MXPushRuleSenderNotificationPermissionConditionChecker.m
@@ -53,7 +53,7 @@
     {
         MXRoomPowerLevels *roomPowerLevels = roomState.powerLevels;
         NSInteger notifLevel = [roomPowerLevels minimumPowerLevelForNotifications:notifLevelKey defaultPower:50];
-        NSInteger senderPowerLevel = [roomPowerLevels powerLevelOfUserWithUserID:event.sender];
+        NSInteger senderPowerLevel = [roomState powerLevelOfUserWithUserID:event.sender];
 
         isSatisfied = (senderPowerLevel >= notifLevel);
     }

--- a/MatrixSDK/Space/MXSpace.swift
+++ b/MatrixSDK/Space/MXSpace.swift
@@ -327,12 +327,13 @@ public class MXSpace: NSObject {
         }
         
         room.state { roomState in
-            guard let powerLevels = roomState?.powerLevels else {
+            guard let roomState,
+                let powerLevels = roomState.powerLevels else {
                 MXLog.warning("[MXSpace] canAddRoom: space power levels not found")
                 completion(false)
                 return
             }
-            let userPowerLevel = powerLevels.powerLevelOfUser(withUserID: userId)
+            let userPowerLevel = roomState.powerLevelOfUser(withUserID: userId)
             let minimumPowerLevel = self.minimumPowerLevelForAddingRoom(with: powerLevels)
             let canAddRoom = userPowerLevel >= minimumPowerLevel
             

--- a/MatrixSDK/VoIP/MXCallManager.m
+++ b/MatrixSDK/VoIP/MXCallManager.m
@@ -1325,7 +1325,7 @@ NSString *const kMXCallManagerConferenceUserDomain  = @"matrix.org";
     else
     {
         MXRoomPowerLevels *powerLevels = roomState.powerLevels;
-        NSInteger oneSelfPowerLevel = [powerLevels powerLevelOfUserWithUserID:room.mxSession.myUserId];
+        NSInteger oneSelfPowerLevel = [roomState powerLevelOfUserWithUserID:room.mxSession.myUserId];
 
         // Only member with invite power level can create a conference call
         if (oneSelfPowerLevel >= powerLevels.invite)

--- a/MatrixSDKTests/MXLocationServiceTests.swift
+++ b/MatrixSDKTests/MXLocationServiceTests.swift
@@ -346,7 +346,7 @@ class MXLocationServiceTests: XCTestCase {
                         
                         _ = liveTimeline.listenToEvents([.roomPowerLevels], { event, direction, state in
                             
-                            XCTAssertEqual(liveTimeline.state?.powerLevels.powerLevelOfUser(withUserID: aliceSession.myUserId), expectedPowerLevel);
+                            XCTAssertEqual(liveTimeline.state?.powerLevelOfUser(withUserID: aliceSession.myUserId), expectedPowerLevel);
                             
                             let aliceLocationService: MXLocationService = aliceSession.locationService
                             

--- a/MatrixSDKTests/MXRoomStateTests.m
+++ b/MatrixSDKTests/MXRoomStateTests.m
@@ -1139,10 +1139,10 @@
                 XCTAssertEqual(roomPowerLevels.users.count, 1);
                 XCTAssertEqualObjects(roomPowerLevels.users[bobRestClient.credentials.userId], [NSNumber numberWithUnsignedInteger: 100], @"By default power level of room creator is 100");
 
-                NSUInteger powerlLevel = [roomPowerLevels powerLevelOfUserWithUserID:bobRestClient.credentials.userId];
+                NSUInteger powerlLevel = [roomState powerLevelOfUserWithUserID:bobRestClient.credentials.userId];
                 XCTAssertEqual(powerlLevel, 100, @"By default power level of room creator is 100");
 
-                powerlLevel = [roomPowerLevels powerLevelOfUserWithUserID:@"randomUserId"];
+                powerlLevel = [roomState powerLevelOfUserWithUserID:@"randomUserId"];
                 XCTAssertEqual(powerlLevel, roomPowerLevels.usersDefault, @"Power level of user with no attributed power level must default to usersDefault");
 
                 // Check minimum power level for actions

--- a/MatrixSDKTests/MXRoomTests.m
+++ b/MatrixSDKTests/MXRoomTests.m
@@ -303,7 +303,7 @@
             [room liveTimeline:^(id<MXEventTimeline> liveTimeline) {
                 [liveTimeline listenToEventsOfTypes:@[kMXEventTypeStringRoomPowerLevels] onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
 
-                    XCTAssertEqual([liveTimeline.state.powerLevels powerLevelOfUserWithUserID:aliceRestClient.credentials.userId], 36);
+                    XCTAssertEqual([liveTimeline.state powerLevelOfUserWithUserID:aliceRestClient.credentials.userId], 36);
 
                     [expectation fulfill];
                 }];

--- a/MatrixSDKTests/MXSessionTests.m
+++ b/MatrixSDKTests/MXSessionTests.m
@@ -877,8 +877,8 @@
                             MXRoomPowerLevels *roomPowerLevels = roomState.powerLevels;
 
                             XCTAssertNotNil(roomPowerLevels);
-                            NSUInteger powerlLevel1 = [roomPowerLevels powerLevelOfUserWithUserID:mxSession.myUserId];
-                            NSUInteger powerlLevel2 = [roomPowerLevels powerLevelOfUserWithUserID:matrixSDKTestsData.aliceCredentials.userId];
+                            NSUInteger powerlLevel1 = [roomState powerLevelOfUserWithUserID:mxSession.myUserId];
+                            NSUInteger powerlLevel2 = [roomState powerLevelOfUserWithUserID:matrixSDKTestsData.aliceCredentials.userId];
                             XCTAssertEqual(powerlLevel1, powerlLevel2, @"The members must have the same power level");
 
                             [expectation fulfill];


### PR DESCRIPTION
Room creator will now have the highest possible power level, which won't be determined by `m.room.power_levels`.
Also a room may have additional creators.

Also the `powerLevelOfUserWithUserID` function from MXPowerLevels has been removed in favour of the newer version in `MXRoomState`.