### PR TITLE
Fix 'occured' -> 'occurred' typos across MatrixSDK (10 files)

### DIFF
--- a/MatrixSDK/ContentScan/MXScanManager.h
+++ b/MatrixSDK/ContentScan/MXScanManager.h
@@ -162,7 +162,7 @@ FOUNDATION_EXPORT NSString * _Nonnull const MXErrorContentScannerReasonValueBadD
  
  @param requestBody the data to encrypt.
  @param completion A block object to be executed when the encrypted body is available. The returned instance is
- null if the server doesn't have a public key, or if an error occured during the encryption.
+ null if the server doesn't have a public key, or if an error occurred during the encryption.
  */
 - (void)encryptRequestBody:(nonnull NSDictionary *)requestBody completion:(void (^ _Nonnull)(MXContentScanEncryptedBody* _Nullable encryptedBody))completion;
 

--- a/MatrixSDK/Crypto/Algorithms/MXEventDecryptionResult.h
+++ b/MatrixSDK/Crypto/Algorithms/MXEventDecryptionResult.h
@@ -53,7 +53,7 @@
 @property (nonatomic, strong) MXEventDecryptionDecoration *decoration;
 
 /**
- If any, the error that occured during decryption.
+ If any, the error that occurred during decryption.
  */
 @property (nonatomic) NSError *error;
 

--- a/MatrixSDK/Crypto/Utils/MXAes.h
+++ b/MatrixSDK/Crypto/Utils/MXAes.h
@@ -48,9 +48,9 @@ typedef NS_ENUM(NSUInteger, MXAesErrorCode)
  @param data data to be encrypted.
  @param aesKey key used for encryption
  @param iv initialization vector used for encryption
- @param error set an error object if error occured
+ @param error set an error object if error occurred
  
- @return encrypted data if no error occured, nil otherwise.
+ @return encrypted data if no error occurred, nil otherwise.
  */
 + (nullable NSData*)encrypt:(NSData*)data
                      aesKey:(NSData*)aesKey iv:(NSData*)iv
@@ -62,9 +62,9 @@ typedef NS_ENUM(NSUInteger, MXAesErrorCode)
  @param data data to be decrypted.
  @param aesKey key used for encryption
  @param iv initialization vector used for encryption
- @param error set an error object if error occured
+ @param error set an error object if error occurred
  
- @return decrypted data if no error occured, nil otherwise.
+ @return decrypted data if no error occurred, nil otherwise.
  */
 + (nullable NSData*)decrypt:(NSData*)data
                      aesKey:(NSData*)aesKey iv:(NSData*)iv

--- a/MatrixSDK/Crypto/Verification/Transactions/QRCode/MXQRCodeTransaction.h
+++ b/MatrixSDK/Crypto/Verification/Transactions/QRCode/MXQRCodeTransaction.h
@@ -34,7 +34,7 @@ typedef NS_ENUM(NSInteger, MXQRCodeTransactionState) {
     MXQRCodeTransactionStateVerified,
     MXQRCodeTransactionStateCancelled,              // Check self.reasonCancelCode for the reason
     MXQRCodeTransactionStateCancelledByMe,          // Check self.reasonCancelCode for the reason
-    MXQRCodeTransactionStateError                   // An error occured. Check self.error. The transaction can be only cancelled
+    MXQRCodeTransactionStateError                   // An error occurred. Check self.error. The transaction can be only cancelled
 };
 
 /**

--- a/MatrixSDK/Crypto/Verification/Transactions/SAS/MXSASTransaction.h
+++ b/MatrixSDK/Crypto/Verification/Transactions/SAS/MXSASTransaction.h
@@ -42,7 +42,7 @@ typedef enum : NSUInteger
     MXSASTransactionStateVerified,
     MXSASTransactionStateCancelled,                         // Check self.reasonCancelCode for the reason
     MXSASTransactionStateCancelledByMe,                     // Check self.reasonCancelCode for the reason
-    MXSASTransactionStateError                              // An error occured. Check self.error. The transaction can be only cancelled
+    MXSASTransactionStateError                              // An error occurred. Check self.error. The transaction can be only cancelled
 } MXSASTransactionState;
 
 /**

--- a/MatrixSDK/Data/MXRoomSummary.h
+++ b/MatrixSDK/Data/MXRoomSummary.h
@@ -431,7 +431,7 @@ FOUNDATION_EXPORT NSUInteger const MXRoomSummaryPaginationChunkSize;
  @param session the session the room belongs to.
  @param summary the room summary.
  @param event the candidate event for the room last message event.
- @param eventState the room state when the event occured.
+ @param eventState the room state when the event occurred.
  @param roomState the current state of the room.
  @return YES if the delegate accepted the event as last message.
          Returning NO can lead to a new call of this method with another candidate event.

--- a/MatrixSDK/Data/MXRoomSummary.m
+++ b/MatrixSDK/Data/MXRoomSummary.m
@@ -684,7 +684,7 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
     }
     
     // TODO: To improve
-    // This delay allows to gather multiple changes that occured in a room
+    // This delay allows to gather multiple changes that occurred in a room
     // and make only computation and request
     MXWeakify(self);
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, kMXRoomSummaryTrustComputationDelayMs * NSEC_PER_MSEC), dispatch_get_main_queue(), ^{
@@ -867,7 +867,7 @@ static NSUInteger const kMXRoomSummaryTrustComputationDelayMs = 1000;
         {
             if (event.isState)
             {
-                // Need to go backward in the state to provide it as it was when the event occured
+                // Need to go backward in the state to provide it as it was when the event occurred
                 if (state.isLive)
                 {
                     state = [state copy];

--- a/MatrixSDK/Utils/MXAnalyticsDelegate.h
+++ b/MatrixSDK/Utils/MXAnalyticsDelegate.h
@@ -141,7 +141,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Report a non-fatal issue, i.e. an internal error that did not result in a crash
  
- @param issue the description of the issue that occured
+ @param issue the description of the issue that occurred
  @param details a dictionary of additional context-dependent details about the issue
  */
 - (void)trackNonFatalIssue:(NSString *)issue

--- a/MatrixSDK/VoIP/MXCall.h
+++ b/MatrixSDK/VoIP/MXCall.h
@@ -427,7 +427,7 @@ extern NSString *const kMXCallSupportsTransferringStatusDidChange;
 - (void)callAvailableAudioOutputsDidChange:(MXCall *)call;
 
 /**
- Tells the delegate an error occured.
+ Tells the delegate an error occurred.
  The call cannot be established.
 
  @param call the instance that changes.

--- a/scripts/symbolicate/symbolicate.py
+++ b/scripts/symbolicate/symbolicate.py
@@ -112,7 +112,7 @@ def symbolicate(crashLogData):
         if not "handleSignal" in crashLogData:
             crashLogData = crashLogData + "\n* Warning: This symbolication seems invalid!\n"
     else:
-        # In the case of a NS Exception, if the crash occured on the main thread, we must find the start and the main function at the call stack root.
+        # In the case of a NS Exception, if the crash occurred on the main thread, we must find the start and the main function at the call stack root.
         # If it is from another thread (ie its stack starts with start_wqthread), we can't validate the result
         if not "start_wqthread" in crashLogData:
             if not ("main" in crashLogData and "start" in crashLogData):


### PR DESCRIPTION
Fix 14 instances of \`occured\` → \`occurred\` across 10 files in MatrixSDK.

## Files

| File | Instances |
|------|-----------|
| \`MatrixSDK/Crypto/Utils/MXAes.h\` | 4 |
| \`MatrixSDK/Data/MXRoomSummary.m\` | 2 |
| \`MatrixSDK/Crypto/Algorithms/MXEventDecryptionResult.h\` | 1 |
| \`scripts/symbolicate/symbolicate.py\` | 1 |
| \`MatrixSDK/VoIP/MXCall.h\` | 1 |
| \`MatrixSDK/Utils/MXAnalyticsDelegate.h\` | 1 |
| \`MatrixSDK/Data/MXRoomSummary.h\` | 1 |
| \`MatrixSDK/Crypto/Verification/Transactions/QRCode/MXQRCodeTransaction.h\` | 1 |
| \`MatrixSDK/ContentScan/MXScanManager.h\` | 1 |
| \`MatrixSDK/Crypto/Verification/Transactions/SAS/MXSASTransaction.h\` | 1 |

All are doc comments or inline comments in public-facing headers, so the misspelling is visible in generated API documentation.