### PR TITLE
fix lazy loading and enable more timeline filtering

### DIFF
--- a/MatrixSDK/Data/EventTimeline/Room/MXRoomEventTimeline.m
+++ b/MatrixSDK/Data/EventTimeline/Room/MXRoomEventTimeline.m
@@ -124,6 +124,26 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
         }
 
         _state = [[MXRoomState alloc] initWithRoomId:room.roomId andMatrixSession:room.mxSession andDirection:YES];
+
+        // During startup, if a cached filterId exists, this code will execute to fetch and create a filter.
+        // However, if a filter is explicitly provided to start(), that filter will overwrite the one allocated here.
+        // Additionally, this code runs when loadRoom() is called after start() to ensure the filter is always initialized.
+        if (!_roomEventFilter && room.mxSession.syncFilterId)
+        {
+            [room.mxSession filterWithFilterId:room.mxSession.syncFilterId success:^(MXFilterJSONModel *filter) {
+                _roomEventFilter = filter.room.timeline;
+
+                // If the event stream runs with lazy loading, the timeline must do the same
+                if (filter.room.state.lazyLoadMembers)
+                {
+                    if (!_roomEventFilter)
+                    {
+                        _roomEventFilter = [MXRoomEventFilter new];
+                    }
+                    _roomEventFilter.lazyLoadMembers = YES;
+                }
+            } failure:nil];
+        }
     }
     return self;
 }

--- a/MatrixSDK/Data/EventTimeline/Room/MXRoomEventTimeline.m
+++ b/MatrixSDK/Data/EventTimeline/Room/MXRoomEventTimeline.m
@@ -124,13 +124,6 @@ NSString *const kMXRoomInviteStateEventIdPrefix = @"invite-";
         }
 
         _state = [[MXRoomState alloc] initWithRoomId:room.roomId andMatrixSession:room.mxSession andDirection:YES];
-
-        // If the event stream runs with lazy loading, the timeline must do the same
-        if (room.mxSession.syncWithLazyLoadOfRoomMembers)
-        {
-            _roomEventFilter = [MXRoomEventFilter new];
-            _roomEventFilter.lazyLoadMembers = YES;
-        }
     }
     return self;
 }

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -946,6 +946,18 @@ typedef void (^MXOnResumeDone)(void);
                 MXLogDebug(@"[MXSession] Set syncWithLazyLoadOfRoomMembers to YES");
                 self->_syncWithLazyLoadOfRoomMembers = YES;
             }
+
+            for (MXRoom *room in self.rooms) {
+                [room liveTimeline:^(id<MXEventTimeline> liveTimeline) {
+                    liveTimeline.roomEventFilter = filter.room.timeline;
+
+                    // If the event stream runs with lazy loading, the timeline must do the same
+                    if (self->_syncWithLazyLoadOfRoomMembers)
+                    {
+                        liveTimeline.roomEventFilter.lazyLoadMembers = YES;
+                    }
+                }];
+            }
         } failure:nil];
     }
     

--- a/changelog.d/pr-1912.bugfix
+++ b/changelog.d/pr-1912.bugfix
@@ -1,0 +1,2 @@
+- Lazy member loading flag was not applied in timeline filter due to init order (setStore before start).
+- Support for additional timeline filters.


### PR DESCRIPTION
Fixes an issue where lazy member loading was never applied to the timeline filter because `initWithRoom` is called by `setStore` before `session.start()`. The flag is now set correctly.

Also added support for additional timeline filters (e.g. by event types).

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request contains a changelog file in ./changelog.d. See https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
