### PR TITLE
`tombStoneEventId` can now be optional

### DIFF
--- a/MatrixSDK/JSONModels/MXRoomPredecessorInfo.h
+++ b/MatrixSDK/JSONModels/MXRoomPredecessorInfo.h
@@ -31,6 +31,6 @@
 /**
  Event id of the `m.room.tombstone` event type in the previous version of the room.
  */
-@property (nonatomic, copy, readonly, nonnull) NSString *tombStoneEventId;
+@property (nonatomic, copy, readonly, nullable) NSString *tombStoneEventId;
 
 @end

--- a/MatrixSDK/JSONModels/MXRoomPredecessorInfo.m
+++ b/MatrixSDK/JSONModels/MXRoomPredecessorInfo.m
@@ -26,7 +26,7 @@ static NSString* const kRoomPredecessorTombstoneEventIdJSONKey = @"event_id";
 @interface MXRoomPredecessorInfo()
 
 @property (nonatomic, copy, readwrite, nonnull) NSString *roomId;
-@property (nonatomic, copy, readwrite, nonnull) NSString *tombStoneEventId;
+@property (nonatomic, copy, readwrite, nullable) NSString *tombStoneEventId;
 
 @end
 
@@ -44,11 +44,14 @@ static NSString* const kRoomPredecessorTombstoneEventIdJSONKey = @"event_id";
     MXJSONModelSetString(roomId, jsonDictionary[kRoomPredecessorRoomIdJSONKey]);
     MXJSONModelSetString(tombStoneEventId, jsonDictionary[kRoomPredecessorTombstoneEventIdJSONKey]);
     
-    if (roomId && tombStoneEventId)
+    if (roomId)
     {
         tombStoneContent = [MXRoomPredecessorInfo new];
         tombStoneContent.roomId = roomId;
-        tombStoneContent.tombStoneEventId = tombStoneEventId;
+        if (tombStoneEventId)
+        {
+            tombStoneContent.tombStoneEventId = tombStoneEventId;
+        }
     }
     
     return tombStoneContent;


### PR DESCRIPTION
Even if not really used in the app, the initialisation of `MXPredecessorInfo` required `tombStoneEventId` to be `nonnull`, since room version 12 now such value can be optional. This PR just makes model able to be initialised if the value is null.